### PR TITLE
add riscv-sifive-elf triple

### DIFF
--- a/litex/soc/cores/cpu/blackparrot/core.py
+++ b/litex/soc/cores/cpu/blackparrot/core.py
@@ -48,7 +48,7 @@ class BlackParrotRV64(CPU):
     name                 = "blackparrot"
     data_width           = 64
     endianness           = "little"
-    gcc_triple           = ("riscv64-unknown-elf", "riscv64-linux")
+    gcc_triple           = ("riscv64-unknown-elf", "riscv64-linux", "riscv-sifive-elf")
     linker_output_format = "elf64-littleriscv"
     io_regions           = {0x30000000: 0x20000000} # origin, length
 

--- a/litex/soc/cores/cpu/minerva/core.py
+++ b/litex/soc/cores/cpu/minerva/core.py
@@ -18,7 +18,7 @@ class Minerva(CPU):
     data_width           = 32
     endianness           = "little"
     gcc_triple           = ("riscv64-unknown-elf", "riscv32-unknown-elf", "riscv-none-embed",
-                            "riscv64-linux")
+                            "riscv64-linux", "riscv-sifive-elf")
     linker_output_format = "elf32-littleriscv"
     io_regions           = {0x80000000: 0x80000000} # origin, length
 

--- a/litex/soc/cores/cpu/picorv32/core.py
+++ b/litex/soc/cores/cpu/picorv32/core.py
@@ -35,7 +35,7 @@ class PicoRV32(CPU):
     data_width           = 32
     endianness           = "little"
     gcc_triple           = ("riscv64-unknown-elf", "riscv32-unknown-elf", "riscv-none-embed",
-                            "riscv64-linux")
+                            "riscv64-linux", "riscv-sifive-elf")
     linker_output_format = "elf32-littleriscv"
     io_regions           = {0x80000000: 0x80000000} # origin, length
 

--- a/litex/soc/cores/cpu/rocket/core.py
+++ b/litex/soc/cores/cpu/rocket/core.py
@@ -67,7 +67,7 @@ class RocketRV64(CPU):
     name                 = "rocket"
     data_width           = 64
     endianness           = "little"
-    gcc_triple           = ("riscv64-unknown-elf", "riscv64-linux")
+    gcc_triple           = ("riscv64-unknown-elf", "riscv64-linux", "riscv-sifive-elf")
     linker_output_format = "elf64-littleriscv"
     io_regions           = {0x10000000: 0x70000000} # origin, length
 

--- a/litex/soc/cores/cpu/vexriscv/core.py
+++ b/litex/soc/cores/cpu/vexriscv/core.py
@@ -79,7 +79,7 @@ class VexRiscv(CPU, AutoCSR):
     data_width           = 32
     endianness           = "little"
     gcc_triple           = ("riscv64-unknown-elf", "riscv32-unknown-elf", "riscv-none-embed",
-                            "riscv64-linux")
+                            "riscv64-linux", "riscv-sifive-elf")
     linker_output_format = "elf32-littleriscv"
     io_regions           = {0x80000000: 0x80000000} # origin, length
 


### PR DESCRIPTION
The AUR (Arch User Repository) [package](https://aur.archlinux.org/packages/riscv-sifive-elf-gcc/) for the sifive toolchain uses the triple `riscv-sifive-elf`. This PR adds this triple to the relevant cpu core.py files. 