### PR TITLE
Improve the error message on memory region conflict.

### DIFF
--- a/litex/soc/integration/common.py
+++ b/litex/soc/integration/common.py
@@ -83,6 +83,11 @@ class SoCMemRegion:
         self.length = length
         self.type   = type
 
+    def __str__(self):
+        return "<SoCMemRegion 0x{:x} 0x{:x} {}>".format(
+            self.origin, self.length, self.type)
+
+
 class SoCCSRRegion:
     def __init__(self, origin, busword, obj):
         self.origin  = origin

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -401,7 +401,11 @@ class SoCCore(Module):
         self.mem_regions[name] = SoCMemRegion(origin, length, type)
         overlap = self.check_regions_overlap(self.mem_regions)
         if overlap is not None:
-            raise ValueError("Memory region conflict between {} and {}".format(overlap[0], overlap[1]))
+            o0, o1 = overlap[0], overlap[1]
+            raise ValueError("Memory region conflict between {} ({}) and {} ({})".format(
+                o0, self.mem_regions[o0],
+                o1, self.mem_regions[o1],
+            ))
 
     def register_mem(self, name, address, interface, size=0x10000000):
         self.add_wb_slave(address, interface, size)


### PR DESCRIPTION
Before;
```
ValueError: Memory region conflict between rom and main_ram
```

After;
```
ValueError: Memory region conflict between rom (<SoCMemRegion 0x10000000 0x10000 cached>) and main_ram (<SoCMemRegion 0x0 0x20000000 cached>)
```

Fixes #296.