### PR TITLE
Wait longer before giving up on the 2nd tftp block.

### DIFF
--- a/litex/soc/software/libnet/tftp.c
+++ b/litex/soc/software/libnet/tftp.c
@@ -133,6 +133,7 @@ int tftp_get(uint32_t ip, const char *filename, void *buffer)
 		}
 	}
 
+	i = 12000000;
 	length_before = total_length;
 	while(!transfer_finished) {
 		if(length_before != total_length) {


### PR DESCRIPTION
Previously we would wait the same number of iterations as it took us to
receive the first data block after sending the request. When using the
build in tftp server in qemu, the first wait loop succeeds (and thus
breaks when 'i' is still 0.

Since the counter was never reset between the first and second data
block, under qemu the tftp_get call would fail before ever checking if
we have received the second block of data.

Now that we initialise 'i' to 12M, we ensure that we wait the same
amount of time for the second data block as it previously did for the
third (and subsequent) blocks.