### PR TITLE
Fix fw bios command

### DIFF
--- a/litex/soc/software/bios/commands/cmd_spi_flash.c
+++ b/litex/soc/software/bios/commands/cmd_spi_flash.c
@@ -43,7 +43,7 @@ static void fw(int nb_params, char **params)
 	if (nb_params == 2) {
 		count = 1;
 	} else {
-		count = strtoul(count, &c, 0);
+		count = strtoul(params[2], &c, 0);
 		if (*c != 0) {
 			printf("Incorrect count");
 			return;


### PR DESCRIPTION
Count of `fw <offset> <value> [count]` was parsed incorrectly.