### PR TITLE
RFC: bios/sdcard: use (512 byte) blocks as the smallest addressable data unit

### DIFF
--- a/litex/soc/software/bios/cmds/cmd_litesdcard.c
+++ b/litex/soc/software/bios/cmds/cmd_litesdcard.c
@@ -73,7 +73,7 @@ static void sdread(int nb_params, char **params)
 		return;
 	}
 
-	sdcard_read(block*512, 1, buf);
+	sdcard_read(block, 1, buf);
 	dump_bytes((uint32_t *)buf, 512, (unsigned long) buf);
 }
 
@@ -115,7 +115,7 @@ static void sdwrite(int nb_params, char **params)
 		}
 	}
 	dump_bytes((uint32_t *)buf, 512, (unsigned long) buf);
-	sdcard_write(block*512, 1, buf);
+	sdcard_write(block, 1, buf);
 }
 
 define_command(sdwrite, sdwrite, "Write SDCard block", LITESDCARD_CMDS);

--- a/litex/soc/software/liblitesdcard/sdcard.c
+++ b/litex/soc/software/liblitesdcard/sdcard.c
@@ -464,7 +464,7 @@ int sdcard_init(void) {
 
 #ifdef CSR_SDBLOCK2MEM_BASE
 
-void sdcard_read(uint32_t sector, uint32_t count, uint8_t* buf)
+void sdcard_read(uint32_t block, uint32_t count, uint8_t* buf)
 {
 	/* Initialize DMA Writer */
 	sdblock2mem_dma_enable_write(0);
@@ -476,7 +476,7 @@ void sdcard_read(uint32_t sector, uint32_t count, uint8_t* buf)
 #ifdef SDCARD_CMD23_SUPPORT
 	sdcard_set_block_count(count);
 #endif
-	sdcard_read_multiple_block(sector, count);
+	sdcard_read_multiple_block(block, count);
 
 	/* Wait for DMA Writer to complete */
 	while ((sdblock2mem_dma_done_read() & 0x1) == 0);
@@ -496,7 +496,7 @@ void sdcard_read(uint32_t sector, uint32_t count, uint8_t* buf)
 
 #ifdef CSR_SDMEM2BLOCK_BASE
 
-void sdcard_write(uint32_t sector, uint32_t count, uint8_t* buf)
+void sdcard_write(uint32_t block, uint32_t count, uint8_t* buf)
 {
 	while (count--) {
 		/* Initialize DMA Reader */
@@ -509,13 +509,13 @@ void sdcard_write(uint32_t sector, uint32_t count, uint8_t* buf)
 #ifdef SDCARD_CMD23_SUPPORT
 		sdcard_set_block_count(1);
 #endif
-		sdcard_write_single_block(sector);
+		sdcard_write_single_block(block);
 
 		sdcard_stop_transmission();
 
-		/* Update buf/sector */
-		buf    += 512;
-		sector += 1;
+		/* Update buf/block */
+		buf   += 512;
+		block += 1;
 	}
 }
 #endif
@@ -538,8 +538,8 @@ DSTATUS disk_initialize(uint8_t drv) {
 	return sdcardstatus;
 }
 
-DRESULT disk_read(uint8_t drv, uint8_t *buf, uint32_t sector, uint32_t count) {
-	sdcard_read(sector, count, buf);
+DRESULT disk_read(uint8_t drv, uint8_t *buf, uint32_t block, uint32_t count) {
+	sdcard_read(block, count, buf);
 	return RES_OK;
 }
 


### PR DESCRIPTION
In liblitesdcard/sdcard.c, replace s/sector/block/ as the 512 byte sized
unit of data transfer to/from the sdcard.

In bios/cmds/cmd_litesdcard.c, do NOT multiply block numbers by 512,
allowing any "block" (a.k.a. "sector") on the sdcard to be addressed for
testing.

Before this patch, user-input "block numbers" were multiplied by 512 and
passed into sdcard_[read|write]() as "sector numbers", with the sdcard
logic internally treating these as 512-byte sized addressable units on
the card. This resulted in only every 512'th 512-byte sized "sector" being
accessible from the bios command line.

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>