### PR TITLE
[RFC] Linker region concept

### DIFF
--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -67,6 +67,7 @@ class Builder:
     def _generate_includes(self):
         cpu_type = self.soc.cpu_type
         memory_regions = self.soc.get_memory_regions()
+        linker_regions = self.soc.get_linker_regions()
         flash_boot_address = getattr(self.soc, "flash_boot_address", None)
         shadow_base = getattr(self.soc, "shadow_base", None)
         csr_regions = self.soc.get_csr_regions()
@@ -109,11 +110,11 @@ class Builder:
             cpu_interface.get_linker_output_format(self.soc.cpu))
         write_to_file(
             os.path.join(generated_dir, "regions.ld"),
-            cpu_interface.get_linker_regions(memory_regions))
+            cpu_interface.get_linker_regions(memory_regions + linker_regions))
 
         write_to_file(
             os.path.join(generated_dir, "mem.h"),
-            cpu_interface.get_mem_header(memory_regions, flash_boot_address, shadow_base))
+            cpu_interface.get_mem_header(memory_regions + linker_regions, flash_boot_address, shadow_base))
         write_to_file(
             os.path.join(generated_dir, "csr.h"),
             cpu_interface.get_csr_header(csr_regions, constants))


### PR DESCRIPTION
I was recently working on supporting `icefun` platform in [LiteX-BuildEnv](https://github.com/timvideos/litex-buildenv) and [Renode](https://github.com/renode/renode).

The problem I stumbled upon was that `icefun` keeps both LiteX BIOS and the firmware in flash and executes the code directly from it. The platform is defined in a way that it generates 3 memory regions:
* [spiflash](https://github.com/timvideos/litex-buildenv/blob/master/targets/icefun/base.py#L88),
* [rom](https://github.com/timvideos/litex-buildenv/blob/master/targets/icefun/base.py#L88)
* [user_flash](https://github.com/timvideos/litex-buildenv/blob/master/targets/icefun/base.py#L93)
where `rom` and `user_flash` are the subregions of `spiflash`.

BTW: Shouldn't [this code](https://github.com/enjoy-digital/litex/blob/master/litex/soc/integration/soc_core.py#L381-L382) prevent such configurations?

I believe that the problem is that `rom` is needed by [the linker script](https://github.com/enjoy-digital/litex/blob/master/litex/soc/software/bios/linker.ld#L13) and `user_flash` is needed by [another one](https://github.com/timvideos/litex-buildenv/blob/master/firmware/linker-xip.ld#L13), but currently the only way of generating those symbols is by using `add_memory_region`.

This PR propose a new way of handling this problem. The idea behind "linker regions" is to allow defining memory subregions for the use of linker scripts without generating actual overlapping memory regions.

What do you think about it?