### PR TITLE
Fix sram size argument

### DIFF
--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -612,7 +612,7 @@ def soc_core_args(parser):
     parser.add_argument("--integrated-rom-file", default=None, type=str,
                         help="integrated (BIOS) ROM binary file (default=32KB)")
     # SRAM parameters
-    parser.add_argument("--integrated_sram_size", default=0x1000,
+    parser.add_argument("--integrated_sram_size", default=0x1000, type=int,
                         help="size/enable the integrated SRAM (default=4KB)")
     # MAIN_RAM parameters
     parser.add_argument("--integrated-main-ram-size", default=None, type=int,

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -612,7 +612,7 @@ def soc_core_args(parser):
     parser.add_argument("--integrated-rom-file", default=None, type=str,
                         help="integrated (BIOS) ROM binary file (default=32KB)")
     # SRAM parameters
-    parser.add_argument("--integrated_sram_size", default=0x1000, type=int,
+    parser.add_argument("--integrated-sram-size", default=0x1000, type=int,
                         help="size/enable the integrated SRAM (default=4KB)")
     # MAIN_RAM parameters
     parser.add_argument("--integrated-main-ram-size", default=None, type=int,


### PR DESCRIPTION
Renaming the argument is a breaking change and might cause some user scripts to fail.
On the other hand this option is broken (wrong type), so I guess those scripts would fail anyway ;)