### PR TITLE
Include the ethernet related header files conditionally

### DIFF
--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -9,8 +9,11 @@
 #include <generated/mem.h>
 #include <generated/csr.h>
 
+#ifdef CSR_ETHMAC_BASE
 #include <net/microudp.h>
 #include <net/tftp.h>
+#endif
+
 #include "sfl.h"
 #include "boot.h"
 

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -10,7 +10,10 @@
 
 #include <generated/csr.h>
 #include <generated/mem.h>
+
+#ifdef CSR_ETHMAC_BASE
 #include <net/microudp.h>
+#endif
 
 #include "sdram.h"
 #include "boot.h"


### PR DESCRIPTION
Only including those header files in the litex firmware is the first step to
move the firmware parts of liteeth to the liteeth tree.