### PR TITLE
libbase: Adding missing vprintf function.

### DIFF
--- a/litex/soc/software/include/base/stdarg.h
+++ b/litex/soc/software/include/base/stdarg.h
@@ -16,6 +16,7 @@ extern "C" {
 int vsnprintf(char *buf, size_t size, const char *fmt, va_list args);
 int vscnprintf(char *buf, size_t size, const char *fmt, va_list args);
 int vsprintf(char *buf, const char *fmt, va_list args);
+int vprintf(const char *format, va_list ap);
 
 #ifdef __cplusplus
 }

--- a/litex/soc/software/libbase/console.c
+++ b/litex/soc/software/libbase/console.c
@@ -64,17 +64,22 @@ void putsnonl(const char *s)
 
 #define PRINTF_BUFFER_SIZE 256
 
-int printf(const char *fmt, ...)
+int vprintf(const char *fmt, va_list args)
 {
-	va_list args;
 	int len;
 	char outbuf[PRINTF_BUFFER_SIZE];
-
-	va_start(args, fmt);
 	len = vscnprintf(outbuf, sizeof(outbuf), fmt, args);
-	va_end(args);
 	outbuf[len] = 0;
 	putsnonl(outbuf);
+	return len;
+}
 
+int printf(const char *fmt, ...)
+{
+	int len;
+	va_list args;
+	va_start(args, fmt);
+	len = vprintf(fmt, args);
+	va_end(args);
 	return len;
 }


### PR DESCRIPTION
Fixes #8.

```
int vprintf(const char *format, va_list ap);

The functions vprintf(), vfprintf(), vsprintf(), vsnprintf() are equivalent to
the functions printf(), fprintf(), sprintf(), snprintf(), respectively, except
that  they  are  called  with  a  va_list instead of a variable number of
arguments.
```