### PR TITLE
soc/integration/soc_core: Avoid an overlap of IRQ sources in PicoRV32.

### DIFF
--- a/litex/boards/targets/ac701.py
+++ b/litex/boards/targets/ac701.py
@@ -77,11 +77,6 @@ class EthernetSoC(BaseSoC):
     }
     csr_map.update(BaseSoC.csr_map)
 
-    interrupt_map = {
-        "ethmac": 3,
-    }
-    interrupt_map.update(BaseSoC.interrupt_map)
-
     mem_map = {
         "ethmac": 0x30000000,  # (shadow @0xb0000000)
     }
@@ -89,7 +84,7 @@ class EthernetSoC(BaseSoC):
 
     def __init__(self, phy="rgmii", **kwargs):
         assert phy in ["rgmii", "1000basex"]
-        BaseSoC.__init__(self, **kwargs)
+        BaseSoC.__init__(self, soc_interrupts=["ethmac"], **kwargs)
 
         if phy == "rgmii":
             self.submodules.ethphy = LiteEthPHYRGMII(self.platform.request("eth_clocks"),

--- a/litex/boards/targets/arty.py
+++ b/litex/boards/targets/arty.py
@@ -81,18 +81,13 @@ class EthernetSoC(BaseSoC):
     }
     csr_map.update(BaseSoC.csr_map)
 
-    interrupt_map = {
-        "ethmac": 3,
-    }
-    interrupt_map.update(BaseSoC.interrupt_map)
-
     mem_map = {
         "ethmac": 0x30000000,  # (shadow @0xb0000000)
     }
     mem_map.update(BaseSoC.mem_map)
 
     def __init__(self, **kwargs):
-        BaseSoC.__init__(self, **kwargs)
+        BaseSoC.__init__(self, soc_interrupts=["ethmac"], **kwargs)
 
         self.submodules.ethphy = LiteEthPHYMII(self.platform.request("eth_clocks"),
                                                self.platform.request("eth"))

--- a/litex/boards/targets/genesys2.py
+++ b/litex/boards/targets/genesys2.py
@@ -72,18 +72,13 @@ class EthernetSoC(BaseSoC):
     }
     csr_map.update(BaseSoC.csr_map)
 
-    interrupt_map = {
-        "ethmac": 3,
-    }
-    interrupt_map.update(BaseSoC.interrupt_map)
-
     mem_map = {
         "ethmac": 0x30000000,  # (shadow @0xb0000000)
     }
     mem_map.update(BaseSoC.mem_map)
 
     def __init__(self, **kwargs):
-        BaseSoC.__init__(self, **kwargs)
+        BaseSoC.__init__(self, soc_interrupts=["ethmac"], **kwargs)
 
         self.submodules.ethphy = LiteEthPHYRGMII(self.platform.request("eth_clocks"),
                                                  self.platform.request("eth"))

--- a/litex/boards/targets/kc705.py
+++ b/litex/boards/targets/kc705.py
@@ -72,18 +72,13 @@ class EthernetSoC(BaseSoC):
     }
     csr_map.update(BaseSoC.csr_map)
 
-    interrupt_map = {
-        "ethmac": 3,
-    }
-    interrupt_map.update(BaseSoC.interrupt_map)
-
     mem_map = {
         "ethmac": 0x30000000,  # (shadow @0xb0000000)
     }
     mem_map.update(BaseSoC.mem_map)
 
     def __init__(self, **kwargs):
-        BaseSoC.__init__(self, **kwargs)
+        BaseSoC.__init__(self, soc_interrupts=["ethmac"], **kwargs)
 
         self.submodules.ethphy = LiteEthPHY(self.platform.request("eth_clocks"),
                                             self.platform.request("eth"), clk_freq=self.clk_freq)

--- a/litex/boards/targets/kcu105.py
+++ b/litex/boards/targets/kcu105.py
@@ -110,18 +110,13 @@ class EthernetSoC(BaseSoC):
     }
     csr_map.update(BaseSoC.csr_map)
 
-    interrupt_map = {
-        "ethmac": 3,
-    }
-    interrupt_map.update(BaseSoC.interrupt_map)
-
     mem_map = {
         "ethmac": 0x30000000,  # (shadow @0xb0000000)
     }
     mem_map.update(BaseSoC.mem_map)
 
     def __init__(self, **kwargs):
-        BaseSoC.__init__(self, **kwargs)
+        BaseSoC.__init__(self, soc_interrupts=["ethmac"], **kwargs)
 
         self.comb += self.platform.request("sfp_tx_disable_n", 0).eq(1)
         self.submodules.ethphy = KU_1000BASEX(self.crg.cd_clk200.clk,

--- a/litex/boards/targets/nexys_video.py
+++ b/litex/boards/targets/nexys_video.py
@@ -76,18 +76,13 @@ class EthernetSoC(BaseSoC):
     }
     csr_map.update(BaseSoC.csr_map)
 
-    interrupt_map = {
-        "ethmac": 3,
-    }
-    interrupt_map.update(BaseSoC.interrupt_map)
-
     mem_map = {
         "ethmac": 0x30000000,  # (shadow @0xb0000000)
     }
     mem_map.update(BaseSoC.mem_map)
 
     def __init__(self, **kwargs):
-        BaseSoC.__init__(self, **kwargs)
+        BaseSoC.__init__(self, soc_interrupts=["ethmac"], **kwargs)
 
         self.submodules.ethphy = LiteEthPHYRGMII(self.platform.request("eth_clocks"),
                                                  self.platform.request("eth"))

--- a/litex/boards/targets/simple.py
+++ b/litex/boards/targets/simple.py
@@ -32,18 +32,13 @@ class EthernetSoC(BaseSoC):
     }
     csr_map.update(BaseSoC.csr_map)
 
-    interrupt_map = {
-        "ethmac": 3,
-    }
-    interrupt_map.update(BaseSoC.interrupt_map)
-
     mem_map = {
         "ethmac": 0x30000000,  # (shadow @0xb0000000)
     }
     mem_map.update(BaseSoC.mem_map)
 
     def __init__(self, platform, **kwargs):
-        BaseSoC.__init__(self, platform, **kwargs)
+        BaseSoC.__init__(self, platform, soc_interrupts=["ethmac"], **kwargs)
 
         self.submodules.ethphy = LiteEthPHY(platform.request("eth_clocks"),
                                             platform.request("eth"))

--- a/litex/boards/targets/versa_ecp5.py
+++ b/litex/boards/targets/versa_ecp5.py
@@ -108,18 +108,13 @@ class EthernetSoC(BaseSoC):
     }
     csr_map.update(BaseSoC.csr_map)
 
-    interrupt_map = {
-        "ethmac": 3,
-    }
-    interrupt_map.update(BaseSoC.interrupt_map)
-
     mem_map = {
         "ethmac": 0x30000000,  # (shadow @0xb0000000)
     }
     mem_map.update(BaseSoC.mem_map)
 
     def __init__(self, toolchain="diamond", **kwargs):
-        BaseSoC.__init__(self, toolchain=toolchain, **kwargs)
+        BaseSoC.__init__(self, toolchain=toolchain, soc_interrupts=["ethmac"], **kwargs)
 
         self.submodules.ethphy = LiteEthPHYRGMII(
             self.platform.request("eth_clocks"),

--- a/litex/soc/cores/cpu/lm32/core.py
+++ b/litex/soc/cores/cpu/lm32/core.py
@@ -33,6 +33,10 @@ class LM32(Module):
     def linker_output_format(self):
         return "elf32-lm32"
 
+    @property
+    def reserved_interrupts(self):
+        return {}
+
     def __init__(self, platform, eba_reset, variant="standard"):
         assert variant in CPU_VARIANTS, "Unsupported variant %s" % variant
         self.platform = platform

--- a/litex/soc/cores/cpu/minerva/core.py
+++ b/litex/soc/cores/cpu/minerva/core.py
@@ -31,6 +31,10 @@ class Minerva(Module):
     def linker_output_format(self):
         return "elf32-littleriscv"
 
+    @property
+    def reserved_interrupts(self):
+        return {}
+
     def __init__(self, platform, cpu_reset_address, variant="standard"):
         assert variant is "standard", "Unsupported variant %s" % variant
         self.platform = platform

--- a/litex/soc/cores/cpu/mor1kx/core.py
+++ b/litex/soc/cores/cpu/mor1kx/core.py
@@ -47,6 +47,10 @@ class MOR1KX(Module):
     def linker_output_format(self):
         return "elf32-or1k"
 
+    @property
+    def reserved_interrupts(self):
+        return { "nmi": 0 }
+
     def __init__(self, platform, reset_pc, variant="standard"):
         assert variant in CPU_VARIANTS, "Unsupported variant %s" % variant
         self.platform = platform

--- a/litex/soc/cores/cpu/picorv32/core.py
+++ b/litex/soc/cores/cpu/picorv32/core.py
@@ -45,6 +45,10 @@ class PicoRV32(Module):
     def linker_output_format(self):
         return "elf32-littleriscv"
 
+    @property
+    def reserved_interrupts(self):
+        return { "picorv32_timer": 0, "picorv32_ebreak_ecall_illegal": 1, "picorv32_bus_error": 2 }
+
     def __init__(self, platform, progaddr_reset, variant="standard"):
         assert variant in CPU_VARIANTS, "Unsupported variant %s" % variant
         self.platform = platform

--- a/litex/soc/cores/cpu/vexriscv/core.py
+++ b/litex/soc/cores/cpu/vexriscv/core.py
@@ -81,6 +81,10 @@ class VexRiscv(Module, AutoCSR):
     def linker_output_format(self):
         return "elf32-littleriscv"
 
+    @property
+    def reserved_interrupts(self):
+        return {}
+
     def __init__(self, platform, cpu_reset_address, variant="standard"):
         assert variant in CPU_VARIANTS, "Unsupported variant %s" % variant
         self.platform = platform

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -174,7 +174,6 @@ class SoCCore(Module):
         "buttons":        6,  # user
         "leds":           7,  # user
     }
-    interrupt_map = {}
     soc_interrupt_map = {
         "timer0": 1, # LiteX Timer
         "uart":   2, # LiteX UART (IRQ 2 for UART matches mor1k standard config).
@@ -197,7 +196,8 @@ class SoCCore(Module):
                 wishbone_timeout_cycles=1e6,
                 reserve_nmi_interrupt=True,
                 with_timer=True,
-                with_ctrl=True):
+                with_ctrl=True,
+                user_interrupts={}):
         self.config = dict()
 
         self.platform = platform
@@ -329,12 +329,16 @@ class SoCCore(Module):
         #else:
         #    del self.soc_interrupt_map["timer0"]
 
+        self.interrupt_map = user_interrupts.copy()
+
         # Invert the interrupt map.
         interrupt_rmap = {}
         for mod_name, interrupt in self.interrupt_map.items():
             assert interrupt not in interrupt_rmap, (
                 "Interrupt vector conflict for IRQ %s, user defined %s conflicts with user defined %s" % (
                     interrupt, mod_name, interrupt_rmap[interrupt]))
+            assert interrupt >= 8 and interrupt <= 31, (
+                "User IRQ %s defined out of allowed range 8-31: %s" % (mod_name, interrupt))
 
             interrupt_rmap[interrupt] = mod_name
 

--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -95,11 +95,6 @@ class SimSoC(SoCSDRAM):
     ]
     csr_map_update(SoCSDRAM.csr_map, csr_peripherals)
 
-    interrupt_map = {
-        "ethmac": 3,
-    }
-    interrupt_map.update(SoCSDRAM.interrupt_map)
-
     mem_map = {
         "ethmac": 0x30000000,  # (shadow @0xb0000000)
     }
@@ -117,7 +112,9 @@ class SimSoC(SoCSDRAM):
             integrated_rom_size=0x8000,
             ident="LiteX Simulation", ident_version=True,
             with_uart=False,
+            soc_interrupts=["ethmac"]
             **kwargs)
+
         # crg
         self.submodules.crg = CRG(platform.request("sys_clk"))
 


### PR DESCRIPTION
In [PicoRV32](https://github.com/cliffordwolf/picorv32#custom-instructions-for-irq-handling) external IRQ sources 0/1/2 are shared with internal interrupts.

This remaps `NMI`, `timer0` and `uart` interrupts to avoid an overlap.