### PR TITLE
adding support to flash an FBI image

### DIFF
--- a/litex/soc/software/bios/sfl.h
+++ b/litex/soc/software/bios/sfl.h
@@ -20,6 +20,8 @@ struct sfl_frame {
 #define SFL_CMD_LOAD		0x01
 #define SFL_CMD_JUMP		0x02
 #define SFL_CMD_LOAD_NO_CRC	0x03
+#define SFL_CMD_FLASH		0x04
+#define SFL_CMD_REBOOT		0x05
 
 /* Replies */
 #define SFL_ACK_SUCCESS		'K'


### PR DESCRIPTION
This PR adds the "--flash" parameter for the lxterm tool, and the implementation for it in the BIOS. It uploads an FBI image with the same commands as serial-flash, but instead of storing it in the SDRAM, it stores it in the flash (currently at the fixed start address 0). After flashing, it executes a reboot, to test the new image.
Tested with a MAX1000 board, with this board configuration:
https://github.com/FrankBuss/litex-boards/blob/master/litex_boards/partner/targets/max1000.py
and with this baremetal test program:
https://github.com/FrankBuss/litex-baremetal-test
Sample session:
```
frank@xps8900:~/litex-baremetal-test$ make
riscv64-unknown-elf-gcc -std=gnu99 -c -Os -D__vexriscv__ -march=rv32im  -mabi=ilp32 -g3 -fomit-frame-pointer -Wall -fno-builtin -nostdinc -fexceptions -Wstrict-prototypes -Wold-style-definition -Wmissing-prototypes -o crt0-vexriscv.o crt0-vexriscv.S
riscv64-unknown-elf-gcc -std=gnu99 -c -Os -D__vexriscv__ -march=rv32im  -mabi=ilp32 -g3 -fomit-frame-pointer -Wall -fno-builtin -nostdinc -fexceptions -Wstrict-prototypes -Wold-style-definition -Wmissing-prototypes -o main.o main.c
riscv64-unknown-elf-gcc -std=gnu99 -D__vexriscv__ -march=rv32im  -mabi=ilp32 -nostdlib -nodefaultlibs -T linker.ld -N -o test.elf crt0-vexriscv.o main.o
riscv64-unknown-elf-objcopy -O binary test.elf test.bin
chmod -x test.bin
python3 -m litex.soc.software.mkmscimg -o test.fbi -l -f test.bin
chmod -x test.fbi
riscv64-unknown-elf-objdump -S test.elf > test.dump
frank@xps8900:~/litex-baremetal-test$ lxterm --serial-boot --kernel test.fbi /dev/ttyUSB0 --flash
[LXTERM] Starting....
�C��IOS CRC passed (8f489378)

 Migen git sha1: 94db729
 LiteX git sha1: c96f31a9

--=============== SoC ==================--
CPU:       VexRiscv @ 50MHz
ROM:       32KB
SRAM:      4KB
L2:        8KB
MAIN-RAM:  8192KB

--========== Initialization ============--
Initializing SDRAM...
SDRAM now under hardware control
Memtest OK

--============== Boot ==================--
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
[LXTERM] Received firmware download request from the device.
[LXTERM] Flashing test.fbi (380 bytes)...
[LXTERM] Upload complete (1.5KB/s).
[LXTERM] Rebooting the device.
[LXTERM] Done.

        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|

 (c) Copyright 2012-2019 Enjoy-Digital

 BIOS built on Nov  8 2019 17:11:11
 BIOS CRC passed (8f489378)

 Migen git sha1: 94db729
 LiteX git sha1: c96f31a9

--=============== SoC ==================--
CPU:       VexRiscv @ 50MHz
ROM:       32KB
SRAM:      4KB
L2:        8KB
MAIN-RAM:  8192KB

--========== Initialization ============--
Initializing SDRAM...
SDRAM now under hardware control
Memtest OK

--============== Boot ==================--
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
Timeout
Booting from flash...
Loading 372 bytes from flash...
Executing booted program at 0x40000000

--============= Liftoff! ===============--
Hello World!
hello World again!
hello World again!
hello World again!
hello World again!
hello World again!
The end.
```
After the `lxterm` call, `quartus_pgm -m jtag -o "p;soc_basesoc_max1000/gateware/top.sof"` was executed in a second shell to load the FPGA confiugration, which then started the flash process in the first shell.