### PR TITLE
Socdoc extensions

### DIFF
--- a/doc/socdoc.md
+++ b/doc/socdoc.md
@@ -125,6 +125,21 @@ register listings. You can add additional modules by passing an array to
     generate_docs("build/documentation", sphinx_extensions=['sphinx.ext.mathjax'])
 ```
 
+You may need to pass additional configuration to `conf.py`. In this case, pass it
+as `sphinx_extra_config`. For example:
+
+```python
+    generate_docs("build/documentation",
+            sphinx_extensions=['sphinx_math_dollar', 'sphinx.ext.mathjax'],
+            sphinx_extra_config=r"""
+   mathjax_config = {
+       'tex2jax': {
+           'inlineMath': [ ["\\(","\\)"] ],
+           'displayMath': [["\\[","\\]"] ],
+       },
+   }""")
+```
+
 By default, `socdoc` unconditionally overwrites all files in the output
 directory, including the sphinx `conf.py` file. To disable this feature
 so you can customize your own `conf.py` file, pass `from_scratch=False`:

--- a/litex/soc/doc/__init__.py
+++ b/litex/soc/doc/__init__.py
@@ -36,12 +36,13 @@ def generate_svd(soc, buildpath, filename=None, name="soc", **kwargs):
 
 
 def generate_docs(soc, base_dir,
-    project_name      = "LiteX SoC Project",
-    author            = "Anonymous",
-    sphinx_extensions = [],
-    quiet             = False,
-    note_pulses       = False,
-    from_scratch      = True):
+    project_name          = "LiteX SoC Project",
+    author                = "Anonymous",
+    sphinx_extensions     = [],
+    quiet                 = False,
+    note_pulses           = False,
+    from_scratch          = True,
+    sphinx_extra_config   = ""):
     """Possible extra extensions:
         [
             'm2r',
@@ -68,6 +69,7 @@ def generate_docs(soc, base_dir,
                 sphinx_ext_str += "\n    \"{}\",".format(ext)
             print(default_sphinx_configuration.format(project_name, year,
                                                       author, author, sphinx_ext_str), file=conf)
+            print(sphinx_extra_config, file=conf)
 
     if not quiet:
         print("Generate the documentation by running `sphinx-build -M html {} {}_build`".format(base_dir, base_dir))


### PR DESCRIPTION
This adds `sphinx_extra_config` to `generate_docs()` to support adding additional configuration parameters to the `conf.py`.