### PR TITLE
Extend generated headers & csv

### DIFF
--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -58,6 +58,7 @@ class Builder:
         cpu_type = self.soc.cpu_type
         memory_regions = self.soc.get_memory_regions()
         flash_boot_address = getattr(self.soc, "flash_boot_address", None)
+        shadow_base = getattr(self.soc, "shadow_base", None)
         csr_regions = self.soc.get_csr_regions()
         constants = self.soc.get_constants()
 
@@ -102,7 +103,7 @@ class Builder:
 
         write_to_file(
             os.path.join(generated_dir, "mem.h"),
-            cpu_interface.get_mem_header(memory_regions, flash_boot_address))
+            cpu_interface.get_mem_header(memory_regions, flash_boot_address, shadow_base))
         write_to_file(
             os.path.join(generated_dir, "csr.h"),
             cpu_interface.get_csr_header(csr_regions, constants))
@@ -119,6 +120,10 @@ class Builder:
         memory_regions = self.soc.get_memory_regions()
         csr_regions = self.soc.get_csr_regions()
         constants = self.soc.get_constants()
+
+        shadow_base = getattr(self.soc, "shadow_base", None)
+        if shadow_base:
+            constants.append(('shadow_base',  shadow_base))
 
         csr_dir = os.path.dirname(os.path.realpath(self.csr_csv))
         os.makedirs(csr_dir, exist_ok=True)

--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -125,6 +125,10 @@ class Builder:
         if shadow_base:
             constants.append(('shadow_base',  shadow_base))
 
+        flash_boot_address = getattr(self.soc, "flash_boot_address", None)
+        if flash_boot_address:
+            constants.append(('flash_boot_address',  flash_boot_address))
+
         csr_dir = os.path.dirname(os.path.realpath(self.csr_csv))
         os.makedirs(csr_dir, exist_ok=True)
         write_to_file(

--- a/litex/soc/integration/cpu_interface.py
+++ b/litex/soc/integration/cpu_interface.py
@@ -70,13 +70,15 @@ def get_linker_regions(regions):
     return r
 
 
-def get_mem_header(regions, flash_boot_address):
+def get_mem_header(regions, flash_boot_address, shadow_base):
     r = generated_banner("//")
     r += "#ifndef __GENERATED_MEM_H\n#define __GENERATED_MEM_H\n\n"
     for name, base, size in regions:
         r += "#define {name}_BASE 0x{base:08x}L\n#define {name}_SIZE 0x{size:08x}\n\n".format(name=name.upper(), base=base, size=size)
     if flash_boot_address is not None:
         r += "#define FLASH_BOOT_ADDRESS 0x{:08x}L\n\n".format(flash_boot_address)
+    if shadow_base is not None:
+        r += "#define SHADOW_BASE 0x{:08x}L\n\n".format(shadow_base)
     r += "#endif\n"
     return r
 


### PR DESCRIPTION
There is [a script in litex-buildenv](https://github.com/timvideos/litex-buildenv/blob/master/scripts/generate-renode-scripts.py) that generates [Renode](https://github.com/renode/renode) platform based on litex configuration from the csv file generated by LiteX. Unfortunatelly, the file does not contain all the necessary information.

This PR adds generation of `shadow_base` and `flash_boot_address` constants to the csv file.

Additionally, it adds generation of `SHADOW_BASE` define to `mem.h`. It is not necessary for the script, but I added it for the symmetry.