### PR TITLE
soc_core: additional CSR safety assertions

### DIFF
--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -137,7 +137,7 @@ class SoCCore(Module):
         self.integrated_sram_size       = integrated_sram_size
         self.integrated_main_ram_size   = integrated_main_ram_size
 
-        assert csr_data_width in [8, 32, 64]
+        assert csr_data_width in [8, 16, 32]
         self.csr_data_width    = csr_data_width
         self.csr_address_width = csr_address_width
 
@@ -257,6 +257,7 @@ class SoCCore(Module):
         csr_alignment = max(csr_alignment, self.cpu.data_width)
         self.config["CSR_DATA_WIDTH"] = csr_data_width
         self.config["CSR_ALIGNMENT"]  = csr_alignment
+        assert csr_data_width <= csr_alignment
         self.csr_data_width = csr_data_width
         self.csr_alignment  = csr_alignment
         if with_wishbone:


### PR DESCRIPTION
Since csr_data_width=64 has probably never worked properly, remove
it as one of the possible options (to be fixed and re-added later).
Add csr_data_width=16, which has been tested and does work.

Additionally, ensure csr_data_width <= csr_alignment (prevent subregister slices
wider than the CPU's native word size or XLen).

Note: somewhat related to Issue #314 