### PR TITLE
Fix SoC CPU crash on minimal variants on call to flush_cpu_dcache().

### DIFF
--- a/litex/soc/cores/cpu/vexriscv/system.h
+++ b/litex/soc/cores/cpu/vexriscv/system.h
@@ -11,7 +11,7 @@ extern "C" {
 
 __attribute__((unused)) static void flush_cpu_icache(void)
 {
-#if defined(CONFIG_CPU_VARIANT_MIN)
+#if defined(CONFIG_CPU_VARIANT_MINIMAL)
   /* No instruction cache */
 #else
   asm volatile(
@@ -27,7 +27,7 @@ __attribute__((unused)) static void flush_cpu_icache(void)
 
 __attribute__((unused)) static void flush_cpu_dcache(void)
 {
-#if defined(CONFIG_CPU_VARIANT_MIN) || defined(CONFIG_CPU_VARIANT_LITE)
+#if defined(CONFIG_CPU_VARIANT_MINIMAL) || defined(CONFIG_CPU_VARIANT_LITE)
   /* No data cache */
 #else
   asm volatile(".word(0x500F)\n");


### PR DESCRIPTION
Generated soc.h says for example
#define CONFIG_CPU_TYPE_VEXRISCV
#define CONFIG_CPU_VARIANT_MINIMAL
#define CONFIG_CPU_HUMAN_NAME "VexRiscv_Min"

but code tested for CONFIG_CPU_VARIANT_MIN not MINIMAL.
Attempted to run instruction unknown to this CPU, most likely cause of hang.

This PR causes the code to correctly checks CONFIG_CPU_VARIANT_MINIMAL.