### PR TITLE
WIP: Enable link-time-optimization on LiteX builds

### DIFF
--- a/litex/soc/software/bios/Makefile
+++ b/litex/soc/software/bios/Makefile
@@ -30,7 +30,8 @@ bios.elf: $(BIOS_DIRECTORY)/linker.ld $(OBJECTS)
 		-L../libnet \
 		-L../libbase \
 		-L../libcompiler_rt \
-		-lnet -lbase-nofloat -lcompiler_rt
+		-lnet -lbase-nofloat -lcompiler_rt \
+		-lgcc
 ifneq ($(OS),Windows_NT)
 	chmod -x $@
 endif

--- a/litex/soc/software/bios/Makefile
+++ b/litex/soc/software/bios/Makefile
@@ -24,7 +24,7 @@ endif
 bios.elf: $(BIOS_DIRECTORY)/linker.ld $(OBJECTS)
 
 %.elf: ../libbase/crt0-$(CPU)-ctr.o ../libnet/libnet.a ../libbase/libbase-nofloat.a ../libcompiler_rt/libcompiler_rt.a
-	$(LD) $(LDFLAGS) -T $(BIOS_DIRECTORY)/linker.ld -N -o $@ \
+	$(CC) $(LDFLAGS) -T $(BIOS_DIRECTORY)/linker.ld -N -o $@ \
 		../libbase/crt0-$(CPU)-ctr.o \
 		$(OBJECTS) \
 		-L../libnet \

--- a/litex/soc/software/common.mak
+++ b/litex/soc/software/common.mak
@@ -49,7 +49,7 @@ INCLUDES = -I$(SOC_DIRECTORY)/software/include/base -I$(SOC_DIRECTORY)/software/
 COMMONFLAGS = $(DEPFLAGS) -Os $(CPUFLAGS) -g3 -fomit-frame-pointer -Wall -fno-builtin -nostdinc $(INCLUDES) -flto -fuse-linker-plugin -Os -ffunction-sections -fdata-sections -flto -nostartfiles -nostdlib -nodefaultlibs
 CFLAGS = $(COMMONFLAGS) -fexceptions -Wstrict-prototypes -Wold-style-definition -Wmissing-prototypes
 CXXFLAGS = $(COMMONFLAGS) -std=c++11 -I$(SOC_DIRECTORY)/software/include/basec++ -fexceptions -fno-rtti -ffreestanding
-LDFLAGS = -nostdlib -nodefaultlibs -L$(BUILDINC_DIRECTORY)
+LDFLAGS = -nostdlib -nodefaultlibs -Os $(CPUFLAGS) -L$(BUILDINC_DIRECTORY)
 #--plugin $(shell $(CC) --print-prog-name liblto_plugin.so)
 
 define compilexx

--- a/litex/soc/software/common.mak
+++ b/litex/soc/software/common.mak
@@ -14,7 +14,7 @@ else
 CC_normal      := $(TARGET_PREFIX)gcc -std=gnu99
 CX_normal      := $(TARGET_PREFIX)g++
 endif
-AR_normal      := $(TARGET_PREFIX)ar
+AR_normal      := $(TARGET_PREFIX)gcc-ar
 LD_normal      := $(TARGET_PREFIX)ld
 OBJCOPY_normal := $(TARGET_PREFIX)objcopy
 
@@ -46,10 +46,11 @@ DEPFLAGS += -MD -MP
 # Toolchain options
 #
 INCLUDES = -I$(SOC_DIRECTORY)/software/include/base -I$(SOC_DIRECTORY)/software/include -I$(SOC_DIRECTORY)/common -I$(BUILDINC_DIRECTORY)
-COMMONFLAGS = $(DEPFLAGS) -Os $(CPUFLAGS) -g3 -fomit-frame-pointer -Wall -fno-builtin -nostdinc $(INCLUDES)
+COMMONFLAGS = $(DEPFLAGS) -Os $(CPUFLAGS) -g3 -fomit-frame-pointer -Wall -fno-builtin -nostdinc $(INCLUDES) -flto -fuse-linker-plugin -Os -ffunction-sections -fdata-sections -flto -nostartfiles -nostdlib -nodefaultlibs
 CFLAGS = $(COMMONFLAGS) -fexceptions -Wstrict-prototypes -Wold-style-definition -Wmissing-prototypes
 CXXFLAGS = $(COMMONFLAGS) -std=c++11 -I$(SOC_DIRECTORY)/software/include/basec++ -fexceptions -fno-rtti -ffreestanding
 LDFLAGS = -nostdlib -nodefaultlibs -L$(BUILDINC_DIRECTORY)
+#--plugin $(shell $(CC) --print-prog-name liblto_plugin.so)
 
 define compilexx
 $(CX) -c $(CXXFLAGS) $(1) $< -o $@

--- a/litex/soc/software/libbase/libc.c
+++ b/litex/soc/software/libbase/libc.c
@@ -276,7 +276,7 @@ int memcmp(const void *cs, const void *ct, size_t count)
  * @c: The byte to fill the area with
  * @count: The size of the area.
  */
-void *memset(void *s, int c, size_t count)
+__attribute__((used)) void *memset(void *s, int c, size_t count)
 {
 	char *xs = s;
 

--- a/litex/soc/software/libbase/libc.c
+++ b/litex/soc/software/libbase/libc.c
@@ -669,7 +669,7 @@ void srand(unsigned int seed)
 	randseed = seed;
 }
 
-void abort(void)
+__attribute__ ((used)) void abort(void)
 {
 	printf("Aborted.");
 	while(1);


### PR DESCRIPTION
LTO can make both the BIOS and bare metal firmware ~30% smaller than current. 

The only issue seems to be that the compiler needs to include `-lgcc` for the link to succeed.