### PR TITLE
boards/arty : Add directly connected spi clk pin 

### DIFF
--- a/litex/boards/platforms/arty.py
+++ b/litex/boards/platforms/arty.py
@@ -79,13 +79,15 @@ _io = [
         IOStandard("LVCMOS33"),
     ),
 
-    ("spiflash4x", 0,  # clock needs to be accessed through STARTUPE2
+    ("spiflash4x", 0,
         Subsignal("cs_n", Pins("L13")),
+        Subsignal("clk", Pins("L16")),
         Subsignal("dq", Pins("K17", "K18", "L14", "M14")),
         IOStandard("LVCMOS33")
     ),
-    ("spiflash", 0,  # clock needs to be accessed through STARTUPE2
+    ("spiflash", 0,
         Subsignal("cs_n", Pins("L13")),
+        Subsignal("clk", Pins("L16")),
         Subsignal("mosi", Pins("K17")),
         Subsignal("miso", Pins("K18")),
         Subsignal("wp", Pins("L14")),


### PR DESCRIPTION
Avoids need for STARTUPE2.  Config pins tristate after download by default, alternate works well through R262.

![shot_2019_06_10_08_34_31](https://user-images.githubusercontent.com/4367175/59206832-9e42b480-8b5a-11e9-8750-a0f42216e79a.png)
