### PR TITLE
travis: add back test on python3.5 (python3.6 is recommended but we c…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ jobs:
     - os: linux
       dist: xenial
       language: python
+      python: "3.5"
+    - os: linux
+      dist: xenial
+      language: python
       python: "3.6"
     - os: linux
       dist: xenial


### PR DESCRIPTION
…an try to keep 3.5 compatibility until we have good reason to no longer support it).