### PR TITLE
Only require rebuild on actual changes

### DIFF
--- a/litex/build/tools.py
+++ b/litex/build/tools.py
@@ -23,6 +23,9 @@ def write_to_file(filename, contents, force_unix=False):
     newline = None
     if force_unix:
         newline = "\n"
+    if os.path.exists(filename):
+        if open(filename, "r", newline=newline).read() == contents:
+            return
     with open(filename, "w", newline=newline) as f:
         f.write(contents)
 

--- a/litex/soc/software/bios/Makefile
+++ b/litex/soc/software/bios/Makefile
@@ -34,4 +34,4 @@ main.o: $(BIOS_DIRECTORY)/main.c
 clean:
 	$(RM) $(OBJECTS) bios.elf bios.bin .*~ *~
 
-.PHONY: all clean main.o
+.PHONY: all clean

--- a/litex/soc/software/bios/Makefile
+++ b/litex/soc/software/bios/Makefile
@@ -22,8 +22,8 @@ bios.elf: $(BIOS_DIRECTORY)/linker.ld $(OBJECTS)
 		-lnet -lbase-nofloat -lcompiler_rt
 	chmod -x $@
 
-main.o: $(BIOS_DIRECTORY)/main.c
-	$(compile)
+# pull in dependency info for *existing* .o files
+-include $(OBJECTS:.o=.d)
 
 %.o: $(BIOS_DIRECTORY)/%.c
 	$(compile)


### PR DESCRIPTION
 * Files are only modified when their contents change.
 * Fix Makefile so bios is correctly rebuilt when dependencies change (but isn't otherwise).