### PR TITLE
lattice/programmer: Use --program-image option with tinyprog if addre…

### DIFF
--- a/litex/build/lattice/programmer.py
+++ b/litex/build/lattice/programmer.py
@@ -76,8 +76,9 @@ class TinyProgProgrammer(GenericProgrammer):
                 # Ditto with user data.
                 subprocess.call(["tinyprog", "-u", bitstream_file])
         else:
-            # Provide override so user can program wherever they wish.
-            subprocess.call(["tinyprog", "-a", str(address), "-p",
+            # Provide override so user can program wherever they wish (outside
+            # of bootloader region).
+            subprocess.call(["tinyprog", "-a", str(address), "--program-image",
                             bitstream_file])
 
     # Force user image to boot if a user reset tinyfpga, the bootloader


### PR DESCRIPTION
…ss is given.

This allows a user to program the concatenated gateware+bios+firmware image with a single command on platforms which support `tinyprog`.