### PR TITLE
diamond: quiet warning about missing clkin freq for EHXPLLL

### DIFF
--- a/litex/soc/cores/clock.py
+++ b/litex/soc/cores/clock.py
@@ -676,6 +676,7 @@ class ECP5PLL(Module):
         clkfb  = Signal()
         self.params.update(
             attr=[
+                ("FREQUENCY_PIN_CLKI",     str(self.clkin_freq/1e6)),
                 ("ICP_CURRENT",            "6"),
                 ("LPF_RESISTOR",          "16"),
                 ("MFG_ENABLE_FILTEROPAMP", "1"),


### PR DESCRIPTION
FREQUENCY_PIN_CLKI should be given in mhz