### PR TITLE
vexriscv: debug: fix reading DATA register

### DIFF
--- a/litex/soc/cores/cpu/vexriscv/core.py
+++ b/litex/soc/cores/cpu/vexriscv/core.py
@@ -95,7 +95,7 @@ class VexRiscv(Module, AutoCSR):
                 # A write to the REFRESH register indicates which register
                 # (DATA or CORE) we want to update from the CPU.
                 ).Elif(debug_refresh.re,
-                    If(~debug_refresh.storage,
+                    If(debug_refresh.storage == 0,
                         refreshing_data.eq(0),
                         debug_bus_cmd_payload_address.eq(0)
                     ).Else(


### PR DESCRIPTION
The REFRESH register accepts an 8-bit address and determines which
register to refresh.  Since there are only two addresses currently in
use, this register can be either 0x00 or 0x04.

A refactor replaced the compare with one that checked for any 0 bits.
Since both 0x00 and 0x04 have 0 bits, this check always evaluated as
true, causing the logic to always refresh the CORE register.

Replace this check with an explicit check for 0x00.

Signed-off-by: Sean Cross <sean@xobs.io>