### PR TITLE
vexriscv: Fix some floating signals

### DIFF
--- a/litex/soc/cores/cpu/vexriscv/core.py
+++ b/litex/soc/cores/cpu/vexriscv/core.py
@@ -126,6 +126,9 @@ class VexRiscv(Module, AutoCSR):
                 i_dBusWishbone_ERR=dbus.err)
 
         if "linux" in variant:
+            # Tie zero to prevent 1'bx here
+            self.cpu_params["i_softwareInterrupt"] = 0
+            self.cpu_params["i_externalInterruptS"] = 0
             self.add_timer()
 
         if "debug" in variant:


### PR DESCRIPTION
Yosys was optimising the 1'bx here very eagerly (but correctly) and breaking the CPU as these signals were floating. Tieing explicitly to 1'b0 fixes this.