### PR TITLE
[WIP] Add generic PHY for the new SPI XIP core

### DIFF
--- a/litex/boards/platforms/netv2.py
+++ b/litex/boards/platforms/netv2.py
@@ -23,7 +23,7 @@ _io = [
         Subsignal("cs_n", Pins("T19")),
         Subsignal("mosi", Pins("P22")),
         Subsignal("miso", Pins("R22")),
-        Subsignal("vpp", Pins("P21")),
+        Subsignal("wp",   Pins("P21")),
         Subsignal("hold", Pins("R21")),
         IOStandard("LVCMOS33")
     ),

--- a/litex/soc/cores/spi_xip/__init__.py
+++ b/litex/soc/cores/spi_xip/__init__.py
@@ -1,0 +1,17 @@
+from migen import *
+
+from litex.soc.interconnect import stream
+
+from litex.soc.cores.spi_xip.core import LiteSPICore
+
+
+class LiteSPI(Module):
+    def __init__(self, phy, endianness="big"):
+        self.submodules.core = core = LiteSPICore(endianness)
+        self.bus = core.bus
+
+        self.comb += [
+            phy.cs_n.eq(core.cs_n),
+            phy.source.connect(core.sink),
+            core.source.connect(phy.sink),
+        ]

--- a/litex/soc/cores/spi_xip/clkgen.py
+++ b/litex/soc/cores/spi_xip/clkgen.py
@@ -1,0 +1,63 @@
+from migen import *
+
+
+class LiteSPIClkGen(Module):
+    def __init__(self, pads, device):
+        self.div     = div     = Signal(8)
+        self.posedge = posedge = Signal()
+        self.negedge = negedge = Signal()
+        self.clk     = clk     = Signal()
+        self.en      = en      = Signal()
+        cnt          = Signal(8)
+        clkd         = Signal()
+
+        self.comb += [
+            posedge.eq(clk & ~clkd),
+            negedge.eq(~clk & clkd),
+        ]
+
+        self.sync += [
+            clkd.eq(clk),
+            If(en,
+                If(cnt < div,
+                    cnt.eq(cnt+1),
+                ).Else(
+                    cnt.eq(0),
+                    clk.eq(~clk),
+                )
+            ).Else(
+                clk.eq(0),
+                cnt.eq(0),
+            )
+        ]
+
+        if not hasattr(pads, "clk"):
+            pads.clk = Signal()
+            if device == "xc7":
+                e2_clk = Signal()
+                e2_net = Signal()
+                e2_cnt = Signal(4)
+                self.specials += Instance("STARTUPE2",
+                    i_CLK=0,
+                    i_GSR=0,
+                    i_GTS=0,
+                    i_KEYCLEARB=0,
+                    i_PACK=0,
+                    i_USRCCLKO=e2_net,
+                    i_USRCCLKTS=0,
+                    i_USRDONEO=1,
+                    i_USRDONETS=1,
+                )
+                # startupe2 needs 3 usrcclko cycles to switch over to user clock
+                self.comb += If(e2_cnt == 6,
+                                 e2_net.eq(pads.clk)
+                             ).Else(
+                                 e2_net.eq(e2_clk)
+                             )
+                self.sync += If(e2_cnt < 6,
+                                 e2_cnt.eq(e2_cnt+1),
+                                 e2_clk.eq(~e2_clk)
+                             )
+            else:
+                raise NotImplementedError
+

--- a/litex/soc/cores/spi_xip/common.py
+++ b/litex/soc/cores/spi_xip/common.py
@@ -1,0 +1,8 @@
+spi_phy_ctl_layout = [
+    ("addr", 32),
+    ("cmd", 1),
+]
+
+spi_phy_data_layout = [
+    ("data", 32),
+]

--- a/litex/soc/cores/spi_xip/core.py
+++ b/litex/soc/cores/spi_xip/core.py
@@ -1,0 +1,77 @@
+from migen import *
+from migen.genlib.fsm import FSM, NextState
+
+from litex.soc.cores.spi_xip.common import *
+from litex.soc.interconnect import wishbone, stream
+from litex.gen.common import reverse_bytes
+
+
+class LiteSPICore(Module):
+    def __init__(self, endianness="big"):
+        self.source = source = stream.Endpoint(spi_phy_ctl_layout)
+        self.sink   = sink   = stream.Endpoint(spi_phy_data_layout)
+        self.bus    = bus    = wishbone.Interface()
+        self.cs_n   = cs_n   = Signal()
+        curr_addr   = Signal(32)
+        bus_read    = Signal()
+        cs_cnt      = Signal(16)
+        cs_val      = Signal(16)
+
+        self.submodules.fsm = fsm = FSM(reset_state="IDLE")
+
+        self.comb += [
+            bus_read.eq(bus.cyc & bus.stb & ~bus.we),
+            bus.dat_r.eq(sink.data if endianness == "big" else reverse_bytes(sink.data)),
+        ]
+
+
+        # TODO: make this configurable via CSR
+        self.comb += cs_val.eq(10000)
+
+        fsm.act("IDLE",
+            cs_n.eq(1),
+            If(bus_read,
+                NextState("CS_DELAY"),
+            )
+        )
+        fsm.act("CMD",
+            source.valid.eq(1),
+            source.cmd.eq(1),
+            source.addr.eq(Cat(0, 0, bus.adr)), # convert wb address to bytes
+            If(source.ready & source.valid,
+                NextValue(curr_addr, bus.adr),
+                NextState("READ_REQ"),
+            )
+        )
+        fsm.act("READ_REQ",
+            source.valid.eq(1),
+            If(source.ready & source.valid,
+                NextState("READ_DAT"),
+            )
+        )
+        fsm.act("READ_DAT",
+            sink.ready.eq(bus.stb),
+            bus.ack.eq(sink.valid),
+            If(sink.ready & sink.valid,
+                NextValue(curr_addr, curr_addr+1),
+                NextState("READY"),
+            )
+        )
+        fsm.act("READY",
+            If(bus_read,
+                If(curr_addr == bus.adr, # is the current flash address ok?
+                    NextState("READ_REQ"),
+                ).Else(
+                    NextState("CS_DELAY"),
+                )
+            )
+        )
+        fsm.act("CS_DELAY",
+            cs_n.eq(1),
+            If(cs_cnt < cs_val,
+                NextValue(cs_cnt, cs_cnt+1),
+            ).Else(
+                NextValue(cs_cnt, 0),
+                NextState("CMD"),
+            )
+        )

--- a/litex/soc/cores/spi_xip/phy/generic.py
+++ b/litex/soc/cores/spi_xip/phy/generic.py
@@ -1,0 +1,122 @@
+from migen import *
+from migen.genlib.fsm import FSM, NextState
+
+from litex.soc.cores.spi_xip.common import *
+from litex.soc.cores.spi_xip.clkgen import *
+
+from litex.soc.interconnect import stream
+
+cmd_oe_mask = 0b0001
+soft_oe_mask = 0b0001
+addr_oe_mask = {
+    1: 0b0001,
+    2: 0b0011,
+    4: 0b1111,
+}
+
+def GetConfig(flash=None):
+    if flash is None:
+        return (24, 8, 1, 1, 1, 0x0b)
+
+class LiteSPIPHY(Module):
+    def shift_out(self, width, bits, next_state, negedge_op=None, posedge_op=None):
+        res = [
+            self.clkgen.en.eq(1),
+            If(self.clkgen.negedge,
+                NextValue(self.fsm_cnt, self.fsm_cnt+width),
+                If(self.fsm_cnt == (bits-width),
+                    NextValue(self.fsm_cnt, 0),
+                    NextState(next_state),
+                ),
+            ),
+        ]
+
+        if negedge_op is not None:
+            res += [If(self.clkgen.negedge, *negedge_op)]
+
+        if posedge_op is not None:
+            res += [If(self.clkgen.posedge, *posedge_op)]
+
+        return res
+
+    def __init__(self, pads, flash=None, device="xc7"):
+        self.source = source = stream.Endpoint(spi_phy_data_layout)
+        self.sink   = sink   = stream.Endpoint(spi_phy_ctl_layout)
+
+        self.cs_n     = Signal()
+
+        self.submodules.clkgen = clkgen = LiteSPIClkGen(pads, device)
+
+        addr_bits, dummy_bits, cmd_width, addr_width, data_width, command = GetConfig(flash)
+
+        data_bits = 32
+        cmd_bits = 8
+
+        self.comb += [
+            clkgen.div.eq(2), # should be SoftCPU configurable
+            pads.cs_n.eq(self.cs_n),
+            pads.clk.eq(clkgen.clk),
+        ]
+
+        if hasattr(pads, "miso"):
+            bus_width = 1
+            pads.dq = [pads.mosi, pads.miso]
+        else:
+            bus_width = len(pads.dq)
+
+        assert bus_width in [1, 2, 4]
+
+        dq_o  = Signal(len(pads.dq))
+        dq_i  = Signal(len(pads.dq))
+        dq_oe = Signal(len(pads.dq))
+
+        for i in range(len(pads.dq)):
+            t = TSTriple()
+            self.specials += t.get_tristate(pads.dq[i])
+            self.comb += [
+                dq_i[i].eq(t.i),
+                t.o.eq(dq_o[i]),
+                t.oe.eq(dq_oe[i]),
+            ]
+
+        self.fsm_cnt = Signal(max=31)
+        addr         = Signal(addr_bits)
+        data         = Signal(data_bits)
+        cmd          = Signal(cmd_bits)
+
+        self.submodules.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            sink.ready.eq(1),
+            If(sink.ready & sink.valid,
+                If(sink.cmd, # command request
+                    NextValue(addr, sink.addr),
+                    NextValue(cmd, command),
+                    NextState("CMD"),
+                ).Else( # data request
+                    NextState("DATA"),
+                ),
+            ),
+        )
+        fsm.act("CMD",
+            dq_oe.eq(cmd_oe_mask),
+            dq_o.eq(cmd[-1] if cmd_width == 1 else cmd[-cmd_width:]),
+            self.shift_out(cmd_width, cmd_bits, "ADDR", negedge_op=[NextValue(cmd, cmd<<cmd_width)]),
+        )
+        fsm.act("ADDR",
+            dq_oe.eq(addr_oe_mask[addr_width]),
+            dq_o.eq(addr[-1] if addr_width == 1 else addr[-addr_width:]),
+            self.shift_out(addr_width, addr_bits, "DUMMY", negedge_op=[NextValue(addr, addr<<addr_width)]),
+        )
+        fsm.act("DUMMY",
+            self.shift_out(addr_width, dummy_bits, "IDLE"),
+        )
+        fsm.act("DATA",
+            self.shift_out(data_width, data_bits, "SEND_DATA", posedge_op=[NextValue(data, Cat(dq_i[1] if data_width == 1 else dq_i[0:data_width], data))]),
+        )
+        fsm.act("SEND_DATA",
+            source.valid.eq(1),
+            source.data.eq(data),
+            If(source.ready & source.valid,
+                NextState("IDLE"),
+            )
+        )

--- a/litex/soc/cores/spi_xip/phy/model.py
+++ b/litex/soc/cores/spi_xip/phy/model.py
@@ -1,0 +1,40 @@
+from migen import *
+from migen.genlib.fsm import FSM, NextState
+
+from litex.soc.cores.spi_xip.common import *
+from litex.soc.interconnect import stream
+
+class LiteSPIPHYModel(Module):
+    def __init__(self, size, init=None):
+        self.source = source = stream.Endpoint(spi_phy_data_layout)
+        self.sink   = sink   = stream.Endpoint(spi_phy_ctl_layout)
+
+
+        self.mem = mem = Memory(32, size//4, init=init)
+
+        read_port  = mem.get_port(async_read=True)
+        read_addr  = Signal(32)
+        self.comb += read_port.adr.eq(read_addr),
+        self.cs_n  = Signal()
+
+        self.specials += mem, read_port
+
+        self.submodules.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            sink.ready.eq(1),
+            If(sink.ready & sink.valid,
+                If(sink.cmd,
+                    NextValue(read_addr, sink.addr[2:31]), # word addressed memory
+                ).Else(
+                    NextState("DATA"),
+                ),
+            ),
+        )
+        fsm.act("DATA",
+            source.valid.eq(1),
+            source.data.eq(read_port.dat_r),
+            If(source.ready & source.valid,
+                NextValue(read_addr, read_addr+1),
+                NextState("IDLE"),
+            ),
+        )

--- a/test/test_spi_xip.py
+++ b/test/test_spi_xip.py
@@ -1,0 +1,68 @@
+import unittest
+
+from migen import *
+
+from litex.soc.cores.spi_xip.core import LiteSPICore
+
+
+class TestSPIXIP(unittest.TestCase):
+    def test_spi_xip_core_syntax(self):
+        spi_xip = LiteSPICore()
+
+    def test_spi_xip_read_test(self):
+        dut = LiteSPICore()
+
+        def wb_gen(dut):
+            dut.data_ok = 0
+
+            yield dut.bus.adr.eq(0xcafe)
+            yield dut.bus.we.eq(0)
+            yield dut.bus.cyc.eq(1)
+            yield dut.bus.stb.eq(1)
+
+            while (yield dut.bus.ack) == 0:
+                yield
+
+            if (yield dut.bus.dat_r) == 0xdeadbeef:
+                dut.data_ok = 1
+
+        def phy_gen(dut):
+            dut.addr_ok = 0
+            dut.cmd_ok = 0
+
+            yield dut.sink.valid.eq(0)
+            yield dut.source.ready.eq(1)
+
+            while (yield dut.source.valid) == 0:
+                yield
+
+            if (yield dut.source.addr) == (0xcafe<<2): # address cmd
+                dut.addr_ok = 1
+            if (yield dut.source.cmd) == 1:
+                dut.cmd_ok += 1
+
+            yield
+
+            while (yield dut.source.valid) == 0:
+                yield
+
+            if (yield dut.source.cmd) == 0: # read cmd
+                dut.cmd_ok += 1
+
+            yield dut.source.ready.eq(0)
+            yield
+
+            yield dut.sink.data.eq(0xdeadbeef)
+            yield dut.sink.valid.eq(1)
+
+            while (yield dut.sink.ready) == 0:
+                yield
+
+            yield
+            yield dut.sink.valid.eq(0)
+            yield
+
+        run_simulation(dut, [wb_gen(dut), phy_gen(dut)])
+        self.assertEqual(dut.data_ok, 1)
+        self.assertEqual(dut.addr_ok, 1)
+        self.assertEqual(dut.cmd_ok, 2)


### PR DESCRIPTION
This adds initial version of a generic PHY for the new SPI XIP core. It was tested on the NeTV2 board with single/dual/quad reads (address only on mosi for now).

Currently missing or untested features are:
- [ ] support for configuring core parameters based on selected chip
- [ ] support for sending address on 2/4 data pins (untested)
- [ ] support for octal mode chips
- [ ] 32-bit addressing (untested)
- [ ] DDR transfers
- [ ] option for software based access to the chip (configure registers, erase/program)

This depends on #440 