### PR TITLE
refactor sdcard (bios) software

### DIFF
--- a/litex/soc/cores/cpu/blackparrot/system.h
+++ b/litex/soc/cores/cpu/blackparrot/system.h
@@ -9,6 +9,7 @@ __attribute__((unused)) static void flush_cpu_icache(void){};  /* FIXME: do some
 __attribute__((unused)) static void flush_cpu_dcache(void){};  /* FIXME: do something useful here! */
 void flush_l2_cache(void);
 void busy_wait(unsigned int ms);
+void busy_wait_us(unsigned int us);
 
 #include <csr-defs.h>
 

--- a/litex/soc/cores/cpu/cv32e40p/system.h
+++ b/litex/soc/cores/cpu/cv32e40p/system.h
@@ -22,6 +22,7 @@ __attribute__((unused)) static void flush_cpu_dcache(void)
 void flush_l2_cache(void);
 
 void busy_wait(unsigned int ms);
+void busy_wait_us(unsigned int us);
 
 #define csrr(reg) ({ unsigned long __tmp; \
   asm volatile ("csrr %0, " #reg : "=r"(__tmp)); \

--- a/litex/soc/cores/cpu/lm32/system.h
+++ b/litex/soc/cores/cpu/lm32/system.h
@@ -27,6 +27,7 @@ __attribute__((unused)) static void flush_cpu_dcache(void)
 void flush_l2_cache(void);
 
 void busy_wait(unsigned int ms);
+void busy_wait_us(unsigned int us);
 
 #ifdef __cplusplus
 }

--- a/litex/soc/cores/cpu/microwatt/system.h
+++ b/litex/soc/cores/cpu/microwatt/system.h
@@ -13,6 +13,7 @@ static inline void flush_cpu_dcache(void){}; /* FIXME: do something useful here!
 void flush_l2_cache(void);
 
 void busy_wait(unsigned int ms);
+void busy_wait_us(unsigned int us);
 
 #ifdef __cplusplus
 }

--- a/litex/soc/cores/cpu/minerva/system.h
+++ b/litex/soc/cores/cpu/minerva/system.h
@@ -9,6 +9,7 @@ __attribute__((unused)) static void flush_cpu_icache(void){}; /* FIXME: do somet
 __attribute__((unused)) static void flush_cpu_dcache(void){}; /* FIXME: do something useful here! */
 void flush_l2_cache(void);
 void busy_wait(unsigned int ms);
+void busy_wait_us(unsigned int us);
 
 #include <csr-defs.h>
 

--- a/litex/soc/cores/cpu/mor1kx/system.h
+++ b/litex/soc/cores/cpu/mor1kx/system.h
@@ -62,6 +62,7 @@ __attribute__((unused)) static void flush_cpu_dcache(void)
 void flush_l2_cache(void);
 
 void busy_wait(unsigned int ms);
+void busy_wait_us(unsigned int us);
 
 #ifdef __cplusplus
 }

--- a/litex/soc/cores/cpu/picorv32/system.h
+++ b/litex/soc/cores/cpu/picorv32/system.h
@@ -10,6 +10,7 @@ __attribute__((unused)) static void flush_cpu_dcache(void){}; /* No instruction 
 void flush_l2_cache(void);
 
 void busy_wait(unsigned int ms);
+void busy_wait_us(unsigned int us);
 
 #ifdef __cplusplus
 }

--- a/litex/soc/cores/cpu/rocket/system.h
+++ b/litex/soc/cores/cpu/rocket/system.h
@@ -10,6 +10,7 @@ __attribute__((unused)) static void flush_cpu_dcache(void){}; /* FIXME: do somet
 void flush_l2_cache(void);
 
 void busy_wait(unsigned int ms);
+void busy_wait_us(unsigned int us);
 
 #include <csr-defs.h>
 

--- a/litex/soc/cores/cpu/serv/system.h
+++ b/litex/soc/cores/cpu/serv/system.h
@@ -10,6 +10,7 @@ __attribute__((unused)) static void flush_cpu_dcache(void){}; /* No instruction 
 void flush_l2_cache(void);
 
 void busy_wait(unsigned int ms);
+void busy_wait_us(unsigned int us);
 
 #ifdef __cplusplus
 }

--- a/litex/soc/cores/cpu/vexriscv/system.h
+++ b/litex/soc/cores/cpu/vexriscv/system.h
@@ -37,6 +37,7 @@ __attribute__((unused)) static void flush_cpu_dcache(void)
 void flush_l2_cache(void);
 
 void busy_wait(unsigned int ms);
+void busy_wait_us(unsigned int us);
 
 #define csrr(reg) ({ unsigned long __tmp; \
   asm volatile ("csrr %0, " #reg : "=r"(__tmp)); \

--- a/litex/soc/cores/cpu/vexriscv_smp/system.h
+++ b/litex/soc/cores/cpu/vexriscv_smp/system.h
@@ -27,6 +27,7 @@ __attribute__((unused)) static void flush_cpu_dcache(void)
 void flush_l2_cache(void);
 
 void busy_wait(unsigned int ms);
+void busy_wait_us(unsigned int us);
 
 #include <csr-defs.h>
 

--- a/litex/soc/software/libbase/system.c
+++ b/litex/soc/software/libbase/system.c
@@ -24,3 +24,13 @@ void busy_wait(unsigned int ms)
 	timer0_update_value_write(1);
 	while(timer0_value_read()) timer0_update_value_write(1);
 }
+
+void busy_wait_us(unsigned int us)
+{
+	timer0_en_write(0);
+	timer0_reload_write(0);
+	timer0_load_write(CONFIG_CLOCK_FREQUENCY/1000000*us);
+	timer0_en_write(1);
+	timer0_update_value_write(1);
+	while(timer0_value_read()) timer0_update_value_write(1);
+}

--- a/litex/soc/software/liblitesdcard/sdcard.c
+++ b/litex/soc/software/liblitesdcard/sdcard.c
@@ -42,16 +42,6 @@ unsigned int sdcard_response[SD_CMD_RESPONSE_SIZE/4];
 /* SDCard command helpers                                                */
 /*-----------------------------------------------------------------------*/
 
-static void busy_wait_us(unsigned int us)
-{
-    timer0_en_write(0);
-    timer0_reload_write(0);
-    timer0_load_write(CONFIG_CLOCK_FREQUENCY/1000000*us);
-    timer0_en_write(1);
-    timer0_update_value_write(1);
-    while(timer0_value_read()) timer0_update_value_write(1);
-}
-
 int sdcard_wait_cmd_done(void) {
 	unsigned int cmdevt;
 	while (1) {

--- a/litex/soc/software/liblitesdcard/sdcard.h
+++ b/litex/soc/software/liblitesdcard/sdcard.h
@@ -72,9 +72,7 @@ int sdcard_all_send_cid(void);
 int sdcard_set_relative_address(void);
 
 int sdcard_send_cid(uint16_t rca);
-void sdcard_decode_cid(void);
 int sdcard_send_csd(uint16_t rca);
-void sdcard_decode_csd(void);
 int sdcard_select_card(uint16_t rca);
 int sdcard_app_set_bus_width(void);
 int sdcard_switch(unsigned int mode, unsigned int group, unsigned int value);
@@ -87,6 +85,9 @@ int sdcard_read_multiple_block(unsigned int blockaddr, unsigned int blockcnt);
 int sdcard_stop_transmission(void);
 int sdcard_send_status(uint16_t rca);
 int sdcard_set_block_count(unsigned int blockcnt);
+uint16_t sdcard_decode_rca(void);
+void sdcard_decode_cid(void);
+void sdcard_decode_csd(void);
 
 /*-----------------------------------------------------------------------*/
 /* SDCard user functions                                                 */

--- a/litex/soc/software/liblitesdcard/sdcard.h
+++ b/litex/soc/software/liblitesdcard/sdcard.h
@@ -66,16 +66,16 @@ int sdcard_wait_response(void);
 
 int sdcard_go_idle(void);
 int sdcard_send_ext_csd(void);
-int sdcard_app_cmd(int rca);
+int sdcard_app_cmd(uint16_t rca);
 int sdcard_app_send_op_cond(int hcs);
 int sdcard_all_send_cid(void);
 int sdcard_set_relative_address(void);
 
-int sdcard_send_cid(unsigned int rca);
+int sdcard_send_cid(uint16_t rca);
 void sdcard_decode_cid(void);
-int sdcard_send_csd(unsigned int rca);
+int sdcard_send_csd(uint16_t rca);
 void sdcard_decode_csd(void);
-int sdcard_select_card(unsigned int rca);
+int sdcard_select_card(uint16_t rca);
 int sdcard_app_set_bus_width(void);
 int sdcard_switch(unsigned int mode, unsigned int group, unsigned int value);
 int sdcard_app_send_scr(void);
@@ -85,7 +85,7 @@ int sdcard_write_multiple_block(unsigned int blockaddr, unsigned int blockcnt);
 int sdcard_read_single_block(unsigned int blockaddr);
 int sdcard_read_multiple_block(unsigned int blockaddr, unsigned int blockcnt);
 int sdcard_stop_transmission(void);
-int sdcard_send_status(unsigned int rca);
+int sdcard_send_status(uint16_t rca);
 int sdcard_set_block_count(unsigned int blockcnt);
 
 /*-----------------------------------------------------------------------*/

--- a/litex/soc/software/liblitesdcard/spisdcard.c
+++ b/litex/soc/software/liblitesdcard/spisdcard.c
@@ -123,16 +123,6 @@ static void spisdcardread_bytes(uint8_t* buf, uint16_t n) {
 /* SPI SDCard blocks Xfer functions                                      */
 /*-----------------------------------------------------------------------*/
 
-static void busy_wait_us(unsigned int us)
-{
-    timer0_en_write(0);
-    timer0_reload_write(0);
-    timer0_load_write(CONFIG_CLOCK_FREQUENCY/1000000*us);
-    timer0_en_write(1);
-    timer0_update_value_write(1);
-    while(timer0_value_read()) timer0_update_value_write(1);
-}
-
 static uint8_t spisdcardreceive_block(uint8_t *buf) {
     uint16_t i;
     uint32_t timeout;


### PR DESCRIPTION
In addition to a bunch of cosmetic/indentation improvements, do the following:

- factor out `busy_wait_us()` (which is identical in both spi- and "regular" sdcard files)
- factor out the common portion of each "send command" function, into a `sdcard_send_command()` inline routine
- avoid reading the 128 (4x32) bit sdcard response after each and every command (unless debugging is enabled). Instead, read it only when (a portion of) its data is needed, e.g., during initialization. This shaves off a bunch of unnecessary mmio CSR reads.

This PR carries no changes in actual functionality of the sdcard subsystem. I'm still in the process of digesting how the sdcard code works (and debugging writes, which are currently broken for me on nexys4ddr with rocket), but thought with these changes the code becomes easier to read and understand.

@enjoy-digital please review when you have a chance, and apply if you agree.