### PR TITLE
add the possibility for a "precise" clock solution

### DIFF
--- a/litex/soc/cores/clock.py
+++ b/litex/soc/cores/clock.py
@@ -74,7 +74,7 @@ class XilinxClocking(Module, AutoCSR):
                         valid = False
                         for d in range(*self.clkout_divide_range):
                             clk_freq = vco_freq/d
-                            if abs(clk_freq - f) < f*m:
+                            if abs(clk_freq - f) <= f*m:
                                 config["clkout{}_freq".format(n)]   = clk_freq
                                 config["clkout{}_divide".format(n)] = d
                                 config["clkout{}_phase".format(n)]  = p


### PR DESCRIPTION
If clocks and multipliers are planned well, we can have
a zero-error solution for clocks. Suggest to change < to <= in
margin comparison loop, so that a "perfect" solution is allowed
to converge.