### PR TITLE
Raise AttributeError.

### DIFF
--- a/litex/soc/tools/remote/csr_builder.py
+++ b/litex/soc/tools/remote/csr_builder.py
@@ -14,7 +14,7 @@ class CSRElements:
             return self.__dict__[attr]
         except KeyError:
             pass
-        raise KeyError("No such element " + attr)
+        raise AttributeError("No such element " + attr)
 
 
 class CSRRegister:


### PR DESCRIPTION
Makes hasattr work correctly.