### PR TITLE
Improve verilator compilation speed

### DIFF
--- a/litex/build/sim/core/Makefile
+++ b/litex/build/sim/core/Makefile
@@ -45,6 +45,9 @@ sim: $(OBJS_SIM) | mkdir
 		$(if $(TRACE_FST), --trace-fst,) \
 		$(if $(COVERAGE), --coverage,) \
 		--unroll-count 256 \
+		--output-split 5000 \
+		--output-split-cfuncs 500 \
+		--output-split-ctrace 500 \
 		$(INC_DIR) \
 		-Wno-BLKANDNBLK \
 		-Wno-WIDTH


### PR DESCRIPTION
by asking verilator to split the C++ model into multiple files.

(copy pasted from the SpinalHDL verilator backend : https://github.com/SpinalHDL/SpinalHDL/blob/c9bd9dd06debf1466d3d45a3d9e12b22ba87e8d6/sim/src/main/scala/spinal/sim/VerilatorBackend.scala#L401)