### PR TITLE
build/lattice/trellis: use additional yosys optimization flags

### DIFF
--- a/litex/build/lattice/trellis.py
+++ b/litex/build/lattice/trellis.py
@@ -138,7 +138,7 @@ class LatticeTrellisToolchain:
         self.yosys_template = [
             "{read_files}",
             "attrmap -tocase keep -imap keep=\"true\" keep=1 -imap keep=\"false\" keep=0 -remove keep=0",
-            "synth_ecp5 -json {build_name}.json -top {build_name}",
+            "synth_ecp5 -abc9 -json {build_name}.json -top {build_name}",
         ]
 
         self.build_template = [


### PR DESCRIPTION
Adding "-nowidelut -abc9" to the yosys command line allows significant
improvements in TRELLIS_SLICE utilization. E.g., when building 64-bit
capable "--with-ethernet --cpu-type rocket --cpu-variant linux", slice
utilization decreases from 127% of an ecp5-45k's capacity to a feasible
value of 98%.

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>