### PR TITLE
RFC: json2dts: set CPU clock-frequency and SoC bus-frequency

### DIFF
--- a/litex/tools/litex_json2dts.py
+++ b/litex/tools/litex_json2dts.py
@@ -56,7 +56,7 @@ def generate_dts(d):
                     #size-cells    = <0>;
                     timebase-frequency = <{sys_clk_freq}>;
                     cpu@0 {{
-                            clock-frequency = <0x0>;
+                            clock-frequency = <{sys_clk_freq}>;
                             compatible = "spinalhdl,vexriscv", "sifive,rocket0", "riscv";
                             d-cache-block-size = <0x40>;
                             d-cache-sets = <0x40>;
@@ -128,9 +128,10 @@ def generate_dts(d):
         soc {
                 #address-cells = <1>;
                 #size-cells    = <1>;
+                bus-frequency  = <{sys_clk_freq}>;
                 compatible = "simple-bus";
                 ranges;
-"""
+""".format(sys_clk_freq=d["constants"]["config_clock_frequency"])
 
     # Interrupt controller -----------------------------------------------------------------------------
 


### PR DESCRIPTION
@enjoy-digital: please don't apply yet, let's discuss first.

@mateusz-holenko : This came up during my effort to get the dma-based litesdcard driver working on 64-bit rocket.

The `timebase-frequency` cell should ***NOT*** be used to indicate the raw CPU clock. That, instead, should be the `clock-frequency` cell attached to each `cpu@X` core.

On vexriscv we should probably set `clock-frequency`, and I'm not sure about whether we'd still want to set `timebase-frequency` to the raw `CONFIG_CLOCK_FREQUENCY` as well, since doing so is probably wrong.

In addition, or instead, we could set a `bus-frequency` cell on the `soc` node. @enjoy-digital -- this mostly depends on whether we're planning to share the same system clock (currently denoted by `CONFIG_CLOCK_FREQUENCY` in soc.h) for both the CPU and the main (wishbone) bus.

@mateusz-holenko -- I've currently modified the sdcard driver to search for the `clock-frequency` cell instead of `timebase-frequency`, and will push my changes into the `litex-rocket-rebase` branch as soon as I figure out how to detect when a card is inserted and/or ejected, which still doesn't work for me properly :) But we should decide whether to go with `clock-frequency` or `bus-frequency`, depending on what Florent thinks is least likely to change (I'm thinking of e.g. cpu clocks on modern systems being a multiple of the bus clock, in which case we should stick with the bus clock rather than `clock-frequency` -- that sort of thing).

**EDIT**: for context, I should mention that the [Linux litesdcard driver](https://github.com/enjoy-digital/litex/blob/master/litex/soc/software/liblitesdcard/sdcard.c#L104) needs to be told about the reference clock that it should use to compute a divisor that will set the sdcard-specific clock signal, similar to what is done in the [LiteX bios](https://github.com/enjoy-digital/litex/blob/master/litex/soc/software/liblitesdcard/sdcard.c#L104).

Any comments, ideas, etc. much appreciated!
