### PR TITLE
Use csr accessors when generating `csr.h`

### DIFF
--- a/litex/soc/integration/cpu_interface.py
+++ b/litex/soc/integration/cpu_interface.py
@@ -123,12 +123,12 @@ def _get_rw_functions_c(reg_name, reg_base, nwords, busword, read_only, with_acc
     if with_access_functions:
         r += "static inline "+ctype+" "+reg_name+"_read(void) {\n"
         if size > 1:
-            r += "\t"+ctype+" r = MMPTR("+hex(reg_base)+");\n"
+            r += "\t"+ctype+" r = csr_readl("+hex(reg_base)+");\n"
             for byte in range(1, nwords):
-                r += "\tr <<= "+str(busword)+";\n\tr |= MMPTR("+hex(reg_base+4*byte)+");\n"
+                r += "\tr <<= "+str(busword)+";\n\tr |= csr_readl("+hex(reg_base+4*byte)+");\n"
             r += "\treturn r;\n}\n"
         else:
-            r += "\treturn MMPTR("+hex(reg_base)+");\n}\n"
+            r += "\treturn csr_readl("+hex(reg_base)+");\n}\n"
 
         if not read_only:
             r += "static inline void "+reg_name+"_write("+ctype+" value) {\n"
@@ -138,7 +138,7 @@ def _get_rw_functions_c(reg_name, reg_base, nwords, busword, read_only, with_acc
                     value_shifted = "value >> "+str(shift)
                 else:
                     value_shifted = "value"
-                r += "\tMMPTR("+hex(reg_base+4*word)+") = "+value_shifted+";\n"
+                r += "\tcsr_writel("+value_shifted+", "+hex(reg_base+4*word)+");\n"
             r += "}\n"
     return r
 
@@ -146,6 +146,7 @@ def _get_rw_functions_c(reg_name, reg_base, nwords, busword, read_only, with_acc
 def get_csr_header(regions, constants, with_access_functions=True, with_shadow_base=True, shadow_base=0x80000000):
     r = "#ifndef __GENERATED_CSR_H\n#define __GENERATED_CSR_H\n"
     if with_access_functions:
+        r += "#include <stdint.h>\n"
         r += "#include <hw/common.h>\n"
     for name, origin, busword, obj in regions:
         if not with_shadow_base:

--- a/litex/soc/integration/cpu_interface.py
+++ b/litex/soc/integration/cpu_interface.py
@@ -147,7 +147,16 @@ def get_csr_header(regions, constants, with_access_functions=True, with_shadow_b
     r = "#ifndef __GENERATED_CSR_H\n#define __GENERATED_CSR_H\n"
     if with_access_functions:
         r += "#include <stdint.h>\n"
+        r += "#ifdef CSR_ACCESSORS_DEFINED\n"
+        r += "extern void csr_writeb(uint8_t value, uint32_t addr);\n"
+        r += "extern uint8_t csr_readb(uint32_t addr);\n"
+        r += "extern void csr_writew(uint16_t value, uint32_t addr);\n"
+        r += "extern uint16_t csr_readw(uint32_t addr);\n"
+        r += "extern void csr_writel(uint32_t value, uint32_t addr);\n"
+        r += "extern uint32_t csr_readl(uint32_t addr);\n"
+        r += "#else /* ! CSR_ACCESSORS_DEFINED */\n"
         r += "#include <hw/common.h>\n"
+        r += "#endif /* ! CSR_ACCESSORS_DEFINED */\n"
     for name, origin, busword, obj in regions:
         if not with_shadow_base:
             origin &= (~shadow_base)

--- a/litex/soc/software/include/hw/common.h
+++ b/litex/soc/software/include/hw/common.h
@@ -1,10 +1,42 @@
 #ifndef __HW_COMMON_H
 #define __HW_COMMON_H
 
+#include <stdint.h>
+
 #ifdef __ASSEMBLER__
 #define MMPTR(x) x
-#else
+#else /* ! __ASSEMBLER__ */
 #define MMPTR(x) (*((volatile unsigned int *)(x)))
-#endif
 
-#endif
+static inline void csr_writeb(uint8_t value, uint32_t addr)
+{
+	*((volatile uint8_t *)addr) = value;
+}
+
+static inline uint8_t csr_readb(uint32_t addr)
+{
+	return *(volatile uint8_t *)addr;
+}
+
+static inline void csr_writew(uint16_t value, uint32_t addr)
+{
+	*((volatile uint16_t *)addr) = value;
+}
+
+static inline uint16_t csr_readw(uint32_t addr)
+{
+	return *(volatile uint16_t *)addr;
+}
+
+static inline void csr_writel(uint32_t value, uint32_t addr)
+{
+	*((volatile uint32_t *)addr) = value;
+}
+
+static inline uint32_t csr_readl(uint32_t addr)
+{
+	return *(volatile uint32_t *)addr;
+}
+#endif /* ! __ASSEMBLER__ */
+
+#endif /* __HW_COMMON_H */

--- a/litex/soc/software/include/hw/common.h
+++ b/litex/soc/software/include/hw/common.h
@@ -3,6 +3,14 @@
 
 #include <stdint.h>
 
+/* To overwrite CSR accessors, define extern, non-inlined versions
+ * of csr_read[bwl]() and csr_write[bwl](), and define
+ * CSR_ACCESSORS_DEFINED.
+ */
+
+#ifndef CSR_ACCESSORS_DEFINED
+#define CSR_ACCESSORS_DEFINED
+
 #ifdef __ASSEMBLER__
 #define MMPTR(x) x
 #else /* ! __ASSEMBLER__ */
@@ -38,5 +46,7 @@ static inline uint32_t csr_readl(uint32_t addr)
 	return *(volatile uint32_t *)addr;
 }
 #endif /* ! __ASSEMBLER__ */
+
+#endif /* ! CSR_ACCESSORS_DEFINED */
 
 #endif /* __HW_COMMON_H */


### PR DESCRIPTION
This patchset replaces MMPTR() with csr_readl() and csr_writel().  These functions are defined as inline, unless `CSR_ACCESSORS_DEFINED` is defined when `csr.h` is included.

This name can be changed, if desired.

This can be used with `etherbone.c` available at https://github.com/xobs/wishbone-adapter/

An example of using this is to start up `litex_server` and build the following file in `dna.c`:

```c++
#define CSR_ACCESSORS_DEFINED
#include <stdio.h>
#include "csr.h"
#include "etherbone.h"

static struct eb_connection *g_eb;

void csr_writel(uint32_t value, uint32_t addr) {
        eb_write32(g_eb, value, addr);
}

uint32_t csr_readl(uint32_t addr) {
        return eb_read32(g_eb, addr);
}

int main(int argc, char **argv) {
        g_eb = eb_connect("127.0.0.1", "1234", 0);

        printf("DNA ID: %lld\n", dna_id_read());

        eb_disconnect(&g_eb);
        return 0;
}
```

Compile with:

```sh
$ gcc dna.c etherbone.c -o dna
```

This uses `dna_id_read()` as generated by litex.  It is easy to see how this could be extended to write complete drivers on a host.