### PR TITLE
tools: litex_gen: fix missing UART pins

### DIFF
--- a/litex/tools/litex_gen.py
+++ b/litex/tools/litex_gen.py
@@ -49,6 +49,15 @@ class LiteXCore(SoCMini):
 
         platform = Platform(_io)
 
+        # UART
+        if kwargs["with_uart"]:
+            platform.add_extension([
+                ("serial", 0,
+                    Subsignal("tx",  Pins(1)),
+                    Subsignal("rx", Pins(1)),
+                )
+            ])
+
         # CRG --------------------------------------------------------------------------------------
         self.submodules.crg = CRG(platform.request("sys_clk"), rst=platform.request("sys_rst"))
 


### PR DESCRIPTION
These changes fix following error:
`raise ConstraintError("Resource not found: {}:{}".format(name, number))
litex.build.generic_platform.ConstraintError: Resource not found: serial:None`

When calling:
`python3 litex_gen.py --with-uart --no-compile-gateware --no-compile-software`