### PR TITLE
post-FatFs cleanup

### DIFF
--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -415,7 +415,7 @@ static unsigned int check_image_in_flash(unsigned int base_address)
 }
 
 #if defined(MAIN_RAM_BASE) && defined(FLASH_BOOT_ADDRESS)
-static int copy_image_from_flash_to_ram(unsigned int flash_address, unsigned int ram_address)
+static int copy_image_from_flash_to_ram(unsigned int flash_address, unsigned long ram_address)
 {
 	uint32_t length;
 	uint32_t offset;
@@ -474,7 +474,7 @@ void flashboot(void)
 
 #if defined(CSR_SPISDCARD_BASE) || defined(CSR_SDCORE_BASE)
 
-static int copy_file_from_sdcard_to_ram(const char * filename, unsigned int ram_address)
+static int copy_file_from_sdcard_to_ram(const char * filename, unsigned long ram_address)
 {
 	FRESULT fr;
 	FATFS fs;

--- a/litex/soc/software/liblitesdcard/sdcard.c
+++ b/litex/soc/software/liblitesdcard/sdcard.c
@@ -719,22 +719,17 @@ int sdcard_test(unsigned int blocks)
 /* SDCard FatFs disk functions                                           */
 /*-----------------------------------------------------------------------*/
 
-static DSTATUS spisdcardstatus = STA_NOINIT;
+static DSTATUS sdcardstatus = STA_NOINIT;
 
 DSTATUS disk_status(uint8_t drv) {
 	if (drv) return STA_NOINIT;
-	return spisdcardstatus;
+	return sdcardstatus;
 }
 
 DSTATUS disk_initialize(uint8_t drv) {
-	uint8_t r;
-
-	if (drv) return RES_NOTRDY;
-
-	r = sdcard_init();
-
-	spisdcardstatus = r ? 0 : STA_NOINIT;
-	return spisdcardstatus;
+	if (drv) return STA_NOINIT;
+	sdcardstatus = sdcard_init() ? 0 : STA_NOINIT;
+	return sdcardstatus;
 }
 
 DRESULT disk_read(uint8_t drv, uint8_t *buf, uint32_t sector, uint32_t count) {

--- a/litex/soc/software/liblitesdcard/spisdcard.c
+++ b/litex/soc/software/liblitesdcard/spisdcard.c
@@ -276,14 +276,9 @@ DSTATUS disk_status(uint8_t drv) {
 }
 
 DSTATUS disk_initialize(uint8_t drv) {
-    uint8_t r;
-
-    if (drv) return RES_NOTRDY;
-
-    r = spisdcard_init();
+    if (drv) return STA_NOINIT;
+    spisdcardstatus = spisdcard_init() ? 0 : STA_NOINIT;
     spisdcard_deselect();
-
-    spisdcardstatus = r ? 0 : STA_NOINIT;
     return spisdcardstatus;
 }
 


### PR DESCRIPTION
- use `unsigned long` to represent addresses (needed on 64-bit CPUs)
- streamline `disk_initialize()`

NOTE @enjoy-digital: depends on PR #567  (i.e., apply that one ***first***)