### PR TITLE
Add option to implement UART without FIFOs

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -888,10 +888,10 @@ class LiteXSoC(SoC):
         self.csr.add(name + "_mem", use_loc_if_exists=True)
 
     # Add UART -------------------------------------------------------------------------------------
-    def add_uart(self, name, baudrate=115200):
+    def add_uart(self, name, baudrate=115200, no_fifo=False):
         from litex.soc.cores import uart
         if name in ["stub", "stream"]:
-            self.submodules.uart = uart.UART()
+            self.submodules.uart = uart.UART(no_fifo=no_fifo)
             if name == "stub":
                 self.comb += self.uart.sink.ready.eq(1)
         elif name == "bridge":
@@ -914,7 +914,7 @@ class LiteXSoC(SoC):
                     pads     = self.platform.request(name),
                     clk_freq = self.sys_clk_freq,
                     baudrate = baudrate)
-            self.submodules.uart = ResetInserter()(uart.UART(self.uart_phy))
+            self.submodules.uart = ResetInserter()(uart.UART(self.uart_phy, no_fifo=no_fifo))
         self.csr.add("uart_phy", use_loc_if_exists=True)
         self.csr.add("uart", use_loc_if_exists=True)
         self.irq.add("uart", use_loc_if_exists=True)

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -86,6 +86,7 @@ class SoCCore(LiteXSoC):
         with_uart                = True,
         uart_name                = "serial",
         uart_baudrate            = 115200,
+        uart_no_fifo             = False,
         # Timer parameters
         with_timer               = True,
         # Controller parameters
@@ -176,7 +177,7 @@ class SoCCore(LiteXSoC):
 
         # Add UART
         if with_uart:
-            self.add_uart(name=uart_name, baudrate=uart_baudrate)
+            self.add_uart(name=uart_name, baudrate=uart_baudrate, no_fifo=uart_no_fifo)
 
         # Add Timer
         if with_timer:
@@ -288,6 +289,8 @@ def soc_core_args(parser):
                         help="UART baudrate (default=115200)")
     parser.add_argument("--uart-stub", default=False, type=bool,
                         help="enable UART stub (default=False)")
+    parser.add_argument("--uart-no-fifo", default=False, type=bool,
+                        help="UART without FIFOs implementation (default=False)")
     # Timer parameters
     parser.add_argument("--with-timer", default=None, type=bool,
                         help="with Timer (default=True)")

--- a/litex/tools/litex_gen.py
+++ b/litex/tools/litex_gen.py
@@ -128,6 +128,7 @@ def soc_argdict(args):
         "bus",
         "with_pwm",
         "with_uart",
+        "uart_no_fifo",
         "with_ctrl",
         "with_timer",
         "with_gpio",
@@ -151,6 +152,7 @@ def main():
     # Cores
     parser.add_argument("--with-pwm",              action="store_true",   help="Add PWM core")
     parser.add_argument("--with-uart",             action="store_true",   help="Add UART core")
+    parser.add_argument("--uart-no-fifo",          action="store_true",   help="Add UART core no FIFOs implementation")
     parser.add_argument("--with-ctrl",             action="store_true",   help="Add bus controller core")
     parser.add_argument("--with-timer",            action="store_true",   help="Add timer core")
     parser.add_argument("--with-spi-master",       action="store_true",   help="Add SPI master core")


### PR DESCRIPTION
These changes introduce optional UART implementation without FIFOs and enables this option in litex_gen tool.