### PR TITLE
crt0: fix .data section initialise on [Serv,Minerva]

### DIFF
--- a/litex/soc/cores/cpu/minerva/crt0.S
+++ b/litex/soc/cores/cpu/minerva/crt0.S
@@ -14,8 +14,8 @@ reset_vector:
 	la t1, _edata
 	la t2, _fdata_rom
 1:	beq t0, t1, 2f
-	lw t3, 0(t0)
-	sw t3, 0(t2)
+	lw t3, 0(t2)
+	sw t3, 0(t0)
 	addi t0, t0, 4
 	addi t2, t2, 4
 	j 1b

--- a/litex/soc/cores/cpu/serv/crt0.S
+++ b/litex/soc/cores/cpu/serv/crt0.S
@@ -14,8 +14,8 @@ reset_vector:
 	la t1, _edata
 	la t2, _fdata_rom
 1:	beq t0, t1, 2f
-	lw t3, 0(t0)
-	sw t3, 0(t2)
+	lw t3, 0(t2)
+	sw t3, 0(t0)
 	addi t0, t0, 4
 	addi t2, t2, 4
 	j 1b


### PR DESCRIPTION
The startup code in `crt0.S` was incorrectly initialising the .data section.

The old code was copying from `_fdata` into `_fdata_rom`. 


This likely hasn't been an issue in the bios before, but with the changes to the command parser if the `.data` section isn't initialised then none of the commands work correctly, since they're stored in `.data`
```
--============= Console ================--

litex> [tab]o[tab]
o    o    o
o    o    o    o    o    o    o    
litex> help
Command not found
litex> 
```