### PR TITLE
[feature] Add SystemVerilog support for the Vivado builder

### DIFF
--- a/litex/build/generic_platform.py
+++ b/litex/build/generic_platform.py
@@ -334,7 +334,7 @@ class GenericPlatform:
         for f in filenames:
             self.add_source(os.path.join(path, f), language, library)
 
-    def add_source_dir(self, path, recursive=True, library=None):
+    def add_source_dir(self, path, recursive=True, language=None, library=None):
         dir_files = []
         if recursive:
             for root, dirs, files in os.walk(path):
@@ -345,9 +345,7 @@ class GenericPlatform:
                 if os.path.isfile(os.path.join(path, item)):
                     dir_files.append(os.path.join(path, item))
         for filename in dir_files:
-            language = tools.language_by_filename(filename)
-            if language is not None:
-                self.add_source(filename, language, library)
+            self.add_source(filename, language, library)
 
     def add_verilog_include_path(self, path):
         self.verilog_include_paths.add(os.path.abspath(path))

--- a/litex/build/tools.py
+++ b/litex/build/tools.py
@@ -19,8 +19,10 @@ def language_by_filename(name):
     extension = name.rsplit(".")[-1]
     if extension in ["v", "vh", "vo"]:
         return "verilog"
-    if extension in ["vhd", "vhdl", "vho"]:
+    elif extension in ["vhd", "vhdl", "vho"]:
         return "vhdl"
+    elif extension in ["sv"]:
+        return "systemverilog"
     return None
 
 

--- a/litex/build/xilinx/vivado.py
+++ b/litex/build/xilinx/vivado.py
@@ -126,10 +126,16 @@ class XilinxVivadoToolchain:
             # "-include_dirs {}" crashes Vivado 2016.4
             for filename, language, library in sources:
                 filename_tcl = "{" + filename + "}"
-                tcl.append("add_files " + filename_tcl)
-                if language == "vhdl":
+                if ("systemverilog" == language):
+                    tcl.append("read_verilog -sv " + filename_tcl)
+                elif ("verilog" == language):
+                    tcl.append("read_verilog " + filename_tcl)
+                elif ("vhdl" == language):
+                    tcl.append("read_vhdl " + filename_tcl)
                     tcl.append("set_property library {} [get_files {}]"
                                .format(library, filename_tcl))
+                else:
+                    tcl.append("add_files " + filename_tcl)
         for filename in edifs:
             filename_tcl = "{" + filename + "}"
             tcl.append("read_edif " + filename_tcl)


### PR DESCRIPTION
The actual Verilog version used by Vivado is 2001. This version doesn't support features like the `$bits` "system call" which has been added in Verilog 2005. To be able to use these nice features, Xilinx recommends to add these files as SystemVerilog files.
This PR adds the possibility to declare files as SystemVerilog files with `add_sources` and `add_source_dir` (new `language` parameter). The ".sv" file extension has also been added for inferred file type identification.