### PR TITLE
build/sim: allow to use environment's {C,LD}FLAGS

### DIFF
--- a/litex/build/sim/core/Makefile
+++ b/litex/build/sim/core/Makefile
@@ -1,8 +1,8 @@
 include variables.mak
 
-CC = gcc
-CFLAGS = -Wall -$(OPT_LEVEL) -ggdb $(if $(COVERAGE), -DVM_COVERAGE)
-LDFLAGS = -lpthread -Wl,--no-as-needed -ljson-c -lm -lstdc++ -Wl,--no-as-needed -ldl -levent
+CC ?= gcc
+CFLAGS += -Wall -$(OPT_LEVEL) -ggdb $(if $(COVERAGE), -DVM_COVERAGE)
+LDFLAGS += -lpthread -Wl,--no-as-needed -ljson-c -lm -lstdc++ -Wl,--no-as-needed -ldl -levent
 
 CC_SRCS ?= "--cc dut.v"
 

--- a/litex/build/sim/core/modules/variables.mak
+++ b/litex/build/sim/core/modules/variables.mak
@@ -1,5 +1,5 @@
-CC = gcc
-CFLAGS = -Wall -O3 -ggdb -fPIC -Werror
-LDFLAGS = -levent -shared -fPIC
+CC ?= gcc
+CFLAGS += -Wall -O3 -ggdb -fPIC -Werror
+LDFLAGS += -levent -shared -fPIC
 
 OBJ_DIR ?= .


### PR DESCRIPTION
There are use cases where additional flags should be added to CFLAGS or
LDFLAGS, e.g. when using Conda environment.