### PR TITLE
Enable to run Linux on mork1x

### DIFF
--- a/litex/boards/targets/arty.py
+++ b/litex/boards/targets/arty.py
@@ -51,10 +51,10 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCSDRAM):
-    def __init__(self, sys_clk_freq=int(100e6), **kwargs):
+    def __init__(self, sys_clk_freq=int(100e6), integrated_rom_size=0x8000, **kwargs):
         platform = arty.Platform()
         SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq,
-                         integrated_rom_size=0x8000,
+                         integrated_rom_size=integrated_rom_size,
                          integrated_sram_size=0x8000,
                          **kwargs)
 
@@ -77,7 +77,7 @@ class EthernetSoC(BaseSoC):
     mem_map.update(BaseSoC.mem_map)
 
     def __init__(self, **kwargs):
-        BaseSoC.__init__(self, **kwargs)
+        BaseSoC.__init__(self, integrated_rom_size=0x10000, **kwargs)
 
         self.submodules.ethphy = LiteEthPHYMII(self.platform.request("eth_clocks"),
                                                self.platform.request("eth"))

--- a/litex/boards/targets/genesys2.py
+++ b/litex/boards/targets/genesys2.py
@@ -44,10 +44,10 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCSDRAM):
-    def __init__(self, sys_clk_freq=int(125e6), **kwargs):
+    def __init__(self, sys_clk_freq=int(125e6), integrated_rom_size=0x8000, **kwargs):
         platform = genesys2.Platform()
         SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq,
-                         integrated_rom_size=0x8000,
+                         integrated_rom_size=integrated_rom_size,
                          integrated_sram_size=0x8000,
                           **kwargs)
 
@@ -70,7 +70,7 @@ class EthernetSoC(BaseSoC):
     mem_map.update(BaseSoC.mem_map)
 
     def __init__(self, **kwargs):
-        BaseSoC.__init__(self, **kwargs)
+        BaseSoC.__init__(self, integrated_rom_size=0x10000, **kwargs)
 
         self.submodules.ethphy = LiteEthPHYRGMII(self.platform.request("eth_clocks"),
                                                  self.platform.request("eth"))

--- a/litex/boards/targets/kc705.py
+++ b/litex/boards/targets/kc705.py
@@ -46,10 +46,10 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCSDRAM):
-    def __init__(self, sys_clk_freq=int(125e6), **kwargs):
+    def __init__(self, sys_clk_freq=int(125e6), integrated_rom_size=0x8000, **kwargs):
         platform = kc705.Platform()
         SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq,
-                         integrated_rom_size=0x8000,
+                         integrated_rom_size=integrated_rom_size,
                          integrated_sram_size=0x8000,
                           **kwargs)
 
@@ -72,7 +72,7 @@ class EthernetSoC(BaseSoC):
     mem_map.update(BaseSoC.mem_map)
 
     def __init__(self, **kwargs):
-        BaseSoC.__init__(self, **kwargs)
+        BaseSoC.__init__(self, integrated_rom_size=0x10000, **kwargs)
 
         self.submodules.ethphy = LiteEthPHY(self.platform.request("eth_clocks"),
                                             self.platform.request("eth"), clk_freq=self.clk_freq)

--- a/litex/boards/targets/kcu105.py
+++ b/litex/boards/targets/kcu105.py
@@ -80,10 +80,10 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCSDRAM):
-    def __init__(self, sys_clk_freq=int(125e6), **kwargs):
+    def __init__(self, sys_clk_freq=int(125e6), integrated_rom_size=0x8000, **kwargs):
         platform = kcu105.Platform()
         SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq,
-                         integrated_rom_size=0x8000,
+                         integrated_rom_size=integrated_rom_size,
                          integrated_sram_size=0x8000,
                           **kwargs)
 
@@ -108,7 +108,7 @@ class EthernetSoC(BaseSoC):
     mem_map.update(BaseSoC.mem_map)
 
     def __init__(self, **kwargs):
-        BaseSoC.__init__(self, **kwargs)
+        BaseSoC.__init__(self, integrated_rom_size=0x10000, **kwargs)
 
         self.comb += self.platform.request("sfp_tx_disable_n", 0).eq(1)
         self.submodules.ethphy = KU_1000BASEX(self.crg.cd_clk200.clk,

--- a/litex/boards/targets/netv2.py
+++ b/litex/boards/targets/netv2.py
@@ -48,10 +48,10 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCSDRAM):
-    def __init__(self, sys_clk_freq=int(100e6), **kwargs):
+    def __init__(self, sys_clk_freq=int(100e6), integrated_rom_size=0x8000, **kwargs):
         platform = netv2.Platform()
         SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq,
-                         integrated_rom_size=0x8000,
+                         integrated_rom_size=integrated_rom_size,
                          integrated_sram_size=0x8000,
                          **kwargs)
 
@@ -74,7 +74,7 @@ class EthernetSoC(BaseSoC):
     mem_map.update(BaseSoC.mem_map)
 
     def __init__(self, **kwargs):
-        BaseSoC.__init__(self, **kwargs)
+        BaseSoC.__init__(self, integrated_rom_size=0x10000, **kwargs)
 
         self.submodules.ethphy = LiteEthPHYRMII(self.platform.request("eth_clocks"),
                                                 self.platform.request("eth"))

--- a/litex/boards/targets/nexys4ddr.py
+++ b/litex/boards/targets/nexys4ddr.py
@@ -49,10 +49,10 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCSDRAM):
-    def __init__(self, sys_clk_freq=int(100e6), **kwargs):
+    def __init__(self, sys_clk_freq=int(100e6), integrated_rom_size=0x8000, **kwargs):
         platform = nexys4ddr.Platform()
         SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq,
-                         integrated_rom_size=0x8000,
+                         integrated_rom_size=integrated_rom_size,
                          integrated_sram_size=0x8000,
                          **kwargs)
 
@@ -76,7 +76,7 @@ class EthernetSoC(BaseSoC):
     mem_map.update(BaseSoC.mem_map)
 
     def __init__(self, **kwargs):
-        BaseSoC.__init__(self, **kwargs)
+        BaseSoC.__init__(self, integrated_rom_size=0x10000, **kwargs)
 
         self.submodules.ethphy = LiteEthPHYRMII(self.platform.request("eth_clocks"),
                                                 self.platform.request("eth"))

--- a/litex/boards/targets/nexys_video.py
+++ b/litex/boards/targets/nexys_video.py
@@ -49,10 +49,10 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCSDRAM):
-    def __init__(self, sys_clk_freq=int(100e6), **kwargs):
+    def __init__(self, sys_clk_freq=int(100e6), integrated_rom_size=0x8000, **kwargs):
         platform = nexys_video.Platform()
         SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq,
-                         integrated_rom_size=0x8000,
+                         integrated_rom_size=integrated_rom_size,
                          integrated_sram_size=0x8000,
                          **kwargs)
 
@@ -75,7 +75,7 @@ class EthernetSoC(BaseSoC):
     mem_map.update(BaseSoC.mem_map)
 
     def __init__(self, **kwargs):
-        BaseSoC.__init__(self, **kwargs)
+        BaseSoC.__init__(self, integrated_rom_size=0x10000, **kwargs)
 
         self.submodules.ethphy = LiteEthPHYRGMII(self.platform.request("eth_clocks"),
                                                  self.platform.request("eth"))

--- a/litex/boards/targets/simple.py
+++ b/litex/boards/targets/simple.py
@@ -19,10 +19,10 @@ from liteeth.mac import LiteEthMAC
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, platform, **kwargs):
+    def __init__(self, platform, integrated_rom_size=0x8000, **kwargs):
         sys_clk_freq = int(1e9/platform.default_clk_period)
         SoCCore.__init__(self, platform, clk_freq=sys_clk_freq,
-            integrated_rom_size=0x8000,
+            integrated_rom_size=integrated_rom_size,
             integrated_main_ram_size=16*1024,
             **kwargs)
         self.submodules.crg = CRG(platform.request(platform.default_clk_name))
@@ -35,7 +35,7 @@ class EthernetSoC(BaseSoC):
     }
     mem_map.update(BaseSoC.mem_map)
 
-    def __init__(self, platform, **kwargs):
+    def __init__(self, platform, integrated_rom_size=0x10000, **kwargs):
         BaseSoC.__init__(self, platform, **kwargs)
 
         self.submodules.ethphy = LiteEthPHY(platform.request("eth_clocks"),

--- a/litex/boards/targets/versa_ecp5.py
+++ b/litex/boards/targets/versa_ecp5.py
@@ -76,10 +76,10 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCSDRAM):
-    def __init__(self, sys_clk_freq=int(75e6), toolchain="diamond", **kwargs):
+    def __init__(self, sys_clk_freq=int(75e6), toolchain="diamond", integrated_rom_size=0x8000, **kwargs):
         platform = versa_ecp5.Platform(toolchain=toolchain)
         SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq,
-                          integrated_rom_size=0x8000,
+                          integrated_rom_size=integrated_rom_size,
                           **kwargs)
 
         # crg
@@ -107,7 +107,7 @@ class EthernetSoC(BaseSoC):
     mem_map.update(BaseSoC.mem_map)
 
     def __init__(self, toolchain="diamond", **kwargs):
-        BaseSoC.__init__(self, toolchain=toolchain, **kwargs)
+        BaseSoC.__init__(self, toolchain=toolchain, integrated_rom_size=0x10000, **kwargs)
 
         self.submodules.ethphy = LiteEthPHYRGMII(
             self.platform.request("eth_clocks"),

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -202,6 +202,15 @@ class SoCCore(Module):
             self.soc_mem_map["csr"]  = 0x12000000
             csr_alignment = 64
 
+        # Mainline Linux OpenRISC arch code requires Linux kernel to be loaded
+        # at the physical address of 0x0. As we are running Linux from the
+        # MAIN_RAM region - move it to satisfy that requirement.
+        if cpu_type == "mor1kx" and cpu_variant == "linux":
+            self.soc_mem_map["main_ram"] = 0x00000000
+            self.soc_mem_map["rom"]      = 0x10000000
+            self.soc_mem_map["sram"]     = 0x50000000
+            self.soc_mem_map["csr"]      = 0x60000000
+
         if cpu_type == "None":
             cpu_type = None
 

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -43,6 +43,15 @@ static void __attribute__((noreturn)) boot(unsigned long r1, unsigned long r2, u
 #ifdef CONFIG_L2_SIZE
 	flush_l2_cache();
 #endif
+
+#if defined(CONFIG_CPU_TYPE_MOR1KX) && defined(CONFIG_CPU_VARIANT_LINUX)
+	/* Mainline Linux expects to have exception vector base address set to the
+	 * base address of Linux kernel; it also expects to be run with an offset
+	 * of 0x100. */
+	mtspr(SPR_EVBAR, addr);
+	addr += 0x100;
+#endif
+
 	boot_helper(r1, r2, r3, addr);
 	while(1);
 }


### PR DESCRIPTION
This increases integrated ROM size to fit bios with ethernet for mork1x and adapts memory map for this CPU to enable mainline Linux.