### PR TITLE
software/microwatt: Fix copying data to RAM and clearing BSS

### DIFF
--- a/litex/soc/cores/cpu/microwatt/core.py
+++ b/litex/soc/cores/cpu/microwatt/core.py
@@ -41,6 +41,7 @@ class Microwatt(CPU):
         flags += "-mlittle-endian "
         flags += "-mstrict-align "
         flags += "-fno-stack-protector "
+        flags += "-mcmodel=small "
         flags += "-D__microwatt__ "
         return flags
 

--- a/litex/soc/cores/cpu/microwatt/crt0.S
+++ b/litex/soc/cores/cpu/microwatt/crt0.S
@@ -41,12 +41,44 @@
 _start:
 	FIXUP_ENDIAN
 
+	/* Grab our own address */
+	bcl	20,31,$+4
+0:	mflr	%r12
+
+	/* Get our TOC */
+	addis	%r2,%r12,(.TOC.-0b)@h
+	addi	%r2,%r2,(.TOC.-0b)@l
+
+	/* Copy data from ROM to SRAM */
+	ld	%r3,_fdata@got(%r2)
+	ld	%r4,_edata@got(%r2)
+	ld	%r5,_fdata_rom@got(%r2)
+	subf	%r6,%r3,%r4
+	srdi.	%r6,%r6,3
+	beq	1f
+	li	%r10,0
+	mtctr	%r6
+0:	ldx	%r0,%r10,%r5
+	stdx	%r0,%r10,%r3
+	addi	%r10,%r10,8
+	bdnz	0b
+1:
+	/* Clear BSS */
+	ld	%r3,_fbss@got(%r2)
+	ld	%r4,_ebss@got(%r2)
+	subf	%r6,%r3,%r4
+	srdi.	%r6,%r6,3
+	beq	1f
+	li	%r0,0
+	subi	%r3,%r3,8
+	mtctr	%r6
+0:	stdu	%r0,8(%r3)
+	bdnz	0b
+1:
 	/* setup stack */
-	LOAD_IMM64(%r1, _fstack - 0x100)
-	LOAD_IMM64(%r12, main)
-	mtctr	%r12,
-	bctrl
-	b .
+	ld	%r1,_fstack@got(%r2)
+	bl	main
+	b	.
 
 #define EXCEPTION(nr)		\
 	.=  nr;      \

--- a/litex/soc/software/bios/linker.ld
+++ b/litex/soc/software/bios/linker.ld
@@ -25,6 +25,7 @@ SECTIONS
 		*(.rodata .rodata.* .gnu.linkonce.r.*)
 		*(.rodata1)
 		*(.got .got.*)
+		*(.toc .toc.*)
 
 		/* Make sure the file is aligned on disk as well
 		   as in memory; CRC calculation requires that. */


### PR DESCRIPTION
This also makes us use the "small" memory model to avoid having to
use more complex constructs and adds the TOC to the linker script

Signed-off-by: Benjamin Herrenschmidt <benh@kernel.crashing.org>