### PR TITLE
Two small fixes

### DIFF
--- a/litex/soc/interconnect/stream.py
+++ b/litex/soc/interconnect/stream.py
@@ -41,12 +41,12 @@ class EndpointDescription:
 
 
 class Endpoint(Record):
-    def __init__(self, description_or_layout):
+    def __init__(self, description_or_layout, name=None, **kwargs):
         if isinstance(description_or_layout, EndpointDescription):
             self.description = description_or_layout
         else:
             self.description = EndpointDescription(description_or_layout)
-        Record.__init__(self, self.description.get_full_layout())
+        Record.__init__(self, self.description.get_full_layout(), name, **kwargs)
 
     def __getattr__(self, name):
         try:

--- a/litex/soc/interconnect/wishbone.py
+++ b/litex/soc/interconnect/wishbone.py
@@ -651,7 +651,7 @@ class SRAM(Module):
         # generate write enable signal
         if not read_only:
             self.comb += [port.we[i].eq(self.bus.cyc & self.bus.stb & self.bus.we & self.bus.sel[i])
-                for i in range(4)]
+                for i in range(bus_data_width//8)]
         # address and data
         self.comb += [
             port.adr.eq(self.bus.adr[:len(port.adr)]),


### PR DESCRIPTION
 * Allow wishbone.SRAM to support non-32bit wishbone widths.
 * Pass extra arguments to Record when creating an Endpoint.