### PR TITLE
bios: Fix build when ethphy is present but ethmac is not.

### DIFF
--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -433,7 +433,7 @@ int main(int i, char **c)
 	printf("\n");
 
 	printf("--========= \e[1mPeripherals init\e[0m ===========--\n");
-#ifdef CSR_ETHPHY_CRG_RESET_ADDR
+#ifdef CSR_ETHMAC_BASE
 	eth_init();
 #endif
 #ifdef CSR_SDRAM_BASE


### PR DESCRIPTION
While testing my Ethernet DMA, I renamed the `ethmac` module to `ethmac_dma` so that it wouldn't be used from the BIOS, but I got an undefined reference to `eth_init` because `bios.c` checks different CSR defines than the code that defines `eth_init`.