### PR TITLE
Support for multiple SDRAM PHYs in single SoC

### DIFF
--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -128,12 +128,16 @@ class Builder:
             cpu_interface.get_git_header()
         )
 
-        if hasattr(self.soc, "sdram"):
+        if hasattr(self.soc, "sdrams") and len(self.soc.sdrams) > 0:
             from litedram.init import get_sdram_phy_c_header
+            sdram_settings = [
+                (sdram.controller.settings.phy,
+                 sdram.controller.settings.timing,
+                 name)
+                for name,sdram in self.soc.sdrams.items()
+            ]
             write_to_file(os.path.join(self.generated_dir, "sdram_phy.h"),
-                get_sdram_phy_c_header(
-                    self.soc.sdram.controller.settings.phy,
-                    self.soc.sdram.controller.settings.timing))
+                          get_sdram_phy_c_header(sdram_settings))
 
     def _generate_csr_map(self, csr_json=None, csr_csv=None):
         if csr_json is not None:

--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -117,6 +117,27 @@ def get_mem_header(regions):
     for name, region in regions.items():
         r += "#define {name}_BASE 0x{base:08x}L\n#define {name}_SIZE 0x{size:08x}\n\n".format(
             name=name.upper(), base=region.origin, size=region.length)
+
+    r += "\n"
+    r += "struct mem_region_t {\n"
+    r += "    unsigned long base;\n"
+    r += "    unsigned long size;\n"
+    r += "    unsigned l2_cache_size;\n"
+    r += "};\n\n"
+
+    r += "static const struct mem_region_t mem_regions_sdram[] = {\n"
+
+    sdram_regions = dict((n,r) for n,r in regions.items() if r.region_type == "sdram" and not r.linker)
+    if len(sdram_regions.keys()) > 0:
+        max_name_len = max(len(n) for n in sdram_regions.keys())
+        entries = []
+        for name, region in sdram_regions.items():
+            l2 = f"0x{region.l2_cache_size:x}" if hasattr(region, "l2_cache_size") else "0"
+            entries.append(f"    /* {name:{max_name_len}} */ {{ 0x{region.origin:08x}, 0x{region.size:08x}, {l2} }}")
+        r += ",\n".join(entries) + "\n"
+
+    r += "};\n\n"
+
     r += "#endif\n"
     return r
 

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1048,3 +1048,9 @@ class LiteXSoC(SoC):
             self.crg.cd_sys.clk,
             phy.crg.cd_eth_rx.clk,
             phy.crg.cd_eth_tx.clk)
+
+    # LiteXSoC finalization ------------------------------------------------------------------------
+    def do_finalize(self):
+        if len(self.sdrams) > 0:
+            self.add_config("SDRAM_PHYS_COUNT", len(self.sdrams))
+        super().do_finalize()

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -238,7 +238,7 @@ class SoCCore(LiteXSoC):
                     break
             self.bus.add_slave(name=wb_name, slave=interface)
 
-        SoC.do_finalize(self)
+        super().do_finalize()
         # Retro-compatibility
         for region in self.bus.regions.values():
             region.length = region.size

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -45,7 +45,7 @@ static void __attribute__((noreturn)) boot(unsigned long r1, unsigned long r2, u
 	flush_cpu_icache();
 #endif
 	flush_cpu_dcache();
-#ifdef CONFIG_L2_SIZE
+#ifdef CONFIG_L2
 	flush_l2_cache();
 #endif
 

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -363,7 +363,7 @@ static void help(void)
 	puts("ident      - display identifier");
 	puts("");
 	puts("flush_cpu_dcache - flush CPU data cache");
-#ifdef CONFIG_L2_SIZE
+#ifdef CONFIG_L2
 	puts("flush_l2_cache   - flush L2 cache");
 #endif
 	puts("");
@@ -438,7 +438,7 @@ static void do_command(char *c)
 	else if(strcmp(token, "ident") == 0) ident();
 
 	else if(strcmp(token, "flush_cpu_dcache") == 0) flush_cpu_dcache();
-#ifdef CONFIG_L2_SIZE
+#ifdef CONFIG_L2
 	else if(strcmp(token, "flush_l2_cache") == 0) flush_l2_cache();
 #endif
 

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -43,6 +43,8 @@
 #include "sdcard.h"
 #include "boot.h"
 
+#define COUNT(x) (sizeof(x)/sizeof(x[0]))
+
 /* General address space functions */
 
 #define NUMBER_OF_BYTES_ON_A_LINE 16
@@ -572,7 +574,7 @@ static void boot_sequence(void)
 	}
 }
 
-int main(int i, char **c)
+int main(int argc, char **argv)
 {
 	char buffer[64];
 	int sdr_ok;
@@ -617,13 +619,21 @@ int main(int i, char **c)
 	printf("Unknown");
 #endif
 	printf(" @ %dMHz\n", CONFIG_CLOCK_FREQUENCY/1000000);
-	printf("\e[1mROM\e[0m:       %dKB\n", ROM_SIZE/1024);
-	printf("\e[1mSRAM\e[0m:      %dKB\n", SRAM_SIZE/1024);
-#ifdef CONFIG_L2_SIZE
-	printf("\e[1mL2\e[0m:        %dKB\n", CONFIG_L2_SIZE/1024);
-#endif
+	printf("\e[1mROM\e[0m:       %7dKB\n", ROM_SIZE/1024);
+	printf("\e[1mSRAM\e[0m:      %7dKB\n", SRAM_SIZE/1024);
 #ifdef MAIN_RAM_SIZE
-	printf("\e[1mMAIN-RAM\e[0m:  %dKB\n", MAIN_RAM_SIZE/1024);
+	printf("\e[1mMAIN-RAM\e[0m:  %7dKB\n", MAIN_RAM_SIZE/1024);
+
+	int i;
+	for(i = 0; i < COUNT(mem_regions_sdram); i++) {
+		const struct mem_region_t *ram = &mem_regions_sdram[i];
+
+		printf("\e[1mSDRAM%d\e[0m:    %7dKB", i, ram->size/1024);
+		if(ram->l2_cache_size > 0)
+			printf(" (\e[1mL2\e[0m: %dKB)\n", ram->l2_cache_size/1024);
+		else
+			printf("\n");
+	}
 #endif
 	printf("\n");
 

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -379,7 +379,7 @@ static void help(void)
 	puts("romboot    - boot from embedded rom");
 #endif
 	puts("");
-#ifdef CSR_SDRAM_BASE
+#ifdef CONFIG_SDRAM_PHYS_COUNT
 	puts("memtest    - run a memory test");
 #endif
 	puts("");
@@ -455,7 +455,7 @@ static void do_command(char *c)
 
 	else if(strcmp(token, "help") == 0) help();
 
-#ifdef CSR_SDRAM_BASE
+#ifdef CONFIG_SDRAM_PHYS_COUNT
 	else if(strcmp(token, "sdrrow") == 0) sdrrow(get_token(&c));
 	else if(strcmp(token, "sdrsw") == 0) sdrsw();
 	else if(strcmp(token, "sdrhw") == 0) sdrhw();
@@ -629,12 +629,12 @@ int main(int i, char **c)
 
         sdr_ok = 1;
 
-#if defined(CSR_ETHMAC_BASE) || defined(CSR_SDRAM_BASE)
+#if defined(CSR_ETHMAC_BASE) || defined(CONFIG_SDRAM_PHYS_COUNT)
     printf("--========== \e[1mInitialization\e[0m ============--\n");
 #ifdef CSR_ETHMAC_BASE
 	eth_init();
 #endif
-#ifdef CSR_SDRAM_BASE
+#ifdef CONFIG_SDRAM_PHYS_COUNT
 	sdr_ok = sdrinit();
 #else
 #ifdef MAIN_RAM_TEST

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -471,7 +471,7 @@ static void do_command(char *c)
 #endif
 	else if(strcmp(token, "sdrlevel") == 0) sdrlevel();
 #endif
-	else if(strcmp(token, "memtest") == 0) memtest();
+	else if(strcmp(token, "memtest") == 0) memtest(get_token(&c), get_token(&c));
 #endif
 
 #ifdef CSR_SDCORE_BASE
@@ -638,7 +638,7 @@ int main(int i, char **c)
 	sdr_ok = sdrinit();
 #else
 #ifdef MAIN_RAM_TEST
-	sdr_ok = memtest();
+	sdr_ok = memtest(NULL, NULL);
 #endif
 #endif
 	if (sdr_ok !=1)

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -382,6 +382,7 @@ static void help(void)
 #endif
 	puts("");
 #ifdef CONFIG_SDRAM_PHYS_COUNT
+	puts("meminfo    - show SDRAMs list");
 	puts("memtest    - run a memory test");
 #endif
 	puts("");
@@ -458,6 +459,7 @@ static void do_command(char *c)
 	else if(strcmp(token, "help") == 0) help();
 
 #ifdef CONFIG_SDRAM_PHYS_COUNT
+	else if(strcmp(token, "meminfo") == 0) meminfo();
 	else if(strcmp(token, "currentsdramphy") == 0) currentsdramphy(get_token(&c));
 	else if(strcmp(token, "sdrrow") == 0) sdrrow(get_token(&c));
 	else if(strcmp(token, "sdrsw") == 0) sdrsw(-1);

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -458,9 +458,10 @@ static void do_command(char *c)
 	else if(strcmp(token, "help") == 0) help();
 
 #ifdef CONFIG_SDRAM_PHYS_COUNT
+	else if(strcmp(token, "currentsdramphy") == 0) currentsdramphy(get_token(&c));
 	else if(strcmp(token, "sdrrow") == 0) sdrrow(get_token(&c));
-	else if(strcmp(token, "sdrsw") == 0) sdrsw();
-	else if(strcmp(token, "sdrhw") == 0) sdrhw();
+	else if(strcmp(token, "sdrsw") == 0) sdrsw(-1);
+	else if(strcmp(token, "sdrhw") == 0) sdrhw(-1);
 	else if(strcmp(token, "sdrrdbuf") == 0) sdrrdbuf(-1);
 	else if(strcmp(token, "sdrrd") == 0) sdrrd(get_token(&c), get_token(&c));
 	else if(strcmp(token, "sdrrderr") == 0) sdrrderr(get_token(&c));

--- a/litex/soc/software/bios/sdram.c
+++ b/litex/soc/software/bios/sdram.c
@@ -13,7 +13,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#ifdef CSR_SDRAM_BASE
+#ifdef CONFIG_SDRAM_PHYS_COUNT
 #include <generated/sdram_phy.h>
 #endif
 #include <generated/mem.h>
@@ -55,7 +55,7 @@ __attribute__((unused)) static void cdelay(int i)
 	}
 }
 
-#ifdef CSR_SDRAM_BASE
+#ifdef CONFIG_SDRAM_PHYS_COUNT
 
 #define DFII_ADDR_SHIFT CONFIG_CSR_ALIGNMENT/8
 
@@ -693,7 +693,7 @@ static void read_level(int module)
 }
 #endif /* CSR_DDRPHY_BASE */
 
-#endif /* CSR_SDRAM_BASE */
+#endif /* CONFIG_SDRAM_PHYS_COUNT */
 
 static unsigned int seed_to_data_32(unsigned int seed, int random)
 {
@@ -952,7 +952,7 @@ int memtest(char *addr, char *len)
 	}
 }
 
-#ifdef CSR_SDRAM_BASE
+#ifdef CONFIG_SDRAM_PHYS_COUNT
 
 #ifdef CSR_DDRPHY_BASE
 int sdrlevel(void)

--- a/litex/soc/software/bios/sdram.c
+++ b/litex/soc/software/bios/sdram.c
@@ -787,7 +787,7 @@ static int memtest_bus(unsigned long addr, unsigned long len)
 		array[i] = ONEZERO;
 	}
 	flush_cpu_dcache();
-#ifdef CONFIG_L2_SIZE
+#ifdef CONFIG_L2
 	flush_l2_cache();
 #endif
 	for(i=0;i<len/4;i++) {
@@ -804,7 +804,7 @@ static int memtest_bus(unsigned long addr, unsigned long len)
 		array[i] = ZEROONE;
 	}
 	flush_cpu_dcache();
-#ifdef CONFIG_L2_SIZE
+#ifdef CONFIG_L2
 	flush_l2_cache();
 #endif
 	for(i=0;i<len/4;i++) {
@@ -844,7 +844,7 @@ static int memtest_data(unsigned long addr, unsigned long len)
 
 	seed_32 = 0;
 	flush_cpu_dcache();
-#ifdef CONFIG_L2_SIZE
+#ifdef CONFIG_L2
 	flush_l2_cache();
 #endif
 	for(i=0;i<len/4;i++) {
@@ -887,7 +887,7 @@ static int memtest_addr(unsigned long addr, unsigned long len)
 
 	seed_16 = 0;
 	flush_cpu_dcache();
-#ifdef CONFIG_L2_SIZE
+#ifdef CONFIG_L2
 	flush_l2_cache();
 #endif
 	for(i=0;i<len/4;i++) {
@@ -931,7 +931,7 @@ static void memspeed(unsigned long addr, unsigned long len)
 
 	/* flush CPU and L2 caches */
 	flush_cpu_dcache();
-#ifdef CONFIG_L2_SIZE
+#ifdef CONFIG_L2
 	flush_l2_cache();
 #endif
 

--- a/litex/soc/software/bios/sdram.c
+++ b/litex/soc/software/bios/sdram.c
@@ -71,8 +71,11 @@ void sdrsw(void)
 
 void sdrhw(void)
 {
-	sdram_dfii_control_write(DFII_CONTROL_SEL);
-	printf("SDRAM now under hardware control\n");
+	int i;
+	for(i = 0; i < CONFIG_SDRAM_PHYS_COUNT; i++) {
+		sdram_phys[i].control_write(DFII_CONTROL_SEL);
+		printf("SDRAM %d now under hardware control\n", i);
+	}
 }
 
 void sdrrow(char *_row)
@@ -1024,7 +1027,7 @@ int sdrinit(void)
 	ddrctrl_init_error_write(0);
 #endif
 
-	init_sequence();
+	sdram_phy_init_all();
 #ifdef CSR_DDRPHY_BASE
 #if CSR_DDRPHY_EN_VTC_ADDR
 	ddrphy_en_vtc_write(0);

--- a/litex/soc/software/bios/sdram.c
+++ b/litex/soc/software/bios/sdram.c
@@ -71,6 +71,21 @@ static inline unsigned dfii_pix_data_bytes(const struct sdram_phy_t *phy) {
 	return phy->pix_data_size * CSR_DATA_BYTES;
 }
 
+void meminfo(void)
+{
+	int i;
+	printf("Name    Address     Size        L2 Cache    Part of Main RAM?\n");
+	for(i = 0; i < COUNT(mem_regions_sdram); i++) {
+		const struct mem_region_t *ram = &mem_regions_sdram[i];
+
+		int is_main_ram = ram->base >= MAIN_RAM_BASE \
+		        && (ram->base+ram->size) <= (MAIN_RAM_BASE+MAIN_RAM_SIZE);
+		printf("SDRAM%d  0x%08x  0x%08x  0x%08x  %s\n",
+		       i, ram->base, ram->size, ram->l2_cache_size,
+		       is_main_ram?"Yes":"No");
+	}
+}
+
 static int current_phy_id = 0;
 
 void currentsdramphy(char *phy_id)

--- a/litex/soc/software/bios/sdram.h
+++ b/litex/soc/software/bios/sdram.h
@@ -3,6 +3,7 @@
 
 #include <generated/csr.h>
 
+void meminfo(void);
 void currentsdramphy(char *phy_id);
 void sdrsw(int phy_id);
 void sdrhw(int phy_id);

--- a/litex/soc/software/bios/sdram.h
+++ b/litex/soc/software/bios/sdram.h
@@ -3,8 +3,9 @@
 
 #include <generated/csr.h>
 
-void sdrsw(void);
-void sdrhw(void);
+void currentsdramphy(char *phy_id);
+void sdrsw(int phy_id);
+void sdrhw(int phy_id);
 void sdrrow(char *_row);
 void sdrrdbuf(int dq);
 void sdrrd(char *startaddr, char *dq);

--- a/litex/soc/software/bios/sdram.h
+++ b/litex/soc/software/bios/sdram.h
@@ -24,7 +24,7 @@ int sdrlevel(void);
 #endif
 
 int memtest_silent(void);
-int memtest(void);
+int memtest(char *addr, char *len);
 int sdrinit(void);
 
 #endif /* __SDRAM_H */

--- a/litex/soc/software/libbase/system.c
+++ b/litex/soc/software/libbase/system.c
@@ -12,6 +12,8 @@
 #include <generated/mem.h>
 #include <generated/csr.h>
 
+#define COUNT(x) (sizeof(x)/sizeof(x[0]))
+
 void flush_cpu_icache(void)
 {
 #if defined (__lm32__)
@@ -119,12 +121,14 @@ void flush_cpu_dcache(void)
 #endif
 }
 
-#ifdef CONFIG_L2_SIZE
+#ifdef CONFIG_L2
 void flush_l2_cache(void)
 {
-	unsigned int i;
-	for(i=0;i<2*CONFIG_L2_SIZE/4;i++) {
-		((volatile unsigned int *) MAIN_RAM_BASE)[i];
+	unsigned int i, j;
+	for(i = 0; i < COUNT(mem_regions_sdram); i++) {
+		for(j = 0; j < 2*mem_regions_sdram[i].l2_cache_size/4; j++) {
+			((volatile unsigned int *) mem_regions_sdram[i].base)[j];
+		}
 	}
 }
 #endif


### PR DESCRIPTION
Requires https://github.com/enjoy-digital/litedram/pull/157

Summary:
* Multiple SDRAM PHYs can be added with `LiteXSoC.add_sdram(...)`:
  * Each SDRAM can be added as part of `main_ram` or as a fully independent region (pass `main_ram = False` to `add_sdram()`).
  * Each SDRAM has a separate L2 cache.
* Generated headers contain additional code:
  * An array of structs with information about each SDRAM has been added to `sdram_phy.h`. Each entry contains properties and pointers to functions used by BIOS code.
  * An array with SDRAM regions and L2 cache sizes has been added to `mem.h`.
  * `CONFIG_L2_SIZE` has been replaced by` CONFIG_L2`. The former was not removed for compatibility with older code.
  * New headers are backward compatible - old code still works.
* Software/BIOS:
  * All SDRAMs are initialized and tested on boot.
  * `memtest` optionally takes 2 arguments: base address and size in bytes.
  * New command for listing SDRAM regions: `meminfo`.
  * New command for choosing the SDRAM on which low-level functions (like `sdrhw` or` sdrrdbuf`) operate - `currentsdramphy <phy_number>`.
  * `flush_l2_cache` flushes all L2 caches.
* Support for multiple SDRAMs in `litex_sim` with `--add-sdram key=val [key=val ...]` command line argument:
  * Available keys: `module`, `data-width`, `address`, `max-size`, `region-name`, `verbosity`, `init`.
  * Can be used with `--with-sdram` (and other old sdram-related arguments) or without it.

Known limitations:
* Only SDRAMPHYModel and S6HalfRateDDRPHY are supported

Todo:
* Tests/CI
* Some cleanup

I'm testing the code with litex_sim and on Pano Logic G2 (litex-buildenv).

Example litex_sim command:
```
litex_sim \
    --add-sdram module=IS42S16320  address=0x10000000 \
    --add-sdram module=MT48LC16M16 address=0x18000000 \
    --add-sdram module=MT48LC16M16 address=0x1c000000 \
```
