### PR TITLE
Add graphviz printing of the module hierarchy

### DIFF
--- a/litex/soc/integration/visualizer.py
+++ b/litex/soc/integration/visualizer.py
@@ -1,0 +1,49 @@
+# This file is Copyright (c) 2020 Paul Florence <perso@florencepaul.com>
+# License: BSD
+
+from graphviz import Digraph
+
+
+class GraphPrinter:
+    def __init__(self, filter=None):
+        # This dict is used to generate unique names for modules which share the same name
+        self.state = dict()
+        self.dot = Digraph(comment='SoC')
+        self.filter = filter
+
+    def render(self, root):
+        root_name = str(root.__class__.__name__)
+        for (name, module) in getattr(root, 'submodules')._fm._submodules:
+            self.__visit_node(name, module, root_name)
+        self.dot.render('soc.gv', view=True)
+
+    # Insert the given name in the graph, and increase the number of occurrences of this name
+    def __insert_node(self, name):
+        if self.state.get(name) is None:
+            self.state[name] = 0
+        else:
+            self.state[name] += 1
+        self.dot.node(name + str(self.state[name]))
+
+    def __generate_node_name(self, name):
+        return name + str(self.state[name])
+
+    def __visit_node(self, name, object, parent_name):
+        if self.filter is not None and self.filter(name):
+            return
+        if len(getattr(object, 'submodules')._fm._submodules) != 0:
+            node_name = parent_name
+            # Skip nodes with no names
+            if name is not None:
+                self.__insert_node(name)
+                node_name = self.__generate_node_name(name)
+                self.dot.edge(parent_name, node_name)
+            # Add children
+            for (s_name, s_module) in getattr(object, 'submodules')._fm._submodules:
+                self.__visit_node(s_name, s_module, node_name)
+        # Leaf node: render it if it's name is not None
+        else:
+            if name is not None:
+                self.__insert_node(name)
+                node_name = self.__generate_node_name(name)
+                self.dot.edge(parent_name, node_name)


### PR DESCRIPTION
Hello everyone !

Would you be interested in merging this small python module ? I wrote it to better understand the architecture of the generated SoC. In the future it could be extended to export bus visualization, or other meaningful information.

Even if the class is quite straightforward to use, I'd like to write an example somewhere. If you are interested in this, could a maintainer point me to the right place ?

Finally, it adds a dependency on `graphviz` and I'm not sure on how to make it optional, any idea ?

Here is a small example of a generated module tree : 
![soc gv](https://user-images.githubusercontent.com/15819864/79555854-8738f100-80a0-11ea-9068-36eda71ca8a7.png)
It was generated by modifying `litex-boards/targets/aller.py`, here is a patch if you want to try it out :
```patch
diff --git a/litex_boards/targets/aller.py b/litex_boards/targets/aller.py
index 24154b1..f7b6c92 100755
--- a/litex_boards/targets/aller.py
+++ b/litex_boards/targets/aller.py
@@ -7,6 +7,7 @@
 import argparse
 import sys
 
+from litex.soc.integration.visualizer import GraphPrinter
 from migen import *
 
 from litex.build import tools
@@ -157,6 +158,9 @@ class PCIeSoC(SoCCore):
         mem_header = get_mem_header(self.mem_regions)
         tools.write_to_file("mem.h", mem_header)
 
+def my_filter(name):
+    return name == "fifo" or name == "controller"
+
 # Build --------------------------------------------------------------------------------------------
 
 def main():
@@ -171,6 +175,8 @@ def main():
 
     platform = aller.Platform()
     soc      = PCIeSoC(platform, **soc_sdram_argdict(args))
+    printer = GraphPrinter(my_filter)
+    printer.render(soc)
     builder  = Builder(soc, **builder_argdict(args))
     vns = builder.build()
     soc.generate_software_headers()
```