### PR TITLE
Add riscv*-unknown-linux-gnu triples and fix existing riscv-linux-gnu triple

### DIFF
--- a/litex/soc/cores/cpu/__init__.py
+++ b/litex/soc/cores/cpu/__init__.py
@@ -38,21 +38,24 @@ class CPUNone(CPU):
 
 CPU_GCC_TRIPLE_RISCV32 = (
     "riscv64-unknown-elf",
+    "riscv64-unknown-linux-gnu",
     "riscv32-unknown-elf",
+    "riscv32-unknown-linux-gnu",
     "riscv64-elf",
     "riscv32-elf",
     "riscv-none-embed",
     "riscv64-linux",
-    "riscv64-linux-gnu-gcc",
+    "riscv64-linux-gnu",
     "riscv-sifive-elf",
     "riscv64-none-elf",
 )
 
 CPU_GCC_TRIPLE_RISCV64 = (
     "riscv64-unknown-elf",
+    "riscv64-unknown-linux-gnu",
     "riscv64-elf",
     "riscv64-linux",
-    "riscv64-linux-gnu-gcc",
+    "riscv64-linux-gnu",
     "riscv-sifive-elf",
     "riscv64-none-elf",
 )

--- a/litex/soc/software/common.mak
+++ b/litex/soc/software/common.mak
@@ -50,7 +50,7 @@ INCLUDES = -I$(SOC_DIRECTORY)/software/include/base \
            -I$(SOC_DIRECTORY)/software \
            -I$(BUILDINC_DIRECTORY) \
            -I$(CPU_DIRECTORY)
-COMMONFLAGS = $(DEPFLAGS) -Os $(CPUFLAGS) -g3 -fomit-frame-pointer -Wall -fno-builtin -nostdinc $(INCLUDES)
+COMMONFLAGS = $(DEPFLAGS) -Os $(CPUFLAGS) -g3 -fomit-frame-pointer -Wall -fno-builtin -nostdinc -fno-stack-protector $(INCLUDES)
 CFLAGS = $(COMMONFLAGS) -fexceptions -Wstrict-prototypes -Wold-style-definition -Wmissing-prototypes
 CXXFLAGS = $(COMMONFLAGS) -std=c++11 -I$(SOC_DIRECTORY)/software/include/basec++ -fexceptions -fno-rtti -ffreestanding
 LDFLAGS = -nostdlib -nodefaultlibs -L$(BUILDINC_DIRECTORY)


### PR DESCRIPTION
Add riscv*-unknown-linux-gnu triples to `soc/cores/cpu/__init__.py` and fix existing `riscv-linux-gnu` triple by removing incorrect `-gcc` suffix.

Also add `-fno-stack-protector` to software makefile to prevent undefined stack guard symbols from being referenced when using non-freestanding toolchains.