### PR TITLE
Fix call to generation of minerva output file

### DIFF
--- a/litex/soc/cores/cpu/minerva/core.py
+++ b/litex/soc/cores/cpu/minerva/core.py
@@ -100,8 +100,10 @@ class Minerva(CPU):
             cli_params.append("--with-dcache")
         if with_muldiv:
             cli_params.append("--with-muldiv")
+        cli_params.append("generate")
+        cli_params.append("--type=v")
         sdir = get_data_mod("cpu", "minerva").data_location
-        if subprocess.call(["python3", os.path.join(sdir, "cli.py"), *cli_params, "generate"],
+        if subprocess.call(["python3", os.path.join(sdir, "cli.py"), *cli_params],
             stdout=open(verilog_filename, "w")):
             raise OSError("Unable to elaborate Minerva CPU, please check your nMigen/Yosys install")
 


### PR DESCRIPTION
With nmigen/nmigen@a7b8ced, `cli.py` no longer defaults to generating
verilog code, so `-t`/`--type` has to be specified explicitly.

```
$ pytest test/test_targets.py -k test_variants_minerva
[...]
cli.py: error: specify file type explicitly with -t
```