### PR TITLE
Two small Travis-CI related patches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,16 @@ jobs:
     - os: osx
       osx_image: xcode10.2 # Includes Python 3.7
       language: shell
-#    - os: windows
-#      language: shell
-#      before_install:
-#        - choco info python3
-#        - choco install python3
-#        - export PATH=/c/Python38/:$PATH
-#        - cp -a /c/Python38/python.exe /c/Python38/python3.exe
+    - os: windows
+      language: shell
+      before_install:
+        - choco info python3
+        - choco install python3
+        - export PATH=/c/Python38/:$PATH
+        - cp -a /c/Python38/python.exe /c/Python38/python3.exe
+  allow_failures:
+    - os: windows
+      language: shell
 
 install:
   # Get Migen / LiteX / Cores

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
 install:
   # Get Migen / LiteX / Cores
   - cd ~/
-  - wget https://raw.githubusercontent.com/enjoy-digital/litex/master/litex_setup.py
+  - cp $TRAVIS_BUILD_DIR/litex_setup.py .
   - python3 litex_setup.py init install
   # Install the LiteX version being tested
   - cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
 * Use the `litex_setup.py` from the checked out code (rather than always downloading the head version).
 * Run the Windows build but allow it to fail (it won't cause Travis to report failure if it fails).