### PR TITLE
[RFC - Do NOT Pull] Align MMIO/CSRs on 64-bit address boundary

### DIFF
--- a/litex/soc/integration/cpu_interface.py
+++ b/litex/soc/integration/cpu_interface.py
@@ -120,7 +120,7 @@ def _get_rw_functions_c(reg_name, reg_base, nwords, busword, read_only, with_acc
         if size > 1:
             r += "\t"+ctype+" r = csr_readl("+hex(reg_base)+"L);\n"
             for byte in range(1, nwords):
-                r += "\tr <<= "+str(busword)+";\n\tr |= csr_readl("+hex(reg_base+4*byte)+"L);\n"
+                r += "\tr <<= "+str(busword)+";\n\tr |= csr_readl("+hex(reg_base+8*byte)+"L);\n"
             r += "\treturn r;\n}\n"
         else:
             r += "\treturn csr_readl("+hex(reg_base)+"L);\n}\n"
@@ -133,7 +133,7 @@ def _get_rw_functions_c(reg_name, reg_base, nwords, busword, read_only, with_acc
                     value_shifted = "value >> "+str(shift)
                 else:
                     value_shifted = "value"
-                r += "\tcsr_writel("+value_shifted+", "+hex(reg_base+4*word)+"L);\n"
+                r += "\tcsr_writel("+value_shifted+", "+hex(reg_base+8*word)+"L);\n"
             r += "}\n"
     return r
 
@@ -162,7 +162,7 @@ def get_csr_header(regions, constants, with_access_functions=True, with_shadow_b
             for csr in obj:
                 nr = (csr.size + busword - 1)//busword
                 r += _get_rw_functions_c(name + "_" + csr.name, origin, nr, busword, isinstance(csr, CSRStatus), with_access_functions)
-                origin += 4*nr
+                origin += 8*nr
 
     r += "\n/* constants */\n"
     for name, value in constants:
@@ -196,7 +196,7 @@ def get_csr_csv(csr_regions=None, constants=None, memory_regions=None):
                 for csr in obj:
                     nr = (csr.size + busword - 1)//busword
                     r += "csr_register,{}_{},0x{:08x},{},{}\n".format(name, csr.name, origin, nr, "ro" if isinstance(csr, CSRStatus) else "rw")
-                    origin += 4*nr
+                    origin += 8*nr
 
     if constants is not None:
         for name, value in constants:

--- a/litex/soc/interconnect/csr_bus.py
+++ b/litex/soc/interconnect/csr_bus.py
@@ -159,20 +159,21 @@ class CSRBank(csr.GenericBank):
         csr.GenericBank.__init__(self, description, len(self.bus.dat_w))
 
         sel = Signal()
-        self.comb += sel.eq(self.bus.adr[9:] == address)
+        self.comb += sel.eq((self.bus.adr[9:] == address) & \
+                            (self.bus.adr[0] == 0))
 
         for i, c in enumerate(self.simple_csrs):
             self.comb += [
                 c.r.eq(self.bus.dat_w[:c.size]),
                 c.re.eq(sel & \
                     self.bus.we & \
-                    (self.bus.adr[:self.decode_bits] == i))
+                    (self.bus.adr[1:self.decode_bits+1] == i))
             ]
 
         brcases = dict((i, self.bus.dat_r.eq(c.w)) for i, c in enumerate(self.simple_csrs))
         self.sync += [
             self.bus.dat_r.eq(0),
-            If(sel, Case(self.bus.adr[:self.decode_bits], brcases))
+            If(sel, Case(self.bus.adr[1:self.decode_bits+1], brcases))
         ]
 
 

--- a/litex/soc/software/bios/sdram.c
+++ b/litex/soc/software/bios/sdram.c
@@ -103,7 +103,7 @@ void sdrrdbuf(int dq)
 
 	for(p=0;p<DFII_NPHASES;p++)
 		for(i=first_byte;i<DFII_PIX_DATA_SIZE;i+=step)
-			printf("%02x", MMPTR(sdram_dfii_pix_rddata_addr[p]+4*i));
+			printf("%02x", MMPTR(sdram_dfii_pix_rddata_addr[p]+8*i));
 	printf("\n");
 }
 
@@ -167,7 +167,7 @@ void sdrrderr(char *count)
 		cdelay(15);
 		for(p=0;p<DFII_NPHASES;p++)
 			for(i=0;i<DFII_PIX_DATA_SIZE;i++)
-				prev_data[p*DFII_PIX_DATA_SIZE+i] = MMPTR(sdram_dfii_pix_rddata_addr[p]+4*i);
+				prev_data[p*DFII_PIX_DATA_SIZE+i] = MMPTR(sdram_dfii_pix_rddata_addr[p]+8*i);
 
 		for(j=0;j<_count;j++) {
 			command_prd(DFII_COMMAND_CAS|DFII_COMMAND_CS|DFII_COMMAND_RDDATA);
@@ -176,7 +176,7 @@ void sdrrderr(char *count)
 				for(i=0;i<DFII_PIX_DATA_SIZE;i++) {
 					unsigned char new_data;
 
-					new_data = MMPTR(sdram_dfii_pix_rddata_addr[p]+4*i);
+					new_data = MMPTR(sdram_dfii_pix_rddata_addr[p]+8*i);
 					errs[p*DFII_PIX_DATA_SIZE+i] |= prev_data[p*DFII_PIX_DATA_SIZE+i] ^ new_data;
 					prev_data[p*DFII_PIX_DATA_SIZE+i] = new_data;
 				}
@@ -211,7 +211,7 @@ void sdrwr(char *startaddr)
 
 	for(p=0;p<DFII_NPHASES;p++)
 		for(i=0;i<DFII_PIX_DATA_SIZE;i++)
-			MMPTR(sdram_dfii_pix_wrdata_addr[p]+4*i) = 0x10*p + i;
+			MMPTR(sdram_dfii_pix_wrdata_addr[p]+8*i) = 0x10*p + i;
 
 	sdram_dfii_piwr_address_write(addr);
 	sdram_dfii_piwr_baddress_write(0);
@@ -458,7 +458,7 @@ static int read_level_scan(int module, int bitslip)
 	/* Write test pattern */
 	for(p=0;p<DFII_NPHASES;p++)
 		for(i=0;i<DFII_PIX_DATA_SIZE;i++)
-			MMPTR(sdram_dfii_pix_wrdata_addr[p]+4*i) = prs[DFII_PIX_DATA_SIZE*p+i];
+			MMPTR(sdram_dfii_pix_wrdata_addr[p]+8*i) = prs[DFII_PIX_DATA_SIZE*p+i];
 	sdram_dfii_piwr_address_write(0);
 	sdram_dfii_piwr_baddress_write(0);
 	command_pwr(DFII_COMMAND_CAS|DFII_COMMAND_WE|DFII_COMMAND_CS|DFII_COMMAND_WRDATA);
@@ -483,9 +483,9 @@ static int read_level_scan(int module, int bitslip)
 		cdelay(15);
 		working = 1;
 		for(p=0;p<DFII_NPHASES;p++) {
-			if(MMPTR(sdram_dfii_pix_rddata_addr[p]+4*(NBMODULES-module-1)) != prs[DFII_PIX_DATA_SIZE*p+(NBMODULES-module-1)])
+			if(MMPTR(sdram_dfii_pix_rddata_addr[p]+8*(NBMODULES-module-1)) != prs[DFII_PIX_DATA_SIZE*p+(NBMODULES-module-1)])
 				working = 0;
-			if(MMPTR(sdram_dfii_pix_rddata_addr[p]+4*(2*NBMODULES-module-1)) != prs[DFII_PIX_DATA_SIZE*p+2*NBMODULES-module-1])
+			if(MMPTR(sdram_dfii_pix_rddata_addr[p]+8*(2*NBMODULES-module-1)) != prs[DFII_PIX_DATA_SIZE*p+2*NBMODULES-module-1])
 				working = 0;
 		}
 #ifdef ECP5DDRPHY
@@ -534,7 +534,7 @@ static void read_level(int module)
 	/* Write test pattern */
 	for(p=0;p<DFII_NPHASES;p++)
 		for(i=0;i<DFII_PIX_DATA_SIZE;i++)
-			MMPTR(sdram_dfii_pix_wrdata_addr[p]+4*i) = prs[DFII_PIX_DATA_SIZE*p+i];
+			MMPTR(sdram_dfii_pix_wrdata_addr[p]+8*i) = prs[DFII_PIX_DATA_SIZE*p+i];
 	sdram_dfii_piwr_address_write(0);
 	sdram_dfii_piwr_baddress_write(0);
 	command_pwr(DFII_COMMAND_CAS|DFII_COMMAND_WE|DFII_COMMAND_CS|DFII_COMMAND_WRDATA);
@@ -554,9 +554,9 @@ static void read_level(int module)
 		cdelay(15);
 		working = 1;
 		for(p=0;p<DFII_NPHASES;p++) {
-			if(MMPTR(sdram_dfii_pix_rddata_addr[p]+4*(NBMODULES-module-1)) != prs[DFII_PIX_DATA_SIZE*p+(NBMODULES-module-1)])
+			if(MMPTR(sdram_dfii_pix_rddata_addr[p]+8*(NBMODULES-module-1)) != prs[DFII_PIX_DATA_SIZE*p+(NBMODULES-module-1)])
 				working = 0;
-			if(MMPTR(sdram_dfii_pix_rddata_addr[p]+4*(2*NBMODULES-module-1)) != prs[DFII_PIX_DATA_SIZE*p+2*NBMODULES-module-1])
+			if(MMPTR(sdram_dfii_pix_rddata_addr[p]+8*(2*NBMODULES-module-1)) != prs[DFII_PIX_DATA_SIZE*p+2*NBMODULES-module-1])
 				working = 0;
 		}
 #ifdef ECP5DDRPHY
@@ -592,9 +592,9 @@ static void read_level(int module)
 		cdelay(15);
 		working = 1;
 		for(p=0;p<DFII_NPHASES;p++) {
-			if(MMPTR(sdram_dfii_pix_rddata_addr[p]+4*(NBMODULES-module-1)) != prs[DFII_PIX_DATA_SIZE*p+(NBMODULES-module-1)])
+			if(MMPTR(sdram_dfii_pix_rddata_addr[p]+8*(NBMODULES-module-1)) != prs[DFII_PIX_DATA_SIZE*p+(NBMODULES-module-1)])
 				working = 0;
-			if(MMPTR(sdram_dfii_pix_rddata_addr[p]+4*(2*NBMODULES-module-1)) != prs[DFII_PIX_DATA_SIZE*p+2*NBMODULES-module-1])
+			if(MMPTR(sdram_dfii_pix_rddata_addr[p]+8*(2*NBMODULES-module-1)) != prs[DFII_PIX_DATA_SIZE*p+2*NBMODULES-module-1])
 				working = 0;
 		}
 #ifdef ECP5DDRPHY


### PR DESCRIPTION
CAUTION: horrendous hack, NOT upstream-ready!!!

Currently, CSRs are split into up-to 8bit (csr_data_width) slices,
which can be addressed at 32-bit aligned addresses: 0x*0, 0x*4, etc.

Within one "bank", registers are addressed by a 14-bit address that is
effectively the ((MMIO_address) >> 2) & 0x3fff. The 5 M.S.Bits (13..9)
appear to identify the bank, whereas a variable number of L.S.Bits
identify the actual 8-bit (slice of a) CSR.

E.g.: 0xE0002014 (uart.ev_enable) will be >>=2'ed to 0x38000805, whose
      lower-14-bits are 0805. This number's 5 M.S.Bits are 0x04
      (starting at bit 9). The L.S.Bits ([0..8], or nine total bits)
      are 0x05. So this is 8-bit-slice #5 of bank #4
      (see soc/interconnect/csr_bus.py:CSRBank).

      Conversely, the bank number (or "mapaddr") is multiplied by 0x800
      (<<=11) and added to the CSR base (0xe0000000) to get the MMIO
      address of the first 8-bit CSR slice in that bank. E.g., for the
      uart.* bank, 0x04 * 0x800 = 0x2000, hence 0xe0002000 for the
      first MMIO register of the uart.* bank (uart.rxtx)
      (see soc/integration/soc_core.py:SoCCore.do_finalize#CSR).

```
uart.ev_enable MMIO addr: 0xe000_2014:
----------- --- --- --- ----------- ----------- ----------- -----------
31 30 29 28 27- 23- 19- 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00
----------- --- --- --- ----------- ----------- ----------- -----------
 1  1  1  0  00  00  00  0  0  1  0  0  0  0  0  0  0  0  1  0  1  0  0
----------- --- --- --- ----------- ----------- ----------- -----------
                        ----- ----------- ----------- -----------
                        13 12 11 10 09 08 07 06 05 04 03 02 01 00
                        ----- ----------- ----------- -----------
                         0  0  1  0  0  0  0  0  0  0  0  1  0  1
                        == =========== -- ----------- -----------
                        <--- Bank ---> <------- CSRslice ------->
```
(edit: switched ASCII art above to fixed-width fonts, should be fine in git proper :) )

Right now this works out to the effect of having a 32-bit-aligned MMIO
address assigned to each 8-bit (slice of a) CSR register (see
soc/integration/cpu_interface.py, where this scheme is exposed to the
software layer as part of the generated include/csr.h header file).

Trouble is, 64-bit MMIO accesses will always touch both slices across
the two 32-bit aligned addresses contained in a 64-bit aligned address,
and the strobe bits are ignored/discarded by the WB-to-CSR bridge. If
the adjacent CSRslices happen to be both writable, one of them will get
written to unintentionally, as "collateral" damage of writing to its
neighbor, and will receive whatever garbage data is in the strobed-out
portion of the 64-bit data word!

This patch modifies CSR address allocation to be aligned at 64-bit
(MMIO) address boundaries. It currently does not deal with the reduced
(by half) number of bits available to intra-bank CSR register slices,
now that the least significant bit is "skipped" (i.e., required to be
0, so we only ever write to the lower-32-bits of a 64-bit-aligned,
64-bit-wide region).

Q. is there a check that verifies upper limit of 2^9 CSRslices per bank?

The alternative approach would be to modify the WB-to-CSR bridge to pass
along strobe signals, and include them in the calculation of the 'sel'
and/or '*.re' (register enable) signal(s).

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>