### PR TITLE
targets/nexys4ddr: fix sdcard clocker initialization

### DIFF
--- a/litex/boards/targets/nexys4ddr.py
+++ b/litex/boards/targets/nexys4ddr.py
@@ -34,11 +34,8 @@ class _CRG(Module):
         self.clock_domains.cd_sys2x_dqs = ClockDomain(reset_less=True)
         self.clock_domains.cd_clk200    = ClockDomain()
         self.clock_domains.cd_eth       = ClockDomain()
-        self.clock_domains.cd_sdcard    = ClockDomain(reset_less=True)
 
         # # #
-
-        self.sd_clk_freq = int(100e6)
 
         self.submodules.pll = pll = S7MMCM(speedgrade=-1)
         self.comb += pll.reset.eq(~platform.request("cpu_reset"))
@@ -48,7 +45,6 @@ class _CRG(Module):
         pll.create_clkout(self.cd_sys2x_dqs, 2*sys_clk_freq, phase=90)
         pll.create_clkout(self.cd_clk200,    200e6)
         pll.create_clkout(self.cd_eth,       50e6)
-        pll.create_clkout(self.cd_sdcard,    self.sd_clk_freq)
 
         self.submodules.idelayctrl = S7IDELAYCTRL(self.cd_clk200)
 
@@ -92,7 +88,7 @@ class BaseSoC(SoCCore):
     def add_sdcard(self):
         sdcard_pads = self.platform.request("sdcard")
         self.comb += sdcard_pads.rst.eq(0)
-        self.submodules.sdclk = SDClockerS7(clkin=ClockSignal("sdcard"), clkin_freq=self.crg.sd_clk_freq)
+        self.submodules.sdclk = SDClockerS7(sys_clk_freq=self.sys_clk_freq)
         self.submodules.sdphy = SDPHY(sdcard_pads, self.platform.device)
         self.submodules.sdcore = SDCore(self.sdphy)
         self.submodules.sdtimer = Timer()
@@ -109,8 +105,8 @@ class BaseSoC(SoCCore):
             self.sdcore.source.connect(self.bist_checker.sink),
             self.bist_generator.source.connect(self.sdcore.sink)
         ]
-        self.platform.add_period_constraint(self.sdclk.cd_sd.clk, period_ns(self.crg.sd_clk_freq))
-        self.platform.add_period_constraint(self.sdclk.cd_sd_fb.clk, period_ns(self.crg.sd_clk_freq))
+        self.platform.add_period_constraint(self.sdclk.cd_sd.clk, period_ns(self.sys_clk_freq))
+        self.platform.add_period_constraint(self.sdclk.cd_sd_fb.clk, period_ns(self.sys_clk_freq))
         self.platform.add_false_path_constraints(
             self.crg.cd_sys.clk,
             self.sdclk.cd_sd.clk,


### PR DESCRIPTION
Following the new clocker from https://github.com/enjoy-digital/litesdcard/commit/2d4230c5e439f114d4fcb0c64c828d996fb5cb20 this is my attempt to get the nexys4ddr to successfully build using `--with-sdcard` once again. Based on my experiments, one would now have to go with at least
```
sdclk 20
sdinit
sdtest 8
```
from the LiteX bios command line. Anything below 20 and initialization fails for me (rocket cpu at `sys_clk_freq=67e6` -- the maximum that will pass timing for rocket when `--with-ethernet` is also selected).

@enjoy-digital PTAL at the new `add_period_constraint()` statements in particular, as I'm not sure `period_ns(self.sys_clk_freq))` is the right value for the constraints (in fact I'm not sure I understand how that part works at all, so if you can explain or point me to where I can figure it out more easily, I'd appreciate that too :) )