### PR TITLE
vivado: Fix segfault with or1k.

### DIFF
--- a/litex/build/xilinx/vivado.py
+++ b/litex/build/xilinx/vivado.py
@@ -97,7 +97,11 @@ class XilinxVivadoToolchain:
 
         tcl.append("read_xdc {}.xdc".format(build_name))
         tcl.extend(c.format(build_name=build_name) for c in self.pre_synthesis_commands)
-        tcl.append("synth_design -top {} -part {} -include_dirs {{{}}}".format(build_name, platform.device, " ".join(platform.verilog_include_paths)))
+        if platform.verilog_include_paths:
+            synth_design_extra = "-include_dirs {{{}}}".format(" ".join(platform.verilog_include_paths))
+        else:
+            synth_design_extra = ""
+        tcl.append("synth_design -top {} -part {} {}".format(build_name, platform.device, synth_design_extra))
         tcl.append("report_utilization -hierarchical -file {}_utilization_hierarchical_synth.rpt".format(build_name))
         tcl.append("report_utilization -file {}_utilization_synth.rpt".format(build_name))
         tcl.append("place_design")


### PR DESCRIPTION
The or1k doesn't have any verilog include paths added. This means the
code use to generate;
```tcl
synth_design -top top -part xc7a50t-csg325-2 -include_dirs {}
```
which causes Vivado to segfault with the following error;
```
Command: synth_design -top top -part xc7a50t-csg325-2 -include_dirs {}
Starting synth_design
Attempting to get a license for feature 'Synthesis' and/or device 'xc7a50t'
INFO: [Common 17-349] Got license for feature 'Synthesis' and/or device 'xc7a50t'
Abnormal program termination (11)
Please check 'build/netv2_base_or1k/gateware/hs_err_pid76959.log' for details
Traceback (most recent call last):
  File "./make.py", line 82, in <module>
```