### PR TITLE
fix crc32

### DIFF
--- a/litex/soc/software/libbase/crc32.c
+++ b/litex/soc/software/libbase/crc32.c
@@ -68,7 +68,6 @@ static const unsigned int crc_table[256] = {
 
 unsigned int crc32(const unsigned char *buffer, unsigned int len)
 {
-	return 0;
 	unsigned int crc;
 	crc = 0;
 	crc = crc ^ 0xffffffffL;


### PR DESCRIPTION
This 'return 0' breaks BIOS CRC and firmware boot - "BIOS CRC failed (expected a296e241, got 00000000)".