### PR TITLE
litex_server: refactor parameters and to allow setting bind address

### DIFF
--- a/litex/utils/litex_server.py
+++ b/litex/utils/litex_server.py
@@ -103,7 +103,7 @@ def main():
     # UART arguments
     parser.add_argument("--uart", action="store_true",
                         help="Select UART interface")
-    parser.add_argument("--uart-port", default="",
+    parser.add_argument("--uart-port", default=None,
                         help="Set UART port")
     parser.add_argument("--uart-baudrate", default=115200,
                         help="Set UART baudrate")
@@ -119,13 +119,16 @@ def main():
     # PCIe arguments
     parser.add_argument("--pcie", action="store_true",
                         help="Select PCIe interface")
-    parser.add_argument("--pcie-bar", default="",
+    parser.add_argument("--pcie-bar", default=None,
                         help="Set PCIe BAR")
     args = parser.parse_args()
 
 
     if args.uart:
         from litex.soc.tools.remote import CommUART
+        if args.uart_port is None:
+            print("Need to specify --uart-port, exiting.")
+            exit()
         uart_port = args.uart_port
         uart_baudrate = int(float(args.uart_baudrate))
         print("[CommUART] port: {} / baudrate: {} / ".format(uart_port, uart_baudrate), end="")
@@ -139,6 +142,9 @@ def main():
     elif args.pcie:
         from litex.soc.tools.remote import CommPCIe
         pcie_bar = args.pcie_bar
+        if args.pcie_bar is None:
+            print("Need to speficy --pcie-bar, exiting.")
+            exit()
         print("[CommPCIe] bar: {} / ".format(args.pcie_bar), end="")
         comm = CommPCIe(args.pcie_bar)
     else:

--- a/litex/utils/litex_server.py
+++ b/litex/utils/litex_server.py
@@ -12,23 +12,18 @@ from litex.soc.tools.remote.etherbone import EtherboneIPC
 
 
 class RemoteServer(EtherboneIPC):
-    def __init__(self, comm, bind, port=1234):
+    def __init__(self, comm, bind_ip, bind_port=1234):
         self.comm = comm
-        self.bind = bind
-        self.port = port
+        self.bind_ip = bind_ip
+        self.bind_port = bind_port
         self.lock = False
 
     def open(self):
         if hasattr(self, "socket"):
             return
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        for i in range(32):
-            try:
-                self.socket.bind((bind, self.port + i))
-                break
-            except:
-                pass
-        print("tcp port: {:d}".format(self.port + i))
+        self.socket.bind((self.bind_ip, self.bind_port))
+        print("tcp port: {:d}".format(self.bind_port))
         self.socket.listen(1)
         self.comm.open()
 
@@ -100,8 +95,10 @@ def main():
     print("LiteX remote server")
     parser = argparse.ArgumentParser()
     # Common arguments
-    parser.add_argument("--bind", default="localhost",
-                        help="Host binding address")
+    parser.add_argument("--bind-ip", default="localhost",
+                        help="Host bind address")
+    parser.add_argument("--bind-port", default=1234,
+                        help="Host bind port")
 
     # UART arguments
     parser.add_argument("--uart", action="store_true",
@@ -148,7 +145,7 @@ def main():
         parser.print_help()
         exit()
 
-    server = RemoteServer(comm, args.bind)
+    server = RemoteServer(comm, args.bind_ip, int(args.bind_port))
     server.open()
     server.start(4)
     try:

--- a/litex/utils/litex_server.py
+++ b/litex/utils/litex_server.py
@@ -22,6 +22,7 @@ class RemoteServer(EtherboneIPC):
         if hasattr(self, "socket"):
             return
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         self.socket.bind((self.bind_ip, self.bind_port))
         print("tcp port: {:d}".format(self.bind_port))
         self.socket.listen(1)


### PR DESCRIPTION
In some cases, it can be useful to bind to "0.0.0.0" instead of "localhost".

While adding bind address support, parameters passing has also been refactored to ease adding parameters in the future.