### PR TITLE
Top module selection (for Verilator and Diamond)

### DIFF
--- a/litex/build/lattice/diamond.py
+++ b/litex/build/lattice/diamond.py
@@ -52,6 +52,7 @@ def _build_files(device, sources, vincpaths, build_name):
         tcl.append("prj_impl option {include path} {\"" + path + "\"}")
     for filename, language, library in sources:
         tcl.append("prj_src add \"" + filename + "\" -work " + library)
+    tcl.append("prj_impl option top \"{}\"".format(build_name))
     tcl.append("prj_run Synthesis -impl implementation -forceOne")
     tcl.append("prj_run Translate -impl implementation")
     tcl.append("prj_run Map -impl implementation")

--- a/litex/build/sim/core/Makefile
+++ b/litex/build/sim/core/Makefile
@@ -26,6 +26,7 @@ $(OBJS_SIM): %.o: $(SRC_DIR)/%.c
 sim: mkdir $(OBJS_SIM)
 	verilator -Wno-fatal -O3 --cc dut.v --exe \
 		$(SRCS_SIM_CPP) $(OBJS_SIM) \
+		--top-module dut \
 		-CFLAGS "$(CFLAGS) -I$(SRC_DIR)" \
 		-LDFLAGS "$(LDFLAGS)" \
 		-trace $(INC_DIR)

--- a/litex/build/sim/verilator.py
+++ b/litex/build/sim/verilator.py
@@ -146,7 +146,7 @@ class SimVerilatorToolchain:
             fragment = fragment.get_fragment()
         platform.finalize(fragment)
 
-        v_output = platform.get_verilog(fragment)
+        v_output = platform.get_verilog(fragment, name=build_name)
         named_sc, named_pc = platform.resolve_signals(v_output.ns)
         v_output.write("dut.v")
 


### PR DESCRIPTION
When dealing with multiple Verilog sources in a design we must explicitly state which module is the top of the design. This change ensures such a selection is made when building designs using Verilator and Lattice Diamond.

While the changes have been tested to work, I am not sure if this is the right way to go about this. Please review carefully.