### PR TITLE
software/liblitedram: fix conditional compilation bug

### DIFF
--- a/litex/soc/software/bios/cmds/cmd_litedram.c
+++ b/litex/soc/software/bios/cmds/cmd_litedram.c
@@ -34,7 +34,7 @@ define_command(sdram_init, sdram_init, "Initialize SDRAM (Init + Calibration)", 
 define_command(sdram_cal, sdram_calibration, "Calibrate SDRAM", LITEDRAM_CMDS);
 #endif
 
-#ifdef CSR_DDRPHY_CDLY_RST_ADDR
+#if defined(CSR_DDRPHY_CDLY_RST_ADDR) && defined(SDRAM_PHY_WRITE_LEVELING_CAPABLE)
 
 /**
  * Command "sdram_rst_cmd_delay"


### PR DESCRIPTION
Fix conditional compilation bug introduced by a601415b.

@enjoy-digital At least it fixes it for me, on the nexys4ddr with a rocket-based litex build. Not 100% sure we need both or if maybe checking just for `defined(SDRAM_PHY_WRITE_LEVELING_CAPABLE)` may be enough... Either way, if you have a more precise fix, please feel free to discard this PR... :)