### PR TITLE
[fix] prevent Vivado from inferring DSP48 in AXIBurst2Beat

### DIFF
--- a/litex/soc/interconnect/axi.py
+++ b/litex/soc/interconnect/axi.py
@@ -113,7 +113,7 @@ class AXIBurst2Beat(Module):
 
         # compute parameters
         self.comb += beat_size.eq(1 << ax_burst.size)
-        self.comb += beat_wrap.eq(ax_burst.len*beat_size)
+        self.comb += beat_wrap.eq(ax_burst.len << ax_burst.size)
 
         # combinatorial logic
         self.comb += [


### PR DESCRIPTION
Vivado (2019.1 and 2017.4) infers a DSP48 to perform the multiplication. It also complained about possible timing issues.
```
WARNING: [DRC DPIP-1] Input pipelining: DSP basesoc_basesoc_axi2wishbone_axi2axi_lite_beat_wrap input basesoc_basesoc_axi2wishbone_axi2axi_lite_beat_wrap/A[29:0] is not pipelined. Pipelining DSP48 input will improve performance.
```
This patch decreases readability, but Vivado does not infer DSP48 anymore