### PR TITLE
software: enable link time optimization (LTO)

### DIFF
--- a/litex/soc/software/bios/Makefile
+++ b/litex/soc/software/bios/Makefile
@@ -29,7 +29,7 @@ bios.elf: $(BIOS_DIRECTORY)/linker.ld $(OBJECTS)
 
 
 %.elf: ../libbase/crt0-$(CPU)-ctr.o ../libnet/libnet.a ../libbase/libbase-nofloat.a ../libcompiler_rt/libcompiler_rt.a
-	$(LD) $(LDFLAGS) -T $(BIOS_DIRECTORY)/linker.ld -N -o $@ \
+	$(CC) $(LDFLAGS) -T $(BIOS_DIRECTORY)/linker.ld -N -o $@ \
 		../libbase/crt0-$(CPU)-ctr.o \
 		$(OBJECTS) \
 		-L../libnet \

--- a/litex/soc/software/common.mak
+++ b/litex/soc/software/common.mak
@@ -14,7 +14,7 @@ else
 CC_normal      := $(TARGET_PREFIX)gcc -std=gnu99
 CX_normal      := $(TARGET_PREFIX)g++
 endif
-AR_normal      := $(TARGET_PREFIX)ar
+AR_normal      := $(TARGET_PREFIX)gcc-ar
 LD_normal      := $(TARGET_PREFIX)ld
 OBJCOPY_normal := $(TARGET_PREFIX)objcopy
 
@@ -46,10 +46,10 @@ DEPFLAGS += -MD -MP
 # Toolchain options
 #
 INCLUDES = -I$(SOC_DIRECTORY)/software/include/base -I$(SOC_DIRECTORY)/software/include -I$(SOC_DIRECTORY)/common -I$(BUILDINC_DIRECTORY)
-COMMONFLAGS = $(DEPFLAGS) -Os $(CPUFLAGS) -g3 -fomit-frame-pointer -Wall -fno-builtin -nostdinc $(INCLUDES)
+COMMONFLAGS = $(DEPFLAGS) -Os $(CPUFLAGS) -g3 -fomit-frame-pointer -Wall -fno-builtin -nostdinc $(INCLUDES) -flto -fuse-linker-plugin -ffunction-sections -fdata-sections -nostartfiles -nostdlib -nodefaultlibs
 CFLAGS = $(COMMONFLAGS) -fexceptions -Wstrict-prototypes -Wold-style-definition -Wmissing-prototypes
 CXXFLAGS = $(COMMONFLAGS) -std=c++11 -I$(SOC_DIRECTORY)/software/include/basec++ -fexceptions -fno-rtti -ffreestanding
-LDFLAGS = -nostdlib -nodefaultlibs -L$(BUILDINC_DIRECTORY)
+LDFLAGS = -nostdlib -nodefaultlibs -Os $(CPUFLAGS) -L$(BUILDINC_DIRECTORY)
 
 define compilexx
 $(CX) -c $(CXXFLAGS) $(1) $< -o $@


### PR DESCRIPTION
It turned out that after merging https://github.com/enjoy-digital/litex/commit/ff2775c264cc452a05119dd895e25b559867dac2 to LiteX, `-flto` works fine with `-Os` and does not require `-lgcc` anymore. That's why we are going back to the simplest solution, originally proposed by @mithro and discussed in: https://github.com/enjoy-digital/litex/pull/253.

Note: enabling LTO in LiteX requires enabling it in linux-on-litex-vexriscv as well. We have a patch prepared and will create a PR shortly.