### PR TITLE
soc_core: additional csr_alignment follow-up fixes

### DIFF
--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -186,11 +186,14 @@ class SoCCore(Module):
 
         # Parameters managment ---------------------------------------------------------------------
 
-        # FIXME: RocketChip reserves the first 256Mbytes for internal use, change default mem_map
+        # NOTE: RocketChip reserves the first 256Mbytes for internal use,
+        #       so we must change default mem_map;
+        #       Also, CSRs *must* be 64-bit aligned.
         if cpu_type == "rocket":
             self.soc_mem_map["rom"]  = 0x10000000
             self.soc_mem_map["sram"] = 0x11000000
             self.soc_mem_map["csr"]  = 0x12000000
+            csr_alignment = 64
 
         if cpu_type == "None":
             cpu_type = None

--- a/litex/soc/software/bios/sdram.c
+++ b/litex/soc/software/bios/sdram.c
@@ -536,7 +536,7 @@ static void read_level(int module)
 	/* Write test pattern */
 	for(p=0;p<DFII_NPHASES;p++)
 		for(i=0;i<DFII_PIX_DATA_SIZE;i++)
-			MMPTR(sdram_dfii_pix_wrdata_addr[p]+4*i) = prs[DFII_PIX_DATA_SIZE*p+i];
+			MMPTR(sdram_dfii_pix_wrdata_addr[p]+DFII_ADDR_SHIFT*i) = prs[DFII_PIX_DATA_SIZE*p+i];
 	sdram_dfii_piwr_address_write(0);
 	sdram_dfii_piwr_baddress_write(0);
 	command_pwr(DFII_COMMAND_CAS|DFII_COMMAND_WE|DFII_COMMAND_CS|DFII_COMMAND_WRDATA);

--- a/litex/soc/software/libbase/id.c
+++ b/litex/soc/software/libbase/id.c
@@ -4,13 +4,14 @@
 #include <string.h>
 #include <id.h>
 
+#define DFII_ADDR_SHIFT CONFIG_CSR_ALIGNMENT/8
 
 void get_ident(char *ident)
 {
 #ifdef CSR_IDENTIFIER_MEM_BASE
     int i;
     for(i=0;i<256;i++)
-        ident[i] = MMPTR(CSR_IDENTIFIER_MEM_BASE + 4*i);
+        ident[i] = MMPTR(CSR_IDENTIFIER_MEM_BASE + DFII_ADDR_SHIFT*i);
 #else
     ident[0] = 0;
 #endif


### PR DESCRIPTION
- Update a few additional places to use DFII_ADDR_SHIFT instead of
  a hard-coded 4, which assumed 32-bit alignment.

- Force 64-bit alignment Rocket -- the only supported configuration!

This is a fixup for commit f4770219, tested on Rocket and 64bit Linux.

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>