### PR TITLE
SPI SDCard fixes and features

### DIFF
--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -593,6 +593,9 @@ static void boot_sequence(void)
 #ifdef ROM_BOOT_ADDRESS
 		romboot();
 #endif
+#ifdef CSR_SPISDCARD_BASE
+		spisdcardboot();
+#endif
 #ifdef CSR_ETHMAC_BASE
 #ifdef CSR_ETHPHY_MODE_DETECTION_MODE_ADDR
 		eth_mode();

--- a/litex/soc/software/bios/sdcard.c
+++ b/litex/soc/software/bios/sdcard.c
@@ -143,16 +143,6 @@ void sdclk_set_clk(unsigned int freq) {
 
 /* command utils */
 
-static void busy_wait(unsigned int ms)
-{
-	timer0_en_write(0);
-	timer0_reload_write(0);
-	timer0_load_write(CONFIG_CLOCK_FREQUENCY/1000*ms);
-	timer0_en_write(1);
-	timer0_update_value_write(1);
-	while(timer0_value_read()) timer0_update_value_write(1);
-}
-
 static void sdtimer_init(void)
 {
 	sdtimer_en_write(0);

--- a/litex/soc/software/include/base/spisdcard.h
+++ b/litex/soc/software/include/base/spisdcard.h
@@ -3,4 +3,4 @@ int spi_sdcard_read_sector(uint32_t device, uint32_t lba,uint_least8_t *buf);
 
 uint8_t spi_sdcard_goidle(void);
 uint8_t spi_sdcard_readMBR(void);
-uint8_t spi_sdcard_readFile(char *, char *, uint32_t);
+uint8_t spi_sdcard_readFile(char *, char *, unsigned long);

--- a/litex/soc/software/include/base/system.h
+++ b/litex/soc/software/include/base/system.h
@@ -9,6 +9,8 @@ void flush_cpu_icache(void);
 void flush_cpu_dcache(void);
 void flush_l2_cache(void);
 
+void busy_wait(unsigned int ms);
+
 #ifdef __or1k__
 #include <spr-defs.h>
 static inline unsigned long mfspr(unsigned long add)

--- a/litex/soc/software/libbase/spisdcard.c
+++ b/litex/soc/software/libbase/spisdcard.c
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include <string.h>
+#include <system.h>
 
 #define USE_SPISCARD_RECLOCKING
 
@@ -217,6 +218,7 @@ uint8_t spi_sdcard_goidle(void)
         spi_write_byte( 0xff ); spi_write_byte( 0x69 ); spi_write_byte( 0x40 ); spi_write_byte( 0x00 ); spi_write_byte( 0x00 ); spi_write_byte( 0x00 ); spi_write_byte( 0x00 );
         r = spi_read_rbyte();
         timeout--;
+        busy_wait(20);
     } while ((r != 0x00) && (timeout>0));
     if(r!=0x00) return FAILURE;
 

--- a/litex/soc/software/libbase/spisdcard.c
+++ b/litex/soc/software/libbase/spisdcard.c
@@ -523,7 +523,7 @@ uint8_t spi_sdcard_readMBR(void)
 //      Return 0 success, 1 failure
 //
 // Details from https://codeandlife.com/2012/04/02/simple-fat-and-sd-tutorial-part-1/
-uint8_t spi_sdcard_readFile(char *filename, char *ext, uint32_t address)
+uint8_t spi_sdcard_readFile(char *filename, char *ext, unsigned long address)
 {
     int i, n, sector;
     uint16_t fileClusterStart;

--- a/litex/soc/software/libbase/system.c
+++ b/litex/soc/software/libbase/system.c
@@ -128,3 +128,13 @@ void flush_l2_cache(void)
 	}
 }
 #endif
+
+void busy_wait(unsigned int ms)
+{
+	timer0_en_write(0);
+	timer0_reload_write(0);
+	timer0_load_write(CONFIG_CLOCK_FREQUENCY/1000*ms);
+	timer0_en_write(1);
+	timer0_update_value_write(1);
+	while(timer0_value_read()) timer0_update_value_write(1);
+}

--- a/litex/soc/software/libnet/microudp.c
+++ b/litex/soc/software/libnet/microudp.c
@@ -448,24 +448,14 @@ void microudp_service(void)
 	}
 }
 
-static void busy_wait(unsigned int ds)
-{
-	timer0_en_write(0);
-	timer0_reload_write(0);
-	timer0_load_write(CONFIG_CLOCK_FREQUENCY/10*ds);
-	timer0_en_write(1);
-	timer0_update_value_write(1);
-	while(timer0_value_read()) timer0_update_value_write(1);
-}
-
 void eth_init(void)
 {
 	printf("Ethernet init...\n");
 #ifdef CSR_ETHPHY_CRG_RESET_ADDR
 	ethphy_crg_reset_write(1);
-	busy_wait(2);
+	busy_wait(200);
 	ethphy_crg_reset_write(0);
-	busy_wait(2);
+	busy_wait(200);
 #endif
 }
 


### PR DESCRIPTION
- ensure parameters representing a host address are `unsigned long` (rather than `uint32_t`) to work on 64-bit CPUs
- factor out `busy_wait()` so we can use the same one throughout the bios source tree
- use `busy_wait()` in SPI SDCard initialization loop to avoid running down the retry counter before card is ready (on some boards, e.g. trellisboard)
- finally, add `spisdcardboot()` to the bios `boot_sequence()`