### PR TITLE
cpu/rocket, soc_sdram: Bypass WB bus for LiteDRAM <-> Rocket link

### DIFF
--- a/litex/soc/cores/cpu/rocket/core.py
+++ b/litex/soc/cores/cpu/rocket/core.py
@@ -88,10 +88,9 @@ class RocketRV64(CPU):
         self.mem_axi   =  mem_axi = axi.AXIInterface(data_width=64, address_width=32, id_width=4)
         self.mmio_axi  = mmio_axi = axi.AXIInterface(data_width=64, address_width=32, id_width=4)
 
-        self.mem_wb    =  mem_wb = wishbone.Interface(data_width=64, adr_width=29)
         self.mmio_wb   = mmio_wb = wishbone.Interface(data_width=64, adr_width=29)
 
-        self.buses     = [mem_wb, mmio_wb]
+        self.buses     = [mmio_wb]
 
         # # #
 
@@ -207,14 +206,12 @@ class RocketRV64(CPU):
         )
 
         # adapt axi interfaces to wishbone
-        mem_a2w  = ResetInserter()(axi.AXI2Wishbone(mem_axi, mem_wb, base_address=0))
         mmio_a2w = ResetInserter()(axi.AXI2Wishbone(mmio_axi, mmio_wb, base_address=0))
         # NOTE: AXI2Wishbone FSMs must be reset with the CPU!
         self.comb += [
-            mem_a2w.reset.eq( ResetSignal() | self.reset),
             mmio_a2w.reset.eq(ResetSignal() | self.reset),
         ]
-        self.submodules += mem_a2w, mmio_a2w
+        self.submodules += mmio_a2w
 
         # add verilog sources
         self.add_sources(platform, variant)

--- a/litex/soc/integration/soc_sdram.py
+++ b/litex/soc/integration/soc_sdram.py
@@ -11,6 +11,7 @@ from litex.soc.interconnect import wishbone
 from litex.soc.integration.soc_core import *
 
 from litedram.frontend.wishbone import *
+from litedram.frontend.axi import *
 from litedram.core import LiteDRAMCore
 
 __all__ = ["SoCSDRAM", "soc_sdram_args", "soc_sdram_argdict"]
@@ -52,18 +53,25 @@ class SoCSDRAM(SoCCore):
             clk_freq        = self.clk_freq,
             **kwargs)
 
-        # SoC <--> L2 Cache <--> LiteDRAM ----------------------------------------------------------
-        if self.with_wishbone:
-            # LiteDRAM port ------------------------------------------------------------------------
-            port = self.sdram.crossbar.get_port()
-            port.data_width = 2**int(log2(port.data_width)) # Round to nearest power of 2
+        # LiteDRAM port ------------------------------------------------------------------------
+        port = self.sdram.crossbar.get_port()
+        port.data_width = 2**int(log2(port.data_width)) # Round to nearest power of 2
 
-            # Parameters ---------------------------------------------------------------------------
-            main_ram_size = 2**(geom_settings.bankbits +
-                                geom_settings.rowbits +
-                                geom_settings.colbits)*phy.settings.databits//8
-            main_ram_size = min(main_ram_size, 0x20000000) # FIXME: limit to 512MB for now
+        # Main RAM size ------------------------------------------------------------------------
+        main_ram_size = 2**(geom_settings.bankbits +
+                            geom_settings.rowbits +
+                            geom_settings.colbits)*phy.settings.databits//8
+        main_ram_size = min(main_ram_size, 0x20000000) # FIXME: limit to 512MB for now
 
+        # SoC [<--> L2 Cache] <--> LiteDRAM ----------------------------------------------------
+        if self.cpu.name == "rocket":
+            # Rocket has its own I/D L1 cache, so connect directly to LiteDRAM:
+            self.submodules += LiteDRAMAXI2Native(self.cpu.mem_axi, port,
+                                                  base_address=self.mem_map["main_ram"])
+            # Register main_ram region (so it will be added to generated/mem.h):
+            self.add_memory_region("main_ram", self.mem_map["main_ram"], main_ram_size)
+        elif self.with_wishbone:
+            # Insert L2 cache inbetween Wishbone bus and LiteDRAM
             l2_size = max(self.l2_size, int(2*port.data_width/8)) # L2 has a minimal size, use it if lower
             l2_size = 2**int(log2(l2_size))                       # Round to nearest power of 2
 


### PR DESCRIPTION
Rocket provides its own L1 i/d cache, and two AXI master ports:
cached RAM accesses are routed over a dedicated 'mem_axi' port,
while uncached MMIO accesses are separately routed over another
dedicated port, 'mmio_axi'.

We bypass the Litex Wishbone bus when Rocket accesses the main
RAM, by connecting 'mem_axi' directly to LiteDRAM.

Remaining CPU models will continue to share the Litex Wishbone
bus for both RAM and MMIO (a.k.a. CSR) accesses.

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>