### PR TITLE
cpu/rocket: variants with double (128b) and quad (256b) wide mem_axi

### DIFF
--- a/litex/soc/cores/cpu/__init__.py
+++ b/litex/soc/cores/cpu/__init__.py
@@ -53,6 +53,8 @@ CPU_VARIANTS = {
     "standard": [None, "std"],
     "full": [],
     "linux" : [],
+    "linuxd" : [],
+    "linuxq" : [],
 }
 CPU_VARIANTS_EXTENSIONS = ["debug", "no-dsp"]
 

--- a/litex/soc/cores/cpu/rocket/core.py
+++ b/litex/soc/cores/cpu/rocket/core.py
@@ -41,12 +41,16 @@ from litex.soc.cores.cpu import CPU
 CPU_VARIANTS = {
     "standard": "freechips.rocketchip.system.LitexConfig",
     "linux":    "freechips.rocketchip.system.LitexLinuxConfig",
+    "linuxd":   "freechips.rocketchip.system.LitexLinuxDConfig",
+    "linuxq":   "freechips.rocketchip.system.LitexLinuxQConfig",
     "full":     "freechips.rocketchip.system.LitexFullConfig",
 }
 
 GCC_FLAGS = {
     "standard": "-march=rv64imac   -mabi=lp64 ",
     "linux":    "-march=rv64imac   -mabi=lp64 ",
+    "linuxd":   "-march=rv64imac   -mabi=lp64 ",
+    "linuxq":   "-march=rv64imac   -mabi=lp64 ",
     "full":     "-march=rv64imafdc -mabi=lp64 ",
 }
 
@@ -54,6 +58,8 @@ AXI_DATA_WIDTHS = {
     # variant : (mem, mmio)
     "standard": ( 64,  64),
     "linux":    ( 64,  64),
+    "linuxd":   (128,  64),
+    "linuxq":   (256,  64),
     "full":     ( 64,  64),
 }
 

--- a/litex/soc/integration/soc_sdram.py
+++ b/litex/soc/integration/soc_sdram.py
@@ -69,10 +69,12 @@ class SoCSDRAM(SoCCore):
         if self.cpu.name == "rocket":
             # Rocket has its own I/D L1 cache: connect directly to LiteDRAM, also bypassing MMIO/CSR wb bus:
             if port.data_width == self.cpu.mem_axi.data_width:
+                print("# Matching AXI MEM data width ({})\n".format(port.data_width))
                 # straightforward AXI link, no data_width conversion needed:
                 self.submodules += LiteDRAMAXI2Native(self.cpu.mem_axi, port,
                                                       base_address=self.mem_map["main_ram"])
             else:
+                print("# Converting MEM data width: ram({}) to cpu({}), via Wishbone\n".format(port.data_width, self.cpu.mem_axi.data_width))
                 # FIXME: replace WB data-width converter with native AXI converter!!!
                 mem_wb  = wishbone.Interface(data_width=self.cpu.mem_axi.data_width,
                                              adr_width=32-log2_int(self.cpu.mem_axi.data_width//8))


### PR DESCRIPTION
Various development boards' native LiteDRAM ports may have
native data widths of either 64 (nexys4ddr), 128 (ecp5versa),
or 256 (trellisboard) bits. Add Rocket variants configured
with mem_axi ports of matching data widths, so that a point
to point connection between the CPU's memory port and LiteDRAM
can be accomplished without any additional data width conversion
gateware.

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>