### PR TITLE
build/sim/verilator: don't use --threads when $(THREADS) is unset

### DIFF
--- a/litex/build/sim/core/Makefile
+++ b/litex/build/sim/core/Makefile
@@ -27,7 +27,7 @@ sim: mkdir $(OBJS_SIM)
 	verilator -Wno-fatal -O3 --cc dut.v --top-module dut --exe \
 		$(SRCS_SIM_CPP) $(OBJS_SIM) \
 		--top-module dut \
-		--threads $(THREADS) \
+		$(if $(THREADS), --threads $(THREADS),) \
 		-CFLAGS "$(CFLAGS) -I$(SRC_DIR)" \
 		-LDFLAGS "$(LDFLAGS)" \
 		-trace $(INC_DIR)


### PR DESCRIPTION
The --thread option must be provided with a value or the build will fail.