### PR TITLE
RFC: Direct link between Rocket/mem_axi <--> LiteDRAM dataport

### DIFF
--- a/litex/soc/cores/cpu/rocket/core.py
+++ b/litex/soc/cores/cpu/rocket/core.py
@@ -88,10 +88,9 @@ class RocketRV64(CPU):
         self.mem_axi   =  mem_axi = axi.AXIInterface(data_width=64, address_width=32, id_width=4)
         self.mmio_axi  = mmio_axi = axi.AXIInterface(data_width=64, address_width=32, id_width=4)
 
-        self.mem_wb    =  mem_wb = wishbone.Interface(data_width=64, adr_width=29)
         self.mmio_wb   = mmio_wb = wishbone.Interface(data_width=64, adr_width=29)
 
-        self.buses     = [mem_wb, mmio_wb]
+        self.buses     = [mmio_wb]
 
         # # #
 
@@ -207,14 +206,11 @@ class RocketRV64(CPU):
         )
 
         # adapt axi interfaces to wishbone
-        mem_a2w  = ResetInserter()(axi.AXI2Wishbone(mem_axi, mem_wb, base_address=0))
-        mmio_a2w = ResetInserter()(axi.AXI2Wishbone(mmio_axi, mmio_wb, base_address=0))
         # NOTE: AXI2Wishbone FSMs must be reset with the CPU!
-        self.comb += [
-            mem_a2w.reset.eq( ResetSignal() | self.reset),
-            mmio_a2w.reset.eq(ResetSignal() | self.reset),
-        ]
-        self.submodules += mem_a2w, mmio_a2w
+        mmio_a2w = ResetInserter()(axi.AXI2Wishbone(mmio_axi, mmio_wb,
+                                                    base_address=0))
+        self.comb += mmio_a2w.reset.eq(ResetSignal() | self.reset)
+        self.submodules += mmio_a2w
 
         # add verilog sources
         self.add_sources(platform, variant)

--- a/litex/soc/cores/cpu/rocket/core.py
+++ b/litex/soc/cores/cpu/rocket/core.py
@@ -50,6 +50,13 @@ GCC_FLAGS = {
     "full":     "-march=rv64imafdc -mabi=lp64 ",
 }
 
+AXI_DATA_WIDTHS = {
+    # variant : (mem, mmio)
+    "standard": ( 64,  64),
+    "linux":    ( 64,  64),
+    "full":     ( 64,  64),
+}
+
 class RocketRV64(CPU):
     name                 = "rocket"
     data_width           = 64
@@ -85,10 +92,12 @@ class RocketRV64(CPU):
         self.reset     = Signal()
         self.interrupt = Signal(4)
 
-        self.mem_axi   =  mem_axi = axi.AXIInterface(data_width=64, address_width=32, id_width=4)
-        self.mmio_axi  = mmio_axi = axi.AXIInterface(data_width=64, address_width=32, id_width=4)
+        mem_dw, mmio_dw = AXI_DATA_WIDTHS[self.variant]
 
-        self.mmio_wb   = mmio_wb = wishbone.Interface(data_width=64, adr_width=29)
+        self.mem_axi   =  mem_axi = axi.AXIInterface(data_width= mem_dw, address_width=32, id_width=4)
+        self.mmio_axi  = mmio_axi = axi.AXIInterface(data_width=mmio_dw, address_width=32, id_width=4)
+
+        self.mmio_wb   = mmio_wb = wishbone.Interface(data_width=mmio_dw, adr_width=32-log2_int(mmio_dw//8))
 
         self.buses     = [mmio_wb]
 

--- a/litex/soc/integration/soc_sdram.py
+++ b/litex/soc/integration/soc_sdram.py
@@ -11,6 +11,7 @@ from litex.soc.interconnect import wishbone
 from litex.soc.integration.soc_core import *
 
 from litedram.frontend.wishbone import *
+from litedram.frontend.axi import *
 from litedram.core import LiteDRAMCore
 
 __all__ = ["SoCSDRAM", "soc_sdram_args", "soc_sdram_argdict"]
@@ -52,18 +53,39 @@ class SoCSDRAM(SoCCore):
             clk_freq        = self.clk_freq,
             **kwargs)
 
-        # SoC <--> L2 Cache <--> LiteDRAM ----------------------------------------------------------
-        if self.with_wishbone:
-            # LiteDRAM port ------------------------------------------------------------------------
-            port = self.sdram.crossbar.get_port()
-            port.data_width = 2**int(log2(port.data_width)) # Round to nearest power of 2
+        # LiteDRAM port ------------------------------------------------------------------------
+        port = self.sdram.crossbar.get_port()
+        port.data_width = 2**int(log2(port.data_width)) # Round to nearest power of 2
 
-            # Parameters ---------------------------------------------------------------------------
-            main_ram_size = 2**(geom_settings.bankbits +
-                                geom_settings.rowbits +
-                                geom_settings.colbits)*phy.settings.databits//8
-            main_ram_size = min(main_ram_size, 0x20000000) # FIXME: limit to 512MB for now
+        # Main RAM size ------------------------------------------------------------------------
+        main_ram_size = 2**(geom_settings.bankbits +
+                            geom_settings.rowbits +
+                            geom_settings.colbits)*phy.settings.databits//8
+        main_ram_size = min(main_ram_size, 0x20000000) # FIXME: limit to 512MB for now
 
+        # SoC [<--> L2 Cache] <--> LiteDRAM ----------------------------------------------------
+        if self.cpu.name == "rocket":
+            # Rocket has its own I/D L1 cache: connect directly to LiteDRAM, also bypassing MMIO/CSR wb bus:
+            if port.data_width == self.cpu.mem_axi.data_width:
+                # straightforward AXI link, no data_width conversion needed:
+                self.submodules += LiteDRAMAXI2Native(self.cpu.mem_axi, port,
+                                                      base_address=self.mem_map["main_ram"])
+            else:
+                # FIXME: replace WB data-width converter with native AXI converter!!!
+                mem_wb  = wishbone.Interface(data_width=self.cpu.mem_axi.data_width,
+                                             adr_width=32-log2_int(self.cpu.mem_axi.data_width//8))
+                # NOTE: AXI2Wishbone FSMs must be reset with the CPU!
+                mem_a2w = ResetInserter()(AXI2Wishbone(self.cpu.mem_axi, mem_wb, base_address=0))
+                self.comb += mem_a2w.reset.eq(ResetSignal() | self.cpu.reset)
+                self.submodules += mem_a2w
+                litedram_wb = wishbone.Interface(port.data_width)
+                self.submodules += LiteDRAMWishbone2Native(litedram_wb, port,
+                                                           base_address=self.mem_map["main_ram"])
+                self.submodules += wishbone.Converter(mem_wb, litedram_wb)
+            # Register main_ram region (so it will be added to generated/mem.h):
+            self.add_memory_region("main_ram", self.mem_map["main_ram"], main_ram_size)
+        elif self.with_wishbone:
+            # Insert L2 cache inbetween Wishbone bus and LiteDRAM
             l2_size = max(self.l2_size, int(2*port.data_width/8)) # L2 has a minimal size, use it if lower
             l2_size = 2**int(log2(l2_size))                       # Round to nearest power of 2
 

--- a/litex/soc/integration/soc_sdram.py
+++ b/litex/soc/integration/soc_sdram.py
@@ -61,7 +61,6 @@ class SoCSDRAM(SoCCore):
         main_ram_size = 2**(geom_settings.bankbits +
                             geom_settings.rowbits +
                             geom_settings.colbits)*phy.settings.databits//8
-        main_ram_size = min(main_ram_size, 0x20000000) # FIXME: limit to 512MB for now
 
         # SoC [<--> L2 Cache] <--> LiteDRAM ----------------------------------------------------
         if self.cpu.name == "rocket":


### PR DESCRIPTION
Attn @enjoy-digital -- do not (immediately) pull into upstream LiteX, let's have a conversation and review first -- maybe it isn't even the right thing to do :) Please also see the related experiment regarding data width at https://github.com/enjoy-digital/litex/issues/299

Use a direct AXI point-to-point link between rocket's cached-ram axi port (mem_axi) and LiteDRAM, whenever the data width of the two ports matches.

For now, as a workaround, use Wishbone based data width conversion when the port widths are mismatched (which is rather inefficient). A future improvement might be to implement a native axi data-width converter.

Additionally, this series prepares Rocket's wrapper file to allow future variants with different, parameterized axi_mem data widths.

Finally, remove the limitation on the maximum size of usable ram (to allow full utilization of the 1GB of RAM present on the trellis board)