### PR TITLE
soc/integration/cpu_interface: more arch-specific address size fixes

### DIFF
--- a/litex/soc/software/include/hw/common.h
+++ b/litex/soc/software/include/hw/common.h
@@ -14,7 +14,7 @@
 #ifdef __ASSEMBLER__
 #define MMPTR(x) x
 #else /* ! __ASSEMBLER__ */
-#define MMPTR(x) (*((volatile unsigned long *)(x)))
+#define MMPTR(x) (*((volatile unsigned int *)(x)))
 
 static inline void csr_writeb(uint8_t value, unsigned long addr)
 {


### PR DESCRIPTION
When generating arch-specific include files (generated/[mem|csr].h)
ensure address literal defines are suffixed by 'L', denoting their
'unsigned long' type. This inhibits compiler warnings when values
computed based on these constants are cast to pointers.

Also ensure csr_[read|write][b|w|l]() function declarations have
'unsigned long' address arguments.

Finally, restore the correct (32-bit, (unsigned *)) expected
behavior of the MMPTR() macro, inadvertently converted to an
arch-specific sized access (unsigned long *) by commit 5c2b8685.

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>