### PR TITLE
integration/soc: fix add_adapter for slaves

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -282,7 +282,7 @@ class SoCBusHandler(Module):
         return is_io
 
     # Add Master/Slave -----------------------------------------------------------------------------
-    def add_adapter(self, name, interface):
+    def add_adapter(self, name, interface, is_master):
         if interface.data_width != self.data_width:
             self.logger.info("{} Bus {} from {}-bit to {}-bit.".format(
                 colorer(name),
@@ -290,7 +290,8 @@ class SoCBusHandler(Module):
                 colorer(interface.data_width),
                 colorer(self.data_width)))
             new_interface = wishbone.Interface(data_width=self.data_width)
-            self.submodules += wishbone.Converter(interface, new_interface)
+            args = (interface, new_interface) if is_master else (new_interface, interface)
+            self.submodules += wishbone.Converter(*args)
             return new_interface
         else:
             return interface
@@ -304,7 +305,7 @@ class SoCBusHandler(Module):
                 colorer("already declared", color="red")))
             self.logger.error(self)
             raise
-        master = self.add_adapter(name, master)
+        master = self.add_adapter(name, master, True)
         self.masters[name] = master
         self.logger.info("{} {} as Bus Master.".format(
             colorer(name,    color="underline"),
@@ -336,7 +337,7 @@ class SoCBusHandler(Module):
                 colorer("already declared", color="red")))
             self.logger.error(self)
             raise
-        slave = self.add_adapter(name, slave)
+        slave = self.add_adapter(name, slave, False)
         self.slaves[name] = slave
         self.logger.info("{} {} as Bus Slave.".format(
             colorer(name, color="underline"),


### PR DESCRIPTION
I have a SoC with 32-bit wishbone bus; it has one Module with wishbone.Interface(data_width=8) connected by add_wb_slave(). It is silently broken (compiles but does not work) with the current implementation of add_adapter() because it does not respect master and slave argument order for wishbone.Converter() it uses. This commit fixes the problem by adding an argument is_master to add_adapter() and swapping arguments to wishbone.Converter() accordingly.