### PR TITLE
diamond: fix include paths

### DIFF
--- a/litex/build/lattice/diamond.py
+++ b/litex/build/lattice/diamond.py
@@ -68,8 +68,8 @@ def _build_tcl(device, sources, vincpaths, build_name):
     ]))
 
     # Add include paths
-    for path in vincpaths:
-        tcl.append("prj_impl option {include path} {\"" + path + "\"}")
+    vincpath = ';'.join(map(lambda x: x.replace('\\', '/'), vincpaths))
+    tcl.append("prj_impl option {include path} {\"" + vincpath + "\"}")
 
     # Add sources
     for filename, language, library in sources:


### PR DESCRIPTION
include paths given via tcl script need semicolon separators and forward slash as directory separator (even on windows)