### PR TITLE
RFC: enable DMA with Rocket

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -845,7 +845,7 @@ class SoC(Module):
                     data_width       = self.bus.data_width,
                 )
                 dma_bus = wishbone.Interface(data_width=self.bus.data_width)
-                self.dma_bus.add_slave("dma", slave=dma_bus, region=SoCRegion(origin=0x00000000, size=0x80000000)) # FIXME: size
+                self.dma_bus.add_slave("dma", slave=dma_bus, region=SoCRegion(origin=0x00000000, size=0x100000000)) # FIXME: covers lower 4GB only
                 self.submodules += wishbone.Converter(dma_bus, self.cpu.dma_bus)
 
             # Connect SoCController's reset to CPU reset

--- a/litex/soc/interconnect/axi.py
+++ b/litex/soc/interconnect/axi.py
@@ -649,6 +649,15 @@ class Wishbone2AXILite(Module):
             NextState("IDLE")
         )
 
+# Wishbone to AXI ----------------------------------------------------------------------------------
+
+class Wishbone2AXI(Module):
+    def __init__(self, wishbone, axi, base_address=0x00000000):
+        axi_lite          = AXILiteInterface(axi.data_width, axi.address_width)
+        wishbone2axi_lite = Wishbone2AXILite(wishbone, axi_lite, base_address)
+        axi_lite2axi      = AXILite2AXI(axi_lite, axi)
+        self.submodules += wishbone2axi_lite, axi_lite2axi
+
 # AXILite to CSR -----------------------------------------------------------------------------------
 
 def axi_lite_to_simple(axi_lite, port_adr, port_dat_r, port_dat_w=None, port_we=None):

--- a/litex/soc/interconnect/axi.py
+++ b/litex/soc/interconnect/axi.py
@@ -496,7 +496,8 @@ class AXILite2Wishbone(Module):
     def __init__(self, axi_lite, wishbone, base_address=0x00000000):
         wishbone_adr_shift = log2_int(axi_lite.data_width//8)
         assert axi_lite.data_width    == len(wishbone.dat_r)
-        assert axi_lite.address_width == len(wishbone.adr) + wishbone_adr_shift
+        assert axi_lite.address_width == len(wishbone.adr) + wishbone_adr_shift, "axi_addr_w={}; len_wb_adr={}; wb_adr_shift={};".format(axi_lite.address_width, len(wishbone.adr), wishbone_adr_shift)
+        print("####\n#### axi_addr_w={}; len_wb_adr={}; wb_adr_shift={};\n####".format(axi_lite.address_width, len(wishbone.adr), wishbone_adr_shift))
 
         _data         = Signal(axi_lite.data_width)
         _r_addr       = Signal(axi_lite.address_width)
@@ -580,7 +581,8 @@ class Wishbone2AXILite(Module):
     def __init__(self, wishbone, axi_lite, base_address=0x00000000):
         wishbone_adr_shift = log2_int(axi_lite.data_width//8)
         assert axi_lite.data_width    == len(wishbone.dat_r)
-        assert axi_lite.address_width == len(wishbone.adr) + wishbone_adr_shift
+        assert axi_lite.address_width == len(wishbone.adr) + wishbone_adr_shift, "axi_addr_w={}; len_wb_adr={}; wb_adr_shift={};".format(axi_lite.address_width, len(wishbone.adr), wishbone_adr_shift)
+        print("####\n#### axi_addr_w={}; len_wb_adr={}; wb_adr_shift={};\n####".format(axi_lite.address_width, len(wishbone.adr), wishbone_adr_shift))
 
         _cmd_done  = Signal()
         _data_done = Signal()

--- a/litex/soc/interconnect/wishbone.py
+++ b/litex/soc/interconnect/wishbone.py
@@ -35,7 +35,7 @@ _layout = [
 
 
 class Interface(Record):
-    def __init__(self, data_width=32, adr_width=30):
+    def __init__(self, data_width=32, adr_width=31):
         self.data_width = data_width
         self.adr_width  = adr_width
         Record.__init__(self, set_layout_parameters(_layout,

--- a/litex/soc/software/liblitesdcard/sdcard.c
+++ b/litex/soc/software/liblitesdcard/sdcard.c
@@ -26,7 +26,7 @@
 #endif
 
 #ifndef SDCARD_CLK_FREQ
-#define SDCARD_CLK_FREQ 50000000
+#define SDCARD_CLK_FREQ 25000000
 #endif
 
 unsigned int sdcard_response[SD_CMD_RESPONSE_SIZE/4];


### PR DESCRIPTION

What the patch does:
  - create a wrapper to convert Wishbone2AXI
  - activate slave AXI port on Rocket, convert to wishbone, expose as `dma_bus`
  - fix `dma_bus` routing by covering entire 4Gbyte region from 0 to `0x1_0000_0000`
      - since rocket has a mmio uncached connection to the "main" wishbone system bus connecting to all slave peripherals, and
         a memory point-to-point link connecting it directly to the DRAM, we need to route any and all dma master accesses through
         the rocket chip so that devices can be reached at addresses below `0x8000_0000` (mmio w.r.t. rocket's memory map), and
         above `0x8000_0000` (RAM as far as rocket-based litex soc is concerned).
  - the `dma_bus` fix requires an extra bit to be added to the address width of the wishbone interconnect i.e. the `adr_width` of the
   entire WB `Interface()`.

The result is that sdcard boot successfully copies `boot.bin` to DRAM (to address `0x8000_0000`), but unfortunately still hangs at `Liftoff!`. I *did* a `mr 0x80000000 0x100` and compared it with a `hexdump -C boot.bin | head`, and found at least the first several hundred bytes matching. Not entirely sure about the origin of a potential error in the dma copy process to DRAM that would cause booting BBL and the 64-bit linux kernel to fail.

The command line to build the bitstream is:

```
litex/litex/boards/targets/nexys4ddr.py --csr-data-width 32 \
        --with-ethernet --with-sdcard \
        --cpu-type rocket --cpu-variant linux \
        --integrated-rom-size=0x10000 --build
```

***EDIT***: added a patch to slow down LiteSDCard clock to 25MHz -- as noted by @enjoy-digital, it appears Rocket's internal DMA routing can't handle DMA writes from LiteSDCard at the full 50MHz rate.