### PR TITLE
Set default csr paging to 0x1000

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -482,7 +482,7 @@ class SoCCSRHandler(SoCLocHandler):
     supported_ordering      = ["big", "little"]
 
     # Creation -------------------------------------------------------------------------------------
-    def __init__(self, data_width=32, address_width=14, alignment=32, paging=0x800, ordering="big", reserved_csrs={}):
+    def __init__(self, data_width=32, address_width=14, alignment=32, paging=0x1000, ordering="big", reserved_csrs={}):
         SoCLocHandler.__init__(self, "CSR", n_locs=alignment//8*(2**address_width)//paging)
         self.logger = logging.getLogger("SoCCSRHandler")
         self.logger.info("Creating CSR Handler...")
@@ -689,7 +689,7 @@ class SoC(Module):
 
         csr_data_width       = 32,
         csr_address_width    = 14,
-        csr_paging           = 0x800,
+        csr_paging           = 0x1000,
         csr_ordering         = "big",
         csr_reserved_csrs    = {},
 

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -83,7 +83,7 @@ class SoCCore(LiteXSoC):
         # CSR parameters
         csr_data_width           = 8,
         csr_address_width        = 14,
-        csr_paging               = 0x800,
+        csr_paging               = 0x1000,
         csr_ordering             = "big",
         # Identifier parameters
         ident                    = "",
@@ -289,7 +289,7 @@ def soc_core_args(parser):
                         help="CSR bus data-width (8 or 32, default=8)")
     parser.add_argument("--csr-address-width", default=14, type=auto_int,
                         help="CSR bus address-width")
-    parser.add_argument("--csr-paging", default=0x800, type=auto_int,
+    parser.add_argument("--csr-paging", default=0x1000, type=auto_int,
                         help="CSR bus paging")
     parser.add_argument("--csr-ordering", default="big",
                         help="CSR registers ordering (default=big)")

--- a/litex/soc/interconnect/csr_bus.py
+++ b/litex/soc/interconnect/csr_bus.py
@@ -84,7 +84,7 @@ class InterconnectShared(Module):
 # CSR SRAM -----------------------------------------------------------------------------------------
 
 class SRAM(Module):
-    def __init__(self, mem_or_size, address, read_only=None, init=None, bus=None, paging=0x800, soc_bus_data_width=32):
+    def __init__(self, mem_or_size, address, read_only=None, init=None, bus=None, paging=0x1000, soc_bus_data_width=32):
         if bus is None:
             bus = Interface()
         self.bus = bus
@@ -163,7 +163,7 @@ class SRAM(Module):
 # CSR Bank -----------------------------------------------------------------------------------------
 
 class CSRBank(csr.GenericBank):
-    def __init__(self, description, address=0, bus=None, paging=0x800, ordering="big", soc_bus_data_width=32):
+    def __init__(self, description, address=0, bus=None, paging=0x1000, ordering="big", soc_bus_data_width=32):
         if bus is None:
             bus = Interface()
         self.bus = bus
@@ -205,7 +205,7 @@ class CSRBank(csr.GenericBank):
 # address_map is called exactly once for each object at each call to
 # scan(), so it can have side effects.
 class CSRBankArray(Module):
-    def __init__(self, source, address_map, *ifargs, paging=0x800, ordering="big", soc_bus_data_width=32, **ifkwargs):
+    def __init__(self, source, address_map, *ifargs, paging=0x1000, ordering="big", soc_bus_data_width=32, **ifkwargs):
         self.source             = source
         self.address_map        = address_map
         self.paging             = paging

--- a/litex/tools/litex_gen.py
+++ b/litex/tools/litex_gen.py
@@ -196,9 +196,9 @@ def main():
     parser.add_argument("--gpio-width",            default=32,  type=int, help="GPIO signals width")
 
     # CSR settings
-    parser.add_argument("--csr-data-width",    default=8,     type=int, help="CSR bus data-width (8 or 32, default=8)")
-    parser.add_argument("--csr-address-width", default=14,    type=int, help="CSR bus address-width")
-    parser.add_argument("--csr-paging",        default=0x800, type=int, help="CSR bus paging")
+    parser.add_argument("--csr-data-width",    default=8,      type=int, help="CSR bus data-width (8 or 32, default=8)")
+    parser.add_argument("--csr-address-width", default=14,     type=int, help="CSR bus address-width")
+    parser.add_argument("--csr-paging",        default=0x1000, type=int, help="CSR bus paging")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This allows to calculate peripheral address on RISC-V with one instruction instead of two.