### PR TITLE
soc/cores/clock: add lock reg and assign reset

### DIFF
--- a/litex/soc/cores/clock.py
+++ b/litex/soc/cores/clock.py
@@ -92,6 +92,7 @@ class XilinxClocking(Module, AutoCSR):
 
     def expose_drp(self):
         self.drp_reset = CSR()
+        self.drp_locked = CSR()
         self.drp_read  = CSR()
         self.drp_write = CSR()
         self.drp_drdy  = CSRStatus()
@@ -261,7 +262,7 @@ class S7MMCM(XilinxClocking):
         config = self.compute_config()
         mmcm_fb = Signal()
         self.params.update(
-            p_BANDWIDTH="OPTIMIZED", o_LOCKED=self.locked,
+            p_BANDWIDTH="OPTIMIZED", o_LOCKED=self.locked, i_RST=self.reset,
 
             # VCO
             p_REF_JITTER1=0.01, p_CLKIN1_PERIOD=1e9/self.clkin_freq,


### PR DESCRIPTION
It was necessary to add drp_locked CSR for reading LOCK signal from
MMCM. Additionally, input signal RESET from MMCM was not driven by
any signal to do a proper reset of MMCM module thus it was impossible
to perform entirely correct dynamic clock reconfiguration.