### PR TITLE
Add support for Terasic DE2-115 and Terasic DE1-SoC boards

### DIFF
--- a/litex/boards/platforms/de1soc.py
+++ b/litex/boards/platforms/de1soc.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2019 Antony Pavlov <antonynpavlov@gmail.com>
+
+from litex.build.generic_platform import *
+from litex.build.altera import AlteraPlatform
+
+# IOs ------------------------------------------------------------------
+
+_io = [
+    ("clk50", 0, Pins("AF14"), IOStandard("3.3-V LVTTL")),
+
+    ("serial", 0,
+        Subsignal("tx", Pins("AC18"), IOStandard("3.3-V LVTTL")), # JP1 GPIO[0]
+        Subsignal("rx", Pins("Y17"), IOStandard("3.3-V LVTTL"))   # JP1 GPIO[1]
+    ),
+
+    ("sdram_clock", 0, Pins("AH12"), IOStandard("3.3-V LVTTL")),
+    ("sdram", 0,
+        Subsignal("a", Pins("AK14 AH14 AG15 AE14 AB15 AC14 AD14 AF15 AH15 AG13 AG12 AH13 AJ14")),
+        Subsignal("ba", Pins("AF13 AJ12")),
+        Subsignal("cs_n", Pins("AG11")),
+        Subsignal("cke", Pins("AK13")),
+        Subsignal("ras_n", Pins("AE13")),
+        Subsignal("cas_n", Pins("AF11")),
+        Subsignal("we_n", Pins("AA13")),
+        Subsignal("dq", Pins("AK6 AJ7 AK7 AK8 AK9 AG10 AK11 AJ11 AH10 AJ10 AJ9 AH9 AH8 AH7 AJ6 AJ5")),
+        Subsignal("dm", Pins("AB13 AK12")),
+        IOStandard("3.3-V LVTTL")
+    ),
+]
+
+# Platform -------------------------------------------------------------
+
+class Platform(AlteraPlatform):
+    default_clk_name = "clk50"
+    default_clk_period = 20
+
+    def __init__(self):
+        AlteraPlatform.__init__(self, "5CSEMA5F31C6", _io)

--- a/litex/boards/platforms/de2_115.py
+++ b/litex/boards/platforms/de2_115.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2019 Antony Pavlov <antonynpavlov@gmail.com>
+
+from litex.build.generic_platform import *
+from litex.build.altera import AlteraPlatform
+
+# IOs ------------------------------------------------------------------
+
+_io = [
+    ("clk50", 0, Pins("Y2"), IOStandard("3.3-V LVTTL")),
+
+    ("serial", 0,
+        Subsignal("tx", Pins("AB22"), IOStandard("3.3-V LVTTL")), # JP5 GPIO[0]
+        Subsignal("rx", Pins("AC15"), IOStandard("3.3-V LVTTL"))  # JP5 GPIO[1]
+    ),
+
+    ("sdram_clock", 0, Pins("AE5"), IOStandard("3.3-V LVTTL")),
+    ("sdram", 0,
+        Subsignal("a", Pins("R6 V8 U8 P1 V5 W8 W7 AA7 Y5 Y6 R5 AA5 Y7")),
+        Subsignal("ba", Pins("U7 R4")),
+        Subsignal("cs_n", Pins("T4")),
+        Subsignal("cke", Pins("AA6")),
+        Subsignal("ras_n", Pins("U6")),
+        Subsignal("cas_n", Pins("V7")),
+        Subsignal("we_n", Pins("V6")),
+        Subsignal("dq", Pins("W3 W2 V4 W1 V3 V2 V1 U3 Y3 Y4 AB1 AA3 AB2 AC1 AB3 AC2")),
+        Subsignal("dm", Pins("U2 W4")),
+        IOStandard("3.3-V LVTTL")
+    ),
+]
+
+# Platform -------------------------------------------------------------
+
+class Platform(AlteraPlatform):
+    default_clk_name = "clk50"
+    default_clk_period = 20
+
+    def __init__(self):
+        AlteraPlatform.__init__(self, "EP4CE115F29C7", _io)

--- a/litex/boards/targets/de1soc.py
+++ b/litex/boards/targets/de1soc.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (C) 2019 Antony Pavlov <antonynpavlov@gmail.com>
+#
+# based on litex/boards/platforms/de0nano.py
+#
+
+import argparse
+
+from migen import *
+
+from litex.boards.platforms import de1soc
+
+from litex.soc.integration.soc_sdram import *
+from litex.soc.integration.builder import *
+
+from litedram.modules import IS42S16320
+from litedram.phy import GENSDRPHY
+
+# CRG ------------------------------------------------------------------
+
+class _CRG(Module):
+    def __init__(self, platform):
+        self.clock_domains.cd_sys = ClockDomain()
+        self.clock_domains.cd_sys_ps = ClockDomain()
+        self.clock_domains.cd_por = ClockDomain(reset_less=True)
+
+        # # #
+
+        self.cd_sys.clk.attr.add("keep")
+        self.cd_sys_ps.clk.attr.add("keep")
+        self.cd_por.clk.attr.add("keep")
+
+        # power on rst
+        rst_n = Signal()
+        self.sync.por += rst_n.eq(1)
+        self.comb += [
+            self.cd_por.clk.eq(self.cd_sys.clk),
+            self.cd_sys.rst.eq(~rst_n),
+            self.cd_sys_ps.rst.eq(~rst_n)
+        ]
+
+        # sys clk / sdram clk
+        clk50 = platform.request("clk50")
+        self.comb += self.cd_sys.clk.eq(clk50)
+        self.specials += \
+            Instance("ALTPLL",
+                p_BANDWIDTH_TYPE="AUTO",
+                p_CLK0_DIVIDE_BY=1,
+                p_CLK0_DUTY_CYCLE=50,
+                p_CLK0_MULTIPLY_BY=1,
+                p_CLK0_PHASE_SHIFT="-3000",
+                p_COMPENSATE_CLOCK="CLK0",
+                p_INCLK0_INPUT_FREQUENCY=20000,
+                p_OPERATION_MODE="ZERO_DELAY_BUFFER",
+                i_INCLK=clk50,
+                o_CLK=self.cd_sys_ps.clk,
+                i_ARESET=~rst_n,
+                i_CLKENA=0x3f,
+                i_EXTCLKENA=0xf,
+                i_FBIN=1,
+                i_PFDENA=1,
+                i_PLLENA=1,
+            )
+        self.comb += platform.request("sdram_clock").eq(self.cd_sys_ps.clk)
+
+# BaseSoC --------------------------------------------------------------
+
+class BaseSoC(SoCSDRAM):
+    def __init__(self, sys_clk_freq=int(50e6), **kwargs):
+        assert sys_clk_freq == int(50e6)
+        platform = de1soc.Platform()
+        SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq,
+                          integrated_rom_size=0x8000,
+                          **kwargs)
+
+        self.submodules.crg = _CRG(platform)
+
+        if not self.integrated_main_ram_size:
+            self.submodules.sdrphy = GENSDRPHY(platform.request("sdram"))
+            # ISSI IS42S16320D-7TL
+            sdram_module = IS42S16320(self.clk_freq, "1:1")
+            self.register_sdram(self.sdrphy,
+                                sdram_module.geom_settings,
+                                sdram_module.timing_settings)
+
+# Build ----------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="LiteX SoC on DE1-SoC")
+    builder_args(parser)
+    soc_sdram_args(parser)
+    args = parser.parse_args()
+
+    soc = BaseSoC(**soc_sdram_argdict(args))
+    builder = Builder(soc, **builder_argdict(args))
+    builder.build()
+
+
+if __name__ == "__main__":
+    main()

--- a/litex/boards/targets/de2_115.py
+++ b/litex/boards/targets/de2_115.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (C) 2019 Antony Pavlov <antonynpavlov@gmail.com>
+#
+# based on litex/boards/platforms/de0nano.py
+#
+
+import argparse
+
+from migen import *
+
+from litex.boards.platforms import de2_115
+
+from litex.soc.integration.soc_sdram import *
+from litex.soc.integration.builder import *
+
+from litedram.modules import IS42S16320
+from litedram.phy import GENSDRPHY
+
+# CRG ------------------------------------------------------------------
+
+class _CRG(Module):
+    def __init__(self, platform):
+        self.clock_domains.cd_sys = ClockDomain()
+        self.clock_domains.cd_sys_ps = ClockDomain()
+        self.clock_domains.cd_por = ClockDomain(reset_less=True)
+
+        # # #
+
+        self.cd_sys.clk.attr.add("keep")
+        self.cd_sys_ps.clk.attr.add("keep")
+        self.cd_por.clk.attr.add("keep")
+
+        # power on rst
+        rst_n = Signal()
+        self.sync.por += rst_n.eq(1)
+        self.comb += [
+            self.cd_por.clk.eq(self.cd_sys.clk),
+            self.cd_sys.rst.eq(~rst_n),
+            self.cd_sys_ps.rst.eq(~rst_n)
+        ]
+
+        # sys clk / sdram clk
+        clk50 = platform.request("clk50")
+        self.comb += self.cd_sys.clk.eq(clk50)
+        self.specials += \
+            Instance("ALTPLL",
+                p_BANDWIDTH_TYPE="AUTO",
+                p_CLK0_DIVIDE_BY=1,
+                p_CLK0_DUTY_CYCLE=50,
+                p_CLK0_MULTIPLY_BY=1,
+                p_CLK0_PHASE_SHIFT="-3000",
+                p_COMPENSATE_CLOCK="CLK0",
+                p_INCLK0_INPUT_FREQUENCY=20000,
+                p_OPERATION_MODE="ZERO_DELAY_BUFFER",
+                i_INCLK=clk50,
+                o_CLK=self.cd_sys_ps.clk,
+                i_ARESET=~rst_n,
+                i_CLKENA=0x3f,
+                i_EXTCLKENA=0xf,
+                i_FBIN=1,
+                i_PFDENA=1,
+                i_PLLENA=1,
+            )
+        self.comb += platform.request("sdram_clock").eq(self.cd_sys_ps.clk)
+
+# BaseSoC --------------------------------------------------------------
+
+class BaseSoC(SoCSDRAM):
+    def __init__(self, sys_clk_freq=int(50e6), **kwargs):
+        assert sys_clk_freq == int(50e6)
+        platform = de2_115.Platform()
+        SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq,
+                          integrated_rom_size=0x8000,
+                          **kwargs)
+
+        self.submodules.crg = _CRG(platform)
+
+        if not self.integrated_main_ram_size:
+            self.submodules.sdrphy = GENSDRPHY(platform.request("sdram"))
+            # ISSI IS42S16320D-7TL
+            sdram_module = IS42S16320(self.clk_freq, "1:1")
+            self.register_sdram(self.sdrphy,
+                                sdram_module.geom_settings,
+                                sdram_module.timing_settings)
+
+# Build ----------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="LiteX SoC on DE2-115")
+    builder_args(parser)
+    soc_sdram_args(parser)
+    args = parser.parse_args()
+
+    soc = BaseSoC(**soc_sdram_argdict(args))
+    builder = Builder(soc, **builder_argdict(args))
+    builder.build()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add support for [Terasic DE2-115](https://www.terasic.com.tw/cgi-bin/page/archive.pl?Language=English&CategoryNo=139&No=502&PartNo=1) and [Terasic DE1-SoC](https://www.terasic.com.tw/cgi-bin/page/archive.pl?Language=English&No=836) boards.

The IS42S16320D-7TL 32Mx16 512Mb SDRAM chips are used in Terasic DE1-SoC and Terasic DE2-115
FPGA development boards, so https://github.com/enjoy-digital/litedram/pull/84 has to be applied to litedram.