### PR TITLE
build/lattice/trellis: generate bitstream directly in svf format

### DIFF
--- a/litex/build/lattice/trellis.py
+++ b/litex/build/lattice/trellis.py
@@ -143,7 +143,7 @@ class LatticeTrellisToolchain:
         self.build_template = [
             "yosys -q -l {build_name}.rpt {build_name}.ys",
             "nextpnr-ecp5 --json {build_name}.json --lpf {build_name}.lpf --textcfg {build_name}.config --{architecture} --package {package} --freq {freq_constraint}",
-            "ecppack {build_name}.config {build_name}.bit"
+            "ecppack {build_name}.config --svf {build_name}.svf --bit {build_name}.bit"
         ]
 
         self.freq_constraints = dict()


### PR DESCRIPTION
Before being able to program the board (e.g., with openocd), one
would have to convert the bitstream file to .svf using a python
script included with the source trellis distribution. However, the
trellis 'ecppack' utility can now generate .svf formatted bitstream
directly.