### PR TITLE
software: use "unsigned long" for address values, also 8-byte alignment

### DIFF
--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -17,9 +17,9 @@
 #include "sfl.h"
 #include "boot.h"
 
-extern void boot_helper(unsigned int r1, unsigned int r2, unsigned int r3, unsigned int addr);
+extern void boot_helper(unsigned long r1, unsigned long r2, unsigned long r3, unsigned long addr);
 
-static void __attribute__((noreturn)) boot(unsigned int r1, unsigned int r2, unsigned int r3, unsigned int addr)
+static void __attribute__((noreturn)) boot(unsigned long r1, unsigned long r2, unsigned long r3, unsigned long addr)
 {
 	printf("Executing booted program at 0x%08x\n", addr);
 	uart_sync();
@@ -83,7 +83,7 @@ int serialboot(void)
 {
 	struct sfl_frame frame;
 	int failed;
-	unsigned int cmdline_adr, initrdstart_adr, initrdend_adr;
+	unsigned long cmdline_adr, initrdstart_adr, initrdend_adr;
 	static const char str[SFL_MAGIC_LEN+1] = SFL_MAGIC_REQ;
 	const char *c;
 	int ack_status;
@@ -146,49 +146,49 @@ int serialboot(void)
 
 				failed = 0;
 				writepointer = (char *)(
-					 ((unsigned int)frame.payload[0] << 24)
-					|((unsigned int)frame.payload[1] << 16)
-					|((unsigned int)frame.payload[2] << 8)
-					|((unsigned int)frame.payload[3] << 0));
+					 ((unsigned long)frame.payload[0] << 24)
+					|((unsigned long)frame.payload[1] << 16)
+					|((unsigned long)frame.payload[2] <<  8)
+					|((unsigned long)frame.payload[3] <<  0));
 				for(i=4;i<frame.length;i++)
 					*(writepointer++) = frame.payload[i];
 				uart_write(SFL_ACK_SUCCESS);
 				break;
 			}
 			case SFL_CMD_JUMP: {
-				unsigned int addr;
+				unsigned long addr;
 
 				failed = 0;
-				addr =  ((unsigned int)frame.payload[0] << 24)
-					|((unsigned int)frame.payload[1] << 16)
-					|((unsigned int)frame.payload[2] << 8)
-					|((unsigned int)frame.payload[3] << 0);
+				addr =   ((unsigned long)frame.payload[0] << 24)
+					|((unsigned long)frame.payload[1] << 16)
+					|((unsigned long)frame.payload[2] <<  8)
+					|((unsigned long)frame.payload[3] <<  0);
 				uart_write(SFL_ACK_SUCCESS);
 				boot(cmdline_adr, initrdstart_adr, initrdend_adr, addr);
 				break;
 			}
 			case SFL_CMD_CMDLINE:
 				failed = 0;
-				cmdline_adr =  ((unsigned int)frame.payload[0] << 24)
-					      |((unsigned int)frame.payload[1] << 16)
-					      |((unsigned int)frame.payload[2] << 8)
-					      |((unsigned int)frame.payload[3] << 0);
+				cmdline_adr =  ((unsigned long)frame.payload[0] << 24)
+					      |((unsigned long)frame.payload[1] << 16)
+					      |((unsigned long)frame.payload[2] <<  8)
+					      |((unsigned long)frame.payload[3] <<  0);
 				uart_write(SFL_ACK_SUCCESS);
 				break;
 			case SFL_CMD_INITRDSTART:
 				failed = 0;
-				initrdstart_adr =  ((unsigned int)frame.payload[0] << 24)
-					          |((unsigned int)frame.payload[1] << 16)
-					          |((unsigned int)frame.payload[2] << 8)
-					          |((unsigned int)frame.payload[3] << 0);
+				initrdstart_adr =  ((unsigned long)frame.payload[0] << 24)
+					          |((unsigned long)frame.payload[1] << 16)
+					          |((unsigned long)frame.payload[2] <<  8)
+					          |((unsigned long)frame.payload[3] <<  0);
 				uart_write(SFL_ACK_SUCCESS);
 				break;
 			case SFL_CMD_INITRDEND:
 				failed = 0;
-				initrdend_adr =  ((unsigned int)frame.payload[0] << 24)
-					        |((unsigned int)frame.payload[1] << 16)
-					        |((unsigned int)frame.payload[2] << 8)
-					        |((unsigned int)frame.payload[3] << 0);
+				initrdend_adr =  ((unsigned long)frame.payload[0] << 24)
+					        |((unsigned long)frame.payload[1] << 16)
+					        |((unsigned long)frame.payload[2] <<  8)
+					        |((unsigned long)frame.payload[3] <<  0);
 				uart_write(SFL_ACK_SUCCESS);
 				break;
 			default:
@@ -243,7 +243,7 @@ static const unsigned char macadr[6] = {0x10, 0xe2, 0xd5, 0x00, 0x00, 0x00};
 void netboot(void)
 {
 	int size;
-	unsigned int cmdline_adr, initrdstart_adr, initrdend_adr;
+	unsigned long cmdline_adr, initrdstart_adr, initrdend_adr;
 	unsigned int ip;
         unsigned short tftp_port;
 

--- a/litex/soc/software/bios/linker.ld
+++ b/litex/soc/software/bios/linker.ld
@@ -14,7 +14,7 @@ SECTIONS
 
 	.rodata :
 	{
-		. = ALIGN(4);
+		. = ALIGN(8);
 		_frodata = .;
 		*(.rodata .rodata.* .gnu.linkonce.r.*)
 		*(.rodata1)
@@ -22,13 +22,13 @@ SECTIONS
 		/* Make sure the file is aligned on disk as well
 		   as in memory; CRC calculation requires that. */
 		FILL(0);
-		. = ALIGN(4);
+		. = ALIGN(8);
 		_erodata = .;
 	} > rom
 
 	.data :
 	{
-		. = ALIGN(4);
+		. = ALIGN(8);
 		_fdata = .;
 		*(.data .data.* .gnu.linkonce.d.*)
 		*(.data1)
@@ -37,13 +37,13 @@ SECTIONS
 		/* Make sure the file is aligned on disk as well
 		   as in memory; CRC calculation requires that. */
 		FILL(0);
-		. = ALIGN(4);
+		. = ALIGN(8);
 		_edata = .;
 	} > rom
 
 	.bss :
 	{
-		. = ALIGN(4);
+		. = ALIGN(8);
 		_fbss = .;
 		*(.dynsbss)
 		*(.sbss .sbss.* .gnu.linkonce.sb.*)
@@ -51,7 +51,7 @@ SECTIONS
 		*(.dynbss)
 		*(.bss .bss.* .gnu.linkonce.b.*)
 		*(COMMON)
-		. = ALIGN(4);
+		. = ALIGN(8);
 		_ebss = .;
 		_end = .;
 	} > sram
@@ -63,4 +63,4 @@ SECTIONS
 	}
 }
 
-PROVIDE(_fstack = ORIGIN(sram) + LENGTH(sram) - 4);
+PROVIDE(_fstack = ORIGIN(sram) + LENGTH(sram) - 8);

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -21,7 +21,7 @@
 /* General address space functions */
 
 #define NUMBER_OF_BYTES_ON_A_LINE 16
-static void dump_bytes(unsigned int *ptr, int count, unsigned addr)
+static void dump_bytes(unsigned int *ptr, int count, unsigned long addr)
 {
 	char *data = (char *)ptr;
 	int line_bytes = 0, i = 0;
@@ -83,7 +83,7 @@ static void mr(char *startaddr, char *len)
 		}
 	}
 
-	dump_bytes(addr, length, (unsigned)addr);
+	dump_bytes(addr, length, (unsigned long)addr);
 }
 
 static void mw(char *addr, char *value, char *count)
@@ -298,8 +298,8 @@ extern unsigned int _ftext, _edata;
 
 static void crcbios(void)
 {
-	unsigned int offset_bios;
-	unsigned int length;
+	unsigned long offset_bios;
+	unsigned long length;
 	unsigned int expected_crc;
 	unsigned int actual_crc;
 
@@ -309,9 +309,9 @@ static void crcbios(void)
 	 * We also use the address of _edata to know the length
 	 * of our code.
 	 */
-	offset_bios = (unsigned int)&_ftext;
+	offset_bios = (unsigned long)&_ftext;
 	expected_crc = _edata;
-	length = (unsigned int)&_edata - offset_bios;
+	length = (unsigned long)&_edata - offset_bios;
 	actual_crc = crc32((unsigned char *)offset_bios, length);
 	if(expected_crc == actual_crc)
 		printf(" BIOS CRC passed (%08x)\n", actual_crc);

--- a/litex/soc/software/include/hw/common.h
+++ b/litex/soc/software/include/hw/common.h
@@ -14,34 +14,34 @@
 #ifdef __ASSEMBLER__
 #define MMPTR(x) x
 #else /* ! __ASSEMBLER__ */
-#define MMPTR(x) (*((volatile unsigned int *)(x)))
+#define MMPTR(x) (*((volatile unsigned long *)(x)))
 
-static inline void csr_writeb(uint8_t value, uint32_t addr)
+static inline void csr_writeb(uint8_t value, unsigned long addr)
 {
 	*((volatile uint8_t *)addr) = value;
 }
 
-static inline uint8_t csr_readb(uint32_t addr)
+static inline uint8_t csr_readb(unsigned long addr)
 {
 	return *(volatile uint8_t *)addr;
 }
 
-static inline void csr_writew(uint16_t value, uint32_t addr)
+static inline void csr_writew(uint16_t value, unsigned long addr)
 {
 	*((volatile uint16_t *)addr) = value;
 }
 
-static inline uint16_t csr_readw(uint32_t addr)
+static inline uint16_t csr_readw(unsigned long addr)
 {
 	return *(volatile uint16_t *)addr;
 }
 
-static inline void csr_writel(uint32_t value, uint32_t addr)
+static inline void csr_writel(uint32_t value, unsigned long addr)
 {
 	*((volatile uint32_t *)addr) = value;
 }
 
-static inline uint32_t csr_readl(uint32_t addr)
+static inline uint32_t csr_readl(unsigned long addr)
 {
 	return *(volatile uint32_t *)addr;
 }


### PR DESCRIPTION
Enable future support for 64-bit CPU models: "unsigned long" matches the native architecture address size, unlike "unsigned int" which is fixed at 32 bits and therefore can't store a 64-bit address.

PS. Also bump tapcfg submodule after applying https://github.com/enjoy-digital/tapcfg/pull/1