### PR TITLE
Fix build issue where sdram_leveling is not found

### DIFF
--- a/litex/soc/software/liblitedram/sdram.c
+++ b/litex/soc/software/liblitedram/sdram.c
@@ -801,7 +801,9 @@ int sdram_init(void)
 	ddrctrl_init_error_write(0);
 #endif
 	init_sequence();
+#if defined(SDRAM_PHY_WRITE_LEVELING_CAPABLE) || defined(SDRAM_PHY_READ_LEVELING_CAPABLE)
 	sdram_leveling();
+#endif
 	sdram_software_control_off();
 	if(!memtest((unsigned int *) MAIN_RAM_BASE, MAIN_RAM_SIZE)) {
 #ifdef CSR_DDRCTRL_BASE


### PR DESCRIPTION
4f76656 rewrote how sdram_leveling() was called, leading
to linking problems for targets with sdram but with
write leveling disabled, e.g. ulx3s.