### PR TITLE
software/bios: fix link order to avoid undefined symbol errors

### DIFF
--- a/litex/soc/software/bios/Makefile
+++ b/litex/soc/software/bios/Makefile
@@ -72,7 +72,7 @@ bios.elf: $(BIOS_DIRECTORY)/linker.ld $(OBJECTS)
 		-L../libliteeth \
 		-L../liblitesdcard \
 		$(BP_LIBS) \
-		-lcompiler_rt -lbase-nofloat -llitedram -lliteeth -llitesdcard \
+		-lcompiler_rt -llitedram -lliteeth -llitesdcard -lbase-nofloat \
 		$(BP_FLAGS)
 
 ifneq ($(OS),Windows_NT)


### PR DESCRIPTION
move `-lbase-nofloat` (providing `busy_wait()` after `-lliteeth` and `-llitesdcard` (which *use* `busy_wait()` to avoid "undefined symbol" error from `$(LD)`.