### PR TITLE
uart: Enable buffering the FIFO.

### DIFF
--- a/litex/soc/cores/uart.py
+++ b/litex/soc/cores/uart.py
@@ -157,7 +157,7 @@ def _get_uart_fifo(depth, sink_cd="sys", source_cd="sys"):
         fifo = stream.AsyncFIFO([("data", 8)], depth)
         return ClockDomainsRenamer({"write": sink_cd, "read": source_cd})(fifo)
     else:
-        return stream.SyncFIFO([("data", 8)], depth)
+        return stream.SyncFIFO([("data", 8)], depth, buffered=True)
 
 
 class UART(Module, AutoCSR):


### PR DESCRIPTION
On the iCE40 FPGA, adding buffering allows the SyncFIFO to be placed in
block RAM rather than consuming a large amount of resources.