### PR TITLE
Fix UART startbit: 1 cycle later

### DIFF
--- a/litex/soc/cores/uart.py
+++ b/litex/soc/cores/uart.py
@@ -99,8 +99,7 @@ class RS232PHYTX(Module):
             If(self.sink.valid & ~tx_busy & ~self.sink.ready,
                 tx_reg.eq(self.sink.data),
                 tx_bitcount.eq(0),
-                tx_busy.eq(1),
-                pads.tx.eq(0)
+                tx_busy.eq(1)
             ).Elif(uart_clk_txen & tx_busy,
                 tx_bitcount.eq(tx_bitcount + 1),
                 If(tx_bitcount == 8,
@@ -112,6 +111,10 @@ class RS232PHYTX(Module):
                 ).Else(
                     pads.tx.eq(tx_reg[0]),
                     tx_reg.eq(Cat(tx_reg[1:], 0))
+                )
+            ).Elif(tx_busy,
+                If(tx_bitcount == 0,
+                    pads.tx.eq(0)
                 )
             )
         ]
@@ -235,7 +238,7 @@ class UART(Module, AutoCSR, UARTInterface):
             self._rxempty.status.eq(~rx_fifo.source.valid),
             self._rxtx.w.eq(rx_fifo.source.data),
             rx_fifo.source.ready.eq(self.ev.rx.clear | (rx_fifo_rx_we & self._rxtx.we)),
-            # Generate RX IRQ when tx_fifo becomes non-empty
+            # Generate RX IRQ when rx_fifo becomes non-empty
             self.ev.rx.trigger.eq(~rx_fifo.source.valid)
         ]
 


### PR DESCRIPTION
So far, the startbit for UART is 1 cycle longer than all the other UART bits. With this PR, the startbit is written one cycle later.

VCD files for both scenarios are attached.

[uart_startbit_vcd.zip](https://github.com/enjoy-digital/litex/files/4673690/uart_startbit_vcd.zip)
