### PR TITLE
software: use native toolchain for same host, target architectures

### DIFF
--- a/litex/soc/integration/cpu_interface.py
+++ b/litex/soc/integration/cpu_interface.py
@@ -15,6 +15,7 @@
 import os
 import json
 from shutil import which
+from sysconfig import get_platform
 
 from migen import *
 
@@ -58,8 +59,13 @@ def get_cpu_mak(cpu):
         r = None
         if not isinstance(triple, tuple):
             triple = (triple,)
+        p = get_platform()
         for i in range(len(triple)):
             t = triple[i]
+            # use native toolchain if host and target platforms are the same
+            if t == 'riscv64-unknown-elf' and p == 'linux-riscv64':
+                r = '--native--'
+                break
             if which(t+"-gcc"):
                 r = t
                 break

--- a/litex/soc/software/common.mak
+++ b/litex/soc/software/common.mak
@@ -1,4 +1,8 @@
+ifeq ($(TRIPLE),--native--)
+TARGET_PREFIX=
+else
 TARGET_PREFIX=$(TRIPLE)-
+endif
 
 RM ?= rm -f
 PYTHON ?= python3


### PR DESCRIPTION
LiteX rightfully assumes that most often the target software must
be cross-compiled from an x86 host platform. However, LiteX can be
also built on a 'linux-riscv64' platform (e.g. Fedora's riscv64
port), where the software for riscv64 targets should be compiled
using the native toolchain.

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>