### PR TITLE
interconnect/csr_bus/SRAM: allow 64-bit alignment (on 64-bit CPUs)

### DIFF
--- a/litex/soc/software/include/hw/common.h
+++ b/litex/soc/software/include/hw/common.h
@@ -14,7 +14,7 @@
 #ifdef __ASSEMBLER__
 #define MMPTR(x) x
 #else /* ! __ASSEMBLER__ */
-#define MMPTR(x) (*((volatile unsigned int *)(x)))
+#define MMPTR(x) (*((volatile unsigned long *)(x)))
 
 static inline void csr_writeb(uint8_t value, unsigned long addr)
 {


### PR DESCRIPTION
Similarly to how CSRBank subregisters are aligned to the CPU word
width (see commit f4770219f), ensure SRAM word_bits are also aligned
to the CPU word width.

Additionally, fix the MMPTR() macro to access CSR subregisters as
CPU word (unsigned long) sized slices.

This fixes the functionality of the 'ident' bios command on 64-bit
CPUs (e.g., Rocket).

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>