### PR TITLE
litex/boards/targets: don't use tab for indentation

### DIFF
--- a/litex/boards/targets/nexys4ddr.py
+++ b/litex/boards/targets/nexys4ddr.py
@@ -103,7 +103,7 @@ def main():
     builder_args(parser)
     soc_sdram_args(parser)
     parser.add_argument("--sys-clk-freq", default=75e6,
-	                    help="system clock frequency (default=75MHz)")
+                        help="system clock frequency (default=75MHz)")
     parser.add_argument("--with-ethernet", action="store_true",
                         help="enable Ethernet support")
     args = parser.parse_args()

--- a/litex/boards/targets/versa_ecp5.py
+++ b/litex/boards/targets/versa_ecp5.py
@@ -131,7 +131,7 @@ def main():
     builder_args(parser)
     soc_sdram_args(parser)
     parser.add_argument("--sys-clk-freq", default=75e6,
-	                    help="system clock frequency (default=75MHz)")
+                        help="system clock frequency (default=75MHz)")
     parser.add_argument("--with-ethernet", action="store_true",
                         help="enable Ethernet support")
     args = parser.parse_args()


### PR DESCRIPTION
Fix pep8 E101 "indentation contains mixed spaces and tab" error.