### PR TITLE
csr: Rework accessors

### DIFF
--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -198,10 +198,8 @@ def get_csr_header(regions, constants, with_access_functions=True):
     r += "#ifndef __GENERATED_CSR_H\n#define __GENERATED_CSR_H\n"
     if with_access_functions:
         r += "#include <stdint.h>\n"
-        r += "#ifdef CSR_ACCESSORS_DEFINED\n"
-        r += "extern void csr_write_simple(unsigned long v, unsigned long a);\n"
-        r += "extern unsigned long csr_read_simple(unsigned long a);\n"
-        r += "#else /* ! CSR_ACCESSORS_DEFINED */\n"
+        r += "#include <system.h>\n"
+        r += "#ifndef CSR_ACCESSORS_DEFINED\n"
         r += "#include <hw/common.h>\n"
         r += "#endif /* ! CSR_ACCESSORS_DEFINED */\n"
     csr_base = regions[next(iter(regions))].origin


### PR DESCRIPTION
Have all the new compound accessors be written in terms of the simple
ones and fix how CSR_ACCCESORS_DEFINED can be used to override the
simple ones but keep the definitions of the other ones around.

This *should* also also fix incorrect multiple accesses done
by  64-bit CPUs to 32-bit CSR busses, and make the accessors not
depend on CONFIG_CSR_ALIGNMENT being the same as sizeof(unsigned long)*8

Signed-off-by: Benjamin Herrenschmidt <benh@kernel.crashing.org>
Reviewed-by: Gabriel Somlo <gsomlo@gmail.com>