### PR TITLE
Add SVD export capability to Builder (csr_svd parameter) and targets …

### DIFF
--- a/litex/soc/doc/__init__.py
+++ b/litex/soc/doc/__init__.py
@@ -32,7 +32,7 @@ def generate_svd(soc, buildpath, filename=None, name="soc", **kwargs):
         filename = name + ".svd"
     kwargs["name"] = name
     with open(buildpath + "/" + filename, "w", encoding="utf-8") as svd:
-        svd.write(export.get_svd(soc, **kwargs))
+        svd.write(export.get_csr_svd(soc, **kwargs))
 
 
 def generate_docs(soc, base_dir,

--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -152,12 +152,12 @@ class Builder:
             os.makedirs(svd_dir, exist_ok=True)
             write_to_file(self.csr_svd, export.get_csr_svd(self.soc))
 
-    def _prepare_software(self):
+    def _prepare_rom_software(self):
         for name, src_dir in self.software_packages:
             dst_dir = os.path.join(self.software_dir, name)
             os.makedirs(dst_dir, exist_ok=True)
 
-    def _generate_software(self, compile_bios=True):
+    def _generate_rom_software(self, compile_bios=True):
          for name, src_dir in self.software_packages:
             if name == "bios" and not compile_bios:
                 pass
@@ -167,7 +167,7 @@ class Builder:
                 if self.compile_software:
                     subprocess.check_call(["make", "-C", dst_dir, "-f", makefile])
 
-    def _initialize_rom(self):
+    def _initialize_rom_software(self):
         bios_file = os.path.join(self.software_dir, "bios", "bios.bin")
         bios_data = soc_core.get_mem_data(bios_file, self.soc.cpu.endianness)
         self.soc.initialize_rom(bios_data)
@@ -182,11 +182,11 @@ class Builder:
         self._generate_includes()
         self._generate_csr_map()
         if self.soc.cpu_type is not None:
-            self._prepare_software()
-            self._generate_software(not self.soc.integrated_rom_initialized)
+            self._prepare_rom_software()
+            self._generate_rom_software(not self.soc.integrated_rom_initialized)
             if self.soc.integrated_rom_size and self.compile_software:
                 if not self.soc.integrated_rom_initialized:
-                    self._initialize_rom()
+                    self._initialize_rom_software()
 
         if "run" not in kwargs:
             kwargs["run"] = self.compile_gateware

--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -180,14 +180,13 @@ class Builder:
         self.soc.finalize()
 
         self._generate_includes()
+        self._generate_csr_map()
         if self.soc.cpu_type is not None:
             self._prepare_software()
             self._generate_software(not self.soc.integrated_rom_initialized)
             if self.soc.integrated_rom_size and self.compile_software:
                 if not self.soc.integrated_rom_initialized:
                     self._initialize_rom()
-
-        self._generate_csr_map()
 
         if "run" not in kwargs:
             kwargs["run"] = self.compile_gateware

--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -281,7 +281,7 @@ def get_csr_csv(csr_regions={}, constants={}, mem_regions={}):
 
 # SVD Export --------------------------------------------------------------------------------------
 
-def get_svd(soc, vendor="litex", name="soc", description=None):
+def get_csr_svd(soc, vendor="litex", name="soc", description=None):
     def sub_csr_bit_range(busword, csr, offset):
         nwords = (csr.size + busword - 1)//busword
         i = nwords - offset - 1
@@ -337,17 +337,12 @@ def get_svd(soc, vendor="litex", name="soc", description=None):
         interrupts[csr] = irq
 
     documented_regions = []
-
-    raw_regions = []
-    if hasattr(soc, "get_csr_regions"):
-        raw_regions = soc.get_csr_regions()
-    else:
-        for region_name, region in soc.csr_regions.items():
-            raw_regions.append((region_name, region.origin,
-                                region.busword, region.obj))
-    for csr_region in raw_regions:
+    for name, region in soc.csr.regions.items():
         documented_regions.append(DocumentedCSRRegion(
-            csr_region, csr_data_width=soc.csr_data_width))
+            name           = name,
+            region         = region,
+            csr_data_width = soc.csr.data_width)
+        )
 
     svd = []
     svd.append('<?xml version="1.0" encoding="utf-8"?>')


### PR DESCRIPTION
…(--csr-svd argument) and fix svd regression.

This allows generating SVD export files during the build as we are already doing for .csv or .json.

Use with Builder:
builder = Builder(soc, csr_svd="csr.svd")

Use with target:
./arty.py --csr-svd=csr.svd