### PR TITLE
bios/litedram: Add command to verify SPD contents with the one used during generation

### DIFF
--- a/litex/build/sim/core/modules/spdeeprom/spdeeprom.c
+++ b/litex/build/sim/core/modules/spdeeprom/spdeeprom.c
@@ -123,7 +123,7 @@ static int spdeeprom_new(void **sess, char *args)
     spd_file = fopen(spd_filename, "r");
   }
   if (spd_filename != NULL && spd_file != NULL) {
-    DBG("[spdeeprom] loading EEPROM contents from file: %s\n", spd_filename);
+    printf("[spdeeprom] loading EEPROM contents from file: %s\n", spd_filename);
     spdeeprom_from_file(s, spd_file);
     fclose(spd_file);
   } else {  // fill in the memory with some data
@@ -389,7 +389,7 @@ static void spdeeprom_from_file(struct session_s *s, FILE *file)
     if ((n_read = getline(&line, &bufsize, file)) < 0) {
       break;
     }
-    byte = strtoul(line, &c, 0);
+    byte = strtoul(line, &c, 16);
     if (c == line) {
       DBG("[spdeeprom] Incorrect value at line %d\n", i);
     } else {

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1045,6 +1045,26 @@ class LiteXSoC(SoC):
             **kwargs)
         self.csr.add("sdram")
 
+        # Save SPD data to be able to verify it at runtime
+        if hasattr(module, "_spd_data"):
+            # pack the data into words of bus width
+            bytes_per_word = self.bus.data_width // 8
+            mem = [0] * ceil(len(module._spd_data) / bytes_per_word)
+            for i in range(len(mem)):
+                for offset in range(bytes_per_word):
+                    mem[i] <<= 8
+                    if self.cpu.endianness == "little":
+                        offset = bytes_per_word - 1 - offset
+                    spd_byte = i * bytes_per_word + offset
+                    if spd_byte < len(module._spd_data):
+                        mem[i] |= module._spd_data[spd_byte]
+            self.add_rom(
+                name="spd",
+                origin=self.mem_map.get("spd", None),
+                size=len(module._spd_data),
+                contents=mem,
+            )
+
         if not with_soc_interconnect: return
 
         # Compute/Check SDRAM size

--- a/litex/soc/software/bios/cmds/cmd_litedram.c
+++ b/litex/soc/software/bios/cmds/cmd_litedram.c
@@ -3,8 +3,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <string.h>
 
 #include <generated/csr.h>
+#include <generated/mem.h>
 #include <i2c.h>
 
 #include <liblitedram/sdram.h>
@@ -272,6 +274,19 @@ static void spdread_handler(int nb_params, char **params)
 	}
 
 	dump_bytes((unsigned int *) buf, len, 0);
+
+#ifdef SPD_BASE
+	{
+		int cmp_result;
+		cmp_result = memcmp(buf, (void *) SPD_BASE, SPD_SIZE);
+		if (cmp_result == 0) {
+			printf("Memory conents matches the data used for gateware generation\n");
+		} else {
+			printf("\nWARNING: memory differs from the data used during gateware generation:\n");
+			dump_bytes((void *) SPD_BASE, SPD_SIZE, 0);
+		}
+	}
+#endif
 }
 define_command(spdread, spdread_handler, "Read SPD EEPROM", LITEDRAM_CMDS);
 #endif


### PR DESCRIPTION
This PR extents `spdread` to also verify that the EEPROM SPD data matches the one used during gateware generation. This is only available if `spd` memory exists, which is only added when generating `SDRAMModule` from SPD data (requires https://github.com/enjoy-digital/litedram/pull/201).

This verification is not automatic because reading EEPROM may require different procedure depending on the board used (as described in https://github.com/enjoy-digital/litex/pull/541). For this reason `spdread` just gets extended when we actually have the SPD data that we can verify.

Example output with error:
```
litex> spdread 0
Memory dump:
0x00000000  23 11 1c 03 45 21 00 08 00 60 00 03 02 03 00 00  #...E!...`......
0x00000010  00 00 06 0d f8 ff 01 00 6e 6e 6e 11 00 6e f0 0a  ........nnn..n..
0x00000020  20 08 00 05 00 f0 2b 34 28 00 78 00 14 3c 00 00   .....+4(.x..<..
0x00000030  00 00 00 00 00 00 00 00 00 00 00 00 16 36 0b 35  .............6.5
0x00000040  16 36 0b 35 00 00 16 36 0b 35 16 36 0b 35 00 00  .6.5...6.5.6.5..
0x00000050  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x00000060  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x00000070  00 00 00 00 00 00 9c b5 00 00 00 00 e7 00 60 5b  ..............`[
0x00000080  0f 01 02 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x00000090  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x000000a0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x000000b0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x000000c0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x000000d0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x000000e0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x000000f0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 c0 e2  ................

WARNING: memory differs from the data used during gateware generation:
Memory dump:
0x00000000  23 11 0c 03 45 21 00 08 00 60 00 03 02 03 00 00  #...E!...`......
0x00000010  00 00 06 0d f8 ff 01 00 6e 6e 6e 11 00 6e f0 0a  ........nnn..n..
0x00000020  20 08 00 05 00 f0 2b 34 28 00 78 00 14 3c 00 00   .....+4(.x..<..
0x00000030  00 00 00 00 00 00 00 00 00 00 00 00 16 36 0b 35  .............6.5
0x00000040  16 36 0b 35 00 00 16 36 0b 35 16 36 0b 35 00 00  .6.5...6.5.6.5..
0x00000050  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x00000060  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x00000070  00 00 00 00 00 00 9c b5 00 00 00 00 e7 00 60 5b  ..............`[
0x00000080  0f 01 02 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x00000090  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x000000a0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x000000b0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x000000c0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x000000d0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x000000e0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x000000f0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 c0 e2  ................
```
and when correct:
```
litex> spdread 0
Memory dump:
0x00000000  23 11 0c 03 45 21 00 08 00 60 00 03 02 03 00 00  #...E!...`......
0x00000010  00 00 06 0d f8 ff 01 00 6e 6e 6e 11 00 6e f0 0a  ........nnn..n..
0x00000020  20 08 00 05 00 f0 2b 34 28 00 78 00 14 3c 00 00   .....+4(.x..<..
0x00000030  00 00 00 00 00 00 00 00 00 00 00 00 16 36 0b 35  .............6.5
0x00000040  16 36 0b 35 00 00 16 36 0b 35 16 36 0b 35 00 00  .6.5...6.5.6.5..
0x00000050  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x00000060  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x00000070  00 00 00 00 00 00 9c b5 00 00 00 00 e7 00 60 5b  ..............`[
0x00000080  0f 01 02 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x00000090  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x000000a0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x000000b0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x000000c0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x000000d0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x000000e0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  ................
0x000000f0  00 00 00 00 00 00 00 00 00 00 00 00 00 00 c0 e2  ................
Memory conents matches the data used for gateware generation
```