### PR TITLE
Bios linker edits to prevent inappropriate optimisation

### DIFF
--- a/litex/soc/software/bios/linker.ld
+++ b/litex/soc/software/bios/linker.ld
@@ -8,6 +8,12 @@ SECTIONS
 	.text :
 	{
 		_ftext = .;
+                /* Make sure crt0 files come first, and they, and the isr */
+                /* don't get disposed of by greedy optimisation */
+                *crt0*(.text)
+                KEEP(*crt0*(.text))
+                KEEP(*(.text.isr))
+
 		*(.text .stub .text.* .gnu.linkonce.t.*)
 		_etext = .;
 	} > rom


### PR DESCRIPTION
Small change to prevent LTO eating sections we don't want disappearing in our target image. 

I'm not comfortable that I understand the full detail of the software ecosystem here yet, but this
change should be conservative anyway as there aren't too many circumstances where you'd want
your bootstrap or ISRs disappearing. 