### PR TITLE
build/sim/core/modules: fix compilation warnings

### DIFF
--- a/litex/build/sim/core/modules/clocker/clocker.c
+++ b/litex/build/sim/core/modules/clocker/clocker.c
@@ -10,7 +10,7 @@ struct session_s {
 
 static int litex_sim_module_pads_get( struct pad_s *pads, char *name, void **signal)
 {
-  int ret;
+  int ret = RC_OK;
   void *sig=NULL;
   int i;
 
@@ -42,7 +42,7 @@ static int clocker_start()
 
 static int clocker_new(void **sess, char *args)
 {
-  int ret=RC_OK;
+  int ret = RC_OK;
 
   struct session_s *s=NULL;
 

--- a/litex/build/sim/core/modules/ethernet/ethernet.c
+++ b/litex/build/sim/core/modules/ethernet/ethernet.c
@@ -74,7 +74,7 @@ out:
 
 static int litex_sim_module_pads_get(struct pad_s *pads, char *name, void **signal)
 {
-  int ret;
+  int ret = RC_OK;
   void *sig = NULL;
   int i;
 
@@ -177,7 +177,7 @@ out:
 
 static int ethernet_add_pads(void *sess, struct pad_list_s *plist)
 {
-  int ret=RC_OK;
+  int ret = RC_OK;
   struct session_s *s = (struct session_s*)sess;
   struct pad_s *pads;
   if(!sess || !plist) {

--- a/litex/build/sim/core/modules/serial2console/serial2console.c
+++ b/litex/build/sim/core/modules/serial2console/serial2console.c
@@ -27,7 +27,7 @@ struct session_s {
 struct event_base *base;
 static int litex_sim_module_pads_get(struct pad_s *pads, char *name, void **signal)
 {
-  int ret;
+  int ret = RC_OK;
   void *sig = NULL;
   int i;
 
@@ -95,7 +95,7 @@ static void event_handler(int fd, short event, void *arg)
 
 static int serial2console_new(void **sess, char *args)
 {
-  int ret=RC_OK;
+  int ret = RC_OK;
   struct timeval tv = {1, 0};
   struct session_s *s = NULL;
 

--- a/litex/build/sim/core/modules/serial2tcp/serial2tcp.c
+++ b/litex/build/sim/core/modules/serial2tcp/serial2tcp.c
@@ -62,7 +62,7 @@ out:
 
 static int litex_sim_module_pads_get( struct pad_s *pads, char *name, void **signal)
 {
-  int ret;
+  int ret = RC_OK;
   void *sig = NULL;
   int i;
 
@@ -186,7 +186,7 @@ out:
 
 static int serial2tcp_add_pads(void *sess, struct pad_list_s *plist)
 {
-  int ret=RC_OK;
+  int ret = RC_OK;
   struct session_s *s=(struct session_s*)sess;
   struct pad_s *pads;
   if(!sess || !plist) {

--- a/litex/build/sim/core/modules/spdeeprom/spdeeprom.c
+++ b/litex/build/sim/core/modules/spdeeprom/spdeeprom.c
@@ -99,7 +99,7 @@ static int spdeeprom_start()
 
 static int spdeeprom_new(void **sess, char *args)
 {
-  int ret=RC_OK;
+  int ret = RC_OK;
   int i;
   char *spd_filename;
   FILE *spd_file;
@@ -403,7 +403,7 @@ static void spdeeprom_from_file(struct session_s *s, FILE *file)
 
 static int litex_sim_module_pads_get(struct pad_s *pads, char *name, void **signal)
 {
-  int ret;
+  int ret = RC_OK;
   void *sig=NULL;
   int i;
 

--- a/litex/build/sim/core/modules/xgmii_ethernet/xgmii_ethernet.c
+++ b/litex/build/sim/core/modules/xgmii_ethernet/xgmii_ethernet.c
@@ -96,7 +96,7 @@ out:
 
 static int litex_sim_module_pads_get(struct pad_s *pads, char *name, void **signal)
 {
-  int ret;
+  int ret = RC_OK;
   void *sig = NULL;
   int i;
 
@@ -199,7 +199,7 @@ out:
 
 static int xgmii_ethernet_add_pads(void *sess, struct pad_list_s *plist)
 {
-  int ret=RC_OK;
+  int ret = RC_OK;
   struct session_s *s = (struct session_s*)sess;
   struct pad_s *pads;
   if(!sess || !plist) {
@@ -358,7 +358,6 @@ static int xgmii_ethernet_tick(void *sess)
       printf("Received: %ld\n", s->ethpack->len );
       for(int i=0; i< s->ethpack->len;) {
 	printf("%02x ", s->inbuf[i++] & 0xff);
-	if (i%8 == 0 && i > 0);
       }
       printf("\n");
       s->inlen = s->ethpack->len;


### PR DESCRIPTION
I had a problem with these modules not compiling because my default CC is clang 10 and it did not let these uninitialized return values and an empty if clause. Therefore these edits.