### PR TITLE
Add openFPGALoader programmer

### DIFF
--- a/litex/build/openfpgaloader.py
+++ b/litex/build/openfpgaloader.py
@@ -1,0 +1,20 @@
+# This file is Copyright (c) 2020 Florent Kermarrec <florent@enjoy-digital.fr>
+# License: BSD
+
+import subprocess
+
+from litex.build.tools import write_to_file
+from litex.build.generic_programmer import GenericProgrammer
+
+# openFPGAloader ------------------------------------------------------------------------------------------
+
+class OpenFPGALoader(GenericProgrammer):
+    needs_bitreverse = False
+
+    def __init__(self, board):
+        self.board = board
+
+    def load_bitstream(self, bitstream_file):
+        print(["openFPGALoader", "--board", self.board, bitstream_file])
+        subprocess.call(["openFPGALoader", "--board", self.board, bitstream_file])
+        print("done")

--- a/litex/build/openfpgaloader.py
+++ b/litex/build/openfpgaloader.py
@@ -15,6 +15,4 @@ class OpenFPGALoader(GenericProgrammer):
         self.board = board
 
     def load_bitstream(self, bitstream_file):
-        print(["openFPGALoader", "--board", self.board, bitstream_file])
         subprocess.call(["openFPGALoader", "--board", self.board, bitstream_file])
-        print("done")


### PR DESCRIPTION
Currently the ULX3S board uses the ujprog programmer, which is specific to this board, and does not have build system that works on my machine.

[OpenFPGALoader](https://github.com/trabucayre/openFPGALoader) is a well-written en maintained program that supports many FPGA boards, and this PR adds a simple class for it.

In a separate PR I'll update the ULX3S target to use this class.