### PR TITLE
bios/sdram: add automatic cdly calibration during write leveling

### DIFF
--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -394,6 +394,7 @@ static void help(void)
 	puts("sdram_cal                       - run SDRAM calibration");
 	puts("sdram_mpr                       - read SDRAM MPR");
 	puts("sdram_mrwr reg value            - write SDRAM mode registers");
+	puts("sdram_cdly_scan enabled         - enable/disable cdly scan");
 #endif
 #ifdef CSR_SPISDCARD_BASE
         puts("spisdcardboot   - boot from SDCard via SPI hardware bitbang");
@@ -505,6 +506,11 @@ static void do_command(char *c)
 		printf("Writing 0x%04x to SDRAM mode register %d\n", value, reg);
 		sdrmrwr(reg, value);
 		sdrhw();
+	}
+	else if(strcmp(token, "sdram_cdly_scan") == 0) {
+		unsigned int enabled;
+		enabled = atoi(get_token(&c));
+		sdr_cdly_scan(enabled);
 	}
 #endif
 #ifdef CSR_SPISDCARD_BASE

--- a/litex/soc/software/bios/sdram.h
+++ b/litex/soc/software/bios/sdram.h
@@ -29,6 +29,7 @@ void ddrphy_cdly(unsigned int delay);
 void sdrcal(void);
 void sdrmrwr(char reg, int value);
 void sdrmpr(void);
+void sdr_cdly_scan(int enabled);
 #endif
 
 #endif /* __SDRAM_H */


### PR DESCRIPTION
This PR extends BIOS to improve automatic SDRAM calibration. 

On some boards we needed to manually delay command lines to be able to properly write level the DRAM (as in https://github.com/litex-hub/litex-boards/issues/49#issuecomment-604297096). This PR extends write leveling process to run it for different cdly values and choose the best one.

Running write leveling for each possible value takes too much time (e.g. ~1 minute on Mercury XU5), so now `write_level` includes a simple algorithm which decreases the number of runs (in my tests it takes ~2sec). At the moment the algorithm tries to find such a cdly that write leveling results in dqs delays in the half of the available range, but we can change that value.

Example leveling on Mercury XU5:
```
--========== Initialization ============--
Initializing SDRAM...
SDRAM now under software control
Write leveling:
cdly scan: |+--.....|-++--|---------|---+-----| best: 31
m0: |000000000011111111111| delay: 158
m1: |000000000001111111111| delay: 162
Read leveling:
m0, b0: |11111000000000000000000000000000| delays: 36+-36
m0, b1: |00000000111111111111111111100000| delays: 267+-153
m0, b2: |00000000000000000000000000000111| delays: 484+-28
m0, b3: |00000000000000000000000000000000| delays: -
m0, b4: |00000000000000000000000000000000| delays: -
m0, b5: |00000000000000000000000000000000| delays: -
m0, b6: |00000000000000000000000000000000| delays: -
m0, b7: |00000000000000000000000000000000| delays: -
best: m0, b1 delays: 268+-153
m1, b0: |11100000000000000000000000000000| delays: 22+-22
m1, b1: |00000011111111111111111110000000| delays: 237+-148
m1, b2: |00000000000000000000000000011111| delays: 471+-41
m1, b3: |00000000000000000000000000000000| delays: -
m1, b4: |00000000000000000000000000000000| delays: -
m1, b5: |00000000000000000000000000000000| delays: -
m1, b6: |00000000000000000000000000000000| delays: -
m1, b7: |00000000000000000000000000000000| delays: -
best: m1, b1 delays: 237+-148
SDRAM now under hardware control
Memtest OK
Memspeed Writes: 245Mbps Reads: 323Mbps
```

During cdly scans write leveling output is suppressed, to show how the scans are done, this is an example with output enabled (ranges are written as `start:step:stop`):
```
Write leveling:
cdly scan:
| 0:64:512
m0: |000000001111111111111| delay: 127
m1: |000000000111111111111| delay: 131
m0: |000000000000111111111| delay: 191
m1: |000000000000011111111| delay: 196
m0: |000000000000000011111| delay: 256
m1: |000000000000000001111| delay: 261
m0: |000000000000000000000| delay: -1
m1: |000000000000000000000| delay: -1
m0: |111000000000000000000| delay: -1
m1: |111000000000000000000| delay: -1
m0: |111111100000000000000| delay: -1
m1: |111111100000000000000| delay: -1
m0: |111111111110000000000| delay: -1
m1: |111111111110000000000| delay: -1
m0: |111111111111111000000| delay: -1
m1: |111111111111111000000| delay: -1
| 0:16:65
m0: |000000001111111111111| delay: 127
m1: |000000000111111111111| delay: 131
m0: |000000000111111111111| delay: 143
m1: |000000000011111111111| delay: 147
m0: |000000000011111111111| delay: 159
m1: |000000000001111111111| delay: 163
m0: |000000000001111111111| delay: 175
m1: |000000000000111111111| delay: 180
m0: |000000000000111111111| delay: 191
m1: |000000000000011111111| delay: 196
| 16:4:49
m0: |000000000111111111111| delay: 143
m1: |000000000011111111111| delay: 147
m0: |000000000011111111111| delay: 146
m1: |000000000011111111111| delay: 151
m0: |000000000011111111111| delay: 151
m1: |000000000011111111111| delay: 155
m0: |000000000011111111111| delay: 155
m1: |000000000011111111111| delay: 159
m0: |000000000011111111111| delay: 159
m1: |000000000001111111111| delay: 163
m0: |000000000001111111111| delay: 163
m1: |000000000001111111111| delay: 167
m0: |000000000001111111111| delay: 167
m1: |000000000001111111111| delay: 171
m0: |000000000001111111111| delay: 171
m1: |000000000001111111111| delay: 175
m0: |000000000001111111111| delay: 175
m1: |000000000000111111111| delay: 180
| 28:1:37
m0: |000000000011111111111| delay: 156
m1: |000000000011111111111| delay: 159
m0: |000000000011111111111| delay: 156
m1: |000000000011111111111| delay: 160
m0: |000000000011111111111| delay: 157
m1: |000000000001111111111| delay: 161
m0: |000000000011111111111| delay: 158
m1: |000000000001111111111| delay: 162
m0: |000000000011111111111| delay: 159
m1: |000000000001111111111| delay: 163
m0: |000000000011111111111| delay: 160
m1: |000000000001111111111| delay: 164
m0: |000000000001111111111| delay: 161
m1: |000000000001111111111| delay: 165
m0: |000000000001111111111| delay: 163
m1: |000000000001111111111| delay: 166
m0: |000000000001111111111| delay: 163
m1: |000000000001111111111| delay: 167
| best: 31
m0: |000000000011111111111| delay: 158
m1: |000000000001111111111| delay: 162
Read leveling:
```

This is still probably too precise now and we could easily decrease write leveling time by over a half by stopping after the scan with step 16.