### PR TITLE
Update removed llvm compiler-rt repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/openrisc/mor1kx.git
 [submodule "litex/soc/software/compiler_rt"]
 	path = litex/soc/software/compiler_rt
-	url = https://git.llvm.org/git/compiler-rt
+	url = https://github.com/llvm-mirror/compiler-rt
 [submodule "litex/soc/cores/cpu/picorv32/verilog"]
 	path = litex/soc/cores/cpu/picorv32/verilog
 	url = https://github.com/cliffordwolf/picorv32


### PR DESCRIPTION
This PR changes `compiler_rt`'s repo path to a github mirror as the original one is no more accessible.

LLVM project moved fully to GitHub, but unfortunatelly it officialy does not provide a separete `compiler_rt` repo anymore. The code is now part of https://github.com/llvm/llvm-project. 

What's more when we tried to clone the whole `llvm-project` repo and use `compier_rt` from there we encountered problems with TI mode emulation:
```
make[1]: Entering directory '/home/grey/linux-on-litex/update/litex-linux-on-litex-vexriscv/build/arty/software/libcompiler_rt'
 CC       umodsi3.o
In file included from /home/grey/linux-on-litex/update/litex-linux-on-litex-vexriscv/litex/litex/soc/software/compiler_rt/lib/builtins/int_lib.h:89,
                 from /home/grey/linux-on-litex/update/litex-linux-on-litex-vexriscv/litex/litex/soc/software/compiler_rt/lib/builtins/umodsi3.c:13:
/home/grey/linux-on-litex/update/litex-linux-on-litex-vexriscv/litex/litex/soc/software/compiler_rt/lib/builtins/int_types.h:70:1: error: unable to emulate 'TI'
 typedef int ti_int __attribute__((mode(TI)));
 ^~~~~~~
/home/grey/linux-on-litex/update/litex-linux-on-litex-vexriscv/litex/litex/soc/software/compiler_rt/lib/builtins/int_types.h:71:1: error: unable to emulate 'TI'
 typedef unsigned tu_int __attribute__((mode(TI)));
 ^~~~~~~
make[1]: *** [/home/grey/linux-on-litex/update/litex-linux-on-litex-vexriscv/litex/litex/soc/software/libcompiler_rt/Makefile:27: umodsi3.o] Error 1
make[1]: Leaving directory '/home/grey/linux-on-litex/update/litex-linux-on-litex-vexriscv/build/arty/software/libcompiler_rt'
```