### PR TITLE
Support SPI-mode SDCard booting on Litex+Rocket (64bit) configuration

### DIFF
--- a/litex/boards/platforms/nexys4ddr.py
+++ b/litex/boards/platforms/nexys4ddr.py
@@ -57,6 +57,15 @@ _io = [
         IOStandard("LVCMOS33"),
     ),
 
+    ("spisdcard", 0,
+        Subsignal("rst",  Pins("E2")),
+        Subsignal("clk",  Pins("B1")),
+        Subsignal("mosi", Pins("C1"), Misc("PULLUP True")),
+        Subsignal("cs_n", Pins("D2"), Misc("PULLUP True")),
+        Subsignal("miso", Pins("C2"), Misc("PULLUP True")),
+        IOStandard("LVCMOS33"), Misc("SLEW=FAST")
+    ),
+
     ("sdcard", 0,
         Subsignal("rst", Pins("E2"), Misc("PULLUP True")),
         Subsignal("data", Pins("C2 E1 F1 D2"), Misc("PULLUP True")),

--- a/litex/boards/targets/nexys4ddr.py
+++ b/litex/boards/targets/nexys4ddr.py
@@ -87,7 +87,8 @@ class BaseSoC(SoCCore):
 
     def add_sdcard(self):
         sdcard_pads = self.platform.request("sdcard")
-        self.comb += sdcard_pads.rst.eq(0)
+        if hasattr(sdcard_pads, "rst"):
+            self.comb += sdcard_pads.rst.eq(0)
         self.submodules.sdclk = SDClockerS7(sys_clk_freq=self.sys_clk_freq)
         self.submodules.sdphy = SDPHY(sdcard_pads, self.platform.device)
         self.submodules.sdcore = SDCore(self.sdphy)

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -494,22 +494,22 @@ void romboot(void)
 
 void spisdcardboot(void)
 {
-    printf("SD Card via SPI Initialising\n");
-    if(spi_sdcard_goidle() == 0) {
-        printf("SD Card Timeout\n");
-        return;
-    }
-    
-    if(spi_sdcard_readMBR() == 0) {
-        printf("SD Card MBR Timeout\n");
-        return;
-    }
-    
-    if(spi_sdcard_readFile("IMAGE","",MAIN_RAM_BASE+KERNEL_IMAGE_RAM_OFFSET)==0) return;
-    if(spi_sdcard_readFile("ROOTFS~1","CPI",MAIN_RAM_BASE+ROOTFS_IMAGE_RAM_OFFSET)==0) return;
-    if(spi_sdcard_readFile("RV32","DTB",MAIN_RAM_BASE+DEVICE_TREE_IMAGE_RAM_OFFSET)==0) return;
-    if(spi_sdcard_readFile("EMULATOR","BIN",EMULATOR_RAM_BASE)==0) return;
-    
-    boot(0,0,0,EMULATOR_RAM_BASE + EMULATOR_IMAGE_RAM_OFFSET);
+	printf("SD Card via SPI Initialising\n");
+	if(spi_sdcard_goidle() == 0) {
+		printf("SD Card Timeout\n");
+		return;
+	}
+
+	if(spi_sdcard_readMBR() == 0) {
+		printf("SD Card MBR Timeout\n");
+		return;
+	}
+
+	if(spi_sdcard_readFile("IMAGE","",MAIN_RAM_BASE+KERNEL_IMAGE_RAM_OFFSET)==0) return;
+	if(spi_sdcard_readFile("ROOTFS~1","CPI",MAIN_RAM_BASE+ROOTFS_IMAGE_RAM_OFFSET)==0) return;
+	if(spi_sdcard_readFile("RV32","DTB",MAIN_RAM_BASE+DEVICE_TREE_IMAGE_RAM_OFFSET)==0) return;
+	if(spi_sdcard_readFile("EMULATOR","BIN",EMULATOR_RAM_BASE)==0) return;
+
+	boot(0,0,0,EMULATOR_RAM_BASE + EMULATOR_IMAGE_RAM_OFFSET);
 }
 #endif

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -505,11 +505,19 @@ void spisdcardboot(void)
 		return;
 	}
 
+#if defined(CONFIG_CPU_TYPE_VEXRISCV) && defined(CONFIG_CPU_VARIANT_LINUX)
 	if(spi_sdcard_readFile("IMAGE","",MAIN_RAM_BASE+KERNEL_IMAGE_RAM_OFFSET)==0) return;
 	if(spi_sdcard_readFile("ROOTFS~1","CPI",MAIN_RAM_BASE+ROOTFS_IMAGE_RAM_OFFSET)==0) return;
 	if(spi_sdcard_readFile("RV32","DTB",MAIN_RAM_BASE+DEVICE_TREE_IMAGE_RAM_OFFSET)==0) return;
 	if(spi_sdcard_readFile("EMULATOR","BIN",EMULATOR_RAM_BASE)==0) return;
 
 	boot(0,0,0,EMULATOR_RAM_BASE + EMULATOR_IMAGE_RAM_OFFSET);
+#else
+	if(spi_sdcard_readFile("BOOT","BIN",MAIN_RAM_BASE)==0) {
+		printf("SD Card SPI boot failed\n");
+		return;
+	}
+	boot(0, 0, 0, MAIN_RAM_BASE);
+#endif
 }
 #endif

--- a/litex/soc/software/libbase/spisdcard.c
+++ b/litex/soc/software/libbase/spisdcard.c
@@ -228,7 +228,7 @@ unsigned char spi_sdcard_goidle(void)
         r=spi_read_byte();
 
     // CMD16 - Set SD CARD block size to 512 - Sector Size for the SD CARD
-    // Command Sequence is DUMMY=0xff (512 as unsigned long = 0x00000200) 0x00 0x00 0x02 0x00 CRC=0xff
+    // Command Sequence is DUMMY=0xff (512 as unsigned int = 0x00000200) 0x00 0x00 0x02 0x00 CRC=0xff
     // Expected R1 response is 0x00 indicating SD CARD is READY
     spi_write_byte( 0xff ); spi_write_byte( 0x50 ); spi_write_byte( 0x00 ); spi_write_byte( 0x00 ); spi_write_byte( 0x02 ); spi_write_byte( 0x00 ); spi_write_byte( 0xff );
     r=spi_read_rbyte();
@@ -294,8 +294,8 @@ typedef struct {
     unsigned char start_chs[3];
     unsigned char partition_type;
     unsigned char end_chs[3];
-    unsigned long start_sector;
-    unsigned long length_sectors;
+    unsigned int start_sector;
+    unsigned int length_sectors;
 } __attribute((packed)) PartitionTable;
 
 PartitionTable sdCardPartition;
@@ -314,13 +314,13 @@ typedef struct {
     unsigned short fat_size_sectors;
     unsigned short sectors_per_track;
     unsigned short number_of_heads;
-    unsigned long hidden_sectors;
-    unsigned long total_sectors_long;
+    unsigned int hidden_sectors;
+    unsigned int total_sectors_long;
 
     unsigned char drive_number;
     unsigned char current_head;
     unsigned char boot_signature;
-    unsigned long volume_id;
+    unsigned int volume_id;
     char volume_label[11];
     char fs_type[8];
     char boot_code[448];
@@ -339,7 +339,7 @@ typedef struct {
     unsigned short modify_time;
     unsigned short modify_date;
     unsigned short starting_cluster;
-    unsigned long file_size;
+    unsigned int file_size;
 } __attribute((packed)) Fat16Entry;
 
 Fat16Entry *sdCardFat16RootDir;
@@ -510,7 +510,7 @@ unsigned char spi_sdcard_readFile(char *filename, char *ext, unsigned long addre
 {
     int i, n, sector;
     unsigned short fileClusterStart;
-    unsigned long fileLength, bytesRemaining, clusterSectorStart;
+    unsigned int fileLength, bytesRemaining, clusterSectorStart;
     unsigned short nameMatch;
     printf("Reading File [%s.%s] into 0x%08x : ",filename, ext, address);
 


### PR DESCRIPTION
specifically targeted at (and successfully tested on) nexys4ddr, but should work on other boards as well

