### PR TITLE
Make booting from SD-Card to behave same as from SPI flash

### DIFF
--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -512,19 +512,34 @@ void spisdcardboot(void)
 		return;
 	}
 
-#if defined(CONFIG_CPU_TYPE_VEXRISCV) && defined(CONFIG_CPU_VARIANT_LINUX)
-	if(spi_sdcard_readFile("IMAGE","",MAIN_RAM_BASE+KERNEL_IMAGE_RAM_OFFSET)==0) return;
-	if(spi_sdcard_readFile("ROOTFS~1","CPI",MAIN_RAM_BASE+ROOTFS_IMAGE_RAM_OFFSET)==0) return;
-	if(spi_sdcard_readFile("RV32","DTB",MAIN_RAM_BASE+DEVICE_TREE_IMAGE_RAM_OFFSET)==0) return;
-	if(spi_sdcard_readFile("EMULATOR","BIN",MAIN_RAM_BASE+EMULATOR_IMAGE_RAM_OFFSET)==0) return;
+	unsigned int result;
 
-	boot(0,0,0,MAIN_RAM_BASE + EMULATOR_IMAGE_RAM_OFFSET);
-#else
-	if(spi_sdcard_readFile("BOOT","BIN",MAIN_RAM_BASE)==0) {
-		printf("SD Card SPI boot failed\n");
+#if defined(CONFIG_CPU_TYPE_VEXRISCV) && defined(CONFIG_CPU_VARIANT_LINUX)
+	result = spi_sdcard_readFile("IMAGE", "",
+				MAIN_RAM_BASE + KERNEL_IMAGE_RAM_OFFSET);
+
+	if(result)
+		result &= spi_sdcard_readFile("ROOTFS~1", "CPI",
+				MAIN_RAM_BASE + ROOTFS_IMAGE_RAM_OFFSET);
+
+	if(result)
+		result &= spi_sdcard_readFile("RV32", "DTB",
+				MAIN_RAM_BASE + DEVICE_TREE_IMAGE_RAM_OFFSET);
+
+	if(result)
+		result &= spi_sdcard_readFile("EMULATOR", "BIN",
+				MAIN_RAM_BASE + EMULATOR_IMAGE_RAM_OFFSET);
+
+	if(result) {
+		boot(0, 0, 0, MAIN_RAM_BASE + EMULATOR_IMAGE_RAM_OFFSET);
 		return;
 	}
-	boot(0, 0, 0, MAIN_RAM_BASE);
 #endif
+
+	result = spi_sdcard_readFile("BOOT", "BIN", MAIN_RAM_BASE);
+	if(result)
+		boot(0, 0, 0, MAIN_RAM_BASE);
+	else
+		printf("SD Card SPI boot failed\n");
 }
 #endif


### PR DESCRIPTION
When trying to boot a firmware BOOT.BIN from SD-card using the Linux variant of the VexRiscv CPU, the BIOS tries to load a Linux Image - which is OK. But if it does not find one it gives up instead of trying to load a firmware BOOT.BIN instead (same as when booting from SPI flash).
This patch makes booting from SD-card behaving the same as from SPI flash.

br
Richard