### PR TITLE
WIP: add SDRAM benchmark

### DIFF
--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -375,6 +375,7 @@ static void help(void)
 	puts("");
 #ifdef CSR_SDRAM_BASE
 	puts("memtest    - run a memory test");
+	puts("sdrbench   - run SDRAM bus efficiency benchmark");
 #endif
 }
 
@@ -458,6 +459,7 @@ static void do_command(char *c)
 	else if(strcmp(token, "sdrlevel") == 0) sdrlevel();
 #endif
 	else if(strcmp(token, "memtest") == 0) memtest();
+	else if(strcmp(token, "sdrbench") == 0) sdram_benchmark(get_token(&c), get_token(&c));
 #endif
 
 	else if(strcmp(token, "") != 0)

--- a/litex/soc/software/bios/sdram.h
+++ b/litex/soc/software/bios/sdram.h
@@ -25,6 +25,7 @@ int sdrlevel(void);
 
 int memtest_silent(void);
 int memtest(void);
+int sdram_benchmark(char *access, char *order);
 int sdrinit(void);
 
 #endif /* __SDRAM_H */


### PR DESCRIPTION
This requires https://github.com/enjoy-digital/litedram/pull/107

Added a benchmark in BIOS that can be used for measuring bus efficiency.

I was trying to recreate the results from John Sully's presentation from ORConf 2018:
https://drive.google.com/file/d/0BycKTLecdlC7LTg2a1J1SFNyaXVEc0VJTkJkeWhKTDZoSUdn/view

At this moment I have two access patters, one traversing by rows first and one by columns.
There are also two cases, either read-only or read+write.

I've got the following results in `litex_sim`:
```
litex> sdrbench all
sdrbench r col:
    n_reads            = 4096
    n_writes           = 0
    n_activates        = 74
    bus_efficiency     = 96.51 %
sdrbench r row:
    n_reads            = 32768
    n_writes           = 0
    n_activates        = 2253
    bus_efficiency     = 47.61 %
sdrbench rw col:
    n_reads            = 4096
    n_writes           = 3072
    n_activates        = 786
    bus_efficiency     = 83.90 %
sdrbench rw row:
    n_reads            = 32768
    n_writes           = 16376
    n_activates        = 2235
    bus_efficiency     = 64.69 %
```
and similar ones on Arty:
```
litex> sdrbench all
sdrbench r col:
    n_reads            = 2048
    n_writes           = 0
    n_activates        = 272
    bus_efficiency     = 96.78 %
sdrbench r row:
    n_reads            = 16384
    n_writes           = 0
    n_activates        = 8587
    bus_efficiency     = 48.82 %
sdrbench rw col:
    n_reads            = 2048
    n_writes           = 1792
    n_activates        = 3633
    bus_efficiency     = 81.85 %
sdrbench rw row:
    n_reads            = 16384
    n_writes           = 8191
    n_activates        = 9179
    bus_efficiency     = 64.09 %
```