### PR TITLE
Add lm32 "lite" variant, remove mult/div from "minimal" and update compiler flags accordingly.

### DIFF
--- a/litex/soc/cores/cpu/lm32/core.py
+++ b/litex/soc/cores/cpu/lm32/core.py
@@ -7,7 +7,7 @@ from litex.soc.interconnect import wishbone
 
 class LM32(Module):
     def __init__(self, platform, eba_reset, variant=None):
-        assert variant in (None, "minimal"), "Unsupported variant %s" % variant
+        assert variant in (None, "lite", "minimal"), "Unsupported variant %s" % variant
         self.reset = Signal()
         self.ibus = i = wishbone.Interface()
         self.dbus = d = wishbone.Interface()
@@ -84,5 +84,7 @@ class LM32(Module):
                 "lm32_dtlb.v")
         if variant == "minimal":
             platform.add_verilog_include_path(os.path.join(vdir, "config_minimal"))
+        elif variant == "lite":
+            platform.add_verilog_include_path(os.path.join(vdir, "config_lite"))
         else:
             platform.add_verilog_include_path(os.path.join(vdir, "config"))

--- a/litex/soc/cores/cpu/lm32/verilog/config_lite/lm32_config.v
+++ b/litex/soc/cores/cpu/lm32/verilog/config_lite/lm32_config.v
@@ -39,13 +39,13 @@
 // in a pipelined one. The multi-cycle multiplier stalls the pipe
 // for 32 cycles. If both options are disabled, multiply operations
 // are not supported.
-//`define CFG_MC_MULTIPLY_ENABLED
+`define CFG_MC_MULTIPLY_ENABLED
 //`define CFG_PL_MULTIPLY_ENABLED
 
 // Enable the multi-cycle divider. Stalls the pipe until the result
 // is ready after 32 cycles. If disabled, the divide operation is not
 // supported.
-//`define CFG_MC_DIVIDE_ENABLED
+`define CFG_MC_DIVIDE_ENABLED
 
 
 //
@@ -82,9 +82,9 @@
 //
 
 // Instruction cache
-//`define CFG_ICACHE_ENABLED
+`define CFG_ICACHE_ENABLED
 `define CFG_ICACHE_ASSOCIATIVITY   1
-`define CFG_ICACHE_SETS            256
+`define CFG_ICACHE_SETS            128
 `define CFG_ICACHE_BYTES_PER_LINE  16
 `define CFG_ICACHE_BASE_ADDRESS    32'h00000000
 `define CFG_ICACHE_LIMIT           32'h7fffffff

--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -56,6 +56,7 @@ class Builder:
 
     def _generate_includes(self):
         cpu_type = self.soc.cpu_type
+        cpu_variant = self.soc.cpu_variant
         memory_regions = self.soc.get_memory_regions()
         flash_boot_address = getattr(self.soc, "flash_boot_address", None)
         csr_regions = self.soc.get_csr_regions()
@@ -68,7 +69,7 @@ class Builder:
         variables_contents = []
         def define(k, v):
             variables_contents.append("{}={}\n".format(k, _makefile_escape(v)))
-        for k, v in cpu_interface.get_cpu_mak(cpu_type):
+        for k, v in cpu_interface.get_cpu_mak(cpu_type, cpu_variant):
             define(k, v)
         define("SOC_DIRECTORY", soc_directory)
         variables_contents.append("export BUILDINC_DIRECTORY\n")

--- a/litex/soc/integration/cpu_interface.py
+++ b/litex/soc/integration/cpu_interface.py
@@ -13,7 +13,7 @@ cpu_endianness = {
     "vexriscv": "little"
 }
 
-def get_cpu_mak(cpu):
+def get_cpu_mak(cpu, variant):
     clang = os.getenv("CLANG", "")
     if clang != "":
         clang = bool(int(clang))
@@ -23,7 +23,10 @@ def get_cpu_mak(cpu):
     if cpu == "lm32":
         assert not clang, "lm32 not supported with clang."
         triple = "lm32-elf"
-        cpuflags = "-mbarrel-shift-enabled -mmultiply-enabled -mdivide-enabled -msign-extend-enabled"
+        if variant == "minimal":
+            cpuflags = "-mbarrel-shift-enabled -msign-extend-enabled"
+        else:
+            cpuflags = "-mbarrel-shift-enabled -mmultiply-enabled -mdivide-enabled -msign-extend-enabled"
         clang = False
     elif cpu == "or1k":
         # Default to CLANG unless told otherwise

--- a/litex/soc/software/libcompiler_rt/Makefile
+++ b/litex/soc/software/libcompiler_rt/Makefile
@@ -15,7 +15,7 @@ all: libcompiler_rt.a
 
 libcompiler_rt.a: $(OBJECTS)
 	$(CC) -c $(CFLAGS) $(1) $(SOC_DIRECTORY)/software/libcompiler_rt/mulsi3.c -o mulsi3.o
-	$(AR) crs libcompiler_rt.a $(OBJECTS)
+	$(AR) crs libcompiler_rt.a $(OBJECTS) mulsi3.o
 
 # pull in dependency info for *existing* .o files
 -include $(OBJECTS:.o=.d)


### PR DESCRIPTION
I have split the `lm32` `minimal` variant into 2 variants, called `lite` and `minimal`:

## Lite

* Same as previous `minimal`, except now with 2kb I-cache (16 bytes per line, 128 lines). This is suitable for running a program from SPI flash without the CPU spending most time waiting for instructions. No data cache, so all RAM references are 2 cycles.

## Minimal

* Same as previous `minimal`, except multiply and divide disabled, barrel shift and sign extend still present. This reduces resources used for debugging purposes.

---

This also serves as a watered-down version of a [PR](https://github.com/mithro/litex/pull/2) on @mithro's litex branch; changing compiler/CPU flags based on variant is now supported!

I have confirmed both variants to boot to the BIOS by testing on tinyfpga.

---

`mulsi3.c` was compiled but never linked into `libcompiler_rt.a`, so I fixed that as well. The `minimal` variant will choke when linking the BIOS without this.