### PR TITLE
software/libbase: memcpy: simple, arch-width agnostic implementation

### DIFF
--- a/litex/soc/software/libbase/libc.c
+++ b/litex/soc/software/libbase/libc.c
@@ -293,71 +293,12 @@ void *memset(void *s, int c, size_t count)
  */
 void *memcpy(void *to, const void *from, size_t n)
 {
-	void *xto = to;
-	size_t temp;
+	char *tmp = to;
+	const char *s = from;
 
-	if(!n)
-		return xto;
-	if((long)to & 1) {
-		char *cto = to;
-		const char *cfrom = from;
-		*cto++ = *cfrom++;
-		to = cto;
-		from = cfrom;
-		n--;
-	}
-	if((long)from & 1) {
-		char *cto = to;
-		const char *cfrom = from;
-		for (; n; n--)
-			*cto++ = *cfrom++;
-		return xto;
-	}
-	if(n > 2 && (long)to & 2) {
-		short *sto = to;
-		const short *sfrom = from;
-		*sto++ = *sfrom++;
-		to = sto;
-		from = sfrom;
-		n -= 2;
-	}
-	if((long)from & 2) {
-		short *sto = to;
-		const short *sfrom = from;
-		temp = n >> 1;
-		for (; temp; temp--)
-			*sto++ = *sfrom++;
-		to = sto;
-		from = sfrom;
-		if(n & 1) {
-			char *cto = to;
-			const char *cfrom = from;
-			*cto = *cfrom;
-		}
-		return xto;
-	}
-	temp = n >> 2;
-	if(temp) {
-		long *lto = to;
-		const long *lfrom = from;
-		for(; temp; temp--)
-			*lto++ = *lfrom++;
-		to = lto;
-		from = lfrom;
-	}
-	if(n & 2) {
-		short *sto = to;
-		const short *sfrom = from;
-		*sto++ = *sfrom++;
-		to = sto;
-		from = sfrom;
-	}
-	if(n & 1) {
-		char *cto = to;
-		const char *cfrom = from;
-		*cto = *cfrom;
-	}
-	return xto;
+	while (n--)
+		*tmp++ = *s++;
+	return to;
 }
 
 /**


### PR DESCRIPTION
Remove optimizations targeted specifically at rv32 architecture,
allowing memcpy to work on all word sizes.

Since this is "only" the BIOS, it is also arguably better to
optimize for size rather than performance, given that control
will be quickly handed over to some other program being loaded.

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>