### PR TITLE
libbase/crt0-picorv32: Add support for .data sections.

### DIFF
--- a/litex/soc/software/libbase/crt0-picorv32.S
+++ b/litex/soc/software/libbase/crt0-picorv32.S
@@ -194,6 +194,20 @@ _crt0:
   la t1, _irq_mask
   sw t0, 0(t1)
 
+#ifdef EXECUTE_IN_PLACE
+  /* Load DATA */
+  la t0, _erodata
+  la t1, _fdata
+  la t2, _edata
+3:
+  lw t3, 0(t0)
+  sw t3, 0(t1)
+  /* _edata is aligned to 16 bytes. Use word-xfers. */
+  addi t0, t0, 4
+  addi t1, t1, 4
+  bltu t1, t2, 3b
+#endif
+
   /* Clear BSS */
   la t0, _fbss
   la t1, _ebss


### PR DESCRIPTION
Self-explanatory, this mirrors PR #106 , except for `picorv32` :).