### PR TITLE
Changes for litepcie support for Altera Cyclone V

### DIFF
--- a/litex/build/altera/common.py
+++ b/litex/build/altera/common.py
@@ -1,6 +1,9 @@
 from migen.fhdl.module import Module
 from migen.fhdl.specials import Instance
 from migen.genlib.io import DifferentialInput, DifferentialOutput
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+from migen.fhdl.structure import *
 
 
 class AlteraDifferentialInputImpl(Module):
@@ -32,8 +35,29 @@ class AlteraDifferentialOutput:
     def lower(dr):
         return AlteraDifferentialOutputImpl(dr.i, dr.o_p, dr.o_n)
 
+class AlteraAsyncResetSynchronizerImpl(Module):
+    def __init__(self, cd, async_reset):
+        if not hasattr(async_reset, "attr"):
+            i, async_reset = async_reset, Signal()
+            self.comb += async_reset.eq(i)
+        rst_meta = Signal()
+        self.specials += [
+            Instance("DFF", i_d=0, i_clk=cd.clk, i_clrn=1,
+                     i_prn=async_reset, o_q=rst_meta,
+                     attr={"async_reg", "ars_ff1"}),
+            Instance("DFF", i_d=rst_meta, i_clk=cd.clk, i_clrn=1,
+                     i_prn=async_reset,  o_q=cd.rst,
+                     attr={"async_reg", "ars_ff2"})
+        ]
+
+class AlteraAsyncResetSynchronizer:
+    @staticmethod
+    def lower(dr):
+        return AlteraAsyncResetSynchronizerImpl(dr.cd, dr.async_reset)
+
 
 altera_special_overrides = {
     DifferentialInput: AlteraDifferentialInput,
-    DifferentialOutput: AlteraDifferentialOutput
+    DifferentialOutput: AlteraDifferentialOutput,
+    AsyncResetSynchronizer: AlteraAsyncResetSynchronizer
 }

--- a/litex/build/altera/quartus.py
+++ b/litex/build/altera/quartus.py
@@ -50,7 +50,7 @@ def _format_qsf(signame, pin, others, resname):
     return '\n'.join(fmt_c)
 
 
-def _build_qsf(named_sc, named_pc):
+def _build_qsf(named_sc, named_pc, build_name):
     lines = []
     for sig, pins, others, resname in named_sc:
         if len(pins) > 1:
@@ -64,7 +64,8 @@ def _build_qsf(named_sc, named_pc):
         lines.append("")
         lines.append("\n\n".join(named_pc))
 
-    lines.append("set_global_assignment -name top_level_entity top")
+    # Set top level name to "build_name" in .qsf file instead always use "top" name
+    lines.append("set_global_assignment -name top_level_entity " + build_name)
     return "\n".join(lines)
 
 
@@ -86,7 +87,7 @@ def _build_files(device, sources, vincpaths, named_sc, named_pc, build_name):
         lines.append("set_global_assignment -name SEARCH_PATH {}".format(
             path.replace("\\", "/")))
 
-    lines.append(_build_qsf(named_sc, named_pc))
+    lines.append(_build_qsf(named_sc, named_pc, build_name))
     lines.append("set_global_assignment -name DEVICE {}".format(device))
     tools.write_to_file("{}.qsf".format(build_name), "\n".join(lines))
 


### PR DESCRIPTION
Contributing to make support for Altera Cyclone V:
- added reset synchronizer;
- changes to make top level assigment in .qsf file with build name instead of always using "top"