### PR TITLE
Re-enable SPI flash bitbanging

### DIFF
--- a/litex/soc/cores/spi_flash.py
+++ b/litex/soc/cores/spi_flash.py
@@ -26,7 +26,7 @@ def _format_cmd(cmd, spi_width):
 
 
 class SpiFlashDualQuad(Module, AutoCSR):
-    def __init__(self, pads, dummy=15, div=2):
+    def __init__(self, pads, dummy=15, div=2, with_bitbang=True):
         """
         Simple SPI flash.
         Supports multi-bit pseudo-parallel reads (aka Dual or Quad I/O Fast
@@ -35,6 +35,11 @@ class SpiFlashDualQuad(Module, AutoCSR):
         self.bus = bus = wishbone.Interface()
         spi_width = len(pads.dq)
         assert spi_width >= 2
+
+        if with_bitbang:
+            self.bitbang = CSRStorage(4)
+            self.miso = CSRStatus()
+            self.bitbang_en = CSRStorage()
 
         # # #
 
@@ -47,7 +52,6 @@ class SpiFlashDualQuad(Module, AutoCSR):
         read_cmd_params = {
             4: (_format_cmd(_QIOFR, 4), 4*8),
             2: (_format_cmd(_DIOFR, 2), 2*8),
-            1: (_format_cmd(_FAST_READ, 1), 1*8)
         }
         read_cmd, cmd_width = read_cmd_params[spi_width]
         addr_width = 24
@@ -58,12 +62,45 @@ class SpiFlashDualQuad(Module, AutoCSR):
         sr = Signal(max(cmd_width, addr_width, wbone_width))
         self.comb += bus.dat_r.eq(sr)
 
-        self.comb += [
+        hw_read_logic = [
             pads.clk.eq(clk),
             pads.cs_n.eq(cs_n),
             dq.o.eq(sr[-spi_width:]),
             dq.oe.eq(dq_oe)
         ]
+
+        if with_bitbang:
+            bitbang_logic = [
+                pads.clk.eq(self.bitbang.storage[1]),
+                pads.cs_n.eq(self.bitbang.storage[2]),
+
+                # In Dual/Quad mode, no single data pin is consistently
+                # an input or output thanks to dual/quad reads, so we need a bit
+                # to swap direction of the pins. Aside from this additional bit,
+                # bitbang mode is identical for Single/Dual/Quad; dq[0] is mosi
+                # and dq[1] is miso, meaning remaining data pin values don't
+                # appear in CSR registers.
+                If(self.bitbang.storage[3],
+                    dq.oe.eq(0)
+                ).Else(
+                    dq.oe.eq(1)
+                ),
+                If(self.bitbang.storage[1], # CPOL=0/CPHA=0 or CPOL=1/CPHA=1 only.
+                    self.miso.status.eq(dq.i[1])
+                ),
+                dq.o.eq(Cat(self.bitbang.storage[0], Replicate(1, spi_width-1)))
+            ]
+
+            self.comb += [
+                If(self.bitbang_en.storage,
+                    bitbang_logic
+                ).Else(
+                    hw_read_logic
+                )
+            ]
+
+        else:
+            self.comb += hw_read_logic
 
         if div < 2:
             raise ValueError("Unsupported value \'{}\' for div parameter for SpiFlash core".format(div))

--- a/litex/soc/software/include/base/spiflash.h
+++ b/litex/soc/software/include/base/spiflash.h
@@ -4,5 +4,6 @@
 void write_to_flash_page(unsigned int addr, const unsigned char *c, unsigned int len);
 void erase_flash_sector(unsigned int addr);
 void write_to_flash(unsigned int addr, const unsigned char *c, unsigned int len);
+void read_from_flash(unsigned int addr, unsigned char *c, unsigned int len);
 
 #endif /* __SPIFLASH_H */

--- a/litex/soc/software/libbase/spiflash.c
+++ b/litex/soc/software/libbase/spiflash.c
@@ -8,6 +8,7 @@
 #define WRDI_CMD         0x04
 #define RDSR_CMD         0x05
 #define WREN_CMD         0x06
+#define RD_CMD           0x0b
 #define SE_CMD           0xd8
 
 #define BITBANG_CLK         (1 << 1)
@@ -22,6 +23,25 @@ static void wait_for_device_ready(void);
 
 #define min(a,b)  (a>b?b:a)
 
+// flash_read/flash_write fcns make no assumptions on bitbang reg on entry.
+// They will all leave the bitbang reg as 0x00 on exit.
+static unsigned char flash_read_byte()
+{
+    int i;
+    unsigned char b = 0;
+    spiflash_bitbang_write(BITBANG_DQ_INPUT); // ~CS_N ~CLK DQ_INPUT
+
+    for(i = 0; i < 8; i++) {
+        b <<= 1;
+        spiflash_bitbang_write(BITBANG_CLK | BITBANG_DQ_INPUT);
+        b |= spiflash_miso_read();
+        spiflash_bitbang_write(0           | BITBANG_DQ_INPUT);
+    }
+
+    spiflash_bitbang_write(0); // ~CS_N ~CLK
+    return b;
+}
+
 static void flash_write_byte(unsigned char b)
 {
     int i;
@@ -34,7 +54,6 @@ static void flash_write_byte(unsigned char b)
     }
 
     spiflash_bitbang_write(0); // ~CS_N ~CLK
-
 }
 
 static void flash_write_addr(unsigned int addr)
@@ -50,6 +69,11 @@ static void flash_write_addr(unsigned int addr)
     spiflash_bitbang_write(0);
 }
 
+
+// Bitbang commands will have flash_read/write fcns set up the bitbang reg
+// on entry. On exit, bitbang command fcns will deassert CS_N bitbang
+// regs (required) and then disable bitbang interface.
+// write_to_flash_page leaves CS_N as 0. Why?
 static void wait_for_device_ready(void)
 {
     unsigned char sr;
@@ -57,14 +81,7 @@ static void wait_for_device_ready(void)
     do {
         sr = 0;
         flash_write_byte(RDSR_CMD);
-        spiflash_bitbang_write(BITBANG_DQ_INPUT);
-        for(i = 0; i < 8; i++) {
-            sr <<= 1;
-            spiflash_bitbang_write(BITBANG_CLK | BITBANG_DQ_INPUT);
-            sr |= spiflash_miso_read();
-            spiflash_bitbang_write(0           | BITBANG_DQ_INPUT);
-        }
-        spiflash_bitbang_write(0);
+        sr = flash_read_byte();
         spiflash_bitbang_write(BITBANG_CS_N);
     } while(sr & SR_WIP);
 }
@@ -82,6 +99,25 @@ void erase_flash_sector(unsigned int addr)
 
     flash_write_byte(SE_CMD);
     flash_write_addr(sector_addr);
+    spiflash_bitbang_write(BITBANG_CS_N);
+
+    wait_for_device_ready();
+
+    spiflash_bitbang_en_write(0);
+}
+
+void read_from_flash(unsigned int addr, const unsigned char *c, unsigned int len)
+{
+    unsigned int i;
+
+    spiflash_bitbang_en_write(1);
+
+    wait_for_device_ready();
+
+    flash_write_byte(RD_CMD);
+    flash_write_addr(addr);
+    for(i = 0; i < len; i++)
+        *c++ = flash_read_byte();
     spiflash_bitbang_write(BITBANG_CS_N);
 
     wait_for_device_ready();

--- a/litex/soc/software/libbase/spiflash.c
+++ b/litex/soc/software/libbase/spiflash.c
@@ -25,7 +25,11 @@ static void wait_for_device_ready(void);
 
 // flash_read/flash_write fcns make no assumptions on bitbang reg on entry.
 // They will all leave the bitbang reg as 0x00 on exit.
-static unsigned char flash_read_byte()
+// We latch on positive edge, so only Modes 0 and 3 supported.
+// FIXME: Bitbang commands that use the read/write primitives
+// leave ~CLK as 0 on exit, which is Mode 0 compatible only.
+// How should we handle Mode 3? Set-once global and mask?
+static unsigned char flash_read_byte(void)
 {
     int i;
     unsigned char b = 0;
@@ -69,11 +73,10 @@ static void flash_write_addr(unsigned int addr)
     spiflash_bitbang_write(0);
 }
 
-
 // Bitbang commands will have flash_read/write fcns set up the bitbang reg
 // on entry. On exit, bitbang command fcns will deassert CS_N bitbang
 // regs (required) and then disable bitbang interface.
-// write_to_flash_page leaves CS_N as 0. Why?
+// XXX: write_to_flash_page leaves CS_N as 0. Why?
 static void wait_for_device_ready(void)
 {
     unsigned char sr;
@@ -106,7 +109,7 @@ void erase_flash_sector(unsigned int addr)
     spiflash_bitbang_en_write(0);
 }
 
-void read_from_flash(unsigned int addr, const unsigned char *c, unsigned int len)
+void read_from_flash(unsigned int addr, unsigned char *c, unsigned int len)
 {
     unsigned int i;
 
@@ -116,6 +119,7 @@ void read_from_flash(unsigned int addr, const unsigned char *c, unsigned int len
 
     flash_write_byte(RD_CMD);
     flash_write_addr(addr);
+    (void) flash_read_byte(); // Higher-speed read has a dummy byte.
     for(i = 0; i < len; i++)
         *c++ = flash_read_byte();
     spiflash_bitbang_write(BITBANG_CS_N);

--- a/litex/soc/software/libbase/spiflash.c
+++ b/litex/soc/software/libbase/spiflash.c
@@ -13,7 +13,9 @@
 
 #define BITBANG_CLK         (1 << 1)
 #define BITBANG_CS_N        (1 << 2)
-#define BITBANG_DQ_INPUT    (1 << 3)
+#define BITBANG_DQ_INPUT    (1 << 3) // This bit is only used for Dual/Quad SPI
+// flash, where MISO/MOSI pins are bidirectional depending on SPI flash command.
+// The bitbang interface does not support Dual/Quad reads.
 
 #define SR_WIP              1
 


### PR DESCRIPTION
This pull request reimplements the CSR interface for writing to SPI flash from a CPU using bitbanging/CSR egister writes. Additionally, _reading_ spiflash via bitbanging is also functional, and I added a `flash_read_byte` function to libbase for convenience. The register interface is identical regardless of whether a board has a naive SPI flash or supports dual/quad mode.

Reading/writing via the bitbang interface has been confirmed to work with both single and quad SPI flash memories.