### PR TITLE
build/trellis: add verilog_read -defer option to yosys script

### DIFF
--- a/litex/build/lattice/trellis.py
+++ b/litex/build/lattice/trellis.py
@@ -49,7 +49,10 @@ def _build_lpf(named_sc, named_pc, build_name):
 # Yosys/Nextpnr Helpers/Templates ------------------------------------------------------------------
 
 _yosys_template = [
+    "verilog_defaults -push",
+    "verilog_defaults -add -defer",
     "{read_files}",
+    "verilog_defaults -pop",
     "attrmap -tocase keep -imap keep=\"true\" keep=1 -imap keep=\"false\" keep=0 -remove keep=0",
     "synth_ecp5 -abc9 {nwl} -json {build_name}.json -top {build_name}",
 ]


### PR DESCRIPTION
This enables Yosys to parse verilog files which contain potential invalid default parameters. 

As a verilog coding style, parameters are left with a value of 0 to force/ensure all instantiated modules fill these parameters with correct values.

This fixes an issue encountered when integrating the serv CPU. https://github.com/enjoy-digital/litex/issues/471#issuecomment-619569830

```
 -defer
        only read the abstract syntax tree and defer actual compilation
        to a later 'hierarchy' command. Useful in cases where the default
        parameters of modules yield invalid or not synthesizable code.
```