### PR TITLE
Fix Vivado crash when using 1:1 wishbone.Converter

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -282,12 +282,15 @@ class SoCBusHandler(Module):
         assert direction in ["m2s", "s2m"]
 
         if isinstance(interface, wishbone.Interface):
-            new_interface = wishbone.Interface(data_width=self.data_width)
-            if direction == "m2s":
-                converter = wishbone.Converter(master=interface, slave=new_interface)
-            if direction == "s2m":
-                converter = wishbone.Converter(master=new_interface, slave=interface)
-            self.submodules += converter
+            if interface.data_width != self.data_width:
+                new_interface = wishbone.Interface(data_width=self.data_width)
+                if direction == "m2s":
+                    converter = wishbone.Converter(master=interface, slave=new_interface)
+                if direction == "s2m":
+                    converter = wishbone.Converter(master=new_interface, slave=interface)
+                self.submodules += converter
+            else:
+                new_interface = interface
         elif isinstance(interface, axi.AXILiteInterface):
             # Data width conversion
             intermediate = axi.AXILiteInterface(data_width=self.data_width)


### PR DESCRIPTION
Fixes an issue with Vivado which crashes when building `litex-buildenv` at:
https://github.com/antmicro/litex-buildenv/commit/cc003bef3ac1407f9788ec8b7cc52d5981f8364a and `litex` bumped to https://github.com/enjoy-digital/litex/commit/2700ec3ce515670a388e2a46a2b87a5b602cc9c8, with the following options:
`export CPU=mor1kx; CPU_VARIANT=linux; export PLATFORM=arty; export FIRMWARE=linux; export TARGET=net`

When investigating the Verilog code, the only difference is that we avoid creating new `wishbone.Interface` and doing
`new_interface.connect(interface)` (this is what `wishbone.Converter` does when the data widths are the same). 
This shouldn't make any difference, but for some reason Vivado crashes with a stack trace.
I've tested it with Vivado v2018.3 and v2019.2. @mateusz-holenko  encountered the same problem.

I don't know if we should merge this change, as this may as well be a random error.

Logs: [logs.zip](https://github.com/enjoy-digital/litex/files/4947996/logs.zip)
