### PR TITLE
lattice/icestorm: Add toolchain_path so it doesn't end up kwargs.

### DIFF
--- a/litex/build/lattice/icestorm.py
+++ b/litex/build/lattice/icestorm.py
@@ -127,7 +127,7 @@ class LatticeIceStormToolchain:
 
     # platform.device should be of the form "ice40-{lp384, hx1k, etc}-{tq144, etc}"
     def build(self, platform, fragment, build_dir="build", build_name="top",
-              use_nextpnr=True, run=True, **kwargs):
+              toolchain_path=None, use_nextpnr=True, run=True, **kwargs):
         os.makedirs(build_dir, exist_ok=True)
         cwd = os.getcwd()
         os.chdir(build_dir)


### PR DESCRIPTION
Fixes the following error;
```
make[1]: Leaving directory `/home/travis/build/mithro/litex-buildenv/build/ice40_hx8k_b_evn_base_lm32.lite/software/stub'
Traceback (most recent call last):
  File "./make.py", line 164, in <module>
    main()
  File "./make.py", line 148, in main
    vns = builder.build(**dict(args.build_option))
  File "/home/travis/build/mithro/litex-buildenv/third_party/litex/litex/soc/integration/builder.py", line 171, in build
    toolchain_path=toolchain_path, **kwargs)
  File "/home/travis/build/mithro/litex-buildenv/third_party/litex/litex/soc/integration/soc_core.py", line 389, in build
    return self.platform.build(self, *args, **kwargs)
  File "/home/travis/build/mithro/litex-buildenv/third_party/litex/litex/build/lattice/platform.py", line 29, in build
    return self.toolchain.build(self, *args, **kwargs)
  File "/home/travis/build/mithro/litex-buildenv/third_party/litex/litex/build/lattice/icestorm.py", line 139, in build
    v_output = platform.get_verilog(fragment, name=build_name, **kwargs)
  File "/home/travis/build/mithro/litex-buildenv/third_party/litex/litex/build/lattice/platform.py", line 26, in get_verilog
    **kwargs)
  File "/home/travis/build/mithro/litex-buildenv/third_party/litex/litex/build/generic_platform.py", line 368, in get_verilog
    create_clock_domains=False, **kwargs)
TypeError: convert() got an unexpected keyword argument 'toolchain_path'
```