### PR TITLE
flush rx buffer when bad crc and fix frame payload length

### DIFF
--- a/litex/soc/software/bios/sfl.h
+++ b/litex/soc/software/bios/sfl.h
@@ -9,7 +9,7 @@
 #define SFL_MAGIC_ACK "z6IHG7cYDID6o\n"
 
 struct sfl_frame {
-	unsigned char length;
+	unsigned char payload_length;
 	unsigned char crc[2];
 	unsigned char cmd;
 	unsigned char payload[255];

--- a/litex/tools/litex_term.py
+++ b/litex/tools/litex_term.py
@@ -52,7 +52,7 @@ sfl_prompt_ack = b"\x06"
 sfl_magic_req = b"sL5DdSMmkekro\n"
 sfl_magic_ack = b"z6IHG7cYDID6o\n"
 
-sfl_payload_length = 251
+sfl_payload_length = 64#251
 
 # General commands
 sfl_cmd_abort       = b"\x00"
@@ -212,7 +212,7 @@ class LiteXTerm:
                                                     100*position//length))
             sys.stdout.flush()
             frame = SFLFrame()
-            frame_data = f.read(min(remaining, sfl_payload_length))
+            frame_data = f.read(min(remaining, sfl_payload_length-4))
             if self.flash:
                 frame.cmd = sfl_cmd_flash
             else:


### PR DESCRIPTION
# Problem
When using async FIFO 245 to `serialboot` the CPU, data was always corrupted.

# Issues/Fixes
- If there was a CRC error, sometimes lxterm would have already started sending the next frame, and the CPU got misaligned in reading frames. This PR fixes that by flushing the "bad" data from the RX buffer upon bad CRC.
- lxterm defined payload as the number of bytes from the upload file while `serialboot` defined payload length as the uploaded file byes _plus_ the address to write them to. Therefore, lxterm was sending 4 more bytes than the CPU was expecting. This PR fixes this by shrinking lxterm's file read by 4 bytes. I also renamed `frame.length` to `frame.payload_length` to avoid future confusion.

# Remaining Issues
- Even with these fixes, the FIFO 245 data transfer is extremely slow, and I am not sure why yet. lxterm's `pyserial` does not use D2XX drivers, which FIFO 245 requires according to the FT2232H datasheet. According to #231 the host can use standard UART to interface with a FIFO 245 configured FTDI device. 
- I had to modify lxterm to send sfl frames in smaller chunks to get the data transfer to work. CRC consistently failed at more than 123 bytes at a time. It would be great to not have to shrink this.