### PR TITLE
.gitignore: litex/build contains valid source, so exclude from .gitig…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 .Python
 env/
 build/
+!litex/build
 develop-eggs/
 dist/
 downloads/


### PR DESCRIPTION
…nore.

Self-explanatory. This was causing Atom tree-view, which respects `.gitignore`, to hide `litex/build`, so I tweaked the `.gitignore` to unhide it :).