### PR TITLE
litex/soc/integration: Add SDK output directory

### DIFF
--- a/litex/soc/software/bios/Makefile
+++ b/litex/soc/software/bios/Makefile
@@ -1,4 +1,4 @@
-include ../include/generated/variables.mak
+include $(SDK_DIRECTORY)/include/generated/variables.mak
 include $(SOC_DIRECTORY)/software/common.mak
 
 ifeq ($(CPU),blackparrot)

--- a/litex/soc/software/libbase/Makefile
+++ b/litex/soc/software/libbase/Makefile
@@ -1,10 +1,15 @@
-include ../include/generated/variables.mak
+include $(SDK_DIRECTORY)/include/generated/variables.mak
 include $(SOC_DIRECTORY)/software/common.mak
 
 OBJECTS=exception.o libc.o errno.o crc16.o crc32.o console.o \
 	system.o id.o uart.o time.o qsort.o strtod.o spiflash.o spisdcard.o strcasecmp.o mdio.o
 
-all: crt0-$(CPU)-ctr.o crt0-$(CPU)-xip.o libbase.a libbase-nofloat.a
+PRODUCTS=crt0-$(CPU)-ctr.o crt0-$(CPU)-xip.o libbase.a libbase-nofloat.a
+
+all: $(PRODUCTS)
+
+install: all
+	cp $(PRODUCTS) $(SDK_DIRECTORY)/lib
 
 libbase.a: $(OBJECTS) vsnprintf.o
 	$(AR) crs libbase.a $(OBJECTS) vsnprintf.o

--- a/litex/soc/software/libcompiler_rt/Makefile
+++ b/litex/soc/software/libcompiler_rt/Makefile
@@ -1,4 +1,4 @@
-include ../include/generated/variables.mak
+include $(SDK_DIRECTORY)/include/generated/variables.mak
 include $(SOC_DIRECTORY)/software/common.mak
 
 ifeq ($(CPUENDIANNESS),big)
@@ -11,7 +11,12 @@ OBJECTS=umodsi3.o udivsi3.o divsi3.o modsi3.o comparesf2.o comparedf2.o negsf2.o
   floatsisf.o floatunsisf.o fixsfsi.o fixdfdi.o fixunssfsi.o fixunsdfdi.o adddf3.o subdf3.o muldf3.o divdf3.o floatsidf.o floatunsidf.o floatdidf.o fixdfsi.o fixunsdfsi.o \
   clzsi2.o ctzsi2.o udivdi3.o umoddi3.o moddi3.o ucmpdi2.o
 
-all: libcompiler_rt.a
+PRODUCTS=libcompiler_rt.a
+
+all: $(PRODUCTS)
+
+install: all
+	cp $(PRODUCTS) $(SDK_DIRECTORY)/lib
 
 libcompiler_rt.a: $(OBJECTS)
 	$(CC) -c $(CFLAGS) $(1) $(SOC_DIRECTORY)/software/libcompiler_rt/mulsi3.c -o mulsi3.o

--- a/litex/soc/software/libnet/Makefile
+++ b/litex/soc/software/libnet/Makefile
@@ -1,9 +1,14 @@
-include ../include/generated/variables.mak
+include $(SDK_DIRECTORY)/include/generated/variables.mak
 include $(SOC_DIRECTORY)/software/common.mak
 
 OBJECTS=microudp.o tftp.o
 
-all: libnet.a
+PRODUCTS=libnet.a
+
+all: $(PRODUCTS)
+
+install: all
+	cp $(PRODUCTS) $(SDK_DIRECTORY)/lib
 
 libnet.a: $(OBJECTS)
 	$(AR) crs libnet.a $(OBJECTS)


### PR DESCRIPTION
This PR adds an SDK output directory and moves includes and binary artifacts into it.

In discussion with @mubes on 1BitSquared discord, we realized that in order for software developers to build programs for our SoCs they would have to have litex setup and at least build the design with `--no-compile-gateware`. It would be much more user friendly if we could ship an SDK along with the bitstream to facilitate firmware development.

To this end, this PR adds a `--sdk-dir` argument which defaults to `soc_<soctype>_<board>/sdk`, adds `install` targets to the litex library makefiles, and modifies `soc/integration/builder.py` to copy headers and binary artifacts to the SDK location as well as adding that directory to `variables.mak`

I'd welcome feedback on this PR, it's a quick (and a bit dirty) implementation of the idea and would love some help to refine it.

Example end-user Makefile:
```
SDK_DIR=../sdk

include $(SDK_DIR)/include/generated/variables.mak
include $(SDK_DIR)/common.mak

OBJECTS=main.o

all: firmware.bin

# pull in dependency info for *existing* .o files
-include $(OBJECTS:.o=.d)

%.bin: %.elf
        $(OBJCOPY) -O binary $< $@
        chmod -x $@

firmware.elf: $(OBJECTS)
        $(LD) $(LDFLAGS) \
                -T linker.ld \
                -N -o $@ \
                $(SDK_DIR)/lib/crt0-$(CPU)-ctr.o \
                $(OBJECTS) \
                -lbase-nofloat -lcompiler_rt
        chmod -x $@

main.o: main.c
        $(compile)

%.o: %.c
        $(compile)

%.o: %.S
        $(assemble)

clean:
        $(RM) $(OBJECTS) $(OBJECTS:.o=.d) firmware.elf firmware.bin .*~ *~

.PHONY: all main.o clean load
```
Example end-user linker script:
```
INCLUDE generated/output_format.ld
ENTRY(_start)

__DYNAMIC = 0;

INCLUDE generated/regions.ld

SECTIONS
{
        .text :
        {
                _ftext = .;
                *(.text .stub .text.* .gnu.linkonce.t.*)
                _etext = .;
        } > main_ram

        .rodata :
        {
                . = ALIGN(4);
                _frodata = .;
                *(.rodata .rodata.* .gnu.linkonce.r.*)
                *(.rodata1)
                _erodata = .;
        } > main_ram

        .data :
        {
                . = ALIGN(4);
                _fdata = .;
                *(.data .data.* .gnu.linkonce.d.*)
                *(.data1)
                _gp = ALIGN(16);
                *(.sdata .sdata.* .gnu.linkonce.s.*)
                _edata = .;
        } > main_ram

        .bss :
        {
                . = ALIGN(4);
                _fbss = .;
                *(.dynsbss)
                *(.sbss .sbss.* .gnu.linkonce.sb.*)
                *(.scommon)
                *(.dynbss)
                *(.bss .bss.* .gnu.linkonce.b.*)
                *(COMMON)
                . = ALIGN(4);
                _ebss = .;
                _end = .;
        } > sram
}

PROVIDE(_fstack = ORIGIN(sram) + LENGTH(sram) - 4);
```