### PR TITLE
change >512 B CSR memory exception to a warning

### DIFF
--- a/litex/soc/interconnect/csr_bus.py
+++ b/litex/soc/interconnect/csr_bus.py
@@ -86,7 +86,7 @@ class SRAM(Module):
             mem = Memory(data_width, mem_or_size//(data_width//8), init=init)
         mem_size = int(mem.width*mem.depth/8)
         if mem_size > 512:
-            raise ValueError("Memory too large to fit in CSR region ({} > 512 bytes)".format(mem_size))
+            print("WARNING: memory > 512 bytes in CSR region requires paged access".format(mem_size))
         csrw_per_memw = (mem.width + data_width - 1)//data_width
         word_bits = log2_int(csrw_per_memw)
         page_bits = log2_int((mem.depth*csrw_per_memw + 511)//512, False)


### PR DESCRIPTION
So regarding https://github.com/enjoy-digital/litex/issues/289 I suggest, at least for now, to demote the exception to a warning, because actually > 512 B memories work and are handled by the code just below this exception.