### PR TITLE
Improving error message when csr name is not found.

### DIFF
--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -1,3 +1,4 @@
+import inspect
 from operator import itemgetter
 
 from migen import *
@@ -256,6 +257,16 @@ class SoCCore(Module):
             name = name + "_" + memory.name_override
         try:
             return self.csr_map[name]
+        except KeyError as e:
+            raise RuntimeError("""\
+Unable to find {} in your SoC's csr address map.
+
+Check {}.csr_map in {}
+
+Found {} in the csr_map""".format(
+                name, self.__class__.__name__, inspect.getfile(self.__class__),
+                ", ".join(self.csr_map.keys()))
+            ) from e
         except ValueError:
             return None
 


### PR DESCRIPTION
Before;
```
"/usr/local/lib/python3.5/dist-packages/litex-0.1-py3.5.egg/litex/soc/integration/soc_core.py",
line 258, in get_csr_dev_address
return self.csr_map[name]
KeyError: 'core'
```

Now;
```
Traceback (most recent call last):
  File "XXXX/github/enjoy-digital/litex/litex/soc/integration/soc_core.py", line 259, in get_csr_dev_address
    return self.csr_map[name]
KeyError: 'ddrphy'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  ...
  File "XXXX/github/enjoy-digital/litex/litex/soc/interconnect/csr_bus.py", line 199, in scan
    mapaddr = self.address_map(name, None)
  File "XXXX/github/enjoy-digital/litex/litex/soc/integration/soc_core.py", line 269, in get_csr_dev_address
    ) from e
RuntimeError: Unable to find ddrphy in your SoC's csr address map.

Check BaseSoC.csr_map in XXXX/github/enjoy-digital/litex/litex/boards/targets/arty.py

Found l2_cache, timer0, ddrphy2, buttons, sdram, identifier_mem, uart, uart_phy, leds, crg in the csr_map
```