### PR TITLE
cpu/rocket: swap main_mem and io regions

### DIFF
--- a/litex/soc/cores/cpu/rocket/core.py
+++ b/litex/soc/cores/cpu/rocket/core.py
@@ -56,15 +56,17 @@ class RocketRV64(CPU):
     endianness           = "little"
     gcc_triple           = ("riscv64-unknown-elf")
     linker_output_format = "elf64-littleriscv"
-    io_regions           = {0x80000000: 0x80000000} # origin, length
+    io_regions           = {0x10000000: 0x70000000} # origin, length
 
     @property
     def mem_map(self):
         # Rocket reserves the first 256Mbytes for internal use, so we must change default mem_map.
         return {
-            "rom"  : 0x10000000,
-            "sram" : 0x11000000,
-            "csr"  : 0x92000000,
+            "rom"      : 0x10000000,
+            "sram"     : 0x11000000,
+            "csr"      : 0x12000000,
+            "ethmac"   : 0x30000000,
+            "main_ram" : 0x80000000,
         }
 
     @property


### PR DESCRIPTION
The total size of RAM (main_mem) can be expected to vary significantly,
and often exceed the size needed for MMIO allocations by a large margin.

As such, place Rocket's MMIO (io regions) below 0x8000_0000, and start
the RAM (main_mem) at 0x8000_0000, with nothing above it to limit its
future growth.

Also, bump the pre-built Rocket verilog submodule to an updated version,
which also comes with matching changes to the way MMIO and RAM accesses
are mapped and routed to their respective AXI interfaces.

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>