### PR TITLE
cpu: add a few missing GCC toolchains

### DIFF
--- a/litex/soc/cores/cpu/__init__.py
+++ b/litex/soc/cores/cpu/__init__.py
@@ -35,15 +35,20 @@ class CPUNone(CPU):
 CPU_GCC_TRIPLE_RISCV32 = (
     "riscv64-unknown-elf",
     "riscv32-unknown-elf",
+    "riscv64-elf",
+    "riscv32-elf",
     "riscv-none-embed",
     "riscv64-linux",
+    "riscv64-linux-gnu-gcc",
     "riscv-sifive-elf",
     "riscv64-none-elf",
 )
 
 CPU_GCC_TRIPLE_RISCV64 = (
     "riscv64-unknown-elf",
+    "riscv64-elf",
     "riscv64-linux",
+    "riscv64-linux-gnu-gcc",
     "riscv-sifive-elf",
     "riscv64-none-elf",
 )


### PR DESCRIPTION
This names are used by Arch Linux for eg.

Signed-off-by: Filipe Laíns <lains@archlinux.org>