### PR TITLE
platform/arty.py: Move Pmod definitions to 'connectors' section.

### DIFF
--- a/litex/boards/platforms/arty.py
+++ b/litex/boards/platforms/arty.py
@@ -106,13 +106,14 @@ _io = [
         Subsignal("crs", Pins("G14")),
         IOStandard("LVCMOS33")
     ),
+]
 
+_connectors = [
     ("pmoda", 0, Pins("G13 B11 A11 D12 D13 B18 A18 K16"), IOStandard("LVCMOS33")),
     ("pmodb", 0, Pins("E15 E16 D15 C15 J17 J18 K15 J15"), IOStandard("LVCMOS33")),
     ("pmodc", 0, Pins("U12 V12 V10 V11 U14 V14 T13 U13"), IOStandard("LVCMOS33")),
     ("pmodd", 0, Pins("D4 D3 F4 F3 E2 D2 H2 G2"), IOStandard("LVCMOS33")),   
 ]
-
 
 class Platform(XilinxPlatform):
     default_clk_name = "clk100"


### PR DESCRIPTION
pmod definitions should be in 'connectors' section of platform definition for the ARTY board.