### PR TITLE
bios/linker: Place .data in sram with initial copy in rom.

### DIFF
--- a/litex/soc/cores/cpu/blackparrot/crt0.S
+++ b/litex/soc/cores/cpu/blackparrot/crt0.S
@@ -57,6 +57,19 @@ crt_init:
   la a0, trap_entry
   csrw mtvec, a0
 
+data_init:
+  la a0, _fdata
+  la a1, _edata
+  la a2, _fdata_rom
+data_loop:
+  beq a0,a1,data_done
+  ld a3,0(a2)
+  sd a3,0(a0)
+  add a0,a0,8
+  add a2,a2,8
+  j data_loop
+data_done:
+
 bss_init:
   la a0, _fbss
   la a1, _ebss

--- a/litex/soc/cores/cpu/cv32e40p/crt0.S
+++ b/litex/soc/cores/cpu/cv32e40p/crt0.S
@@ -94,6 +94,19 @@ crt_init:
   la a0, vector_table
   csrw mtvec, a0
 
+data_init:
+  la a0, _fdata
+  la a1, _edata
+  la a2, _fdata_rom
+data_loop:
+  beq a0,a1,data_done
+  lw a3,0(a2)
+  sw a3,0(a0)
+  add a0,a0,4
+  add a2,a2,4
+  j data_loop
+data_done:
+
 bss_init:
   la a0, _fbss
   la a1, _ebss

--- a/litex/soc/cores/cpu/lm32/crt0.S
+++ b/litex/soc/cores/cpu/lm32/crt0.S
@@ -112,10 +112,9 @@ _crt0:
 	mvhi    sp, hi(_fstack)
 	ori     sp, sp, lo(_fstack)
 
-#ifdef EXECUTE_IN_PLACE
 	/* Load DATA */
-	mvhi    r1, hi(_erodata)
-	ori     r1, r1, lo(_erodata)
+	mvhi    r1, hi(_fdata_rom)
+	ori     r1, r1, lo(_fdata_rom)
 	mvhi    r2, hi(_fdata)
 	ori     r2, r2, lo(_fdata)
 	mvhi    r3, hi(_edata)
@@ -128,7 +127,6 @@ _crt0:
 	addi    r1, r1, 4
 	addi    r2, r2, 4
 	bi     .moveDATA
-#endif
 
 .doBSS:
 	/* Clear BSS */

--- a/litex/soc/cores/cpu/minerva/crt0.S
+++ b/litex/soc/cores/cpu/minerva/crt0.S
@@ -9,14 +9,26 @@ reset_vector:
 	la t0, trap_vector
 	csrw mtvec, t0
 
+	// initialize .data
+	la t0, _fdata
+	la t1, _edata
+	la t2, _fdata_rom
+1:	beq t0, t1, 2f
+	lw t3, 0(t0)
+	sw t3, 0(t2)
+	addi t0, t0, 4
+	addi t2, t2, 4
+	j 1b
+2:
+
 	// initialize .bss
 	la t0, _fbss
 	la t1, _ebss
-1:	beq t0, t1, 2f
+1:	beq t0, t1, 3f
 	sw zero, 0(t0)
 	addi t0, t0, 4
 	j 1b
-2:
+3:
 	// enable external interrupts
 	li t0, MIE_MEIE
 	csrs mie, t0

--- a/litex/soc/cores/cpu/picorv32/crt0.S
+++ b/litex/soc/cores/cpu/picorv32/crt0.S
@@ -194,9 +194,8 @@ _crt0:
   la t1, _irq_mask
   sw t0, 0(t1)
 
-#ifdef EXECUTE_IN_PLACE
   /* Load DATA */
-  la t0, _erodata
+  la t0, _fdata_rom
   la t1, _fdata
   la t2, _edata
 3:
@@ -206,7 +205,6 @@ _crt0:
   addi t0, t0, 4
   addi t1, t1, 4
   bltu t1, t2, 3b
-#endif
 
   /* Clear BSS */
   la t0, _fbss

--- a/litex/soc/cores/cpu/rocket/crt0.S
+++ b/litex/soc/cores/cpu/rocket/crt0.S
@@ -57,6 +57,19 @@ crt_init:
   la a0, trap_entry
   csrw mtvec, a0
 
+data_init:
+  la a0, _fdata
+  la a1, _edata
+  la a2, _fdata_rom
+data_loop:
+  beq a0,a1,data_done
+  ld a3,0(a2)
+  sd a3,0(a0)
+  add a0,a0,8
+  add a2,a2,8
+  j data_loop
+data_done:
+
 bss_init:
   la a0, _fbss
   la a1, _ebss

--- a/litex/soc/cores/cpu/serv/crt0.S
+++ b/litex/soc/cores/cpu/serv/crt0.S
@@ -9,14 +9,26 @@ reset_vector:
 	la t0, trap_vector
 	csrw mtvec, t0
 
+	// initialize .data
+	la t0, _fdata
+	la t1, _edata
+	la t2, _fdata_rom
+1:	beq t0, t1, 2f
+	lw t3, 0(t0)
+	sw t3, 0(t2)
+	addi t0, t0, 4
+	addi t2, t2, 4
+	j 1b
+2:
+
 	// initialize .bss
 	la t0, _fbss
 	la t1, _ebss
-1:	beq t0, t1, 2f
+1:	beq t0, t1, 3f
 	sw zero, 0(t0)
 	addi t0, t0, 4
 	j 1b
-2:
+3:
 	// enable external interrupts
 	li t0, MIE_MEIE
 	csrs mie, t0

--- a/litex/soc/cores/cpu/vexriscv/crt0.S
+++ b/litex/soc/cores/cpu/vexriscv/crt0.S
@@ -58,6 +58,19 @@ crt_init:
   la a0, trap_entry
   csrw mtvec, a0
 
+data_init:
+  la a0, _fdata
+  la a1, _edata
+  la a2, _fdata_rom
+data_loop:
+  beq a0,a1,data_done
+  lw a3,0(a2)
+  sw a3,0(a0)
+  add a0,a0,4
+  add a2,a2,4
+  j data_loop
+data_done:
+
 bss_init:
   la a0, _fbss
   la a1, _ebss

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -75,7 +75,7 @@ class SoCCore(LiteXSoC):
         integrated_rom_size      = 0,
         integrated_rom_init      = [],
         # SRAM parameters
-        integrated_sram_size     = 0x1000,
+        integrated_sram_size     = 0x2000,
         integrated_sram_init     = [],
         # MAIN_RAM parameters
         integrated_main_ram_size = 0,
@@ -264,8 +264,8 @@ def soc_core_args(parser):
     parser.add_argument("--integrated-rom-file", default=None, type=str,
                         help="integrated (BIOS) ROM binary file")
     # SRAM parameters
-    parser.add_argument("--integrated-sram-size", default=0x1000, type=auto_int,
-                        help="size/enable the integrated SRAM (default=4KB)")
+    parser.add_argument("--integrated-sram-size", default=0x2000, type=auto_int,
+                        help="size/enable the integrated SRAM (default=8KB)")
     # MAIN_RAM parameters
     parser.add_argument("--integrated-main-ram-size", default=None, type=auto_int,
                         help="size/enable the integrated main RAM")

--- a/litex/soc/software/bios/helpers.c
+++ b/litex/soc/software/bios/helpers.c
@@ -11,7 +11,7 @@
 #include "helpers.h"
 #include "command.h"
 
-extern unsigned int _ftext, _edata;
+extern unsigned int _ftext, _edata_rom;
 
 #define NUMBER_OF_BYTES_ON_A_LINE 16
 void dump_bytes(unsigned int *ptr, int count, unsigned long addr)
@@ -59,14 +59,14 @@ void crcbios(void)
 	unsigned int actual_crc;
 
 	/*
-	 * _edata is located right after the end of the flat
+	 * _edata_rom is located right after the end of the flat
 	 * binary image. The CRC tool writes the 32-bit CRC here.
-	 * We also use the address of _edata to know the length
+	 * We also use the address of _edata_rom to know the length
 	 * of our code.
 	 */
 	offset_bios = (unsigned long)&_ftext;
-	expected_crc = _edata;
-	length = (unsigned long)&_edata - offset_bios;
+	expected_crc = _edata_rom;
+	length = (unsigned long)&_edata_rom - offset_bios;
 	actual_crc = crc32((unsigned char *)offset_bios, length);
 	if (expected_crc == actual_crc)
 		printf(" BIOS CRC passed (%08x)\n", actual_crc);

--- a/litex/soc/software/bios/linker.ld
+++ b/litex/soc/software/bios/linker.ld
@@ -53,7 +53,7 @@ SECTIONS
 		FILL(0);
 		. = ALIGN(8);
 		_edata = .;
-	} > rom
+	} > sram AT > rom
 
 	.bss :
 	{
@@ -78,3 +78,6 @@ SECTIONS
 }
 
 PROVIDE(_fstack = ORIGIN(sram) + LENGTH(sram) - 8);
+
+PROVIDE(_fdata_rom = LOADADDR(.data));
+PROVIDE(_edata_rom = LOADADDR(.data) + SIZEOF(.data));

--- a/litex/soc/software/bios/linker.ld
+++ b/litex/soc/software/bios/linker.ld
@@ -24,6 +24,7 @@ SECTIONS
 		_frodata = .;
 		*(.rodata .rodata.* .gnu.linkonce.r.*)
 		*(.rodata1)
+		*(.got .got.*)
 
 		/* Make sure the file is aligned on disk as well
 		   as in memory; CRC calculation requires that. */


### PR DESCRIPTION
As per #566, `.data` section is currently located in rom, rendering it read-only. This PR moves `.data` to sram, leaving initial state in rom that needs to be copied to sram during startup. This means that every `crt0.S` needs to be updated to fix this.

* `vexriscv`: Updated and tested.
* `rocket`: Updated and tested.
* `serv`: Updated and tested.
* `blackparrot`: Identical to `rocket`, not tested.
* `cv32e40p`: Identical to `vexriscv`, not tested.
* `minerva`: Identical to `serv`, not tested.
* `picorv32`: Existing copy code updated, not tested.
* `lm32`: Existing copy code updated, not tested.
* `mor1kx`: Still needs to be updated.
* `microwatt`: Still needs to be updated. Seems to also miss `.bss` initialization.

Fixes #566.