### PR TITLE
software/bios: fixup for Ultrascale SDRAM debug

### DIFF
--- a/litex/soc/software/bios/sdram.c
+++ b/litex/soc/software/bios/sdram.c
@@ -1063,6 +1063,7 @@ static void sdrmproff(void)
 void sdrmpr(void)
 {
 	int module, phase;
+	unsigned char buf[DFII_PIX_DATA_BYTES];
 	printf("Read SDRAM MPR...\n");
 
 	/* rst phy */
@@ -1084,8 +1085,10 @@ void sdrmpr(void)
 	for (module=0; module < NBMODULES; module++) {
 		printf("m%d: ", module);
 		for(phase=0; phase<DFII_NPHASES; phase++) {
-			printf("%d", MMPTR(sdram_dfii_pix_rddata_addr[phase]+4*(NBMODULES-module-1)) & 0x1);
-			printf("%d", MMPTR(sdram_dfii_pix_rddata_addr[phase]+4*(2*NBMODULES-module-1)) & 0x1);
+			csr_rd_buf_uint8(sdram_dfii_pix_rddata_addr[phase],
+					 buf, DFII_PIX_DATA_BYTES);
+			printf("%d", buf[  NBMODULES-module-1] & 0x1);
+			printf("%d", buf[2*NBMODULES-module-1] & 0x1);
 		}
 		printf("\n");
 	}


### PR DESCRIPTION
Keep CSR accesses independent of csr_data_width and csr_alignment.

@enjoy-digital Please test before applying -- I'm _guessing_ the assumption was that  alignment is 32 and csr-data-width is 8, but I'm not 100% sure :)