### PR TITLE
integration/soc: add_ethernet: honor self.map["ethmac"], if present

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1044,7 +1044,8 @@ class LiteXSoC(SoC):
             dw         = 32,
             interface  = "wishbone",
             endianness = self.cpu.endianness)
-        ethmac_region = SoCRegion(size=0x2000, cached=False)
+        ethmac_region = SoCRegion(origin=self.mem_map.get("ethmac", None),
+                                  size=0x2000, cached=False)
         self.bus.add_slave(name="ethmac", slave=self.ethmac.bus, region=ethmac_region)
         self.add_csr("ethmac")
         self.add_interrupt("ethmac")


### PR DESCRIPTION
Can't (yet) stop setting `self.map["ethmac"]` in Rocket, because doing so would break the build on targets _other_ than nexys4ddr (which don't yet use `LiteXSoC.add_ethernet()`).

But at least for now they're consistent across targets.

This (partially) fixes https://github.com/enjoy-digital/litex/issues/420.