### PR TITLE
Initial Edalize support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
 install:
   # Get Migen / LiteX / Cores
   - cd ~/
-  - pip3 install requests
+  - pip3 install requests edalize
   - cp $TRAVIS_BUILD_DIR/litex_setup.py .
   - python3 litex_setup.py init install
   # Install the LiteX version being tested

--- a/litex/boards/targets/arty.py
+++ b/litex/boards/targets/arty.py
@@ -10,7 +10,6 @@ import argparse
 from migen import *
 
 from litex.boards.platforms import arty
-from litex.build.xilinx.vivado import vivado_build_args, vivado_build_argdict
 
 from litex.soc.cores.clock import *
 from litex.soc.integration.soc_core import *
@@ -68,8 +67,8 @@ class _CRG(Module):
 # BaseSoC ------------------------------------------------------------------------------------------
 
 class BaseSoC(SoCCore):
-    def __init__(self, toolchain="vivado", sys_clk_freq=int(100e6), with_ethernet=False, with_etherbone=False, **kwargs):
-        platform = arty.Platform(toolchain=toolchain)
+    def __init__(self, toolchain="vivado", sys_clk_freq=int(100e6), with_ethernet=False, with_etherbone=False, platform_args={}, **kwargs):
+        platform = arty.Platform(**platform_args)
 
         # SoCCore ----------------------------------------------------------------------------------
         if toolchain == "symbiflow":
@@ -121,19 +120,18 @@ def main():
     parser = argparse.ArgumentParser(description="LiteX SoC on Arty A7")
     parser.add_argument("--build", action="store_true", help="Build bitstream")
     parser.add_argument("--load",  action="store_true", help="Load bitstream")
-    parser.add_argument("--toolchain", default="vivado", help="Gateware toolchain to use, vivado (default) or symbiflow")
     builder_args(parser)
     soc_sdram_args(parser)
-    vivado_build_args(parser)
+    arty.platform_args(parser)
     parser.add_argument("--with-ethernet",  action="store_true", help="Enable Ethernet support")
     parser.add_argument("--with-etherbone", action="store_true", help="Enable Etherbone support")
     args = parser.parse_args()
 
     assert not (args.with_ethernet and args.with_etherbone)
-    soc = BaseSoC(args.toolchain, with_ethernet=args.with_ethernet, with_etherbone=args.with_etherbone,
+    soc = BaseSoC(args.toolchain, with_ethernet=args.with_ethernet, with_etherbone=args.with_etherbone, platform_args=arty.platform_argdict(args),
         **soc_sdram_argdict(args))
     builder = Builder(soc, **builder_argdict(args))
-    builder_kwargs = vivado_build_argdict(args) if args.toolchain == "vivado" else {}
+    builder_kwargs = arty.platform_build_argdict(args)
     builder.build(**builder_kwargs, run=args.build)
 
     if args.load:

--- a/litex/build/edalize.py
+++ b/litex/build/edalize.py
@@ -1,0 +1,142 @@
+# This file is Copyright (c) 2020 Antmicro <www.antmicro.com>
+# License: BSD
+
+import math
+import edalize
+import re
+
+from litex.build.generic_platform import IOStandard, Drive, Misc, Inverted
+from litex.build import edalize_ext
+
+# EdalizeToolchain ---------------------------------------------------------------------------------
+
+class EdalizeToolchain:
+    def __init__(self, toolchain):
+        self.bitstream_commands                   = []
+        self.additional_commands                  = []
+        self.pre_synthesis_commands               = []
+        self.pre_placement_commands               = []
+        self.pre_routing_commands                 = []
+
+        self.clocks      = dict()
+        self.false_paths = set()
+
+        edalize_toolchain_name_map = {}
+        self._toolchain = edalize_toolchain_name_map.get(toolchain, toolchain)
+
+    def build(self, platform, fragment, build_dir, build_name, run, verilog_args={},
+        **kwargs):
+
+        # Generate verilog
+        v_output = platform.get_verilog(fragment, name=build_name, **verilog_args)
+        named_sc, named_pc = platform.resolve_signals(v_output.ns)
+        v_file = build_name + ".v"
+        v_output.write(v_file)
+        platform.add_source(v_file)
+
+        # Translate IO information
+        io = []
+        for sig, pins, properties, _ in named_sc:
+            # Translate properties from Litex classes to generic tuples
+            io_properties = []
+            for p in properties:
+                if isinstance(p, IOStandard):
+                    io_properties.append(("iostandard", p.name))
+                elif isinstance(p, Drive):
+                    io_properties.append(("drive", str(p.strength)))
+                elif isinstance(p, Inverted):
+                    io_properties.append(("inverted"))
+                elif isinstance(p, Misc):
+                    io_properties.append(("custom", str(p.misc)))
+                else:
+                    raise ValueError(f"unknown constraint {p}")
+            io.append({
+                "signal": sig,
+                "pins": pins,
+                "properties": io_properties
+            })
+
+        # Resolve signals in constraints
+        period_constraints = dict()
+        for clk, period in self.clocks.items():
+            clk_signal = v_output.ns.get_name(clk)
+            period_constraints[clk_signal] = period
+        false_paths = set()
+        for from_, to in self.false_paths:
+            from_sig = v_output.ns.get_name(from_)
+            to_sig   = v_output.ns.get_name(to)
+            false_paths.add((from_sig, to_sig))
+
+        # Make sure add_*_constraint cannot be used again
+        del self.clocks
+        del self.false_paths
+
+        # Map Litex toolchain options to edalize's tool_options.
+        tool_options = {}
+        if self._toolchain == "vivado":
+            tool_options = {
+                "part":     platform.device,
+                "synth":    kwargs.get("synth_mode", "vivado")
+            }
+
+        # Edalize
+        edam = {
+            "files":        [],
+            "hooks":        [],
+            "name":         build_name,
+            "parameters":   {},
+            "tool_options": {
+                self._toolchain: tool_options
+            },
+            "toplevel":     build_name,
+            "vpi":          [],
+
+            # edalize_ext
+            "constraints": {
+                "period":     period_constraints,
+                "false_path": false_paths,
+                "io":         io,
+                "custom":     named_pc
+            }
+        }
+
+        file_type_map = {
+            "systemverilog": "systemVerilogSource",
+            "verilog":       "verilogSource",
+            "vhdl":          "vhdlSource",
+        }
+        for filename, language, library in platform.sources:
+            edam["files"].append({ "name": filename, "file_type": file_type_map.get(language, "unknown") })
+
+        if hasattr(platform, "ips"):
+            for filename, disable_constraints in platform.ips.items():
+                edam["files"].append({ "name": filename, "file_type": "xci" })
+
+        for path in platform.verilog_include_paths:
+            # name and file_type are not used, but documentation marks them as mandatory.
+            edam["files"].append({ "name": "", "file_type": "", "is_include_file": True, "include_path": path })
+
+        backend_ext = edalize_ext.get_edatool(self._toolchain)(edam=edam, work_root=build_dir)
+        backend_ext.configure()
+
+        # NOTE: backend_ext.configure() modifies edam, so call it before this
+        backend = edalize.get_edatool(self._toolchain)(edam=edam, work_root=build_dir)
+        backend.configure()
+
+        # Run
+        if run:
+            backend.build()
+
+        return v_output.ns
+
+    def add_period_constraint(self, platform, clk, period):
+        period = math.floor(period*1e3)/1e3 # round to lowest picosecond
+        if clk in self.clocks:
+            if period != self.clocks[clk]:
+                raise ValueError("Clock already constrained to {:.2f}ns, new constraint to {:.2f}ns"
+                    .format(self.clocks[clk], period))
+        self.clocks[clk] = period
+
+    def add_false_path_constraint(self, platform, from_, to):
+        if (to, from_) not in self.false_paths:
+            self.false_paths.add((from_, to))

--- a/litex/build/edalize_ext/__init__.py
+++ b/litex/build/edalize_ext/__init__.py
@@ -1,0 +1,4 @@
+from importlib import import_module
+
+def get_edatool(toolchain):
+    return getattr(import_module(f"{__name__}.{toolchain}"), toolchain.capitalize())

--- a/litex/build/edalize_ext/vivado.py
+++ b/litex/build/edalize_ext/vivado.py
@@ -1,0 +1,107 @@
+# This file is Copyright (c) 2014-2020 Florent Kermarrec <florent@enjoy-digital.fr>
+# This file is Copyright (c) 2020 Antmicro <www.antmicro.com>
+# License: BSD
+
+import os
+from litex.build import tools
+
+
+def _xdc_separator(msg):
+    r =  "#"*80 + "\n"
+    r += "# " + msg + "\n"
+    r += "#"*80 + "\n"
+    return r
+
+def _format_xdc_constraint(c):
+    if c[0] == "location":
+        return "set_property LOC " + c[1]
+    elif c[0] == "iostandard":
+        return "set_property IOSTANDARD " + c[1]
+    elif c[0] == "drive":
+        return "set_property DRIVE " + c[1]
+    elif c[0] == "custom":
+        return "set_property " + c[1].replace("=", " ")
+    elif c[0] == "inverted":
+        return None
+    else:
+        raise ValueError("unknown constraint {}".format(c))
+
+def _format_xdc(signame, *constraints):
+    fmt_c = [_format_xdc_constraint(c) for c in constraints]
+    r = ""
+    for c in fmt_c:
+        if c is not None:
+            r += c + " [get_ports {" + signame + "}]\n"
+    r += "\n"
+    return r
+
+def _build_xdc(io, constraints):
+    r = _xdc_separator("IO constraints") + "\n"
+    for entry in io:
+        sig = entry["signal"]
+        pins = entry.get("pins", [])
+        properties = entry.get("properties", [])
+        if len(pins) > 1:
+            for i, p in enumerate(pins):
+                r += _format_xdc(sig + "[" + str(i) + "]", ("location", p), *properties)
+        elif pins:
+            r += _format_xdc(sig, ("location", pins[0]), *properties)
+        else:
+            r += _format_xdc(sig, *properties)
+    if constraints:
+        r += _xdc_separator("Design constraints")
+        r += "\n" + "\n".join(constraints)
+    r += "\n"
+    return r
+
+
+class Vivado:
+    def __init__(self, edam=None, work_root=None):
+        self._edam = edam
+        self._work_root = work_root
+
+    def configure(self):
+        io = self._edam.get("constraints", {}).get("io", [])
+        period_constraints = self._edam.get("constraints", {}).get("period", {})
+        false_paths = self._edam.get("constraints", {}).get("false_path", {})
+        custom_constraints = self._edam.get("constraints", {}).get("custom", [])
+
+        constraints = custom_constraints[:]
+
+        # Process constraints
+        constraints.append("\n" + _xdc_separator("Clock constraints"))
+        for clk, period in period_constraints.items():
+            constraints.append(
+                f"create_clock -name {clk} -period {str(period)} [get_nets {clk}]")
+        for from_, to in false_paths:
+            constraints.append(
+                "set_clock_groups "
+                f"-group [get_clocks -include_generated_clocks -of [get_nets {from_}]] "
+                f"-group [get_clocks -include_generated_clocks -of [get_nets {to}]] "
+                "-asynchronous")
+
+        constraints.append("\n" + _xdc_separator("False path constraints"))
+        # The asynchronous input to a MultiReg is a false path
+        constraints.append(
+            "set_false_path -quiet "
+            "-through [get_nets -hierarchical -filter {mr_ff == TRUE}]"
+        )
+        # The asychronous reset input to the AsyncResetSynchronizer is a false path
+        constraints.append(
+            "set_false_path -quiet "
+            "-to [get_pins -filter {REF_PIN_NAME == PRE} "
+                "-of_objects [get_cells -hierarchical -filter {ars_ff1 == TRUE || ars_ff2 == TRUE}]]"
+        )
+        # clock_period-2ns to resolve metastability on the wire between the AsyncResetSynchronizer FFs
+        constraints.append(
+            "set_max_delay 2 -quiet "
+            "-from [get_pins -filter {REF_PIN_NAME == C} "
+                "-of_objects [get_cells -hierarchical -filter {ars_ff1 == TRUE}]] "
+            "-to [get_pins -filter {REF_PIN_NAME == D} "
+                "-of_objects [get_cells -hierarchical -filter {ars_ff2 == TRUE}]]"
+        )
+
+        # Create .xdc
+        xdc = os.path.join(self._work_root, self._edam.get("name", "top") + ".xdc")
+        self._edam["files"].append({ "name": xdc, "file_type": "xdc" })
+        tools.write_to_file(xdc, _build_xdc(io, constraints))

--- a/litex/build/xilinx/ise.py
+++ b/litex/build/xilinx/ise.py
@@ -211,14 +211,13 @@ TIMESPEC "TS{from_}TO{to}" = FROM "TIG{from_}" TO "TIG{to}" TIG;
                 to=to,
                 )
 
-    def build(self, platform, fragment, build_dir, build_name, run,
-            mode = "xst",
-            **kwargs):
+    def build(self, platform, fragment, build_dir, build_name, run, verilog_args={},
+            mode = "xst"):
         self._process_constraints(platform)
 
         if mode in ["xst", "yosys", "cpld"]:
             # Generate verilog
-            v_output = platform.get_verilog(fragment, name=build_name, **kwargs)
+            v_output = platform.get_verilog(fragment, name=build_name, **verilog_args)
             vns = v_output.ns
             named_sc, named_pc = platform.resolve_signals(vns)
             v_file = build_name + ".v"

--- a/litex/build/xilinx/ise.py
+++ b/litex/build/xilinx/ise.py
@@ -165,16 +165,6 @@ bitgen {bitgen_opt} {build_name}.ncd {build_name}.bit{fail_stmt}
 # XilinxISEToolchain --------------------------------------------------------------------------------
 
 class XilinxISEToolchain:
-    attr_translate = {
-        "keep":             ("keep", "true"),
-        "no_retiming":      ("register_balancing", "no"),
-        "async_reg":        None,
-        "mr_ff":            None,
-        "ars_ff1":          None,
-        "ars_ff2":          None,
-        "no_shreg_extract": ("shreg_extract", "no")
-    }
-
     def __init__(self):
         self.xst_opt = "-ifmt MIXED\n-use_new_parser yes\n-opt_mode SPEED\n-register_balancing yes"
         self.map_opt = "-ol high -w"

--- a/litex/build/xilinx/platform.py
+++ b/litex/build/xilinx/platform.py
@@ -14,10 +14,43 @@ from litex.build.xilinx import common, vivado, ise, symbiflow
 class XilinxPlatform(GenericPlatform):
     bitstream_ext = ".bit"
 
+    attr_translations = {
+        "ise": {
+            "keep":             ("keep", "true"),
+            "no_retiming":      ("register_balancing", "no"),
+            "async_reg":        None,
+            "mr_ff":            None,
+            "ars_ff1":          None,
+            "ars_ff2":          None,
+            "no_shreg_extract": ("shreg_extract", "no")
+        },
+        "vivado": {
+            "keep":            ("dont_touch", "true"),
+            "no_retiming":     ("dont_touch", "true"),
+            "async_reg":       ("async_reg",  "true"),
+            "mr_ff":           ("mr_ff",      "true"), # user-defined attribute
+            "ars_ff1":         ("ars_ff1",    "true"), # user-defined attribute
+            "ars_ff2":         ("ars_ff2",    "true"), # user-defined attribute
+            "no_shreg_extract": None
+        },
+        "symbiflow": {
+            "keep":            ("dont_touch", "true"),
+            "no_retiming":     ("dont_touch", "true"),
+            "async_reg":       ("async_reg",  "true"),
+            "mr_ff":           ("mr_ff",      "true"), # user-defined attribute
+            "ars_ff1":         ("ars_ff1",    "true"), # user-defined attribute
+            "ars_ff2":         ("ars_ff2",    "true"), # user-defined attribute
+            "no_shreg_extract": None
+        }
+    }
+
     def __init__(self, *args, toolchain="ise", **kwargs):
         GenericPlatform.__init__(self, *args, **kwargs)
         self.edifs = set()
         self.ips   = {}
+
+        self.toolchain_name = toolchain
+
         if toolchain == "ise":
             self.toolchain = ise.XilinxISEToolchain()
         elif toolchain == "vivado":
@@ -43,7 +76,7 @@ class XilinxPlatform(GenericPlatform):
             so.update(common.xilinx_us_special_overrides)
         so.update(special_overrides)
         return GenericPlatform.get_verilog(self, *args, special_overrides=so,
-            attr_translate=self.toolchain.attr_translate, **kwargs)
+            attr_translate=self.attr_translations[self.toolchain_name], **kwargs)
 
     def get_edif(self, fragment, **kwargs):
         return GenericPlatform.get_edif(self, fragment, "UNISIMS", "Xilinx", self.device, **kwargs)

--- a/litex/build/xilinx/platform.py
+++ b/litex/build/xilinx/platform.py
@@ -83,3 +83,17 @@ class XilinxPlatform(GenericPlatform):
         from_.attr.add("keep")
         to.attr.add("keep")
         self.toolchain.add_false_path_constraint(self, from_, to)
+
+
+# XilinxPlatform arguments --------------------------------------------------------------------------
+
+def xilinx_platform_args(parser):
+    pass
+
+def xilinx_platform_argdict(args):
+    r = {}
+    return r
+
+def xilinx_platform_build_argdict(args):
+    r = {}
+    return r

--- a/litex/build/xilinx/symbiflow.py
+++ b/litex/build/xilinx/symbiflow.py
@@ -97,16 +97,6 @@ def _run_make():
 # SymbiflowToolchain -------------------------------------------------------------------------------
 
 class SymbiflowToolchain:
-    attr_translate = {
-        "keep":            ("dont_touch", "true"),
-        "no_retiming":     ("dont_touch", "true"),
-        "async_reg":       ("async_reg",  "true"),
-        "mr_ff":           ("mr_ff",      "true"), # user-defined attribute
-        "ars_ff1":         ("ars_ff1",    "true"), # user-defined attribute
-        "ars_ff2":         ("ars_ff2",    "true"), # user-defined attribute
-        "no_shreg_extract": None
-    }
-
     def __init__(self):
         self.clocks = dict()
         self.false_paths = set()

--- a/litex/build/xilinx/symbiflow.py
+++ b/litex/build/xilinx/symbiflow.py
@@ -184,7 +184,7 @@ class SymbiflowToolchain:
 
         tools.write_to_file("Makefile", makefile.generate())
 
-    def _build_clock_constraints(self, platform):
+    def _process_constraints(self, platform):
         for clk, (period, phase) in sorted(self.clocks.items(), key=lambda x: x[0].duid):
             rising_edge = math.floor(period/360.0 * phase * 1e3)/1e3
             falling_edge = math.floor(((rising_edge + period/2) % period) * 1.e3)/1e3
@@ -216,7 +216,7 @@ class SymbiflowToolchain:
                 self._fix_instance(instance)
 
         # Generate timing constraints
-        self._build_clock_constraints(platform)
+        self._process_constraints(platform)
 
         # Generate verilog
         v_output = platform.get_verilog(fragment, name=build_name, **kwargs)

--- a/litex/build/xilinx/symbiflow.py
+++ b/litex/build/xilinx/symbiflow.py
@@ -204,8 +204,7 @@ class SymbiflowToolchain:
                 if isinstance(item, Instance.Parameter) and re.fullmatch("CLKOUT[0-9]_(PHASE|DUTY_CYCLE)", item.name):
                     item.value = wrap(math.floor(_unwrap(item.value) * 1000))
 
-    def build(self, platform, fragment, build_dir, build_name, run,
-            enable_xpm = False,
+    def build(self, platform, fragment, build_dir, build_name, run, verilog_args = {},
             **kwargs):
 
         self._check_properties(platform)
@@ -219,7 +218,7 @@ class SymbiflowToolchain:
         self._process_constraints(platform)
 
         # Generate verilog
-        v_output = platform.get_verilog(fragment, name=build_name, **kwargs)
+        v_output = platform.get_verilog(fragment, name=build_name, **verilog_args)
         named_sc, named_pc = platform.resolve_signals(v_output.ns)
         v_file = build_name + ".v"
         v_output.write(v_file)

--- a/litex/build/xilinx/vivado.py
+++ b/litex/build/xilinx/vivado.py
@@ -292,15 +292,14 @@ class XilinxVivadoToolchain:
         del self.clocks
         del self.false_paths
 
-    def build(self, platform, fragment, build_dir, build_name, run,
+    def build(self, platform, fragment, build_dir, build_name, run, verilog_args = {},
             synth_mode = "vivado",
-            enable_xpm = False,
-            **kwargs):
+            enable_xpm = False):
         # Generate timing constraints
         self._process_constraints(platform)
 
         # Generate verilog
-        v_output = platform.get_verilog(fragment, name=build_name, **kwargs)
+        v_output = platform.get_verilog(fragment, name=build_name, **verilog_args)
         named_sc, named_pc = platform.resolve_signals(v_output.ns)
         v_file = build_name + ".v"
         v_output.write(v_file)

--- a/litex/build/xilinx/vivado.py
+++ b/litex/build/xilinx/vivado.py
@@ -293,23 +293,10 @@ class XilinxVivadoToolchain:
         )
 
 
-    def build(self, platform, fragment,
-        build_dir  = "build",
-        build_name = "top",
-        run        = True,
-        synth_mode = "vivado",
-        enable_xpm = False,
-        **kwargs):
-
-        # Create build directory
-        os.makedirs(build_dir, exist_ok=True)
-        cwd = os.getcwd()
-        os.chdir(build_dir)
-
-        # Finalize design
-        if not isinstance(fragment, _Fragment):
-            fragment = fragment.get_fragment()
-        platform.finalize(fragment)
+    def build(self, platform, fragment, build_dir, build_name, run,
+            synth_mode = "vivado",
+            enable_xpm = False,
+            **kwargs):
 
         # Generate timing constraints
         self._build_clock_constraints(platform)
@@ -340,12 +327,9 @@ class XilinxVivadoToolchain:
             script = _build_script(build_name)
             _run_script(script)
 
-        os.chdir(cwd)
-
         return v_output.ns
 
     def add_period_constraint(self, platform, clk, period):
-        clk.attr.add("keep")
         period = math.floor(period*1e3)/1e3 # round to lowest picosecond
         if clk in self.clocks:
             if period != self.clocks[clk]:
@@ -354,8 +338,6 @@ class XilinxVivadoToolchain:
         self.clocks[clk] = period
 
     def add_false_path_constraint(self, platform, from_, to):
-        from_.attr.add("keep")
-        to.attr.add("keep")
         if (to, from_) not in self.false_paths:
             self.false_paths.add((from_, to))
 

--- a/litex/build/xilinx/vivado.py
+++ b/litex/build/xilinx/vivado.py
@@ -92,16 +92,6 @@ def _run_script(script):
 # XilinxVivadoToolchain ----------------------------------------------------------------------------
 
 class XilinxVivadoToolchain:
-    attr_translate = {
-        "keep":            ("dont_touch", "true"),
-        "no_retiming":     ("dont_touch", "true"),
-        "async_reg":       ("async_reg",  "true"),
-        "mr_ff":           ("mr_ff",      "true"), # user-defined attribute
-        "ars_ff1":         ("ars_ff1",    "true"), # user-defined attribute
-        "ars_ff2":         ("ars_ff2",    "true"), # user-defined attribute
-        "no_shreg_extract": None
-    }
-
     def __init__(self):
         self.bitstream_commands                   = []
         self.additional_commands                  = []

--- a/test/test_targets.py
+++ b/test/test_targets.py
@@ -80,6 +80,13 @@ class TestTargets(unittest.TestCase):
         ])
         self.assertEqual(errors, 0)
 
+    def test_arty_edalize_vivado(self):
+        from litex.boards.targets.arty import BaseSoC
+        errors = build_test([
+            BaseSoC(toolchain="vivado", platform_args={"use_edalize": True}, **test_kwargs)
+        ])
+        self.assertEqual(errors, 0)
+
     # Kintex-7
     def test_genesys2(self):
         from litex.boards.targets.genesys2 import BaseSoC


### PR DESCRIPTION
This is a PoC of using Edalize (https://github.com/olofk/edalize) as Litex toolchain library. It is implemented for Xilinx platform/Vivado toolchain as an option. Necessary command line argument (`--use-edalize`) is added to Arty target.

In order to add Edalize, I've done some refactoring in Xilinx platform and Xilinx toolchains to remove shared code (adding constraints, creating/changing build directories, etc) from toolchain classes. Similar refactoring can be done without bigger problems in other platforms/toolchains (except Sim/Verilator, where it would need more work). Common code is currently placed in XilinxPlatform, but I think it would be more suitable to make a class like `GenericToolchain` and inherit it in all toolchains.

Edalize needs following changes to be able to fully replace Litex toolchain wrappers:
* Toolchain-independent API for setting period and false path constraints and automatic generation of constraints file(s). I've placed example implementation for Vivado in litex/build/edalize_ext/vivado.py.
* A way for passing custom toolchain-specific platform commands
* Fixes/updates for some toolchains (e.g. ISE, which doesn't work as good as Litex ISE backend)