### PR TITLE
RFC: cores/dma, liblitesdcard/sdcard: use 64 bits for dma base address

### DIFF
--- a/litex/soc/cores/dma.py
+++ b/litex/soc/cores/dma.py
@@ -72,7 +72,7 @@ class WishboneDMAReader(Module, AutoCSR):
             self.add_csr()
 
     def add_csr(self):
-        self._base   = CSRStorage(32)
+        self._base   = CSRStorage(64)
         self._length = CSRStorage(32)
         self._enable = CSRStorage()
         self._done   = CSRStatus()
@@ -158,7 +158,7 @@ class WishboneDMAWriter(Module, AutoCSR):
         self._sink = self.sink
         self.sink  = stream.Endpoint([("data", self.bus.data_width)])
 
-        self._base   = CSRStorage(32)
+        self._base   = CSRStorage(64)
         self._length = CSRStorage(32)
         self._enable = CSRStorage()
         self._done   = CSRStatus()

--- a/litex/soc/software/liblitesdcard/sdcard.c
+++ b/litex/soc/software/liblitesdcard/sdcard.c
@@ -561,7 +561,7 @@ void sdcard_read(uint32_t sector, uint32_t count, uint8_t* buf)
 {
 	/* Initialize DMA Writer */
 	sdblock2mem_dma_enable_write(0);
-	sdblock2mem_dma_base_write((uint32_t) buf);
+	sdblock2mem_dma_base_write((uint64_t) buf);
 	sdblock2mem_dma_length_write(512*count);
 	sdblock2mem_dma_enable_write(1);
 
@@ -594,7 +594,7 @@ void sdcard_write(uint32_t sector, uint32_t count, uint8_t* buf)
 	while (count--) {
 		/* Initialize DMA Reader */
 		sdmem2block_dma_enable_write(0);
-		sdmem2block_dma_base_write((uint32_t) buf);
+		sdmem2block_dma_base_write((uint64_t) buf);
 		sdmem2block_dma_length_write(512);
 		sdmem2block_dma_enable_write(1);
 


### PR DESCRIPTION
Currently, the DMA base addresses use 32 bit registers, on the implicit assumption that physical address space is limited to 4GB. That's not true for LiteX SoC versions with 64bit CPUs, which may end up with physical RAM in excess of 4GB, requiring 64 bit address registers to cover all possible addresses that may be accessed by a DMA master.

This patch (tested with rocket and vexrisccv) bumps the DMA base address to 64 bit (length/size is left as a 32 bit register, since a 4GB limit per individual DMA transfer "should be enough for everyone" ;)