### PR TITLE
builder: use the SoC's existing shadow base with get_csr_header()

### DIFF
--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -109,7 +109,10 @@ class Builder:
             cpu_interface.get_mem_header(self.soc.mem_regions))
         write_to_file(
             os.path.join(generated_dir, "csr.h"),
-            cpu_interface.get_csr_header(self.soc.csr_regions, self.soc.constants))
+            cpu_interface.get_csr_header(self.soc.csr_regions,
+                                         self.soc.constants,
+                                         shadow_base=self.soc.shadow_base)
+        )
         write_to_file(
             os.path.join(generated_dir, "git.h"),
             cpu_interface.get_git_header()


### PR DESCRIPTION
Both the SoC and get_csr_header() have independently set defaults
for the value of 'shadow_base'. If the SoC's value was modified,
ensure that get_csr_header() uses the modified value instead of
its own default.

Signed-off-by: Gabriel Somlo <somlo@cmu.edu>