### PR TITLE
Add support for ecp5 12k device in trellis.py 

### DIFF
--- a/litex/boards/targets/ulx3s.py
+++ b/litex/boards/targets/ulx3s.py
@@ -86,7 +86,7 @@ def main():
     parser.add_argument("--gateware-toolchain", dest="toolchain", default="trellis",
         help="gateware toolchain to use, trellis (default) or diamond")
     parser.add_argument("--device", dest="device", default="LFE5U-45F",
-        help="FPGA device, ULX3S can be populated with LFE5U-45F (default) or LFE5U-85F")
+        help="FPGA device, ULX3S can be populated with LFE5U-12F, LFE5U-25F, LFE5U-45F (default) or LFE5U-85F")
     parser.add_argument("--sys-clk-freq", default=50e6,
                         help="system clock frequency (default=50MHz)")
     parser.add_argument("--sdram-module", default="MT48LC16M16",

--- a/litex/build/lattice/trellis.py
+++ b/litex/build/lattice/trellis.py
@@ -97,6 +97,7 @@ def nextpnr_ecp5_parse_device(device):
     return (family, size, speed_grade, package)
 
 nextpnr_ecp5_architectures = {
+    "lfe5u-12f"   : "12k",
     "lfe5u-25f"   : "25k",
     "lfe5u-45f"   : "45k",
     "lfe5u-85f"   : "85k",


### PR DESCRIPTION
It's a minor change specific to trellis, so we can skip it if we decide that it's not that important. 

Update the help description for --device option for ulx3s

I've tested the changes on my ulx3s-12k board and it works.