### PR TITLE
Make CSR documentation diagrams, with more than 8 bits, be split into multiple lanes.

### DIFF
--- a/litex/soc/doc/csr.py
+++ b/litex/soc/doc/csr.py
@@ -235,7 +235,9 @@ class DocumentedCSRRegion:
         print("", file=stream)
         print("        {", file=stream)
         print("            \"reg\": [", file=stream)
+        multilane = False
         if len(reg.fields) > 0:
+            min_field_size = self.csr_data_width
             bit_offset = 0
             for field in reg.fields:
                 field_name = field.name
@@ -254,6 +256,9 @@ class DocumentedCSRRegion:
                     term=""
                 print("                {\"name\": \"" + field_name + "\",  " + type_str + attr_str + "\"bits\": " + str(field.size) + "}" + term, file=stream)
                 bit_offset = field.offset + field.size
+                min_field_size = min(min_field_size, field.size)
+                if min_field_size < 8:
+                    multilane = True
             if bit_offset != self.busword:
                 print("                {\"bits\": " + str(self.busword - bit_offset) + "}", file=stream)
         else:
@@ -265,8 +270,12 @@ class DocumentedCSRRegion:
                 attr_str = "\"attr\": 'reset: " + str(reg.reset_value) + "', "
             print("                {\"name\": \"" + reg.short_name.lower() + self.bit_range(reg.offset, reg.offset + reg.size, empty_if_zero=True) + "\", " + attr_str + "\"bits\": " + str(reg.size) + "}" + term, file=stream)
             if reg.size != self.csr_data_width:
+                multilane = True
                 print("                {\"bits\": " + str(self.csr_data_width - reg.size) + "},", file=stream)
-        lanes = self.busword / 8
+        if multilane:
+            lanes = self.busword / 8
+        else:
+            lanes = 1
         print("            ], \"config\": {\"hspace\": 400, \"bits\": " + str(self.busword) + ", \"lanes\": " + str(lanes) + " }, \"options\": {\"hspace\": 400, \"bits\": " + str(self.busword) + ", \"lanes\": " + str(lanes) + "}", file=stream)
         print("        }", file=stream)
         print("", file=stream)

--- a/litex/soc/doc/csr.py
+++ b/litex/soc/doc/csr.py
@@ -266,7 +266,8 @@ class DocumentedCSRRegion:
             print("                {\"name\": \"" + reg.short_name.lower() + self.bit_range(reg.offset, reg.offset + reg.size, empty_if_zero=True) + "\", " + attr_str + "\"bits\": " + str(reg.size) + "}" + term, file=stream)
             if reg.size != self.csr_data_width:
                 print("                {\"bits\": " + str(self.csr_data_width - reg.size) + "},", file=stream)
-        print("            ], \"config\": {\"hspace\": 400, \"bits\": " + str(self.busword) + ", \"lanes\": 1 }, \"options\": {\"hspace\": 400, \"bits\": " + str(self.busword) + ", \"lanes\": 1}", file=stream)
+        lanes = self.busword / 8
+        print("            ], \"config\": {\"hspace\": 400, \"bits\": " + str(self.busword) + ", \"lanes\": " + str(lanes) + " }, \"options\": {\"hspace\": 400, \"bits\": " + str(self.busword) + ", \"lanes\": " + str(lanes) + "}", file=stream)
         print("        }", file=stream)
         print("", file=stream)
 


### PR DESCRIPTION
In cases when each CSR bit has a name and we use CSR with more than 8
bits, the register diagram quickly becomes crowded and hard to read.

With this patch we split the register into multiple lanes of 8 bits
each.

The motivation for this patch is motivated by the [iCEBESOC documentation](https://icebreaker-fpga.github.io/icebreaker-litex-examples/leds.html#leds-out).

I might be missing some details here. Let me know if there is a better way of doing this. We might want to add a member variable to the CSR that will allow us to fine tune if we want the register to be split into 4 lanes or not. Maybe even a way to select if we want it to be split into 16bit lanes instead of 8bit.

@xobs your input is very much appreciated. :)