### PR TITLE
boards/nexys4ddr: ethernet support fix-up

### DIFF
--- a/litex/boards/targets/nexys4ddr.py
+++ b/litex/boards/targets/nexys4ddr.py
@@ -102,9 +102,12 @@ def main():
     parser = argparse.ArgumentParser(description="LiteX SoC on Nexys4DDR")
     builder_args(parser)
     soc_sdram_args(parser)
+    parser.add_argument("--with-ethernet", action="store_true",
+                        help="enable Ethernet support")
     args = parser.parse_args()
 
-    soc = BaseSoC(**soc_sdram_argdict(args))
+    cls = EthernetSoC if args.with_ethernet else BaseSoC
+    soc = cls(**soc_sdram_argdict(args))
     builder = Builder(soc, **builder_argdict(args))
     builder.build()
 


### PR DESCRIPTION
Commit 5f6e7874 added ethernet support, let's now also expose it via
the "--with-ethernet" command line argument.