### PR TITLE
libbase/crt0-lm32.S: Add provisions for loading .data from flash.

### DIFF
--- a/litex/soc/software/libbase/Makefile
+++ b/litex/soc/software/libbase/Makefile
@@ -4,7 +4,7 @@ include $(SOC_DIRECTORY)/software/common.mak
 OBJECTS=exception.o libc.o errno.o crc16.o crc32.o console.o \
 	system.o id.o uart.o time.o qsort.o strtod.o spiflash.o strcasecmp.o
 
-all: crt0-$(CPU).o libbase.a libbase-nofloat.a
+all: crt0-$(CPU).o crt0-$(CPU)-flash.o libbase.a libbase-nofloat.a
 
 libbase.a: $(OBJECTS) vsnprintf.o
 	$(AR) crs libbase.a $(OBJECTS) vsnprintf.o
@@ -24,8 +24,11 @@ vsnprintf-nofloat.o: $(LIBBASE_DIRECTORY)/vsnprintf.c
 %.o: $(LIBBASE_DIRECTORY)/%.S
 	$(assemble)
 
+crt0-$(CPU)-flash.o: $(LIBBASE_DIRECTORY)/crt0-$(CPU).S
+	$(CC) -c -DFLASH_DATA_SECTION $(CFLAGS) -o $@ $<
+
 .PHONY: all clean
 
 clean:
-	$(RM) $(OBJECTS) crt0-$(CPU).o vsnprintf.o vsnprintf-nofloat.o
+	$(RM) $(OBJECTS) crt0-$(CPU).o crt0-$(CPU)-flash.o vsnprintf.o vsnprintf-nofloat.o
 	$(RM) libbase.a libbase-nofloat.a .*~ *~

--- a/litex/soc/software/libbase/crt0-lm32.S
+++ b/litex/soc/software/libbase/crt0-lm32.S
@@ -112,6 +112,25 @@ _crt0:
 	mvhi    sp, hi(_fstack)
 	ori     sp, sp, lo(_fstack)
 
+#ifdef FLASH_DATA_SECTION
+	/* Load DATA */
+	mvhi    r1, hi(_erodata)
+	ori     r1, r1, lo(_erodata)
+	mvhi    r2, hi(_fdata)
+	ori     r2, r2, lo(_fdata)
+	mvhi    r3, hi(_edata)
+	ori     r3, r3, lo(_edata)
+.moveDATA:
+	be      r2, r3, .doBSS
+	lw      r4, (r1+0)
+	sw      (r2+0), r4
+	/* _edata is aligned to 16 bytes. Use word-xfers. */
+	addi    r1, r1, 4
+	addi    r2, r2, 4
+	bi     .moveDATA
+#endif
+
+.doBSS:
 	/* Clear BSS */
 	mvhi    r1, hi(_fbss)
 	ori     r1, r1, lo(_fbss)


### PR DESCRIPTION
Like it or not, some firmware will have a `.data` section (although at present the `litex` BIOS doesn't need one). The normal solution for this is to load the said firmware into DRAM (`main_ram`) before executing it. However, on some boards without DRAM or limited block RAM resources (like TinyFPGA) it is still desirable to execute firmware from flash, and use block RAM as primary memory.

In the "execute from flash" case, globals in the `.data` section have to be copied manually to block RAM in the startup code before running the main program; I have added lines to the `lm32` (_and `lm32` only at present_) startup code to do this.

Because the flash `crt0` and standard `crt0` are so similar, I have opted to gate this functionality behind a compile-time define called `FLASH_DATA_SECTION`; the `libbase` firmware will build both versions of `crt0`, and it's up to the user to decide which startup code they want to link against in their application.