### PR TITLE
Use 0x43/0xc3 for USB bridge magic packet

### DIFF
--- a/litex/tools/remote/comm_usb.py
+++ b/litex/tools/remote/comm_usb.py
@@ -20,12 +20,12 @@ import time
 # The SETUP packet looks like this:
 #
 # +----+----+----------+----+----+
-# | C0 | 00 | ADDRESS  | 04 | 00 |   read packet
+# | C3 | 00 | ADDRESS  | 04 | 00 |   read packet
 # +----+----+----------+----+----+
 #   1    1        4      1    1
 #
 # +----+----+----------+----+----+
-# | 40 | 00 | ADDRESS  | 04 | 00 |   write packet
+# | 43 | 00 | ADDRESS  | 04 | 00 |   write packet
 # +----+----+----------+----+----+
 #   1    1        4      1    1
 #
@@ -37,8 +37,8 @@ import time
 # byte indicates what type of packet it is, and that it is a Wishbone Bridge
 # packet.  This is the value "0x40" (VENDOR type packet destined for DEVICE)
 # with the "Data Phase Transfer" bit either set or cleared:
-#     - Read:  0xc0
-#     - Write: 0x40
+#     - Read:  0xc3
+#     - Write: 0x43
 #
 # The next byte is bRequest, which in the current implementation is unused.
 # Set this value to 0.
@@ -103,7 +103,7 @@ class CommUSB:
 
     def usb_read(self, addr, depth=0):
         try:
-            value = self.dev.ctrl_transfer(bmRequestType=0xc0,
+            value = self.dev.ctrl_transfer(bmRequestType=0xc3,
                         bRequest=0x00,
                         wValue=addr & 0xffff,
                         wIndex=(addr >> 16) & 0xffff,
@@ -127,7 +127,7 @@ class CommUSB:
 
     def usb_write(self, addr, value, depth=0):
         try:
-            self.dev.ctrl_transfer(bmRequestType=0x40, bRequest=0x00,
+            self.dev.ctrl_transfer(bmRequestType=0x43, bRequest=0x00,
                     wValue=addr & 0xffff,
                     wIndex=(addr >> 16) & 0xffff,
                     data_or_wLength=bytes([(value >> 0) & 0xff,


### PR DESCRIPTION
The previous value -- 0xc0 -- is used by Windows to request WCID values, which causes the bridge to be completely unusable under Windows.  Furthermore, it breaks enumeration.  So we had to change it to 0x43/0xc3, which is not yet used.

This patchset also adds error printing when the user attempts to open a device when they don't have access to it.