### PR TITLE
tools/litex_sim: restore functionality of '--with-sdram' option

### DIFF
--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -116,6 +116,7 @@ class SimSoC(SoCSDRAM):
             sdram_module =  MT48LC16M16(100e6, "1:1") # use 100MHz timings
             phy_settings = PhySettings(
                 memtype="SDR",
+                databits=32,
                 dfi_databits=16,
                 nphases=1,
                 rdphase=0,


### PR DESCRIPTION
After LiteDRAM commit #50e1d478, an additional positional argument
('databits') is required by the PhySettings() constructor.

The value used here (32) will generate a 64MByte simulated SDRAM.