### PR TITLE
Allow to define multiple simulation clocks

### DIFF
--- a/litex/build/sim/config.py
+++ b/litex/build/sim/config.py
@@ -5,9 +5,10 @@
 import json
 
 class SimConfig():
-    def __init__(self, default_clk=None):
+    def __init__(self, default_clk=None, timebase_ps=1):
         self.modules = []
         self.default_clk = default_clk
+        self.timebase = timebase_ps
         if default_clk:
             self.add_clocker(default_clk)
 
@@ -22,6 +23,9 @@ class SimConfig():
                 obj = {"name": name, "index": index}
             new.append(obj)
         return new
+
+    def _format_timebase(self):
+        return {"timebase": int(self.timebase)}
 
     def add_clocker(self, clk):
         self.add_module("clocker", [], clocks=clk, tickfirst=True)
@@ -49,4 +53,5 @@ class SimConfig():
         return False
 
     def get_json(self):
-        return json.dumps(self.modules, indent=4)
+        config = self.modules + [self._format_timebase()]
+        return json.dumps(config, indent=4)

--- a/litex/build/sim/core/modules.h
+++ b/litex/build/sim/core/modules.h
@@ -4,6 +4,7 @@
 #define __MODULE_H_
 
 #include <stdint.h>
+#include <stdbool.h>
 #include "pads.h"
 
 struct interface_s {
@@ -34,8 +35,24 @@ struct ext_module_list_s {
   struct ext_module_list_s *next;
 };
 
+struct clk_edge_t {
+  int last_clk;
+};
+
 int litex_sim_file_parse(char *filename, struct module_s **mod, uint64_t *timebase);
 int litex_sim_load_ext_modules(struct ext_module_list_s **mlist);
 int litex_sim_find_ext_module(struct ext_module_list_s *first, char *name , struct ext_module_list_s **found);
+
+inline bool clk_pos_edge(struct clk_edge_t *edge, int new_clk) {
+  bool is_edge = edge->last_clk == 0 && new_clk == 1;
+  edge->last_clk = new_clk;
+  return is_edge;
+}
+
+inline bool clk_neg_edge(struct clk_edge_t *edge, int new_clk) {
+  bool is_edge = edge->last_clk == 1 && new_clk == 0;
+  edge->last_clk = new_clk;
+  return is_edge;
+}
 
 #endif

--- a/litex/build/sim/core/modules.h
+++ b/litex/build/sim/core/modules.h
@@ -3,6 +3,7 @@
 #ifndef __MODULE_H_
 #define __MODULE_H_
 
+#include <stdint.h>
 #include "pads.h"
 
 struct interface_s {
@@ -33,7 +34,7 @@ struct ext_module_list_s {
   struct ext_module_list_s *next;
 };
 
-int litex_sim_file_to_module_list(char *filename, struct module_s **mod);
+int litex_sim_file_parse(char *filename, struct module_s **mod, uint64_t *timebase);
 int litex_sim_load_ext_modules(struct ext_module_list_s **mlist);
 int litex_sim_find_ext_module(struct ext_module_list_s *first, char *name , struct ext_module_list_s **found);
 

--- a/litex/build/sim/core/modules.h
+++ b/litex/build/sim/core/modules.h
@@ -26,7 +26,7 @@ struct ext_module_s {
   int (*new_sess)(void **, char *);
   int (*add_pads)(void *, struct pad_list_s *);
   int (*close)(void*);
-  int (*tick)(void*);
+  int (*tick)(void*, uint64_t);
 };
 
 struct ext_module_list_s {

--- a/litex/build/sim/core/modules/clocker/clocker.c
+++ b/litex/build/sim/core/modules/clocker/clocker.c
@@ -1,11 +1,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <json-c/json.h>
 #include "error.h"
 #include "modules.h"
 
 struct session_s {
   char *sys_clk;
+  uint32_t freq_hz;
+  uint16_t phase_deg;
 };
 
 static int litex_sim_module_pads_get( struct pad_s *pads, char *name, void **signal)
@@ -34,6 +37,55 @@ out:
   return ret;
 }
 
+static int clocker_parse_args(struct session_s *s, const char *args)
+{
+  int ret = RC_OK;
+  json_object *args_json = NULL;
+  json_object *freq_json = NULL;
+  json_object *phase_json = NULL;
+
+  args_json = json_tokener_parse(args);
+  if (!args_json) {
+    ret = RC_JSERROR;
+    fprintf(stderr, "[clocker] Could not parse args: %s\n", args);
+    goto out;
+  }
+
+  if(!json_object_object_get_ex(args_json, "freq_hz", &freq_json))
+  {
+    ret = RC_JSERROR;
+    fprintf(stderr, "[clocker] \"freq_hz\" not found in args: %s\n", json_object_to_json_string(args_json));
+    goto out;
+  }
+
+  if(!json_object_object_get_ex(args_json, "phase_deg", &phase_json))
+  {
+    ret = RC_JSERROR;
+    fprintf(stderr, "[clocker] \"phase_deg\" not found in args: %s\n", json_object_to_json_string(args_json));
+    goto out;
+  }
+
+  s->freq_hz = json_object_get_uint64(freq_json);
+  s->phase_deg = json_object_get_uint64(phase_json);
+
+  if (s->freq_hz == 0) {
+    ret = RC_JSERROR;
+    fprintf(stderr, "[clocker] \"freq_hz\" must be different than 0\n");
+    goto out;
+  }
+
+  if (s->phase_deg >= 360) {
+    ret = RC_JSERROR;
+    fprintf(stderr, "[clocker] \"phase_deg\" must be in range [0, 360)\n");
+    goto out;
+  }
+
+  printf("[clocker] freq_hz=%u, phase_deg=%u\n", s->freq_hz, s->phase_deg);
+out:
+  if(args_json) json_object_put(args_json);
+  return ret;
+}
+
 static int clocker_start()
 {
   printf("[clocker] loaded\n");
@@ -58,6 +110,7 @@ static int clocker_new(void **sess, char *args)
   }
   memset(s, 0, sizeof(struct session_s));
 
+  clocker_parse_args(s, args);
 out:
   *sess=(void*)s;
   return ret;
@@ -85,10 +138,22 @@ out:
   return ret;
 }
 
-static int clocker_tick(void *sess)
+static int clocker_tick(void *sess, uint64_t time_ps)
 {
-  struct session_s *s=(struct session_s*)sess;
-  *s->sys_clk = ~(*s->sys_clk);
+  static const uint64_t ps_in_sec = 1000000000000ull;
+  struct session_s *s = (struct session_s*) sess;
+
+  uint64_t period_ps = ps_in_sec / s->freq_hz;
+  uint64_t phase_shift_ps = period_ps * s->phase_deg / 360;
+
+  // phase-shifted time relative to start of current period
+  uint64_t rel_time_ps = (time_ps - phase_shift_ps) % period_ps;
+  if (rel_time_ps < (period_ps/2)) {
+    *s->sys_clk = 1;
+  } else {
+    *s->sys_clk = 0;
+  }
+
   return 0;
 }
 

--- a/litex/build/sim/core/modules/ethernet/ethernet.c
+++ b/litex/build/sim/core/modules/ethernet/ethernet.c
@@ -200,14 +200,16 @@ out:
   return ret;
 }
 
-static int ethernet_tick(void *sess)
+static int ethernet_tick(void *sess, uint64_t time_ps)
 {
+  static struct clk_edge_t edge;
   char c;
   struct session_s *s = (struct session_s*)sess;
   struct eth_packet_s *pep;
 
-  if(*s->sys_clk == 0)
+  if(!clk_pos_edge(&edge, *s->sys_clk)) {
     return RC_OK;
+  }
 
   *s->tx_ready = 1;
   if(*s->tx_valid == 1) {

--- a/litex/build/sim/core/modules/jtagremote/jtagremote.c
+++ b/litex/build/sim/core/modules/jtagremote/jtagremote.c
@@ -208,14 +208,16 @@ out:
   return ret;
 
 }
-static int jtagremote_tick(void *sess)
+static int jtagremote_tick(void *sess, uint64_t time_ps)
 {
+  static struct clk_edge_t edge;
 	char c, val;
 	int ret = RC_OK;
 
   struct session_s *s = (struct session_s*)sess;
-  if(*s->sys_clk == 0)
+  if(!clk_pos_edge(&edge, *s->sys_clk)) {
     return RC_OK;
+  }
 
   s->cntticks++;
   if(s->cntticks % 10)

--- a/litex/build/sim/core/modules/serial2console/serial2console.c
+++ b/litex/build/sim/core/modules/serial2console/serial2console.c
@@ -145,10 +145,11 @@ out:
   return ret;
 }
 
-static int serial2console_tick(void *sess) {
+static int serial2console_tick(void *sess, uint64_t time_ps) {
+  static struct clk_edge_t edge;
   struct session_s *s = (struct session_s*)sess;
 
-  if(*s->sys_clk == 0) {
+  if(!clk_pos_edge(&edge, *s->sys_clk)) {
     return RC_OK;
   }
 

--- a/litex/build/sim/core/modules/serial2tcp/serial2tcp.c
+++ b/litex/build/sim/core/modules/serial2tcp/serial2tcp.c
@@ -210,14 +210,16 @@ out:
   return ret;
 
 }
-static int serial2tcp_tick(void *sess)
+static int serial2tcp_tick(void *sess, uint64_t time_ps)
 {
+  static struct clk_edge_t edge;
   char c;
   int ret = RC_OK;
 
   struct session_s *s = (struct session_s*)sess;
-  if(*s->sys_clk == 0)
+  if(!clk_pos_edge(&edge, *s->sys_clk)) {
     return RC_OK;
+  }
 
   *s->tx_ready = 1;
   if(s->fd && *s->tx_valid) {

--- a/litex/build/sim/core/modules/spdeeprom/spdeeprom.c
+++ b/litex/build/sim/core/modules/spdeeprom/spdeeprom.c
@@ -65,7 +65,7 @@ struct session_s {
 static int spdeeprom_start();
 static int spdeeprom_new(void **sess, char *args);
 static int spdeeprom_add_pads(void *sess, struct pad_list_s *plist);
-static int spdeeprom_tick(void *sess);
+static int spdeeprom_tick(void *sess, uint64_t time_ps);
 // EEPROM simulation
 static void fsm_tick(struct session_s *s);
 static enum SerialState state_serial_next(struct session_s *s);
@@ -162,15 +162,16 @@ out:
   return ret;
 }
 
-static int spdeeprom_tick(void *sess)
+static int spdeeprom_tick(void *sess, uint64_t time_ps)
 {
+  static struct clk_edge_t edge;
   struct session_s *s = (struct session_s*) sess;
 
   if (s->sda_in == 0 || s->sda_out == 0 || s->scl == 0) {
       return RC_OK;
   }
 
-  if(*s->sys_clk == 0) {
+  if(!clk_pos_edge(&edge, *s->sys_clk)) {
     return RC_OK;
   }
 

--- a/litex/build/sim/core/modules/xgmii_ethernet/xgmii_ethernet.c
+++ b/litex/build/sim/core/modules/xgmii_ethernet/xgmii_ethernet.c
@@ -233,12 +233,13 @@ unsigned int g_mask = 0xff;
 unsigned int g_idle = 0x07070707;
 #endif
 
-static int xgmii_ethernet_tick(void *sess)
+static int xgmii_ethernet_tick(void *sess, uint64_t time_ps)
 {
+  static struct clk_edge_t edge;
   struct session_s *s = (struct session_s*)sess;
   struct eth_packet_s *pep;
 
-  if(*s->sys_clk == 0) {
+  if(!clk_pos_edge(&edge, *s->sys_clk)) {
     s->preamble=0;
     return RC_OK;
   }

--- a/litex/build/sim/core/parse.c
+++ b/litex/build/sim/core/parse.c
@@ -228,11 +228,10 @@ static int json_to_module_list(json_object *obj, struct module_s **mod)
   for(i = 0; i < n; i++)
   {
     tobj = json_object_array_get_idx(obj, i);
+
     if(!json_object_object_get_ex(tobj, "module", &name))
     {
-      ret=RC_JSERROR;
-      eprintf("expected \"module\" in object (%s)\n", json_object_to_json_string(tobj));
-      goto out;
+      continue;
     }
 
     if(!json_object_object_get_ex(tobj, "interface", &interface))
@@ -288,6 +287,14 @@ static int json_to_module_list(json_object *obj, struct module_s **mod)
       m->tickfirst = json_object_get_boolean(tickfirst);
     }
   }
+
+  if (!m)
+  {
+      ret = RC_JSERROR;
+      eprintf("No modules found in config file:\n%s\n", json_object_to_json_string(obj));
+      goto out;
+  }
+
   *mod = first;
   first=NULL;
 
@@ -299,7 +306,68 @@ out:
   return ret;
 }
 
-int litex_sim_file_to_module_list(char *filename, struct module_s **mod)
+static int json_get_timebase(json_object *obj, uint64_t *timebase)
+{
+  json_object *tobj;
+  int ret=RC_OK;
+  int i, n;
+  uint64_t _timebase = 0;
+  json_object *json_timebase;
+
+  if(!obj || !timebase)
+  {
+    ret = RC_INVARG;
+    eprintf("Wrong arguments\n");
+    goto out;
+  }
+
+  if(!json_object_is_type(obj, json_type_array))
+  {
+    ret=RC_JSERROR;
+    eprintf("Config file must be an array\n");
+    goto out;
+  }
+
+  n = json_object_array_length(obj);
+  for(i = 0; i < n; i++)
+  {
+    tobj = json_object_array_get_idx(obj, i);
+
+    if(!json_object_object_get_ex(tobj, "timebase", &json_timebase))
+    {
+      continue;
+    }
+
+    if (_timebase != 0)
+    {
+      ret=RC_JSERROR;
+      eprintf("\"timebase\" found multiple times: in object (%s)\n", json_object_to_json_string(tobj));
+      goto out;
+    }
+
+    _timebase = json_object_get_uint64(json_timebase);
+    if (_timebase == 0)
+    {
+      ret=RC_JSERROR;
+      eprintf("\"timebase\" cannot be zero: in object (%s)\n", json_object_to_json_string(tobj));
+      goto out;
+    }
+  }
+
+  if (_timebase == 0)
+  {
+    ret=RC_JSERROR;
+    eprintf("No \"timebase\" found in config:\n%s\n", json_object_to_json_string(obj));
+    goto out;
+  }
+  *timebase = _timebase;
+
+out:
+  return ret;
+}
+
+
+int litex_sim_file_parse(char *filename, struct module_s **mod, uint64_t *timebase)
 {
   struct module_s *m=NULL;
   json_object *obj=NULL;
@@ -313,6 +381,12 @@ int litex_sim_file_to_module_list(char *filename, struct module_s **mod)
   }
 
   ret = file_to_js(filename, &obj);
+  if(RC_OK != ret)
+  {
+    goto out;
+  }
+
+  ret = json_get_timebase(obj, timebase);
   if(RC_OK != ret)
   {
     goto out;

--- a/litex/build/sim/core/sim.c
+++ b/litex/build/sim/core/sim.c
@@ -186,7 +186,7 @@ static void cb(int sock, short which, void *arg)
         s->module->tick(s->session, sim_time_ps);
     }
 
-    litex_sim_eval(vsim);
+    litex_sim_eval(vsim, sim_time_ps);
     litex_sim_dump();
 
     for(s = sesslist; s; s=s->next)
@@ -195,7 +195,7 @@ static void cb(int sock, short which, void *arg)
         s->module->tick(s->session, sim_time_ps);
     }
 
-    sim_time_ps = litex_sim_increment_time(timebase_ps);
+    sim_time_ps += timebase_ps;
 
     if (litex_sim_got_finish()) {
         event_base_loopbreak(base);

--- a/litex/build/sim/core/sim.c
+++ b/litex/build/sim/core/sim.c
@@ -32,6 +32,7 @@ struct session_list_s {
 };
 
 uint64_t timebase_ps = 1;
+uint64_t sim_time_ps = 0;
 struct session_list_s *sesslist=NULL;
 struct event_base *base=NULL;
 
@@ -182,17 +183,19 @@ static void cb(int sock, short which, void *arg)
     for(s = sesslist; s; s=s->next)
     {
       if(s->tickfirst)
-	s->module->tick(s->session);
+        s->module->tick(s->session, sim_time_ps);
     }
+
     litex_sim_eval(vsim);
     litex_sim_dump();
+
     for(s = sesslist; s; s=s->next)
     {
       if(!s->tickfirst)
-	s->module->tick(s->session);
+        s->module->tick(s->session, sim_time_ps);
     }
 
-    litex_sim_increment_time(timebase_ps);
+    sim_time_ps = litex_sim_increment_time(timebase_ps);
 
     if (litex_sim_got_finish()) {
         event_base_loopbreak(base);

--- a/litex/build/sim/core/sim.c
+++ b/litex/build/sim/core/sim.c
@@ -31,6 +31,7 @@ struct session_list_s {
   struct session_list_s *next;
 };
 
+uint64_t timebase_ps = 1;
 struct session_list_s *sesslist=NULL;
 struct event_base *base=NULL;
 
@@ -63,7 +64,7 @@ static int litex_sim_initialize_all(void **sim, void *base)
   }
 
   /* Load configuration */
-  ret = litex_sim_file_to_module_list("sim_config.js", &ml);
+  ret = litex_sim_file_parse("sim_config.js", &ml, &timebase_ps);
   if(RC_OK != ret)
   {
     goto out;
@@ -190,6 +191,8 @@ static void cb(int sock, short which, void *arg)
       if(!s->tickfirst)
 	s->module->tick(s->session);
     }
+
+    litex_sim_increment_time(timebase_ps);
 
     if (litex_sim_got_finish()) {
         event_base_loopbreak(base);

--- a/litex/build/sim/core/veril.cpp
+++ b/litex/build/sim/core/veril.cpp
@@ -27,8 +27,9 @@ extern "C" void litex_sim_eval(void *vsim)
   sim->eval();
 }
 
-extern "C" void litex_sim_increment_time(unsigned long dt_ps) {
+extern "C" uint64_t litex_sim_increment_time(unsigned long dt_ps) {
     main_time += dt_ps;
+    return main_time;
 }
 
 extern "C" void litex_sim_init_cmdargs(int argc, char *argv[])

--- a/litex/build/sim/core/veril.cpp
+++ b/litex/build/sim/core/veril.cpp
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 #include "Vsim.h"
 #include "verilated.h"
 #ifdef TRACE_FST
@@ -16,13 +17,18 @@ VerilatedFstC* tfp;
 #else
 VerilatedVcdC* tfp;
 #endif
-long tfp_start;
-long tfp_end;
+uint64_t tfp_start;
+uint64_t tfp_end;
+uint64_t main_time = 0;
 
 extern "C" void litex_sim_eval(void *vsim)
 {
   Vsim *sim = (Vsim*)vsim;
   sim->eval();
+}
+
+extern "C" void litex_sim_increment_time(unsigned long dt_ps) {
+    main_time += dt_ps;
 }
 
 extern "C" void litex_sim_init_cmdargs(int argc, char *argv[])
@@ -34,7 +40,7 @@ extern "C" void litex_sim_init_tracer(void *vsim, long start, long end)
 {
   Vsim *sim = (Vsim*)vsim;
   tfp_start = start;
-  tfp_end = end;
+  tfp_end = end >= 0 ? end : UINT64_MAX;
   Verilated::traceEverOn(true);
 #ifdef TRACE_FST
       tfp = new VerilatedFstC;
@@ -45,20 +51,15 @@ extern "C" void litex_sim_init_tracer(void *vsim, long start, long end)
       sim->trace(tfp, 99);
       tfp->open("sim.vcd");
 #endif
+  tfp->set_time_unit("1ps");
+  tfp->set_time_resolution("1ps");
 }
 
 extern "C" void litex_sim_tracer_dump()
 {
-  static unsigned int ticks=0;
-  int dump = 1;
-  if (ticks < tfp_start)
-      dump = 0;
-  if (tfp_end != -1)
-      if (ticks > tfp_end)
-          dump = 0;
-  if (dump)
-      tfp->dump(ticks);
-  ticks++;
+  if (tfp_start <= main_time && main_time <= tfp_end) {
+    tfp->dump(main_time);
+  }
 }
 
 extern "C" int litex_sim_got_finish()
@@ -73,7 +74,6 @@ extern "C" void litex_sim_coverage_dump()
 }
 #endif
 
-vluint64_t main_time = 0;
 double sc_time_stamp()
 {
   return main_time;

--- a/litex/build/sim/core/veril.cpp
+++ b/litex/build/sim/core/veril.cpp
@@ -21,15 +21,11 @@ uint64_t tfp_start;
 uint64_t tfp_end;
 uint64_t main_time = 0;
 
-extern "C" void litex_sim_eval(void *vsim)
+extern "C" void litex_sim_eval(void *vsim, uint64_t time_ps)
 {
   Vsim *sim = (Vsim*)vsim;
   sim->eval();
-}
-
-extern "C" uint64_t litex_sim_increment_time(unsigned long dt_ps) {
-    main_time += dt_ps;
-    return main_time;
+  main_time = time_ps;
 }
 
 extern "C" void litex_sim_init_cmdargs(int argc, char *argv[])

--- a/litex/build/sim/core/veril.h
+++ b/litex/build/sim/core/veril.h
@@ -7,17 +7,15 @@
 
 #ifdef __cplusplus
 extern "C" void litex_sim_init_cmdargs(int argc, char *argv[]);
-extern "C" void litex_sim_eval(void *vsim);
-extern "C" uint64_t litex_sim_increment_time(unsigned long dt_ps);
-extern "C" void litex_sim_init_tracer(void *vsim, long start, long end)
+extern "C" void litex_sim_eval(void *vsim, uint64_t time_ps);
+extern "C" void litex_sim_init_tracer(void *vsim, long start, long end);
 extern "C" void litex_sim_tracer_dump();
 extern "C" int litex_sim_got_finish();
 #if VM_COVERAGE
 extern "C" void litex_sim_coverage_dump();
 #endif
 #else
-void litex_sim_eval(void *vsim);
-uint64_t litex_sim_increment_time(unsigned long dt_ps);
+void litex_sim_eval(void *vsim, uint64_t time_ps);
 void litex_sim_init_tracer(void *vsim);
 void litex_sim_tracer_dump();
 int litex_sim_got_finish();

--- a/litex/build/sim/core/veril.h
+++ b/litex/build/sim/core/veril.h
@@ -3,10 +3,12 @@
 #ifndef __VERIL_H_
 #define __VERIL_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" void litex_sim_init_cmdargs(int argc, char *argv[]);
 extern "C" void litex_sim_eval(void *vsim);
-extern "C" void litex_sim_increment_time(unsigned long dt_ps);
+extern "C" uint64_t litex_sim_increment_time(unsigned long dt_ps);
 extern "C" void litex_sim_init_tracer(void *vsim, long start, long end)
 extern "C" void litex_sim_tracer_dump();
 extern "C" int litex_sim_got_finish();
@@ -15,7 +17,7 @@ extern "C" void litex_sim_coverage_dump();
 #endif
 #else
 void litex_sim_eval(void *vsim);
-void litex_sim_increment_time(unsigned long dt_ps);
+uint64_t litex_sim_increment_time(unsigned long dt_ps);
 void litex_sim_init_tracer(void *vsim);
 void litex_sim_tracer_dump();
 int litex_sim_got_finish();

--- a/litex/build/sim/core/veril.h
+++ b/litex/build/sim/core/veril.h
@@ -6,6 +6,7 @@
 #ifdef __cplusplus
 extern "C" void litex_sim_init_cmdargs(int argc, char *argv[]);
 extern "C" void litex_sim_eval(void *vsim);
+extern "C" void litex_sim_increment_time(unsigned long dt_ps);
 extern "C" void litex_sim_init_tracer(void *vsim, long start, long end)
 extern "C" void litex_sim_tracer_dump();
 extern "C" int litex_sim_got_finish();
@@ -14,6 +15,7 @@ extern "C" void litex_sim_coverage_dump();
 #endif
 #else
 void litex_sim_eval(void *vsim);
+void litex_sim_increment_time(unsigned long dt_ps);
 void litex_sim_init_tracer(void *vsim);
 void litex_sim_tracer_dump();
 int litex_sim_got_finish();

--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -343,7 +343,9 @@ def main():
     soc_kwargs     = soc_sdram_argdict(args)
     builder_kwargs = builder_argdict(args)
 
-    sim_config = SimConfig(default_clk="sys_clk")
+    # timebase is half of the period of main simulation clock
+    sys_clk_freq = int(1e6)
+    sim_config = SimConfig(default_clk="sys_clk", timebase_ps=(1/sys_clk_freq / 2) * 1e12)
 
     # Configuration --------------------------------------------------------------------------------
 

--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -343,9 +343,9 @@ def main():
     soc_kwargs     = soc_sdram_argdict(args)
     builder_kwargs = builder_argdict(args)
 
-    # timebase is half of the period of main simulation clock
     sys_clk_freq = int(1e6)
-    sim_config = SimConfig(default_clk="sys_clk", timebase_ps=(1/sys_clk_freq / 2) * 1e12)
+    sim_config = SimConfig()
+    sim_config.add_clocker("sys_clk", freq_hz=sys_clk_freq)
 
     # Configuration --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Currently in `litex_sim` it is not possible to easily create clocks that have higher frequency than `sys_clk` or a different phase. This PR allows to create multiple `clocker` simulation modules based on `SimConfig`.

This update will be useful for simulating RPC DRAM https://github.com/enjoy-digital/litedram/issues/211, and similar changes were already needed and implemented for Mircon model simulations in https://github.com/enjoy-digital/litex/pull/536 by @mglb. This PR bases on that previous work and extracts only the part of configuring clocks in `litex_sim` and cleans it up.

The simulation now keeps track of the current time and modules' API has been updated to pass the current simulation time to each module's `tick()` method. The whole simulation uses a single timebase with resolution of 1 ps. The time is updated in `sim.c` and passed to modules and `veril.cpp`, where it is used when saving dump files, so the time in GTKWave is correct now.

Because we can have multiple clocks, each simulation module has a `clk_edge_t`, which is a simple clock edge detector added to avoid boilerplate code in each module.

A clocker module now takes a clock and specified frequency/phase, and on each step updates the clock state. Multiple clockers can be added for different clocks (different `_io` pins) using the `SimConfig.add_clocker(self, clk, freq_hz, phase_deg=0)` method.  Other modules still have hard-coded `"sys_clk"` clocks in their C source code, but this could be changed if needed. `SimConfig` has been changed to require to add clockers explicitly (at least one), passing frequency and phase, e.g.
```python
sys_clk_freq = int(100e6)
sim_config = SimConfig()
sim_config.add_clocker("sys_clk",       freq_hz=sys_clk_freq)
sim_config.add_clocker("sys2x_90_clk",  freq_hz=2*sys_clk_freq, phase_deg=90)
```
The data is then stored in the JSON file like this:
```json
[
    {
        "module": "clocker",
        "interface": [
            "sys_clk"
        ],
        "args": {
            "freq_hz": 100000000,
            "phase_deg": 0
        },
        "tickfirst": true
    },
    {
        "module": "clocker",
        "interface": [
            "sys2x_90_clk"
        ],
        "args": {
            "freq_hz": 200000000,
            "phase_deg": 90
        },
        "tickfirst": true
    },
    {
        "module": "serial2console",
        "interface": [
            "serial",
            "sys_clk"
        ]
    },
    {
        "timebase": 1250
    }
]
```

The timebase is calculated by `SimConfig` based on the specification of all clockers. Currently it is very restrictive, as it will not accept non-integer half-periods or phase-shifts. It finds the timebase as the gratest common denominator of all half-periods/phase-shifts. This results in the simulation failing even for clock frequencies like 150 MHz (period = 6666.(6) ps), so the current implementation is best suited for simple clock multiples like x2 and x4 and simple phase shifts, like 90 or 180 degrees.

Here is an example of running litex_sim with more clocks (sys_clk = 100 MHz, calculated timebase = 1250 ps): 
![sys_clk_100MHz](https://user-images.githubusercontent.com/16623787/89294584-ffcbb980-d65f-11ea-8f7e-d72f7234b244.png)

### Improvements

I first wanted to loosen the restrictions on the timebase, but this can introduce subtle bugs, and is hard to get right. Ultimately I think that, if we want to support more clock configurations, we should move the clocker logic to the simulation core (`sim.c`), store the time as floating point number, and just use dynamic timebase by always moving to the next edge of all existing clocks.

Another note is that the simulation code is probably a bit too low-level and hard to extend. As Verilator uses C++ anyway, we could probable have it all done in C++ and simplify the whole error handling, memory management (with C++ stdlib instead of manually allocated lists), JSON parsing, etc. After adding the `spdeeprom.c` module and working on this PR I think there's quite a bit of boilerplate work when one wants to add a new module, and we're not forced to use C as this is a simulator.

Both the dynamic time stepping and general rewrite would require some time to complete and are not of high priority as for now, but maybe we could think about it in the future?

