### PR TITLE
soc_sdram, bios/sdram: support sdram init for csr_data_width <= 32

### DIFF
--- a/litex/soc/integration/soc_sdram.py
+++ b/litex/soc/integration/soc_sdram.py
@@ -29,8 +29,8 @@ class SoCSDRAM(SoCCore):
     def __init__(self, platform, clk_freq, l2_size=8192, **kwargs):
         SoCCore.__init__(self, platform, clk_freq, **kwargs)
         if not self.integrated_main_ram_size:
-            if self.cpu_type is not None and self.csr_data_width != 8:
-                 raise NotImplementedError("BIOS supports SDRAM initialization only for csr_data_width=8")
+            if self.cpu_type is not None and self.csr_data_width > 32:
+                 raise NotImplementedError("BIOS supports SDRAM initialization only for csr_data_width<=32")
         self.l2_size = l2_size
 
         self._sdram_phy    = []


### PR DESCRIPTION
Read leveling tested with csr_data_width [8, 16, 32] on the
ecp5-versa5g and trellisboard (using yosys/trellis/nextpnr),
and on the nexys4ddr (using Vivado).

FIXME:
    - Not tested sdrrdbuf(), sdrrderr(), and sdrwr();
    - Still need to update write_level() routine!!!

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>