### PR TITLE
Integrate micron memory model simulation

### DIFF
--- a/litex/build/sim/config.py
+++ b/litex/build/sim/config.py
@@ -24,7 +24,7 @@ class SimConfig():
         return new
 
     def add_clocker(self, clk):
-        self.add_module("clocker", [], clocks=clk, tickfirst=True)
+        self.add_module("clocker", [], clocks=[clk, "dram_clk"], tickfirst=True)
 
     def add_module(self, name, interfaces, clocks=None, args=None, tickfirst=False):
         interfaces = self._format_interfaces(interfaces)

--- a/litex/build/sim/core/Makefile
+++ b/litex/build/sim/core/Makefile
@@ -41,7 +41,7 @@ sim: $(OBJS_SIM) | mkdir
 		$(if $(THREADS), --threads $(THREADS),) \
 		-CFLAGS "$(CFLAGS) -I$(SRC_DIR)" \
 		-LDFLAGS "$(LDFLAGS)" \
-		--trace \
+		$(if $(TRACE), --trace,) \
 		$(if $(TRACE_FST), --trace-fst,) \
 		$(if $(COVERAGE), --coverage,) \
 		--unroll-count 256 \

--- a/litex/build/sim/core/modules/clocker/clocker.c
+++ b/litex/build/sim/core/modules/clocker/clocker.c
@@ -1,11 +1,15 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 #include "error.h"
 #include "modules.h"
 
 struct session_s {
   char *sys_clk;
+  char *dram_full_clk;
+  char *dram_half_a_clk;
+  char *dram_half_b_clk;
 };
 
 static int litex_sim_module_pads_get( struct pad_s *pads, char *name, void **signal)
@@ -67,28 +71,48 @@ static int clocker_add_pads(void *sess, struct pad_list_s *plist)
 {
   int ret = RC_OK;
   struct session_s *s = (struct session_s*)sess;
-  struct pad_s *pads;
 
   if(!sess || !plist) {
     ret = RC_INVARG;
     goto out;
   }
-  pads = plist->pads;
 
-  if(!strcmp(plist->name, "sys_clk")) {
-    litex_sim_module_pads_get(pads, "sys_clk", (void**)&s->sys_clk);
+  if(!strcmp("sys_clk", plist->name)) {
+    litex_sim_module_pads_get(plist->pads, "sys_clk", (void**)&s->sys_clk);
+    *s->sys_clk=0;
+  } else if(!strcmp("dram_clk", plist->name)) {
+    litex_sim_module_pads_get(plist->pads, "full_clk", (void**)&s->dram_full_clk);
+    litex_sim_module_pads_get(plist->pads, "half_a_clk", (void**)&s->dram_half_a_clk);
+    litex_sim_module_pads_get(plist->pads, "half_b_clk", (void**)&s->dram_half_b_clk);
+    *s->dram_full_clk = 0;
+    *s->dram_half_a_clk = 0;
+    *s->dram_half_b_clk = 0;
   }
-
-  *s->sys_clk=0;
 
 out:
   return ret;
 }
 
+inline static unsigned clock_gen(unsigned freq_hz, unsigned phase_deg, uint64_t tick, unsigned tick_period_ps) {
+  static uint64_t const ps_in_s = 1000000000000ull;
+  unsigned const period_ticks = ps_in_s / freq_hz / tick_period_ps;
+  unsigned const phase_ticks = (phase_deg * period_ticks + 180) / 360;
+  return tick >= phase_ticks ? ((tick - phase_ticks) % period_ticks < (period_ticks/2)) : 0;
+}
+
 static int clocker_tick(void *sess)
 {
+  static uint64_t const tick_period_ps = 125;
   struct session_s *s=(struct session_s*)sess;
-  *s->sys_clk = ~(*s->sys_clk);
+  static uint64_t tick = 0;
+
+  *s->sys_clk         = clock_gen(200000000, 0,   tick, tick_period_ps);
+  *s->dram_full_clk   = clock_gen(800000000, 0,   tick, tick_period_ps);
+  *s->dram_half_a_clk = clock_gen(400000000, 270, tick, tick_period_ps);
+  *s->dram_half_b_clk = clock_gen(400000000, 180, tick, tick_period_ps);
+
+  tick++;
+
   return 0;
 }
 

--- a/litex/build/sim/core/sim.c
+++ b/litex/build/sim/core/sim.c
@@ -190,6 +190,7 @@ static void cb(int sock, short which, void *arg)
       if(!s->tickfirst)
 	s->module->tick(s->session);
     }
+    litex_sim_increment_time();
 
     if (litex_sim_got_finish()) {
         event_base_loopbreak(base);

--- a/litex/build/sim/core/veril.cpp
+++ b/litex/build/sim/core/veril.cpp
@@ -18,11 +18,17 @@ VerilatedVcdC* tfp;
 #endif
 long tfp_start;
 long tfp_end;
+vluint64_t main_time;
 
 extern "C" void litex_sim_eval(void *vdut)
 {
   Vdut *dut = (Vdut*)vdut;
   dut->eval();
+}
+
+extern "C" void litex_sim_increment_time()
+{
+  main_time += 1;
 }
 
 extern "C" void litex_sim_init_cmdargs(int argc, char *argv[])
@@ -73,7 +79,6 @@ extern "C" void litex_sim_coverage_dump()
 }
 #endif
 
-vluint64_t main_time = 0;
 double sc_time_stamp()
 {
   return main_time;

--- a/litex/build/sim/core/veril.cpp
+++ b/litex/build/sim/core/veril.cpp
@@ -28,7 +28,7 @@ extern "C" void litex_sim_eval(void *vdut)
 
 extern "C" void litex_sim_increment_time()
 {
-  main_time += 1;
+  main_time += 125; // ps
 }
 
 extern "C" void litex_sim_init_cmdargs(int argc, char *argv[])

--- a/litex/build/sim/core/veril.cpp
+++ b/litex/build/sim/core/veril.cpp
@@ -44,10 +44,14 @@ extern "C" void litex_sim_init_tracer(void *vdut, long start, long end)
   Verilated::traceEverOn(true);
 #ifdef TRACE_FST
       tfp = new VerilatedFstC;
+      tfp->set_time_unit("1ps");
+      tfp->set_time_resolution("1ps");
       dut->trace(tfp, 99);
       tfp->open("dut.fst");
 #else
       tfp = new VerilatedVcdC;
+      tfp->set_time_unit("1ps");
+      tfp->set_time_resolution("1ps");
       dut->trace(tfp, 99);
       tfp->open("dut.vcd");
 #endif

--- a/litex/build/sim/core/veril.h
+++ b/litex/build/sim/core/veril.h
@@ -5,6 +5,7 @@
 
 #ifdef __cplusplus
 extern "C" void litex_sim_init_cmdargs(int argc, char *argv[]);
+extern "C" void litex_sim_increment_time();
 extern "C" void litex_sim_eval(void *vdut);
 extern "C" void litex_sim_init_tracer(void *vdut, long start, long end)
 extern "C" void litex_sim_tracer_dump();
@@ -14,6 +15,7 @@ extern "C" void litex_sim_coverage_dump();
 #endif
 #else
 void litex_sim_eval(void *vdut);
+void litex_sim_increment_time();
 void litex_sim_init_tracer(void *vdut);
 void litex_sim_tracer_dump();
 int litex_sim_got_finish();

--- a/litex/build/sim/verilator.py
+++ b/litex/build/sim/verilator.py
@@ -119,19 +119,20 @@ def _generate_sim_config(config):
     tools.write_to_file("sim_config.js", content)
 
 
-def _build_sim(build_name, sources, threads, coverage, opt_level="O3", trace_fst=False):
+def _build_sim(build_name, sources, threads, coverage, opt_level="O3", trace=False, trace_fst=False):
     makefile = os.path.join(core_directory, 'Makefile')
     cc_srcs = []
     for filename, language, library in sources:
         cc_srcs.append("--cc " + filename + " ")
     build_script_contents = """\
 rm -rf obj_dir/
-make -C . -f {} {} {} {} {} {}
+make -C . -f {} {} {} {} {} {} {}
 """.format(makefile,
     "CC_SRCS=\"{}\"".format("".join(cc_srcs)),
     "THREADS={}".format(threads) if int(threads) > 1 else "",
     "COVERAGE=1" if coverage else "",
     "OPT_LEVEL={}".format(opt_level),
+    "TRACE=1" if trace else "",
     "TRACE_FST=1" if trace_fst else "",
     )
     build_script_file = "build_" + build_name + ".sh"
@@ -203,7 +204,7 @@ class SimVerilatorToolchain:
                 _generate_sim_config(sim_config)
 
             # build
-            _build_sim(build_name, platform.sources, threads, coverage, opt_level, trace_fst)
+            _build_sim(build_name, platform.sources, threads, coverage, opt_level, trace, trace_fst)
 
         # run
         if run:

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -622,58 +622,56 @@ int main(int i, char **c)
 #endif
 	uart_init();
 
-	printf("\n");
-	printf("\e[1m        __   _ __      _  __\e[0m\n");
-	printf("\e[1m       / /  (_) /____ | |/_/\e[0m\n");
-	printf("\e[1m      / /__/ / __/ -_)>  <\e[0m\n");
-	printf("\e[1m     /____/_/\\__/\\__/_/|_|\e[0m\n");
-	printf("\e[1m   Build your hardware, easily!\e[0m\n");
-	printf("\n");
-	printf(" (c) Copyright 2012-2020 Enjoy-Digital\n");
-	printf(" (c) Copyright 2007-2015 M-Labs\n");
-	printf("\n");
-	printf(" BIOS built on "__DATE__" "__TIME__"\n");
-	crcbios();
-	printf("\n");
-	printf(" Migen git sha1: "MIGEN_GIT_SHA1"\n");
-	printf(" LiteX git sha1: "LITEX_GIT_SHA1"\n");
-	printf("\n");
-	printf("--=============== \e[1mSoC\e[0m ==================--\n");
-	printf("\e[1mCPU\e[0m:       ");
-#ifdef __lm32__
-	printf("LM32");
-#elif __or1k__
-	printf("MOR1KX");
-#elif __picorv32__
-	printf("PicoRV32");
-#elif __vexriscv__
-	printf("VexRiscv");
-#elif __minerva__
-	printf("Minerva");
-#elif __rocket__
-	printf("RocketRV64[imac]");
-#elif __blackparrot__
-        printf("BlackParrotRV64[ia]");
-#elif __serv__
-	printf("SERV");
-#else
-	printf("Unknown");
-#endif
-	printf(" @ %dMHz\n", CONFIG_CLOCK_FREQUENCY/1000000);
-	printf("\e[1mROM\e[0m:       %dKB\n", ROM_SIZE/1024);
-	printf("\e[1mSRAM\e[0m:      %dKB\n", SRAM_SIZE/1024);
-#ifdef CONFIG_L2_SIZE
-	printf("\e[1mL2\e[0m:        %dKB\n", CONFIG_L2_SIZE/1024);
-#endif
-#ifdef MAIN_RAM_SIZE
-	printf("\e[1mMAIN-RAM\e[0m:  %dKB\n", MAIN_RAM_SIZE/1024);
-#endif
-	printf("\n");
+	// printf("\n");
+	// printf("\e[1m        __   _ __      _  __\e[0m\n");
+	// printf("\e[1m       / /  (_) /____ | |/_/\e[0m\n");
+	// printf("\e[1m      / /__/ / __/ -_)>  <\e[0m\n");
+	// printf("\e[1m     /____/_/\\__/\\__/_/|_|\e[0m\n");
+	// printf("\e[1m   Build your hardware, easily!\e[0m\n");
+	// printf("\n");
+	// printf(" (c) Copyright 2012-2020 Enjoy-Digital\n");
+	// printf(" (c) Copyright 2007-2015 M-Labs\n");
+	// printf("\n");
+	// printf(" BIOS built on "__DATE__" "__TIME__"\n");
+	// crcbios();
+	// printf("\n");
+	// printf(" Migen git sha1: "MIGEN_GIT_SHA1"\n");
+	// printf(" LiteX git sha1: "LITEX_GIT_SHA1"\n");
+// 	printf("\n");
+// 	printf("--=============== \e[1mSoC\e[0m ==================--\n");
+// 	printf("\e[1mCPU\e[0m:       ");
+// #ifdef __lm32__
+// 	printf("LM32");
+// #elif __or1k__
+// 	printf("MOR1KX");
+// #elif __picorv32__
+// 	printf("PicoRV32");
+// #elif __vexriscv__
+// 	printf("VexRiscv");
+// #elif __minerva__
+// 	printf("Minerva");
+// #elif __rocket__
+// 	printf("RocketRV64[imac]");
+// #elif __blackparrot__
+//         printf("BlackParrotRV64[ia]");
+// #else
+// 	printf("Unknown");
+// #endif
+// 	printf(" @ %dMHz\n", CONFIG_CLOCK_FREQUENCY/1000000);
+// 	printf("\e[1mROM\e[0m:       %dKB\n", ROM_SIZE/1024);
+// 	printf("\e[1mSRAM\e[0m:      %dKB\n", SRAM_SIZE/1024);
+// #ifdef CONFIG_L2_SIZE
+// 	printf("\e[1mL2\e[0m:        %dKB\n", CONFIG_L2_SIZE/1024);
+// #endif
+// #ifdef MAIN_RAM_SIZE
+// 	printf("\e[1mMAIN-RAM\e[0m:  %dKB\n", MAIN_RAM_SIZE/1024);
+// #endif
+// 	printf("\n");
 
         sdr_ok = 1;
 
 #if defined(CSR_ETHMAC_BASE) || defined(CSR_SDRAM_BASE)
-    printf("--========== \e[1mInitialization\e[0m ============--\n");
+    // printf("--========== \e[1mInitialization\e[0m ============--\n");
 #ifdef CSR_ETHMAC_BASE
 	eth_init();
 #endif

--- a/litex/soc/software/include/base/system.h
+++ b/litex/soc/software/include/base/system.h
@@ -5,6 +5,21 @@
 extern "C" {
 #endif
 
+#include <generated/csr.h>
+#ifdef CSR_DEBUG_HELPER_TAG_SIZE
+static void debug_helper_set_tag(const char *tag) {
+	char val[CSR_DEBUG_HELPER_TAG_SIZE] = {0};
+	int i;
+	for(i = 0; i < CSR_DEBUG_HELPER_TAG_SIZE && tag[i] != 0; ++i) {
+		val[i] = tag[i];
+	}
+	csr_wr_buf_uint8(CSR_DEBUG_HELPER_TAG_ADDR, val, CSR_DEBUG_HELPER_TAG_SIZE);
+}
+#else
+#define debug_helper_set_tag(x)
+#define debug_helper_arg_write(x)
+#endif
+
 void flush_cpu_icache(void);
 void flush_cpu_dcache(void);
 void flush_l2_cache(void);

--- a/litex/soc/software/libbase/system.c
+++ b/litex/soc/software/libbase/system.c
@@ -12,6 +12,8 @@
 #include <generated/mem.h>
 #include <generated/csr.h>
 
+#include <stdio.h>
+
 void flush_cpu_icache(void)
 {
 #if defined (__lm32__)
@@ -126,10 +128,18 @@ void flush_cpu_dcache(void)
 #ifdef CONFIG_L2_SIZE
 void flush_l2_cache(void)
 {
+	#if CONFIG_L2_SIZE > 0
 	unsigned int i;
+	debug_helper_set_tag("L2-flush");
 	for(i=0;i<2*CONFIG_L2_SIZE/4;i++) {
+		debug_helper_arg_write(i);
+		printf("  > %d/%d          \r", i, 2*CONFIG_L2_SIZE/4);
 		((volatile unsigned int *) MAIN_RAM_BASE)[i];
 	}
+	printf("\r  > %d/%d\n", CONFIG_L2_SIZE/4, CONFIG_L2_SIZE/4);
+	debug_helper_set_tag("");
+	debug_helper_arg_write(~0);
+	#endif
 }
 #endif
 

--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -39,6 +39,13 @@ from litedram.phy.genericddr3phy import GenericDDR3PHY
 from litedram.core import ControllerSettings
 from litedram.modules import MT41K64M16
 
+class DebugHelper(Module, AutoCSR):
+    def __init__(self):
+        self.tag = CSRStorage(128, atomic_write=True)
+        self.arg = CSRStorage(32, atomic_write=True, reset=0xFFFFFFFF)
+        self.finish = CSR()
+        self.sync += If(self.finish.re, Finish())
+
 # IOs ----------------------------------------------------------------------------------------------
 
 _io = [
@@ -334,6 +341,9 @@ class SimSoC(SoCSDRAM):
                 clock_domain = "sys",
                 csr_csv      = "analyzer.csv")
             self.add_csr("analyzer")
+        
+        self.submodules.debug_helper = DebugHelper()
+        self.add_csr("debug_helper")
 
 # Build --------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Issues:
* The simulation is hardcoded in litex_sim; should be optional
* Clocker should be configurable to allow additional clocks which are faster than sys_clk.
* Simulation time resolution is changed to 1ps, with 125ps increments in each loop. This will cause unnecessary performance drop in simulations which don't need 800MHz clock. Should be configurable

LiteDRAM PR: https://github.com/enjoy-digital/litedram/pull/196