### PR TITLE
[WIP] Add initial version of the new SPI XIP core (simulation only)

### DIFF
--- a/litex/soc/cores/spi_xip/__init__.py
+++ b/litex/soc/cores/spi_xip/__init__.py
@@ -1,0 +1,17 @@
+from migen import *
+
+from litex.soc.interconnect import stream
+
+from litex.soc.cores.spi_xip.core import LiteSPICore
+
+
+class LiteSPI(Module):
+    def __init__(self, phy, endianness="big"):
+        self.submodules.core = core = LiteSPICore(endianness)
+        self.bus = core.bus
+
+        self.comb += [
+            phy.cs_n.eq(core.cs_n),
+            phy.source.connect(core.sink),
+            core.source.connect(phy.sink),
+        ]

--- a/litex/soc/cores/spi_xip/common.py
+++ b/litex/soc/cores/spi_xip/common.py
@@ -1,0 +1,8 @@
+spi_phy_ctl_layout = [
+    ("addr", 32),
+    ("cmd", 1),
+]
+
+spi_phy_data_layout = [
+    ("data", 32),
+]

--- a/litex/soc/cores/spi_xip/core.py
+++ b/litex/soc/cores/spi_xip/core.py
@@ -1,0 +1,77 @@
+from migen import *
+from migen.genlib.fsm import FSM, NextState
+
+from litex.soc.cores.spi_xip.common import *
+from litex.soc.interconnect import wishbone, stream
+from litex.gen.common import reverse_bytes
+
+
+class LiteSPICore(Module):
+    def __init__(self, endianness="big"):
+        self.source = source = stream.Endpoint(spi_phy_ctl_layout)
+        self.sink   = sink   = stream.Endpoint(spi_phy_data_layout)
+        self.bus    = bus    = wishbone.Interface()
+        self.cs_n   = cs_n   = Signal()
+        curr_addr   = Signal(32)
+        bus_read    = Signal()
+        cs_cnt      = Signal(16)
+        cs_val      = Signal(16)
+
+        self.submodules.fsm = fsm = FSM(reset_state="IDLE")
+
+        self.comb += [
+            bus_read.eq(bus.cyc & bus.stb & ~bus.we),
+            bus.dat_r.eq(sink.data if endianness == "big" else reverse_bytes(sink.data)),
+        ]
+
+
+        # TODO: make this configurable via CSR
+        self.comb += cs_val.eq(10000)
+
+        fsm.act("IDLE",
+            cs_n.eq(1),
+            If(bus_read,
+                NextState("CS_DELAY"),
+            )
+        )
+        fsm.act("CMD",
+            source.valid.eq(1),
+            source.cmd.eq(1),
+            source.addr.eq(Cat(0, 0, bus.adr)), # convert wb address to bytes
+            If(source.ready & source.valid,
+                NextValue(curr_addr, bus.adr),
+                NextState("READ_REQ"),
+            )
+        )
+        fsm.act("READ_REQ",
+            source.valid.eq(1),
+            If(source.ready & source.valid,
+                NextState("READ_DAT"),
+            )
+        )
+        fsm.act("READ_DAT",
+            sink.ready.eq(bus.stb),
+            bus.ack.eq(sink.valid),
+            If(sink.ready & sink.valid,
+                NextValue(curr_addr, curr_addr+1),
+                NextState("READY"),
+            )
+        )
+        fsm.act("READY",
+            If(bus_read,
+                If(curr_addr == bus.adr, # is the current flash address ok?
+                    NextState("READ_REQ"),
+                ).Else(
+                    NextState("CS_DELAY"),
+                )
+            )
+        )
+        fsm.act("CS_DELAY",
+            cs_n.eq(1),
+            If(cs_cnt < cs_val,
+                NextValue(cs_cnt, cs_cnt+1),
+            ).Else(
+                NextValue(cs_cnt, 0),
+                NextState("CMD"),
+            )
+        )

--- a/litex/soc/cores/spi_xip/phy/model.py
+++ b/litex/soc/cores/spi_xip/phy/model.py
@@ -1,0 +1,40 @@
+from migen import *
+from migen.genlib.fsm import FSM, NextState
+
+from litex.soc.cores.spi_xip.common import *
+from litex.soc.interconnect import stream
+
+class LiteSPIPHYModel(Module):
+    def __init__(self, size, init=None):
+        self.source = source = stream.Endpoint(spi_phy_data_layout)
+        self.sink   = sink   = stream.Endpoint(spi_phy_ctl_layout)
+
+
+        self.mem = mem = Memory(32, size//4, init=init)
+
+        read_port  = mem.get_port(async_read=True)
+        read_addr  = Signal(32)
+        self.comb += read_port.adr.eq(read_addr),
+        self.cs_n  = Signal()
+
+        self.specials += mem, read_port
+
+        self.submodules.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            sink.ready.eq(1),
+            If(sink.ready & sink.valid,
+                If(sink.cmd,
+                    NextValue(read_addr, sink.addr[2:31]), # word addressed memory
+                ).Else(
+                    NextState("DATA"),
+                ),
+            ),
+        )
+        fsm.act("DATA",
+            source.valid.eq(1),
+            source.data.eq(read_port.dat_r),
+            If(source.ready & source.valid,
+                NextValue(read_addr, read_addr+1),
+                NextState("IDLE"),
+            ),
+        )

--- a/test/test_spi_xip.py
+++ b/test/test_spi_xip.py
@@ -1,0 +1,68 @@
+import unittest
+
+from migen import *
+
+from litex.soc.cores.spi_xip.core import LiteSPICore
+
+
+class TestSPIXIP(unittest.TestCase):
+    def test_spi_xip_core_syntax(self):
+        spi_xip = LiteSPICore()
+
+    def test_spi_xip_read_test(self):
+        dut = LiteSPICore()
+
+        def wb_gen(dut):
+            dut.data_ok = 0
+
+            yield dut.bus.adr.eq(0xcafe)
+            yield dut.bus.we.eq(0)
+            yield dut.bus.cyc.eq(1)
+            yield dut.bus.stb.eq(1)
+
+            while (yield dut.bus.ack) == 0:
+                yield
+
+            if (yield dut.bus.dat_r) == 0xdeadbeef:
+                dut.data_ok = 1
+
+        def phy_gen(dut):
+            dut.addr_ok = 0
+            dut.cmd_ok = 0
+
+            yield dut.sink.valid.eq(0)
+            yield dut.source.ready.eq(1)
+
+            while (yield dut.source.valid) == 0:
+                yield
+
+            if (yield dut.source.addr) == (0xcafe<<2): # address cmd
+                dut.addr_ok = 1
+            if (yield dut.source.cmd) == 1:
+                dut.cmd_ok += 1
+
+            yield
+
+            while (yield dut.source.valid) == 0:
+                yield
+
+            if (yield dut.source.cmd) == 0: # read cmd
+                dut.cmd_ok += 1
+
+            yield dut.source.ready.eq(0)
+            yield
+
+            yield dut.sink.data.eq(0xdeadbeef)
+            yield dut.sink.valid.eq(1)
+
+            while (yield dut.sink.ready) == 0:
+                yield
+
+            yield
+            yield dut.sink.valid.eq(0)
+            yield
+
+        run_simulation(dut, [wb_gen(dut), phy_gen(dut)])
+        self.assertEqual(dut.data_ok, 1)
+        self.assertEqual(dut.addr_ok, 1)
+        self.assertEqual(dut.cmd_ok, 2)


### PR DESCRIPTION
This PR adds initial version of the new SPI XIP core, it currently consists of 2 parts:
- `LiteSPICore` that is responsible for handling the Wishbone bus, controlling the `cs_n` pin and deciding when end the SPI transfer and send new command + address
- `LiteSPIPHYModel` is a simulation model that can be used instead of the real PHY in `litex_sim`

Those two parts communicate via pair of Litex streams.
At this point the `LiteSPICore` is still missing a CSR for configuring the delay between ending a transfer and starting a new one during which `cs_n` stays high.