### PR TITLE
RFC: Updated CSR accessors

### DIFF
--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -43,10 +43,16 @@ class SoCController(Module, AutoCSR):
     def __init__(self):
         self._reset      = CSRStorage(1, description="""
             Write a ``1`` to this register to reset the SoC.""")
-        self._scratch    = CSRStorage(32, reset=0x12345678, description="""
-            Use this register as a scratch space to verify that software read/write accesses
-            to the Wishbone/CSR bus are working correctly. The initial reset value of 0x1234578
-            can be used to verify endianness.""")
+        #self._scratch    = CSRStorage(32, reset=0x12345678, description="""
+        #    Use this register as a scratch space to verify that software read/write accesses
+        #    to the Wishbone/CSR bus are working correctly. The initial reset value of 0x1234578
+        #    can be used to verify endianness.""")
+        self._scratch8   = CSRStorage(  8, reset=0x10)
+        self._scratch16  = CSRStorage( 16, reset=0x2021)
+        self._scratch32  = CSRStorage( 32, reset=0x30313233)
+        self._scratch48  = CSRStorage( 48, reset=0xa0a1a2a3a4a5)
+        self._scratch64  = CSRStorage( 64, reset=0x4041424344454647)
+        self._scratch128 = CSRStorage(128, reset=0x505152535455565758595a5b5c5d5e5f)
         self._bus_errors = CSRStatus(32, description="""
             Total number of Wishbone bus errors (timeouts) since last reset.""")
 

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -627,6 +627,110 @@ int main(int i, char **c)
 		printf("\n");
 	}
 
+	printf("1.scratch8: %s\n",
+		(ctrl_scratch8_read() == 0x10) ? "pass":"fail");
+	printf("1.scratch16: %s\n",
+		(ctrl_scratch16_read() == 0x2021) ? "pass":"fail");
+	printf("1.scratch32: %s\n",
+		(ctrl_scratch32_read() == 0x30313233) ? "pass":"fail");
+	printf("1.scratch48: %s\n",
+		(ctrl_scratch48_read() == 0xa0a1a2a3a4a5) ? "pass":"fail");
+	printf("1.scratch64: %s\n",
+		(ctrl_scratch64_read() == 0x4041424344454647) ? "pass":"fail");
+	union {
+		uint64_t ll[2];
+		uint32_t  l[4];
+		uint16_t  s[8];
+		uint8_t  c[16];
+	} foo;
+/* write test */
+	csr_rd_buf_uint8(CSR_CTRL_SCRATCH128_ADDR, &(foo.c[0]), 16);
+	for (int i = 0; i < 16; i++)
+		foo.c[i] += 0x10;
+	csr_wr_buf_uint8(CSR_CTRL_SCRATCH128_ADDR, &(foo.c[0]), 16);
+
+	csr_rd_buf_uint16(CSR_CTRL_SCRATCH128_ADDR, &(foo.s[0]), 8);
+	for (int i = 0; i < 8; i++)
+		foo.s[i] += 0x1000;
+	csr_wr_buf_uint16(CSR_CTRL_SCRATCH128_ADDR, &(foo.s[0]), 8);
+
+	csr_rd_buf_uint32(CSR_CTRL_SCRATCH128_ADDR, &(foo.l[0]), 4);
+	for (int i = 0; i < 4; i++)
+		foo.l[i] += 0x10000000;
+	csr_wr_buf_uint32(CSR_CTRL_SCRATCH128_ADDR, &(foo.l[0]), 4);
+
+	csr_rd_buf_uint64(CSR_CTRL_SCRATCH128_ADDR, &(foo.ll[0]), 2);
+	for (int i = 0; i < 2; i++)
+		foo.ll[i] += 0x1000000000000000;
+	csr_wr_buf_uint64(CSR_CTRL_SCRATCH128_ADDR, &(foo.ll[0]), 3);
+/* read test */
+	csr_rd_buf_uint8(CSR_CTRL_SCRATCH128_ADDR, &(foo.c[0]), 16);
+	printf("8bit array:");
+	for (int i = 0; i < 16; i++)
+		printf(" %02x", foo.c[i]);
+	printf("\n");
+	csr_rd_buf_uint16(CSR_CTRL_SCRATCH128_ADDR, &(foo.s[0]), 8);
+	printf("16bit array:");
+	for (int i = 0; i < 8; i++)
+		printf(" %04x", foo.s[i]);
+	printf("\n");
+	csr_rd_buf_uint32(CSR_CTRL_SCRATCH128_ADDR, &(foo.l[0]), 4);
+	printf("32bit array:");
+	for (int i = 0; i < 4; i++)
+		printf(" %08x", foo.l[i]);
+	printf("\n");
+	csr_rd_buf_uint64(CSR_CTRL_SCRATCH128_ADDR, &(foo.ll[0]), 2);
+	printf("64bit array (Only prints ok on rocket!):");
+	for (int i = 0; i < 2; i++)
+		printf(" %016Lx", foo.ll[i]);
+	printf("\n");
+/* Output should match following results from (csr_data_width == 8):
+ *
+ * - with write test commented out:
+ *
+ *   8bit array: 50 51 52 53 54 55 56 57 58 59 5a 5b 5c 5d 5e 5f
+ *   16bit array: 5051 5253 5455 5657 5859 5a5b 5c5d 5e5f
+ *   32bit array: 50515253 54555657 58595a5b 5c5d5e5f
+ *   64bit array (Only prints ok on rocket!): 5051525354555657 58595a5b5c5d5e5f
+ *
+ * - with write test enabled:
+ *
+ *   8bit array: 90 61 72 63 84 65 76 67 98 69 7a 6b 8c 6d 7e 6f
+ *   16bit array: 9061 7263 8465 7667 9869 7a6b 8c6d 7e6f
+ *   32bit array: 90617263 84657667 98697a6b 8c6d7e6f
+ *   64bit array (Only prints ok on rocket!): 9061726384657667 98697a6b8c6d7e6f
+ */
+        ctrl_scratch8_write(0xa0);
+        ctrl_scratch16_write(0xb0b1);
+        ctrl_scratch32_write(0xc0c1c2c3);
+        ctrl_scratch48_write(0x404142434445);
+        ctrl_scratch64_write(0xd0d1d2d3d4d5d6d7);
+	printf("2.scratch8: %s\n",
+		(ctrl_scratch8_read() == 0xa0) ? "pass":"fail");
+	printf("2.scratch16: %s\n",
+		(ctrl_scratch16_read() == 0xb0b1) ? "pass":"fail");
+	printf("2.scratch32: %s\n",
+		(ctrl_scratch32_read() == 0xc0c1c2c3) ? "pass":"fail");
+	printf("2.scratch48: %s\n",
+		(ctrl_scratch48_read() == 0x404142434445) ? "pass":"fail");
+	printf("2.scratch64: %s\n",
+		(ctrl_scratch64_read() == 0xd0d1d2d3d4d5d6d7) ? "pass":"fail");
+        csr_wr_uint8(0x01, CSR_CTRL_SCRATCH8_ADDR);
+        csr_wr_uint16(0x2345, CSR_CTRL_SCRATCH16_ADDR);
+        csr_wr_uint32(0x6789abcd, CSR_CTRL_SCRATCH32_ADDR);
+        csr_wr_uint64(0xef0123456789abcd, CSR_CTRL_SCRATCH64_ADDR);
+	printf("3.scratch8: %s\n",
+		(csr_rd_uint8(CSR_CTRL_SCRATCH8_ADDR) == 0x01) ?
+		"pass":"fail");
+	printf("3.scratch16: %s\n",
+		(csr_rd_uint16(CSR_CTRL_SCRATCH16_ADDR) == 0x2345) ?
+		"pass":"fail");
+	printf("3.scratch32: %s\n",
+		(csr_rd_uint32(CSR_CTRL_SCRATCH32_ADDR) == 0x6789abcd) ?
+		"pass":"fail");
+	printf("3.scratch64: %s\n",
+		(csr_rd_uint64(CSR_CTRL_SCRATCH64_ADDR) == 0xef0123456789abcd) ?
+		"pass":"fail");
 	printf("--============= \e[1mConsole\e[0m ================--\n");
 	while(1) {
 		putsnonl("\e[92;1mlitex\e[0m> ");

--- a/litex/soc/software/include/hw/common.h
+++ b/litex/soc/software/include/hw/common.h
@@ -4,8 +4,8 @@
 #include <stdint.h>
 
 /* To overwrite CSR accessors, define extern, non-inlined versions
- * of csr_read[bwl]() and csr_write[bwl](), and define
- * CSR_ACCESSORS_DEFINED.
+ * of csr_rd_uint[8|16|32|64]() and csr_wr_uint[8|16|32|64](), and
+ * define CSR_ACCESSORS_DEFINED.
  */
 
 #ifndef CSR_ACCESSORS_DEFINED
@@ -14,37 +14,234 @@
 #ifdef __ASSEMBLER__
 #define MMPTR(x) x
 #else /* ! __ASSEMBLER__ */
-#define MMPTR(x) (*((volatile unsigned long *)(x)))
 
-static inline void csr_writeb(uint8_t value, unsigned long addr)
+/* CSRs are stored in subregister slices of CONFIG_CSR_DATA_WIDTH (native
+ * endianness), with the least significant slice at the lowest aligned
+ * (base) address. */
+
+#include <generated/soc.h>
+#if !defined(CONFIG_CSR_ALIGNMENT) || !defined(CONFIG_CSR_DATA_WIDTH)
+#error csr alignment and data-width MUST be set before including this file!
+#endif
+
+#if CONFIG_CSR_DATA_WIDTH > CONFIG_CSR_ALIGNMENT
+#error invalid CONFIG_CSR_DATA_WIDTH (must not exceed CONFIG_CSR_ALIGNMENT)!
+#endif
+
+/* FIXME: preprocessor can't evaluate 'sizeof()' operator, is there a better
+ * way to implement the following assertion?
+ * #if sizeof(unsigned long) != CONFIG_CSR_ALIGNMENT/8
+ * #error invalid CONFIG_CSR_ALIGNMENT (must match native CPU word size)!
+ * #endif
+ */
+
+/* CSR data width (subregister width) in bytes, for direct comparson to sizeof() */
+#define CSR_DW_BYTES (CONFIG_CSR_DATA_WIDTH/8)
+
+/* CSR subregisters are embedded inside native CPU word aligned locations: */
+#define MMPTR(a) (*((volatile unsigned long *)(a)))
+
+/* Number of subregs required for various total byte sizes, by subreg width:
+ * NOTE: 1, 2, 4, and 8 bytes represent uint[8|16|32|64]_t C types; However,
+ *       CSRs of intermediate byte sizes (24, 40, 48, and 56) are NOT padded
+ *       (with extra unallocated subregisters) to the next valid C type!
+ *  +-----+-----------------+
+ *  | csr |      bytes      |
+ *  | _dw | 1 2 3 4 5 6 7 8 |
+ *  |     |-----=---=-=-=---|
+ *  |  1  | 1 2 3 4 5 6 7 8 |
+ *  |  2  | 1 1 2 2 3 3 4 4 |
+ *  |  4  | 1 1 1 1 2 2 2 2 |
+ *  |  8  | 1 1 1 1 1 1 1 1 |
+ *  +-----+-----------------+ */
+static inline int num_subregs(int csr_bytes)
 {
-	*((volatile uint8_t *)addr) = value;
+	return (csr_bytes - 1) / CSR_DW_BYTES + 1;
 }
 
-static inline uint8_t csr_readb(unsigned long addr)
+/* Read a CSR of size 'csr_bytes' located at address 'a'. */
+static inline uint64_t _csr_rd(unsigned long *a, int csr_bytes)
 {
-	return *(volatile uint8_t *)addr;
+	uint64_t r = a[0];
+	for (int i = 1; i < num_subregs(csr_bytes); i++) {
+		r <<= CONFIG_CSR_DATA_WIDTH;
+		r |= a[i];
+	}
+	return r;
 }
 
-static inline void csr_writew(uint16_t value, unsigned long addr)
+/* Write value 'v' to a CSR of size 'csr_bytes' located at address 'a'. */
+static inline void _csr_wr(unsigned long *a, uint64_t v, int csr_bytes)
 {
-	*((volatile uint16_t *)addr) = value;
+	int ns = num_subregs(csr_bytes);
+	for (int i = 0; i < ns; i++)
+		a[i] = v >> (CONFIG_CSR_DATA_WIDTH * (ns - 1 - i));
 }
 
-static inline uint16_t csr_readw(unsigned long addr)
+// FIXME: - should we provide 24, 40, 48, and 56 bit csr_[rd|wr] methods?
+
+static inline uint8_t csr_rd_uint8(unsigned long a)
 {
-	return *(volatile uint16_t *)addr;
+	return _csr_rd((unsigned long *)a, sizeof(uint8_t));
 }
 
-static inline void csr_writel(uint32_t value, unsigned long addr)
+static inline void csr_wr_uint8(uint8_t v, unsigned long a)
 {
-	*((volatile uint32_t *)addr) = value;
+	_csr_wr((unsigned long *)a, v, sizeof(uint8_t));
 }
 
-static inline uint32_t csr_readl(unsigned long addr)
+static inline uint16_t csr_rd_uint16(unsigned long a)
 {
-	return *(volatile uint32_t *)addr;
+	return _csr_rd((unsigned long *)a, sizeof(uint16_t));
 }
+
+static inline void csr_wr_uint16(uint16_t v, unsigned long a)
+{
+	_csr_wr((unsigned long *)a, v, sizeof(uint16_t));
+}
+
+static inline uint32_t csr_rd_uint32(unsigned long a)
+{
+	return _csr_rd((unsigned long *)a, sizeof(uint32_t));
+}
+
+static inline void csr_wr_uint32(uint32_t v, unsigned long a)
+{
+	_csr_wr((unsigned long *)a, v, sizeof(uint32_t));
+}
+
+static inline uint64_t csr_rd_uint64(unsigned long a)
+{
+	return _csr_rd((unsigned long *)a, sizeof(uint64_t));
+}
+
+static inline void csr_wr_uint64(uint64_t v, unsigned long a)
+{
+	_csr_wr((unsigned long *)a, v, sizeof(uint64_t));
+}
+
+/* Read a CSR located at address 'a' into an array 'buf' of 'cnt' elements
+ * of type 'uintX_t'.
+ *
+ * NOTE: Since CSR_DW_BYTES is a constant here, we might be tempted to further
+ * optimize things by leaving out one or the other of the if() branches below,
+ * depending on each unsigned type width;
+ * However, this code is also meant to serve as a reference for how CSRs are
+ * to be manipulated by other programs (e.g., an OS kernel), which may benefit
+ * from dynamically handling multiple possible CSR subregister data widths
+ * (e.g., by passing a value in through the Device Tree).
+ * Ultimately, if CSR_DW_BYTES is indeed a constant, the compiler should be
+ * able to determine on its own whether it can automatically optimize away one
+ * of the if() branches! */
+#define _csr_rd_buf(a, uintX_t, buf, cnt) \
+{ \
+	int i, j, nsubs, n_sub_elem; \
+	unsigned long *addr = (unsigned long *)(a); \
+	uint64_t r; \
+	if (sizeof(uintX_t) >= CSR_DW_BYTES) { \
+		/* one or more subregisters per element */ \
+		for (i = 0; i < cnt; i++) { \
+			buf[i] = _csr_rd(addr, sizeof(uintX_t)); \
+			addr += num_subregs(sizeof(uintX_t)); \
+		} \
+	} else { \
+		/* multiple elements per subregister (2, 4, or 8) */ \
+		nsubs = num_subregs(sizeof(uintX_t) * cnt); \
+		n_sub_elem = CSR_DW_BYTES / sizeof(uintX_t); \
+		for (i = 0; i < nsubs; i++) { \
+			r = addr[i]; \
+			for (j = n_sub_elem - 1; j >= 0; j--) { \
+				if (i * n_sub_elem + j < cnt) \
+					buf[i * n_sub_elem + j] = r; \
+				r >>= sizeof(uintX_t) * 8; \
+			} \
+		} \
+	} \
+}
+
+/* Write an array 'buf' of 'cnt' elements of type 'uintX_t' to a CSR
+ * located at address 'a'.
+ *
+ * NOTE: The same optimization considerations apply here as with _csr_rd_buf()
+ * above.
+ */
+#define _csr_wr_buf(a, uintX_t, buf, cnt) \
+{ \
+	int i, j, nsubs, n_sub_elem; \
+	unsigned long *addr = (unsigned long *)(a); \
+	uint64_t v; \
+	if (sizeof(uintX_t) >= CSR_DW_BYTES) { \
+		/* one or more subregisters per element */ \
+		for (i = 0; i < cnt; i++) { \
+			_csr_wr(addr, buf[i], sizeof(uintX_t)); \
+			addr += num_subregs(sizeof(uintX_t)); \
+		} \
+	} else { \
+		/* multiple elements per subregister (2, 4, or 8) */ \
+		nsubs = num_subregs(sizeof(uintX_t) * cnt); \
+		n_sub_elem = CSR_DW_BYTES / sizeof(uintX_t); \
+		for (i = 0; i < nsubs; i++) { \
+			v = buf[i * n_sub_elem + 0]; \
+			for (j = 1; j < n_sub_elem; j++) { \
+				if (i * n_sub_elem + j == cnt) \
+					break; \
+				v <<= sizeof(uintX_t) * 8; \
+				v |= buf[i * n_sub_elem + j]; \
+			} \
+			addr[i] = v; \
+		} \
+	} \
+}
+
+static inline void csr_rd_buf_uint8(unsigned long a, uint8_t *buf, int cnt)
+{
+	_csr_rd_buf(a, uint8_t, buf, cnt);
+}
+
+static inline void csr_wr_buf_uint8(unsigned long a,
+					const uint8_t *buf, int cnt)
+{
+	_csr_wr_buf(a, uint8_t, buf, cnt);
+}
+
+static inline void csr_rd_buf_uint16(unsigned long a, uint16_t *buf, int cnt)
+{
+	_csr_rd_buf(a, uint16_t, buf, cnt);
+}
+
+static inline void csr_wr_buf_uint16(unsigned long a,
+					const uint16_t *buf, int cnt)
+{
+	_csr_wr_buf(a, uint16_t, buf, cnt);
+}
+
+static inline void csr_rd_buf_uint32(unsigned long a, uint32_t *buf, int cnt)
+{
+	_csr_rd_buf(a, uint32_t, buf, cnt);
+}
+
+static inline void csr_wr_buf_uint32(unsigned long a,
+					const uint32_t *buf, int cnt)
+{
+	_csr_wr_buf(a, uint32_t, buf, cnt);
+}
+
+/* NOTE: the "else" branch is never reached, so we don't need to be warned
+ * about a >= 64bit left shift! */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshift-count-overflow"
+static inline void csr_rd_buf_uint64(unsigned long a, uint64_t *buf, int cnt)
+{
+	_csr_rd_buf(a, uint64_t, buf, cnt);
+}
+
+static inline void csr_wr_buf_uint64(unsigned long a,
+					const uint64_t *buf, int cnt)
+{
+	_csr_wr_buf(a, uint64_t, buf, cnt);
+}
+#pragma GCC diagnostic pop
+
 #endif /* ! __ASSEMBLER__ */
 
 #endif /* ! CSR_ACCESSORS_DEFINED */


### PR DESCRIPTION
@enjoy-digital Please review, but don't apply until the intra-subregister endianness issue has been elucidated :)
Once we know more about that, I'd also like us to consider the possibility of adding memcpy-_**like**_ methods for CSRs that are wider than 64 bits, such as `sdram_dfii_pix_rddata_addr` and `sdram_dfii_pix_wrdata_addr`, and `CSR_IDENTIFIER_MEM_BASE`, so that we can get rid of `MMPTR` altogether.

I'm hoping that ultimately this could serve as an "OS/kernel programmer's reference", so we can implement a flexible set of accessors in e.g. Linux, with csr_data_width passed in as a DTB parameter. (see https://github.com/litex-hub/linux-on-litex-vexriscv/pull/60).