### PR TITLE
soc/software/bios/sdram: On ECP5 strobe dly_sel after read leveling

### DIFF
--- a/litex/soc/software/bios/sdram.c
+++ b/litex/soc/software/bios/sdram.c
@@ -943,6 +943,13 @@ int sdrlevel(void)
 		printf("\n");
 	}
 
+#ifdef ECP5DDRPHY
+	/* Toggle all dly_sel lines. 
+	 * Which toggles all DQSBUFM.PAUSE lines, this ensures they're using the correct delays. */
+	ddrphy_dly_sel_write(0xFF);
+	ddrphy_dly_sel_write(0);
+#endif
+
 	return 1;
 }
 #endif

--- a/litex/soc/software/bios/sdram.c
+++ b/litex/soc/software/bios/sdram.c
@@ -419,6 +419,12 @@ static void read_delay_rst(int module) {
 
 	/* unsel module */
 	ddrphy_dly_sel_write(0);
+
+#ifdef ECP5DDRPHY
+	/* Sync all DQSBUFM's, By toggling all dly_sel (DQSBUFM.PAUSE) lines. */
+	ddrphy_dly_sel_write(0xFF);
+	ddrphy_dly_sel_write(0);
+#endif
 }
 
 static void read_delay_inc(int module) {
@@ -430,6 +436,12 @@ static void read_delay_inc(int module) {
 
 	/* unsel module */
 	ddrphy_dly_sel_write(0);
+
+#ifdef ECP5DDRPHY
+	/* Sync all DQSBUFM's, By toggling all dly_sel (DQSBUFM.PAUSE) lines. */
+	ddrphy_dly_sel_write(0xFF);
+	ddrphy_dly_sel_write(0);
+#endif
 }
 
 static void read_bitslip_rst(char m)
@@ -943,12 +955,6 @@ int sdrlevel(void)
 		printf("\n");
 	}
 
-#ifdef ECP5DDRPHY
-	/* Toggle all dly_sel lines. 
-	 * Which toggles all DQSBUFM.PAUSE lines, this ensures they're using the correct delays. */
-	ddrphy_dly_sel_write(0xFF);
-	ddrphy_dly_sel_write(0);
-#endif
 
 	return 1;
 }


### PR DESCRIPTION
This change appears to fix this issue I've seen with some of my ECP5 based OrangeCrab boards https://github.com/enjoy-digital/litedram/issues/103

I'm not entirely sure why this fixes things. But I suspect strobing the DQSBUFM.PAUSE lines after all the delays have been set is getting things to work.