### PR TITLE
cpu: Adding "variant" support.

### DIFF
--- a/litex/soc/cores/cpu/lm32/core.py
+++ b/litex/soc/cores/cpu/lm32/core.py
@@ -6,7 +6,8 @@ from litex.soc.interconnect import wishbone
 
 
 class LM32(Module):
-    def __init__(self, platform, eba_reset):
+    def __init__(self, platform, eba_reset, variant=None):
+        assert variant == None, "No lm32 variants currently supported."
         self.ibus = i = wishbone.Interface()
         self.dbus = d = wishbone.Interface()
         self.interrupt = Signal(32)


### PR DESCRIPTION
It is useful to support slightly different variants of the CPU
configurations. This adds a "cpu_variant" option.

For the mor1k we now have the default mor1k configuration and the
"linux" variant which enables the features needed for Linux support on
the mor1k.

Currently there are no variants for the lm32, but we will likely add a
"tiny" variant for usage on the iCE40.