### PR TITLE
Allow all memory regions to be used as IO with CPUNone

### DIFF
--- a/litex/soc/cores/cpu/__init__.py
+++ b/litex/soc/cores/cpu/__init__.py
@@ -22,7 +22,7 @@ class CPU(Module):
 class CPUNone(CPU):
     data_width           = 32
     reset_address        = 0x00000000
-    io_regions           = {0x00000000: 0xf0000000} # origin, length
+    io_regions           = {0x00000000: 0x1_0000_0000} # origin, length
 
 # CPUS ---------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Previously, only `0x00000000`-`0xefffffff` were usable as IO with `CPUNone`, in the spirit of b627a8fe71b55f1987a9cd5181da14cddd3203c1 ("all address range can be used as IO"), the entire address space is now usable.

This PR is only compatible with python>=3.6 due to the digit separators in the integer literal. That version was released over 3 years ago, is that enough backwards compatibility or should I stay on the safe side?