### PR TITLE
Patches to make it easier to work with Etherbone

### DIFF
--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -98,6 +98,7 @@ class SoCCore(Module):
 
         self.submodules.wishbone2csr = wishbone2csr.WB2CSR(
             bus_csr=csr_bus.Interface(csr_data_width, csr_address_width))
+        self.add_constant("CSR_DATA_WIDTH", csr_data_width)
         self.register_mem("csr", self.mem_map["csr"], self.wishbone2csr.wishbone)
 
         if with_uart:

--- a/litex/soc/tools/remote/comm_udp.py
+++ b/litex/soc/tools/remote/comm_udp.py
@@ -5,7 +5,7 @@ from litex.soc.tools.remote.etherbone import EtherboneReads, EtherboneWrites
 from litex.soc.tools.remote.csr_builder import CSRBuilder
 
 class CommUDP(CSRBuilder):
-    def __init__(self, server="192.168.1.50", port=1234, csr_csv="csr.csv", csr_data_width=32, debug=False):
+    def __init__(self, server="192.168.1.50", port=1234, csr_csv="csr.csv", csr_data_width=None, debug=False):
         if csr_csv is not None:
             CSRBuilder.__init__(self, self, csr_csv, csr_data_width)
         self.server = server

--- a/litex/soc/tools/remote/csr_builder.py
+++ b/litex/soc/tools/remote/csr_builder.py
@@ -52,9 +52,20 @@ class CSRMemoryRegion:
 
 
 class CSRBuilder:
-    def __init__(self, comm, csr_csv, csr_data_width):
-        self.csr_data_width = csr_data_width
+    def __init__(self, comm, csr_csv, csr_data_width=None):
         self.constants = self.build_constants(csr_csv)
+
+        # Load csr_data_width from the constants, otherwise it must be provided
+        constant_csr_data_width = self.constants.d.get('csr_data_width', None)
+        if csr_data_width is None:
+            csr_data_width = constant_csr_data_width
+        if csr_data_width is None:
+            raise KeyError('csr_data_width not found in constants, please provide!')
+        if csr_data_width != constant_csr_data_width:
+            raise KeyError('csr_data_width of {} provided but {} found in constants'.format(
+                csr_data_width, constant_csr_data_width))
+
+        self.csr_data_width = csr_data_width
         self.bases = self.build_bases(csr_csv)
         self.regs = self.build_registers(csr_csv, comm.read, comm.write)
         self.mems = self.build_memories(csr_csv)

--- a/litex/soc/tools/remote/csr_builder.py
+++ b/litex/soc/tools/remote/csr_builder.py
@@ -3,11 +3,15 @@ import csv
 
 class CSRElements:
     def __init__(self, d):
-        self.d = d
+        self.__dict__.update(d)
+
+    @property
+    def d(self):
+        return self.__dict__
 
     def __getattr__(self, attr):
         try:
-            return self.__dict__['d'][attr]
+            return self.__dict__[attr]
         except KeyError:
             pass
         raise KeyError("No such element " + attr)

--- a/litex/soc/tools/remote/litex_client.py
+++ b/litex/soc/tools/remote/litex_client.py
@@ -7,9 +7,11 @@ from litex.soc.tools.remote.csr_builder import CSRBuilder
 
 
 class RemoteClient(EtherboneIPC, CSRBuilder):
-    def __init__(self, host="localhost", port=1234, csr_csv="csr.csv", csr_data_width=32, debug=False):
+    def __init__(self, host="localhost", port=1234, csr_csv="csr.csv", csr_data_width=None, debug=False):
         if csr_csv is not None:
             CSRBuilder.__init__(self, self, csr_csv, csr_data_width)
+        else:
+            assert csr_data_width is not None
         self.host = host
         self.port = port
         self.debug = debug


### PR DESCRIPTION
 * Provide the CSR data bus width in a constant.
 * Allow the Etherbone objects to autocompleted in things like `IPython` and `bpython`.