### PR TITLE
tools/litex_sim: fix default endianness for mem_init

### DIFF
--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -214,10 +214,10 @@ def main():
     sim_config = SimConfig(default_clk="sys_clk")
     sim_config.add_module("serial2console", "serial")
 
-    cpu_endianness = "big"
+    cpu_endianness = "little"
     if "cpu_type" in soc_kwargs:
-        if soc_kwargs["cpu_type"] in ["picorv32", "vexriscv"]:
-            cpu_endianness = "little"
+        if soc_kwargs["cpu_type"] in ["mor1kx", "lm32"]:
+            cpu_endianness = "big"
 
     if args.rom_init:
         soc_kwargs["integrated_rom_init"] = get_mem_data(args.rom_init, cpu_endianness)


### PR DESCRIPTION
Initializing ROM and/or RAM content requires knowing the CPU
endianness before the SimSoC->SoCSDRAM->SoCCore constructor
sequence is invoked (before the SoC's self.cpu.endianness
could be accessed). Given that the majority of supported CPU
models use "little", set it as the new default, and override
only for the two models that use "big" endianness.