### PR TITLE
Fix all remaining indentation issues in python code

### DIFF
--- a/litex/boards/platforms/kcu105.py
+++ b/litex/boards/platforms/kcu105.py
@@ -61,7 +61,7 @@ _io = [
         Subsignal("tx", Pins("K26")),
         Subsignal("rx", Pins("G25")),
         IOStandard("LVCMOS18")
-	),
+    ),
 
     ("spiflash", 0,  # clock needs to be accessed through primitive
         Subsignal("cs_n", Pins("U7")),

--- a/litex/soc/cores/xadc.py
+++ b/litex/soc/cores/xadc.py
@@ -28,7 +28,7 @@ class XADC(Module, AutoCSR):
         drdy = Signal()
 
         self.specials += Instance("XADC",
-        	# from ug480
+            # from ug480
             p_INIT_40=0x9000, p_INIT_41=0x2ef0, p_INIT_42=0x0400,
             p_INIT_48=0x4701, p_INIT_49=0x000f,
             p_INIT_4A=0x4700, p_INIT_4B=0x0000,

--- a/litex/soc/tools/litex_term.py
+++ b/litex/soc/tools/litex_term.py
@@ -216,7 +216,7 @@ class LiteXTerm:
                 if c == b"\r":
                     sys.stdout.buffer.write(b"\n")
                 else:
-                	sys.stdout.buffer.write(c)
+                    sys.stdout.buffer.write(c)
                 sys.stdout.flush()
 
                 if self.kernel_image is not None:

--- a/litex/soc/tools/remote/litex_server.py
+++ b/litex/soc/tools/remote/litex_server.py
@@ -43,7 +43,7 @@ class RemoteServer(EtherboneIPC):
                         if packet == 0:
                             break
                     except:
-                    	break
+                        break
                     packet = EtherbonePacket(packet)
                     packet.decode()
 


### PR DESCRIPTION
I ran a script that shouldn't have missed any tab in the python source files.