### PR TITLE
Unconditionally ask dfu-util to "Issue USB Reset"

### DIFF
--- a/litex/build/dfu.py
+++ b/litex/build/dfu.py
@@ -21,4 +21,4 @@ class DFUProg(GenericProgrammer):
     def load_bitstream(self, bitstream_file):
         subprocess.call(["cp", bitstream_file, bitstream_file + ".dfu"])
         subprocess.call(["dfu-suffix", "-v", self.vid, "-p", self.pid, "-a", bitstream_file + ".dfu"])
-        subprocess.call(["dfu-util", "--download", bitstream_file + ".dfu"])
+        subprocess.call(["dfu-util", "--download", bitstream_file + ".dfu", "-R"])


### PR DESCRIPTION
Unconditionally ask dfu-util to "Issue USB Reset signalling once we're finished".

Some host machines need it.
Else host machine does not detect the USB in the design, lxterm fails, etc.
Issuing -R here fixes everything.

If issuing -R always does not cause any trouble to anyone, then this PR is relevant.