### PR TITLE
software/bios: Gate flush_l2_cache() if L2 Cache isn't present.

### DIFF
--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -27,7 +27,9 @@ static void __attribute__((noreturn)) boot(unsigned int r1, unsigned int r2, uns
 	irq_setie(0);
 	flush_cpu_icache();
 	flush_cpu_dcache();
+#ifdef L2_SIZE
 	flush_l2_cache();
+#endif
 	boot_helper(r1, r2, r3, addr);
 	while(1);
 }


### PR DESCRIPTION
I assume this is an oversight, but without using `#ifdef L2_SIZE` to gate `flush_l2_cache()`, I would get undefined symbol errors when attempting to link a BIOS on systems without L2 Cache (such as `tinyfpga`). This commit fixes my issues.