### PR TITLE
build/sim/core: Initialize Verilator commandArgs

### DIFF
--- a/litex/build/sim/core/sim.c
+++ b/litex/build/sim/core/sim.c
@@ -203,7 +203,7 @@ static void cb(int sock, short which, void *arg)
   }
 }
 
-int main()
+int main(int argc, char *argv[])
 {
   void *vdut=NULL;
   struct timeval tv;
@@ -224,6 +224,7 @@ int main()
     goto out;
   }
 
+  litex_sim_init_cmdargs(argc, argv);
   if(RC_OK != (ret = litex_sim_initialize_all(&vdut, base)))
   {
     goto out;

--- a/litex/build/sim/core/veril.cpp
+++ b/litex/build/sim/core/veril.cpp
@@ -17,6 +17,11 @@ extern "C" void litex_sim_eval(void *vdut)
   dut->eval();
 }
 
+extern "C" void litex_sim_init_cmdargs(int argc, char *argv[])
+{
+  Verilated::commandArgs(argc, argv);
+}
+
 extern "C" void litex_sim_init_tracer(void *vdut)
 {
   Vdut *dut = (Vdut*)vdut;

--- a/litex/build/sim/core/veril.h
+++ b/litex/build/sim/core/veril.h
@@ -4,6 +4,7 @@
 #define __VERIL_H_
 
 #ifdef __cplusplus
+extern "C" void litex_sim_init_cmdargs(int argc, char *argv[]);
 extern "C" void litex_sim_eval(void *vdut);
 extern "C" void litex_sim_init_tracer(void *vdut);
 extern "C" void litex_sim_tracer_dump();


### PR DESCRIPTION
Required when DUT is using plusargs. Prevents Verilator simulation
from crashing with "Verilog called $test$plusargs or $value$plusargs
without testbench C first calling Verilated::commandArgs(argc,argv)".