### PR TITLE
RFC: optional '-nowidelut' flag for yosys synth_ecp5

### DIFF
--- a/litex/boards/targets/versa_ecp5.py
+++ b/litex/boards/targets/versa_ecp5.py
@@ -11,6 +11,8 @@ from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex.boards.platforms import versa_ecp5
 
+from litex.build.lattice.trellis import yosys_args, yosys_argdict
+
 from litex.soc.cores.clock import *
 from litex.soc.integration.soc_sdram import *
 from litex.soc.integration.builder import *
@@ -133,6 +135,7 @@ def main():
         help='gateware toolchain to use, diamond (default) or  trellis')
     builder_args(parser)
     soc_sdram_args(parser)
+    yosys_args(parser)
     parser.add_argument("--sys-clk-freq", default=75e6,
                         help="system clock frequency (default=75MHz)")
     parser.add_argument("--with-ethernet", action="store_true",
@@ -142,7 +145,7 @@ def main():
     cls = EthernetSoC if args.with_ethernet else BaseSoC
     soc = cls(toolchain=args.toolchain, sys_clk_freq=int(float(args.sys_clk_freq)), **soc_sdram_argdict(args))
     builder = Builder(soc, **builder_argdict(args))
-    builder.build()
+    builder.build(**yosys_argdict(args))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
NOTE: this is a RFC, and probably should be re-spun as a more elegant, less
"hacky" modification to the ecp5versa trellis build harness. I think I'd like to gather
feedback and force-push this at least once more before it getting applied...
Thanks,
--Gabriel

Passing '-nowidelut' to yosys' synth_ecp5 command improves area utilization
to the point where a (linux variant) rocket-chip based design will fit on a
versa_ecp5 board. Usually '-nowidelut' incurs a timing penalty, but that is
then mitigated by using DSP inference (enabled by default from yosys commit
8474c5b3).

Off by default, this flag can be enabled by adding '--yosys-nowidelut=True'
to the litex/boards/targets/versa_ecp5.py command line.