### PR TITLE
platform/netv2: add proper I2C pins for HDMI IN0

### DIFF
--- a/litex/boards/platforms/netv2.py
+++ b/litex/boards/platforms/netv2.py
@@ -139,8 +139,10 @@ _io = [
         Subsignal("data1_n", Pins("J21"), IOStandard("TMDS_33"), Inverted()),
         Subsignal("data2_p", Pins("J22"), IOStandard("TMDS_33"), Inverted()),
         Subsignal("data2_n", Pins("H22"), IOStandard("TMDS_33"), Inverted()),
-        Subsignal("scl", Pins("T18"), IOStandard("LVCMOS33")),
-        Subsignal("sda", Pins("V18"), IOStandard("LVCMOS33")),
+        Subsignal("scl", Pins("T18"), Inverted(), IOStandard("LVCMOS33")),
+        Subsignal("sda", Pins("V18"), Inverted(), IOStandard("LVCMOS33")),
+        Subsignal("sda_pu", Pins("G20"), IOStandard("LVCMOS33")),
+        Subsignal("sda_pd", Pins("F20"), IOStandard("LVCMOS33")),
     ),
 
     ("hdmi_in", 1,


### PR DESCRIPTION
This PR adds `SDA_PU` and `SDA_PD` pins to NeTV2 platform and inverts `SCL` and `SDA` pins. With this and a small modification to LiteVideo it is possible to get EDID information from the board.