### PR TITLE
Fix Makefile dependency inclusion for other software.

### DIFF
--- a/litex/soc/software/libbase/Makefile
+++ b/litex/soc/software/libbase/Makefile
@@ -11,6 +11,9 @@ libbase.a: $(OBJECTS) vsnprintf.o
 libbase-nofloat.a: $(OBJECTS) vsnprintf-nofloat.o
 	$(AR) crs libbase-nofloat.a $(OBJECTS) vsnprintf-nofloat.o
 
+# pull in dependency info for *existing* .o files
+-include $(OBJECTS:.o=.d)
+
 vsnprintf-nofloat.o: $(LIBBASE_DIRECTORY)/vsnprintf.c
 	$(call compile,-DNO_FLOAT)
 

--- a/litex/soc/software/libcompiler_rt/Makefile
+++ b/litex/soc/software/libcompiler_rt/Makefile
@@ -17,6 +17,9 @@ libcompiler_rt.a: $(OBJECTS)
 	$(CC) -c $(CFLAGS) $(1) $(SOC_DIRECTORY)/software/libcompiler_rt/mulsi3.c -o mulsi3.o
 	$(AR) crs libcompiler_rt.a $(OBJECTS)
 
+# pull in dependency info for *existing* .o files
+-include $(OBJECTS:.o=.d)
+
 mulsi3.o: $(SOC_DIRECTORY)/software/libcompiler_rt/mulsi3.c
 	$(compile)
 

--- a/litex/soc/software/libnet/Makefile
+++ b/litex/soc/software/libnet/Makefile
@@ -8,6 +8,9 @@ all: libnet.a
 libnet.a: $(OBJECTS)
 	$(AR) crs libnet.a $(OBJECTS)
 
+# pull in dependency info for *existing* .o files
+-include $(OBJECTS:.o=.d)
+
 %.o: $(LIBNET_DIRECTORY)/%.c
 	$(compile)
 


### PR DESCRIPTION
I previously fixed it for the bios, but not these libraries.