### PR TITLE
liblitesdcard/sdcard: adjust card-ready timeout

### DIFF
--- a/litex/soc/software/liblitesdcard/sdcard.c
+++ b/litex/soc/software/liblitesdcard/sdcard.c
@@ -448,7 +448,7 @@ void sdcard_decode_csd(void) {
 
 int sdcard_init(void) {
 	unsigned short rca;
-    uint16_t timeout;
+	uint16_t timeout;
 
 	/* initialize freq */
 	sdcard_set_clk_freq(16000000);
@@ -462,15 +462,13 @@ int sdcard_init(void) {
 	busy_wait(1);
 	sdcard_send_ext_csd();
 	/* wait for card to be ready */
-	timeout = 10;
-	while (timeout) {
+	for (timeout = 128; timeout > 0; timeout--) {
 		sdcard_app_cmd(0);
 		sdcard_app_send_op_cond(1, 0);
 		if (sdcard_response[3] & 0x80000000) {
 			break;
 		}
-		busy_wait(1);
-		timeout--;
+		busy_wait(10);
 	}
 	if (timeout == 0)
 		return 0;


### PR DESCRIPTION
Testing on nexys4ddr and rocket, approximately 12 iterations of the
timeout loop are needed to receive a "ready" response from the SDcard,
assuming a "warm" reset where the card has already been previously
initialized.

If the SDcard is ejected and re-inserted, or if the board is "cold-reset"
(e.g., reprogrammed via openocd vs. a simple push of the reset button),
it takes approximately 450 iterations before the SDCard responds with a
"ready" message.

In either case, a timeout of 10 is insufficient, so let's bump it to 1024.

This patch also adds some minor cosmetic improvements.

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>