### PR TITLE
Add AXILite components: AXILiteSRAM and AXILite2CSR

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -280,6 +280,21 @@ class SoCBusHandler(Module):
     # Add Master/Slave -----------------------------------------------------------------------------
     def add_adapter(self, name, interface, direction="m2s"):
         assert direction in ["m2s", "s2m"]
+
+        if isinstance(interface, axi.AXILiteInterface):
+            self.logger.info("{} Bus {} from {} to {}.".format(
+                colorer(name),
+                colorer("converted", color="cyan"),
+                colorer("AXILite"),
+                colorer("Wishbone")))
+            new_interface = wishbone.Interface(data_width=interface.data_width)
+            if direction == "m2s":
+                converter = axi.AXILite2Wishbone(axi_lite=interface, wishbone=new_interface)
+            elif direction == "s2m":
+                converter = axi.Wishbone2AXILite(wishbone=new_interface, axi_lite=interface)
+            self.submodules += converter
+            interface = new_interface
+
         if interface.data_width != self.data_width:
             self.logger.info("{} Bus {} from {}-bit to {}-bit.".format(
                 colorer(name),

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -753,28 +753,19 @@ class SoC(Module):
         setattr(self.submodules, name, SoCController(**kwargs))
         self.csr.add(name, use_loc_if_exists=True)
 
-    def add_ram(self, name, origin, size, contents=[], mode="rw", bus=None):
-        if bus is None:
-            bus = wishbone.Interface(data_width=self.bus.data_width)
-
-        if isinstance(bus, wishbone.Interface):
-            ram = wishbone.SRAM(size, bus=bus, init=contents, read_only=(mode == "r"))
-        elif isinstance(bus, axi.AXILiteInterface):
-            ram = axi.AXILiteSRAM(size, bus=bus, init=contents, read_only=(mode == "r"))
-        else:
-            raise TypeError(bus)
-
+    def add_ram(self, name, origin, size, contents=[], mode="rw"):
+        ram_bus = wishbone.Interface(data_width=self.bus.data_width)
+        ram     = wishbone.SRAM(size, bus=ram_bus, init=contents, read_only=(mode == "r"))
         self.bus.add_slave(name, ram.bus, SoCRegion(origin=origin, size=size, mode=mode))
         self.check_if_exists(name)
-        self.logger.info("{} RAM {} {} {}.".format(
-            colorer("Wishbone" if isinstance(bus, wishbone.Interface) else "AXILite"),
+        self.logger.info("RAM {} {} {}.".format(
             colorer(name),
             colorer("added", color="green"),
             self.bus.regions[name]))
         setattr(self.submodules, name, ram)
 
-    def add_rom(self, name, origin, size, contents=[], bus=None):
-        self.add_ram(name, origin, size, contents, mode="r", bus=bus)
+    def add_rom(self, name, origin, size, contents=[]):
+        self.add_ram(name, origin, size, contents, mode="r")
 
     def add_csr_bridge(self, origin):
         self.submodules.csr_bridge = wishbone.Wishbone2CSR(

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -281,35 +281,45 @@ class SoCBusHandler(Module):
     def add_adapter(self, name, interface, direction="m2s"):
         assert direction in ["m2s", "s2m"]
 
-        if isinstance(interface, axi.AXILiteInterface):
-            self.logger.info("{} Bus {} from {} to {}.".format(
-                colorer(name),
-                colorer("converted", color="cyan"),
-                colorer("AXILite"),
-                colorer("Wishbone")))
-            new_interface = wishbone.Interface(data_width=interface.data_width)
-            if direction == "m2s":
-                converter = axi.AXILite2Wishbone(axi_lite=interface, wishbone=new_interface)
-            elif direction == "s2m":
-                converter = axi.Wishbone2AXILite(wishbone=new_interface, axi_lite=interface)
-            self.submodules += converter
-            interface = new_interface
-
-        if interface.data_width != self.data_width:
-            self.logger.info("{} Bus {} from {}-bit to {}-bit.".format(
-                colorer(name),
-                colorer("converted", color="cyan"),
-                colorer(interface.data_width),
-                colorer(self.data_width)))
+        if isinstance(interface, wishbone.Interface):
             new_interface = wishbone.Interface(data_width=self.data_width)
             if direction == "m2s":
                 converter = wishbone.Converter(master=interface, slave=new_interface)
             if direction == "s2m":
                 converter = wishbone.Converter(master=new_interface, slave=interface)
             self.submodules += converter
-            return new_interface
+        elif isinstance(interface, axi.AXILiteInterface):
+            # Data width conversion
+            intermediate = axi.AXILiteInterface(data_width=self.data_width)
+            if direction == "m2s":
+                converter = axi.AXILiteConverter(master=interface, slave=intermediate)
+            if direction == "s2m":
+                converter = axi.AXILiteConverter(master=intermediate, slave=interface)
+            self.submodules += converter
+            # Bus type conversion
+            new_interface = wishbone.Interface(data_width=self.data_width)
+            if direction == "m2s":
+                converter = axi.AXILite2Wishbone(axi_lite=intermediate, wishbone=new_interface)
+            elif direction == "s2m":
+                converter = axi.Wishbone2AXILite(wishbone=new_interface, axi_lite=intermediate)
+            self.submodules += converter
         else:
-            return interface
+            raise TypeError(interface)
+
+        fmt = "{name} Bus {converted} from {frombus} {frombits}-bit to {tobus} {tobits}-bit."
+        frombus  = "Wishbone" if isinstance(interface, wishbone.Interface) else "AXILite"
+        tobus    = "Wishbone" if isinstance(new_interface, wishbone.Interface) else "AXILite"
+        frombits = interface.data_width
+        tobits   = new_interface.data_width
+        if frombus != tobus or frombits != tobits:
+            self.logger.info(fmt.format(
+                name      = colorer(name),
+                converted = colorer("converted", color="cyan"),
+                frombus   = colorer("Wishbone" if isinstance(interface, wishbone.Interface) else "AXILite"),
+                frombits  = colorer(interface.data_width),
+                tobus     = colorer("Wishbone" if isinstance(new_interface, wishbone.Interface) else "AXILite"),
+                tobits    = colorer(new_interface.data_width)))
+        return new_interface
 
     def add_master(self, name=None, master=None):
         if name is None:

--- a/litex/soc/interconnect/axi.py
+++ b/litex/soc/interconnect/axi.py
@@ -676,3 +676,22 @@ class AXILiteSRAM(Module):
                                        port_we=port.we if not read_only else None)
         self.submodules.fsm = fsm
         self.comb += comb
+
+# AXILite Data Width Converter ---------------------------------------------------------------------
+
+class AXILiteConverter(Module):
+    """AXILite data width converter"""
+    def __init__(self, master, slave):
+        self.master = master
+        self.slave = slave
+
+        # # #
+
+        dw_from = len(master.r.data)
+        dw_to = len(slave.r.data)
+        if dw_from > dw_to:
+            raise NotImplementedError
+        elif dw_from < dw_to:
+            raise NotImplementedError
+        else:
+            self.comb += master.connect(slave)


### PR DESCRIPTION
This is a part of https://github.com/enjoy-digital/litex/issues/590.

This PR adds a bridge from AXILite to CSR bus and an SRAM with AXILite interface.
Methods for adding RAM (`add_ram` and `add_rom`) accept additional `bus` parameter, and will use either `wishbone.SRAM` or `axi.AXILiteSRAM` depending on the bus type, defaulting to wishbone. The `add_adapter` method will perform conversion from AXILite to wishbone and do the data width conversion. For now `AXILiteConverter` is a dummy implementation that can connect only interfaces with the same width, and I am working on adding a proper converter.

I added tests for `AXILite2CSR` and `AXILiteSRAM` and I was also able to successfully test them in `litex_sim`.

