### PR TITLE
soc_core: Don't fail if name is the same.

### DIFF
--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -171,7 +171,7 @@ class SoCCore(Module):
 
         # Add the base SoC's interrupt map
         for mod_name, interrupt in self.soc_interrupt_map.items():
-            assert interrupt not in interrupt_rmap, (
+            assert interrupt not in interrupt_rmap or mod_name == interrupt_rmap[interrupt], (
                 "Interrupt vector conflict for IRQ %s, user defined %s conflicts with SoC inbuilt %s" % (
                     interrupt, mod_name, interrupt_rmap[interrupt]))
 


### PR DESCRIPTION
This was preventing constants from getting added to the csr.h header file.