### PR TITLE
fix signed char type to be explicitly signed

### DIFF
--- a/litex/soc/software/include/base/stdint.h
+++ b/litex/soc/software/include/base/stdint.h
@@ -16,15 +16,15 @@ typedef unsigned char uint8_t;
 typedef long long int64_t;
 typedef int int32_t;
 typedef short int16_t;
-typedef char int8_t;
+typedef signed char int8_t;
 
-typedef char int_least8_t;
+typedef signed char int_least8_t;
 typedef unsigned char uint_least8_t;
-typedef short int_least16_t;
+typedef signed short int_least16_t;
 typedef unsigned short uint_least16_t;
-typedef int int_least32_t;
+typedef signed int int_least32_t;
 typedef unsigned int uint_least32_t;
-typedef long long int_least64_t;
+typedef signed long long int_least64_t;
 typedef unsigned long long uint_least64_t;
   
 #define __int_c_join(a, b) a ## b


### PR DESCRIPTION
sorry, I found an issue after porting the library where the "char" type apparently is unsigned unless you explicitly add the "signed" specifier. 

This PR fixes that oversight. The library works now, so this fix is tested.