### PR TITLE
bios/boot: allow to customize flash offsets of Linux images

### DIFF
--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -409,10 +409,18 @@ static int copy_image_from_flash_to_ram(unsigned int flash_address, unsigned int
 }
 #endif
 
-#define KERNEL_IMAGE_FLASH_OFFSET      0x00000000 //  0MB
-#define ROOTFS_IMAGE_FLASH_OFFSET      0x00500000 //  5MB
-#define DEVICE_TREE_IMAGE_FLASH_OFFSET 0x00D00000 // 13MB
-#define EMULATOR_IMAGE_FLASH_OFFSET    0x00E00000 // 14MB
+#ifndef KERNEL_IMAGE_FLASH_OFFSET
+	#define KERNEL_IMAGE_FLASH_OFFSET      0x00000000 //  0MB
+#endif
+#ifndef ROOTFS_IMAGE_FLASH_OFFSET
+	#define ROOTFS_IMAGE_FLASH_OFFSET      0x00500000 //  5MB
+#endif
+#ifndef DEVICE_TREE_IMAGE_FLASH_OFFSET
+	#define DEVICE_TREE_IMAGE_FLASH_OFFSET 0x00D00000 // 13MB
+#endif
+#ifndef EMULATOR_IMAGE_FLASH_OFFSET
+	#define EMULATOR_IMAGE_FLASH_OFFSET    0x00E00000 // 14MB
+#endif
 
 void flashboot(void)
 {


### PR DESCRIPTION
This is to allow loading bigger binaries for platforms with more flash space.

Another reason, and in fact the main one in my case, for this is to be able to define those offsets as a part of the platform so that they are generated to `csr.csv` (and headers). This, in turn, allows to automate generation of scripts preparing flash image without the need of hardcoding any offsets there.

At first I wanted to add generation of those offsets to the configuration in this repo. I noticed, however, that the whole `flashboot` part is guarded by `FLASH_BOOT_ADDRESS` define that is not generated in LiteX at all (but is generated in `linux-on-litex-vexriscv` and in `litex-buildenv`). As a result I didn't find any sutiable place to put the generation in python code in LiteX. As a workaround I decided simply to allow external platforms to do that.

If you have any better idea on how to solve it, I'm open for suggestions!
