### PR TITLE
Fix ordering of libraries

### DIFF
--- a/litex/soc/software/bios/Makefile
+++ b/litex/soc/software/bios/Makefile
@@ -75,7 +75,7 @@ bios.elf: $(BIOS_DIRECTORY)/linker.ld $(OBJECTS)
 		-L../liblitespi \
 		-L../liblitesdcard \
 		$(BP_LIBS) \
-		-lcompiler_rt -llitedram -lliteeth -llitespi -llitesdcard -lbase-nofloat \
+		-llitedram -lliteeth -llitespi -llitesdcard -lbase-nofloat -lcompiler_rt \
 		$(BP_FLAGS)
 
 ifneq ($(OS),Windows_NT)


### PR DESCRIPTION
Since libcompiler_rt provides functions for other
libraries (e.g., __muldiv3), it must be listed
at the end.