### PR TITLE
PicoRV32 Enhancements

### DIFF
--- a/litex/soc/cores/cpu/picorv32/core.py
+++ b/litex/soc/cores/cpu/picorv32/core.py
@@ -29,31 +29,39 @@ class PicoRV32(Module):
         mem_wstrb = Signal(4)
         mem_rdata = Signal(32)
 
+        # PicoRV32 parameters. To create a new variant, modify this dictionary
+        # and change the desired parameters.
+        picorv32_params = {
+            "p_ENABLE_COUNTERS" : 1,
+            "p_ENABLE_COUNTERS64" : 1,
+            # Changing REGS has no effect as on FPGAs, the registers are
+            # implemented using a register file stored in DPRAM.
+            "p_ENABLE_REGS_16_31" : 1,
+            "p_ENABLE_REGS_DUALPORT" : 1,
+            "p_LATCHED_MEM_RDATA" : 0,
+            "p_TWO_STAGE_SHIFT" : 1,
+            "p_TWO_CYCLE_COMPARE" : 0,
+            "p_TWO_CYCLE_ALU" : 0,
+            "p_CATCH_MISALIGN" : 1,
+            "p_CATCH_ILLINSN" : 1,
+            "p_ENABLE_PCPI" : 0,
+            "p_ENABLE_MUL" : 1,
+            "p_ENABLE_DIV" : 1,
+            "p_ENABLE_FAST_MUL" : 0,
+            "p_ENABLE_IRQ" : 1,
+            "p_ENABLE_IRQ_QREGS" : 1,
+            "p_ENABLE_IRQ_TIMER" : 1,
+            "p_ENABLE_TRACE" : 0,
+            "p_MASKED_IRQ" : 0x00000000,
+            "p_LATCHED_IRQ" : 0xffffffff,
+            "p_PROGADDR_RESET" : progaddr_reset,
+            "p_PROGADDR_IRQ" : 0x00000010,
+            "p_STACKADDR" : 0xffffffff
+        }
+
         self.specials += Instance("picorv32",
             # parameters
-            p_ENABLE_COUNTERS=1,
-            p_ENABLE_COUNTERS64=1,
-            p_ENABLE_REGS_16_31=1,
-            p_ENABLE_REGS_DUALPORT=1,
-            p_LATCHED_MEM_RDATA=0,
-            p_TWO_STAGE_SHIFT=1,
-            p_TWO_CYCLE_COMPARE=0,
-            p_TWO_CYCLE_ALU=0,
-            p_CATCH_MISALIGN=1,
-            p_CATCH_ILLINSN=1,
-            p_ENABLE_PCPI=0,
-            p_ENABLE_MUL=1,
-            p_ENABLE_DIV=1,
-            p_ENABLE_FAST_MUL=0,
-            p_ENABLE_IRQ=1,
-            p_ENABLE_IRQ_QREGS=1,
-            p_ENABLE_IRQ_TIMER=1,
-            p_ENABLE_TRACE=0,
-            p_MASKED_IRQ=0x00000000,
-            p_LATCHED_IRQ=0xffffffff,
-            p_PROGADDR_RESET=progaddr_reset,
-            p_PROGADDR_IRQ=0x00000010,
-            p_STACKADDR=0xffffffff,
+            **picorv32_params,
 
             # clock / reset
             i_clk=ClockSignal(),

--- a/litex/soc/cores/cpu/picorv32/core.py
+++ b/litex/soc/cores/cpu/picorv32/core.py
@@ -57,7 +57,7 @@ class PicoRV32(Module):
             "p_MASKED_IRQ" : 0x00000000,
             "p_LATCHED_IRQ" : 0xffffffff,
             "p_PROGADDR_RESET" : progaddr_reset,
-            "p_PROGADDR_IRQ" : 0x00000010,
+            "p_PROGADDR_IRQ" : progaddr_reset + 0x00000010,
             "p_STACKADDR" : 0xffffffff
         }
 

--- a/litex/soc/software/libbase/crt0-picorv32.S
+++ b/litex/soc/software/libbase/crt0-picorv32.S
@@ -18,7 +18,23 @@ _start:
 
 .org 0x00000010 # IRQ
 _irq_vector:
-  j _irq
+  addi sp, sp, -16
+  sw t0, 4(sp)
+  sw ra, 8(sp)
+  /* By convention, q2 holds true IRQ vector, but remains caller-save.
+  We rely on the assumption that compiler-generated code will never touch
+  the QREGs. q3 is truly scratch/caller-save. */
+  picorv32_getq_insn(t0, q2)
+  sw t0, 12(sp)
+
+  jalr t0 // Call the true IRQ vector.
+
+  lw t0, 12(sp)
+  picorv32_setq_insn(q2, t0) // Restore the true IRQ vector.
+  lw ra, 8(sp)
+  lw t0, 4(sp)
+  addi sp, sp, 16
+  picorv32_retirq_insn() // return from interrupt
 
 
 /*
@@ -132,9 +148,7 @@ _irq:
   /* restore x1 - x2 from q registers */
   picorv32_getq_insn(x1, q1)
   picorv32_getq_insn(x2, q2)
-
-  /* return from interrupt */
-  picorv32_retirq_insn()
+  ret
 
 /*
  * Reset handler, branched to from the vector.
@@ -191,6 +205,12 @@ _crt0:
   /* set main stack */
   la sp, _fstack
 
+  /* Set up address to IRQ handler since vector is hardcoded.
+  By convention, q2 keeps the pointer to the true IRQ handler,
+  to emulate relocatable interrupts. */
+  la t0, _irq
+  picorv32_setq_insn(q2, t0)
+
   /* jump to main */
   jal ra, main
 
@@ -214,7 +234,7 @@ _irq_enable:
   picorv32_maskirq_insn(zero, t0)
   ret
 
-/* 
+/*
  * Disable interrupts by masking all interrupts (the mask should already be
  * up to date)
  */
@@ -247,7 +267,7 @@ _irq_setmask:
   picorv32_maskirq_insn(zero, a0)
 1:
   ret
-  
+
 
 .section .bss
 irq_regs:
@@ -280,4 +300,3 @@ _irq_mask:
 .global _irq_enabled
 _irq_enabled:
   .word 0
-

--- a/litex/soc/software/libbase/crt0-picorv32.S
+++ b/litex/soc/software/libbase/crt0-picorv32.S
@@ -180,6 +180,14 @@ _crt0:
   la t1, _irq_mask
   sw t0, 0(t1)
 
+  /* Clear BSS */
+  la t0, _fbss
+  la t1, _ebss
+2:
+  sw zero, 0(t0)
+  addi t0, t0, 4
+  bltu t0, t1, 2b
+
   /* set main stack */
   la sp, _fstack
 


### PR DESCRIPTION
This PR adds the following features to the PicoRV32 core:
* Refactor PicoRV32's `core.py` file to support variants.
* Make sure IRQ vector is always located 16 bytes after the reset vector (was hardcoded to `0x00000010`).
* Clear `.bss` in `crt0` before running main program (required if using FPGA RAM that doesn't clear itself when a bitstream is loaded, such as up5k's `SPRAM`, or ASICs :))
* Emulate support for a relocatable `IRQ` vector; required for `fupy`. I use the `q2` register to hold the "true" IRQ vector location.