### PR TITLE
platforms/tinyfpga_b: Move serial peripheral out of default I/O, make it

### DIFF
--- a/litex/boards/platforms/tinyfpga_b.py
+++ b/litex/boards/platforms/tinyfpga_b.py
@@ -9,12 +9,6 @@ _io = [
         IOStandard("LVCMOS33")
     ),
 
-    ("serial", 0,
-        Subsignal("tx", Pins("B2")),
-        Subsignal("rx", Pins("A2")),
-        IOStandard("LVCMOS33")
-    ),
-
     ("spiflash", 0,
         Subsignal("cs_n", Pins("F7"), IOStandard("LVCMOS33")),
         Subsignal("clk", Pins("G7"), IOStandard("LVCMOS33")),
@@ -31,6 +25,16 @@ _connectors = [
     # E8, Pin 20 (Input only)
     ("GPIO", "B2 A2 A1 B1 C1 D1 E1 G1 H1 J1 D9 C9 A9 A8 A7 A6"),
     ("GBIN", "E8")
+]
+
+
+# Default peripherals
+serial = [
+    ("serial", 0,
+        Subsignal("tx", Pins("GPIO:0")),
+        Subsignal("rx", Pins("GPIO:1")),
+        IOStandard("LVCMOS33")
+    )
 ]
 
 


### PR DESCRIPTION
Self-explanatory and bikeshedding.

As has been done in the past w/ Migen, users should _opt into_ using connectors/not-dedicated pins as `_io` using `add_extension`, rather than having non-dedicated pins assigned static functions by default. 

I prefer to add default pin assignments in the board namespace that users can assign to the board via `add_extension`. This permits maximum flexibility for users who need the I/O pins for something else, as well as providing default pins for those who want to use the first two I/O pins as a serial port.