### PR TITLE
Standalone sim fixes

### DIFF
--- a/litex/build/sim/verilator.py
+++ b/litex/build/sim/verilator.py
@@ -171,9 +171,10 @@ def _run_sim(build_name, as_root=False):
 
 class SimVerilatorToolchain:
     def build(self, platform, fragment, build_dir="build", build_name="dut",
-            serial="console", build=True, run=True, threads=1,
-            verbose=True, sim_config=None, coverage=False, opt_level="O0",
-            trace=False, trace_fst=False, trace_start=0, trace_end=-1):
+              serial="console", build=True, run=True, threads=1,
+              verbose=True, sim_config=None, coverage=False, opt_level="O0",
+              trace=False, trace_fst=False, trace_start=0, trace_end=-1,
+              **kwargs):
 
         # create build directory
         os.makedirs(build_dir, exist_ok=True)

--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -135,7 +135,8 @@ class Builder:
         write_to_file(
             os.path.join(self.generated_dir, "csr.h"),
             export.get_csr_header(self.soc.csr_regions,
-                                         self.soc.constants)
+                                  self.soc.constants,
+                                  self.soc.mem_regions['csr'].origin)
         )
         write_to_file(
             os.path.join(self.generated_dir, "git.h"),

--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -118,8 +118,10 @@ def get_mem_header(regions):
     r = generated_banner("//")
     r += "#ifndef __GENERATED_MEM_H\n#define __GENERATED_MEM_H\n\n"
     for name, region in regions.items():
+        r += "#ifndef {name}\n".format(name=name.upper())
         r += "#define {name}_BASE 0x{base:08x}L\n#define {name}_SIZE 0x{size:08x}\n\n".format(
             name=name.upper(), base=region.origin, size=region.length)
+        r += "#endif\n"
     r += "#endif\n"
     return r
 
@@ -190,7 +192,7 @@ def _get_rw_functions_c(reg_name, reg_base, nwords, busword, alignment, read_onl
     return r
 
 
-def get_csr_header(regions, constants, with_access_functions=True):
+def get_csr_header(regions, constants, csr_base = 0, with_access_functions=True):
     alignment = constants.get("CONFIG_CSR_ALIGNMENT", 32)
     r = generated_banner("//")
     if with_access_functions: # FIXME
@@ -202,7 +204,6 @@ def get_csr_header(regions, constants, with_access_functions=True):
         r += "#ifndef CSR_ACCESSORS_DEFINED\n"
         r += "#include <hw/common.h>\n"
         r += "#endif /* ! CSR_ACCESSORS_DEFINED */\n"
-    csr_base = regions[next(iter(regions))].origin
     r += "#ifndef CSR_BASE\n"
     r += "#define CSR_BASE {}L\n".format(hex(csr_base))
     r += "#endif\n"

--- a/litex/soc/integration/soc_zynq.py
+++ b/litex/soc/integration/soc_zynq.py
@@ -214,5 +214,6 @@ class SoCZynq(SoCCore):
     def generate_software_header(self, filename):
         csr_header = get_csr_header(self.csr_regions,
                                     self.constants,
+                                    self.mem_regions['csr'].origin,
                                     with_access_functions=False)
         tools.write_to_file(filename, csr_header)

--- a/litex/soc/software/bios/sdram.c
+++ b/litex/soc/software/bios/sdram.c
@@ -30,10 +30,12 @@
 
 __attribute__((unused)) static void cdelay(int i)
 {
+#ifndef CONFIG_SIM_DISABLE_DELAYS
 	while(i > 0) {
 		__asm__ volatile(CONFIG_CPU_NOP);
 		i--;
 	}
+#endif
 }
 
 #ifdef CSR_SDRAM_BASE


### PR DESCRIPTION
These are fixes and improvements that help generated standalone simulation models such as standalone litedram for use in external projects. It's a pre-requisite to the correponding litedram branch.

The CSR_BASE fix in there could be useful in other circumstances as well.