### PR TITLE
bios: Increment address when writing to flash

### DIFF
--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -210,7 +210,7 @@ static void fw(char *addr, char *value, char *count)
 			return;
 		}
 	}
-	for (i=0;i<count2;i++) write_to_flash(addr2, (unsigned char *)&value2, 4);
+	for (i=0;i<count2;i++) write_to_flash(addr2 + i * 4, (unsigned char *)&value2, 4);
 }
 #endif
 


### PR DESCRIPTION
When writing multiple words using the "fw" command from bios, the address it wrote to wasn't incremented so the same address was just written to multiple times.