### PR TITLE
cpu/mor1kx: fix .data initialization (follow-up to PR #567)

### DIFF
--- a/litex/soc/cores/cpu/mor1kx/crt0.S
+++ b/litex/soc/cores/cpu/mor1kx/crt0.S
@@ -153,6 +153,25 @@ _crt0:
     l.movhi    r1, hi(_fstack)
     l.ori     r1, r1, lo(_fstack)
 
+    /* Init DATA */
+    l.movhi   r14,hi(_fdata_rom)
+    l.ori     r14,r14,lo(_fdata_rom)
+    l.movhi   r18,hi(_fdata)
+    l.ori     r18,r18,lo(_fdata)
+    l.movhi   r20,hi(_edata)
+    l.ori     r20,r20,lo(_edata)
+.copyDATA:
+    l.sfeq    r18,r20
+    l.bf      .doneDATA
+     l.nop
+    l.lwz     r3,0(r14)
+    l.sw      0(r18),r3
+    l.addi    r14,r14,4
+    l.addi    r18,r18,4
+    l.j       .copyDATA
+     l.nop
+.doneDATA:
+
     /* Clear BSS */
     l.movhi    r21, hi(_fbss)
     l.ori     r21, r21, lo(_fbss)


### PR DESCRIPTION
I tested this in the simulator with the following test patch:

```
diff --git a/litex/soc/software/bios/main.c b/litex/soc/software/bios/main.c
index dd0989ab..93bc891c 100644
--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -69,6 +69,16 @@ static void boot_sequence(void)
        }
 }
 
+static int foo = 42; // testing .data writability
+
+static __attribute__((noinline)) int mod_foo(int bar) {
+       if (bar)
+               foo = 32;
+       else
+               foo = 52;
+       return foo;
+}
+
 int main(int i, char **c)
 {
        char buffer[CMD_LINE_BUFFER_SIZE];
@@ -95,6 +105,11 @@ int main(int i, char **c)
        printf(" (c) Copyright 2007-2015 M-Labs\n");
        printf("\n");
        printf(" BIOS built on "__DATE__" "__TIME__"\n");
+       printf(" testing .data write access, should be 42: %d\n", foo);
+       mod_foo(1);
+       printf(" testing .data write access, should be 32: %d\n", foo);
+       mod_foo(0);
+       printf(" testing .data write access, should be 52: %d\n", foo);
        crcbios();
        printf("\n");
        printf(" Migen git sha1: "MIGEN_GIT_SHA1"\n");
```

and the first line was indeed 42 (used to be 0 before this patch, because .data hadn't been copied over). @zyp @enjoy-digital, PTAL.