### PR TITLE
Allow for multiple synthesis directives in specials.

### DIFF
--- a/litex/gen/fhdl/specials.py
+++ b/litex/gen/fhdl/specials.py
@@ -181,11 +181,18 @@ class Instance(Special):
                 r += "\t." + name_inst + "(" + name_design + ")"
         if not firstp:
             r += "\n"
-        if instance.synthesis_directive is not None:
-            synthesis_directive = "/* synthesis {} */".format(instance.synthesis_directive)
-            r += ")" + synthesis_directive + ";\n\n"
-        else:
-            r += ");\n\n"
+
+        directives = instance.synthesis_directive
+        if directives is None:
+            directives = []
+        elif type(directives) == str :
+            directives = [directives,]
+
+        r += ")";
+        for directive in directives:
+            r += "\n\t/* synthesis {} */".format(directive)
+        r += ";\n\n"
+
         return r
 
 


### PR DESCRIPTION
This is needed to specify timing constraints on some Lattice Diamond library specials, like the EHXPLLL.

To keep backwards compatibility we allow the directive to still be a single string. If it's not, we assume it's an iterable.