### PR TITLE
soc/cores/spi_flash: Don't tristate DQ2/DQ3 when bitbanging

### DIFF
--- a/litex/soc/cores/spi_flash.py
+++ b/litex/soc/cores/spi_flash.py
@@ -8,6 +8,7 @@
 
 from migen import *
 from migen.genlib.misc import timeline
+from migen.fhdl.specials import Tristate
 
 from litex.gen import *
 
@@ -117,7 +118,11 @@ class SpiFlashDualQuad(SpiFlashCommon, AutoCSR):
         addr_width = 24
 
         dq = TSTriple(spi_width)
-        self.specials.dq = dq.get_tristate(pads.dq)
+        # Keep DQ2,DQ3 as outputs during bitbang, this ensures they activate ~WP or ~HOLD functions
+        self.specials.dq0 = Tristate(pads.dq[0], o=dq.o[0], i=dq.i[0], oe=dq.oe)
+        self.specials.dq1 = Tristate(pads.dq[1], o=dq.o[1], i=dq.i[1], oe=dq.oe)
+        self.specials.dq2 = Tristate(pads.dq[2], o=dq.o[2], i=dq.i[2], oe=(dq.oe | self.bitbang_en.storage))
+        self.specials.dq3 = Tristate(pads.dq[3], o=dq.o[3], i=dq.i[3], oe=(dq.oe | self.bitbang_en.storage))
 
         sr = Signal(max(cmd_width, addr_width, wbone_width))
         if endianness == "big":


### PR DESCRIPTION
This change keeps DQ2/DQ3 as outputs when bit-banging is enabled.

Current behaviour when (bitbang_en=1 & dir=1), all the DQ pins get tristated. However bit-banging currently only support SPI modes.

This can cause issues for unconfigured flash chips, which treat DQ2 as ~WP, DQ3 as ~HOLD. 
This results in no output or bad output when attempting to read any data from the FLASH in bitbang mode, specifically: JEDEC ID codes, and programming status bits.