### PR TITLE
Fix DeprecationWarning for collections.abc

### DIFF
--- a/litex/gen/fhdl/verilog.py
+++ b/litex/gen/fhdl/verilog.py
@@ -143,7 +143,7 @@ def _printnode(ns, at, level, node, target_filter=None):
         else:
             assignment = " <= "
         return "\t"*level + _printexpr(ns, node.l)[0] + assignment + _printexpr(ns, node.r)[0] + ";\n"
-    elif isinstance(node, collections.Iterable):
+    elif isinstance(node, collections.abc.Iterable):
         return "".join(_printnode(ns, at, level, n, target_filter) for n in node)
     elif isinstance(node, If):
         r = "\t"*level + "if (" + _printexpr(ns, node.cond)[0] + ") begin\n"

--- a/litex/gen/sim/core.py
+++ b/litex/gen/sim/core.py
@@ -223,7 +223,7 @@ class Evaluator:
                         break
                 if not found and "default" in s.cases:
                     self.execute(s.cases["default"])
-            elif isinstance(s, collections.Iterable):
+            elif isinstance(s, collections.abc.Iterable):
                 self.execute(s)
             elif isinstance(s, Display):
                 args = []
@@ -275,7 +275,7 @@ class Simulator:
         self.generators = dict()
         self.passive_generators = set()
         for k, v in generators.items():
-            if (isinstance(v, collections.Iterable)
+            if (isinstance(v, collections.abc.Iterable)
                     and not inspect.isgenerator(v)):
                 self.generators[k] = list(v)
             else:


### PR DESCRIPTION
`DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working`