### PR TITLE
Add SERV support (The SErial RISC-V CPU)

### DIFF
--- a/litex/soc/cores/cpu/__init__.py
+++ b/litex/soc/cores/cpu/__init__.py
@@ -37,17 +37,19 @@ from litex.soc.cores.cpu.minerva import Minerva
 from litex.soc.cores.cpu.rocket import RocketRV64
 from litex.soc.cores.cpu.microwatt import Microwatt
 from litex.soc.cores.cpu.blackparrot import BlackParrotRV64
+from litex.soc.cores.cpu.serv import SERV
 
 CPUS = {
-    "None"       : CPUNone,
-    "lm32"       : LM32,
-    "mor1kx"     : MOR1KX,
-    "picorv32"   : PicoRV32,
-    "vexriscv"   : VexRiscv,
-    "minerva"    : Minerva,
-    "rocket"     : RocketRV64,
-    "microwatt"  : Microwatt,
+    "None"        : CPUNone,
+    "lm32"        : LM32,
+    "mor1kx"      : MOR1KX,
+    "picorv32"    : PicoRV32,
+    "vexriscv"    : VexRiscv,
+    "minerva"     : Minerva,
+    "rocket"      : RocketRV64,
+    "microwatt"   : Microwatt,
     "blackparrot" : BlackParrotRV64,
+    "serv"        : SERV
 }
 
 # CPU Variants/Extensions Definition ---------------------------------------------------------------

--- a/litex/soc/cores/cpu/serv/__init__.py
+++ b/litex/soc/cores/cpu/serv/__init__.py
@@ -1,0 +1,1 @@
+from litex.soc.cores.cpu.serv.core import SERV

--- a/litex/soc/cores/cpu/serv/core.py
+++ b/litex/soc/cores/cpu/serv/core.py
@@ -44,7 +44,7 @@ class SERV(CPU):
         self.cpu_params = dict(
             # clock / reset
             i_clk   = ClockSignal(),
-            i_i_rst = ResetSignal(),
+            i_i_rst = ResetSignal() | self.reset,
 
             # timer irq
             i_i_timer_irq = 0,

--- a/litex/soc/cores/cpu/serv/core.py
+++ b/litex/soc/cores/cpu/serv/core.py
@@ -36,7 +36,7 @@ class SERV(CPU):
         self.reset     = Signal()
         self.ibus      = ibus = wishbone.Interface()
         self.dbus      = dbus = wishbone.Interface()
-        self.buses     = [self.ibus, dbus]
+        self.buses     = [ibus, dbus]
         self.interrupt = Signal(32)
 
         # # #
@@ -50,14 +50,13 @@ class SERV(CPU):
             i_i_timer_irq = 0,
 
             # ibus
-            o_o_ibus_adr = ibus.adr,
+            o_o_ibus_adr = Cat(Signal(2), ibus.adr),
             o_o_ibus_cyc = ibus.cyc,
             i_i_ibus_rdt = ibus.dat_r,
             i_i_ibus_ack = ibus.ack,
 
-
             # dbus
-            o_o_dbus_adr = dbus.adr,
+            o_o_dbus_adr = Cat(Signal(2), dbus.adr),
             o_o_dbus_dat = dbus.dat_w,
             o_o_dbus_sel = dbus.sel,
             o_o_dbus_we  = dbus.we,
@@ -67,6 +66,7 @@ class SERV(CPU):
         )
         self.comb += [
             ibus.stb.eq(ibus.cyc),
+            ibus.sel.eq(0xf),
             dbus.stb.eq(dbus.cyc),
         ]
 

--- a/litex/soc/cores/cpu/serv/core.py
+++ b/litex/soc/cores/cpu/serv/core.py
@@ -1,5 +1,5 @@
 # This file is Copyright (c) 2020 Florent Kermarrec <florent@enjoy-digital.fr>
-
+# This file is Copyright (c) 2020 Greg Davill <greg.davill@gmail.com>
 # License: BSD
 
 import os

--- a/litex/soc/cores/cpu/serv/core.py
+++ b/litex/soc/cores/cpu/serv/core.py
@@ -88,4 +88,4 @@ class SERV(CPU):
 
     def do_finalize(self):
         assert hasattr(self, "reset_address")
-        self.specials += Instance("serv_top", **self.cpu_params)
+        self.specials += Instance("serv_rf_top", **self.cpu_params)

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -132,6 +132,9 @@ class SoCCore(LiteXSoC):
         self.cpu_type                   = cpu_type
         self.cpu_variant                = cpu_variant
 
+        if cpu_type == "serv":
+            self.add_constant("UART_POLLING") # FIXME: use UART in polling mode for SERV bringup
+
         self.integrated_rom_size        = integrated_rom_size
         self.integrated_rom_initialized = integrated_rom_init != []
         self.integrated_sram_size       = integrated_sram_size

--- a/litex/soc/software/bios/boot-helper-serv.S
+++ b/litex/soc/software/bios/boot-helper-serv.S
@@ -1,0 +1,4 @@
+	.section .text, "ax", @progbits
+	.global boot_helper
+boot_helper:
+	jr x13

--- a/litex/soc/software/bios/isr.c
+++ b/litex/soc/software/bios/isr.c
@@ -8,7 +8,7 @@
 #include <uart.h>
 #include <stdio.h>
 
- 
+
 #if defined(__blackparrot__) /*TODO: Update this function for BP*/ //
 
 void isr(void);
@@ -21,7 +21,7 @@ void isr(void)
     onetime++;
   }
 }
-#elif defined(__rocket__) 
+#elif defined(__rocket__)
 void plic_init(void);
 void plic_init(void)
 {
@@ -65,7 +65,7 @@ void isr(void)
 void isr(void);
 void isr(void)
 {
-	unsigned int irqs;
+	__attribute__((unused)) unsigned int irqs;
 
 	irqs = irq_pending() & irq_getmask();
 

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -647,6 +647,8 @@ int main(int i, char **c)
 	printf("RocketRV64[imac]");
 #elif __blackparrot__
         printf("BlackParrotRV64[ia]");
+#elif __serv__
+	printf("SERV");
 #else
 	printf("Unknown");
 #endif

--- a/litex/soc/software/bios/sdram.c
+++ b/litex/soc/software/bios/sdram.c
@@ -48,6 +48,8 @@ __attribute__((unused)) static void cdelay(int i)
 		__asm__ volatile("nop");
 #elif defined (__blackparrot__)
 		__asm__ volatile("nop");
+#elif defined (__serv__)
+		__asm__ volatile("nop");
 #else
 #error Unsupported architecture
 #endif

--- a/litex/soc/software/include/base/irq.h
+++ b/litex/soc/software/include/base/irq.h
@@ -75,6 +75,8 @@ static inline unsigned int irq_getie(void)
 	return 0; // FIXME
 #elif defined (__blackparrot__) 
 	return (csrr(mstatus) & CSR_MSTATUS_MIE) != 0;//TODO
+#elif defined (__serv__)
+	return 0; /* FIXME */
 #else
 #error Unsupported architecture
 #endif
@@ -104,6 +106,8 @@ static inline void irq_setie(unsigned int ie)
 	// FIXME
 #elif defined (__blackparrot__)
 	if(ie) csrs(mstatus,CSR_MSTATUS_MIE); else csrc(mstatus,CSR_MSTATUS_MIE);//TODO:BP
+#elif defined (__serv__)
+	/* FIXME */
 #else
 #error Unsupported architecture
 #endif
@@ -135,6 +139,8 @@ static inline unsigned int irq_getmask(void)
 	return 0; // FIXME
 #elif defined (__blackparrot__)
 	//TODO:BP
+#elif defined (__serv__)
+	return 0; /* FIXME */
 #else
 #error Unsupported architecture
 #endif
@@ -160,6 +166,8 @@ static inline void irq_setmask(unsigned int mask)
 	// FIXME
 #elif defined (__blackparrot__)
 	//TODO:BP
+#elif defined (__serv__)
+	/* FIXME */
 #else
 #error Unsupported architecture
 #endif
@@ -189,6 +197,8 @@ static inline unsigned int irq_pending(void)
 	return 0; // FIXME
 #elif defined (__blackparrot__)
 	return csr_readl(PLIC_PENDING) >> 1;//TODO:BP
+#elif defined (__serv__)
+	return 0;/* FIXME */
 #else
 #error Unsupported architecture
 #endif

--- a/litex/soc/software/include/base/irq.h
+++ b/litex/soc/software/include/base/irq.h
@@ -72,11 +72,11 @@ static inline unsigned int irq_getie(void)
 #elif defined (__rocket__)
 	return (csrr(mstatus) & CSR_MSTATUS_MIE) != 0;
 #elif defined (__microwatt__)
-	return 0; // FIXME
-#elif defined (__blackparrot__) 
-	return (csrr(mstatus) & CSR_MSTATUS_MIE) != 0;//TODO
+	return 0; /* No interrupt support on Microwatt */
+#elif defined (__blackparrot__)
+	return (csrr(mstatus) & CSR_MSTATUS_MIE) != 0; /* FIXME */
 #elif defined (__serv__)
-	return 0; /* FIXME */
+	return 0; /* No interrupt support on SERV */
 #else
 #error Unsupported architecture
 #endif
@@ -103,11 +103,11 @@ static inline void irq_setie(unsigned int ie)
 #elif defined (__rocket__)
 	if(ie) csrs(mstatus,CSR_MSTATUS_MIE); else csrc(mstatus,CSR_MSTATUS_MIE);
 #elif defined (__microwatt__)
-	// FIXME
+	/* No interrupt support on Microwatt */
 #elif defined (__blackparrot__)
-	if(ie) csrs(mstatus,CSR_MSTATUS_MIE); else csrc(mstatus,CSR_MSTATUS_MIE);//TODO:BP
+	if(ie) csrs(mstatus,CSR_MSTATUS_MIE); else csrc(mstatus,CSR_MSTATUS_MIE); /* FIXME */
 #elif defined (__serv__)
-	/* FIXME */
+	/* No interrupt support on SERV */
 #else
 #error Unsupported architecture
 #endif
@@ -136,11 +136,11 @@ static inline unsigned int irq_getmask(void)
 #elif defined (__rocket__)
 	return *((unsigned int *)PLIC_ENABLED) >> 1;
 #elif defined (__microwatt__)
-	return 0; // FIXME
+	return 0; /* No interrupt support on Microwatt */
 #elif defined (__blackparrot__)
-	//TODO:BP
-#elif defined (__serv__)
 	return 0; /* FIXME */
+#elif defined (__serv__)
+	return 0; /* No interrupt support on SERV */
 #else
 #error Unsupported architecture
 #endif
@@ -163,11 +163,11 @@ static inline void irq_setmask(unsigned int mask)
 #elif defined (__rocket__)
 	*((unsigned int *)PLIC_ENABLED) = mask << 1;
 #elif defined (__microwatt__)
-	// FIXME
+	/* No interrupt support on Microwatt */
 #elif defined (__blackparrot__)
-	//TODO:BP
-#elif defined (__serv__)
 	/* FIXME */
+#elif defined (__serv__)
+	/* No interrupt support on SERV */
 #else
 #error Unsupported architecture
 #endif
@@ -194,11 +194,11 @@ static inline unsigned int irq_pending(void)
 #elif defined (__rocket__)
 	return *((unsigned int *)PLIC_PENDING) >> 1;
 #elif defined (__microwatt__)
-	return 0; // FIXME
+	return 0; /* No interrupt support on Microwatt */
 #elif defined (__blackparrot__)
-	return csr_readl(PLIC_PENDING) >> 1;//TODO:BP
+	return csr_readl(PLIC_PENDING) >> 1; /* FIXME */
 #elif defined (__serv__)
-	return 0;/* FIXME */
+	return 0; /* No interrupt support on SERV */
 #else
 #error Unsupported architecture
 #endif

--- a/litex/soc/software/libbase/crt0-serv.S
+++ b/litex/soc/software/libbase/crt0-serv.S
@@ -1,0 +1,63 @@
+#define MIE_MEIE 	0x800
+
+	.global _start
+_start:
+	j reset_vector
+
+reset_vector:
+	la sp, _fstack
+	la t0, trap_vector
+	csrw mtvec, t0
+
+	// initialize .bss
+	la t0, _fbss
+	la t1, _ebss
+1:	beq t0, t1, 2f
+	sw zero, 0(t0)
+	addi t0, t0, 4
+	j 1b
+2:
+	// enable external interrupts
+	li t0, MIE_MEIE
+	csrs mie, t0
+
+	call main
+1:	j 1b
+
+trap_vector:
+	addi sp, sp, -16*4
+	sw ra,  0*4(sp)
+	sw t0,  1*4(sp)
+	sw t1,  2*4(sp)
+	sw t2,  3*4(sp)
+	sw a0,  4*4(sp)
+	sw a1,  5*4(sp)
+	sw a2,  6*4(sp)
+	sw a3,  7*4(sp)
+	sw a4,  8*4(sp)
+	sw a5,  9*4(sp)
+	sw a6, 10*4(sp)
+	sw a7, 11*4(sp)
+	sw t3, 12*4(sp)
+	sw t4, 13*4(sp)
+	sw t5, 14*4(sp)
+	sw t6, 15*4(sp)
+	call isr
+	lw ra,  0*4(sp)
+	lw t0,  1*4(sp)
+	lw t1,  2*4(sp)
+	lw t2,  3*4(sp)
+	lw a0,  4*4(sp)
+	lw a1,  5*4(sp)
+	lw a2,  6*4(sp)
+	lw a3,  7*4(sp)
+	lw a4,  8*4(sp)
+	lw a5,  9*4(sp)
+	lw a6, 10*4(sp)
+	lw a7, 11*4(sp)
+	lw t3, 12*4(sp)
+	lw t4, 13*4(sp)
+	lw t5, 14*4(sp)
+	lw t6, 15*4(sp)
+	addi sp, sp, 16*4
+	mret

--- a/litex/soc/software/libbase/system.c
+++ b/litex/soc/software/libbase/system.c
@@ -62,6 +62,8 @@ void flush_cpu_icache(void)
 #elif defined (__blackparrot__)
 	/* TODO: BP do something useful here! */
 	asm volatile("nop");
+#elif defined (__serv__)
+	/* no instruction cache */
 #else
 #error Unsupported architecture
 #endif
@@ -114,6 +116,8 @@ void flush_cpu_dcache(void)
 #elif defined (__blackparrot__)
 	/* FIXME: do something useful here! */
 	asm volatile("nop");
+#elif defined (__serv__)
+	/* no data cache */
 #else
 #error Unsupported architecture
 #endif


### PR DESCRIPTION
SERV is a bit-serial RISC-V core that could be useful in some designs to replace a complex FSM by a CPU while still minimizing resource usage. This would be a perfect fit for LiteDRAM standalone core where the CPU is only doing the DRAM initialization.