### PR TITLE
build/xilinx/symbiflow: Add xc7a100tscg324-1 to supported devices

### DIFF
--- a/litex/build/xilinx/symbiflow.py
+++ b/litex/build/xilinx/symbiflow.py
@@ -123,6 +123,7 @@ class SymbiflowToolchain:
                 self.symbiflow_device = {
                     # FIXME: fine for now since only a few devices are supported, do more clever device re-mapping.
                     "xc7a35ticsg324-1L" : "xc7a50t_test",
+                    "xc7a100tcsg324-1" : "xc7a100t_test",
                 }[platform.device]
             except KeyError:
                 raise ValueError(f"symbiflow_device is not specified")
@@ -136,6 +137,7 @@ class SymbiflowToolchain:
         # FIXME: prjxray-db doesn't have xc7a35ticsg324-1L - use closest replacement
         self._partname = {
             "xc7a35ticsg324-1L" : "xc7a35tcsg324-1",
+            "xc7a100tcsg324-1" : "xc7a100tcsg324-1",
         }.get(platform.device, platform.device)
 
     def _generate_makefile(self, platform, build_name):


### PR DESCRIPTION
This PR adds `xc7a100tscg324-1` to a list of devices supported by the SymbiFlow toolchain. The configuration for that device can be found in the `symbiflow/xc7/install/share/symbiflow/arch/xc7a100t_test` directory of the SymbiFlow toolchain package:

```
wget https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/66/20200914-111752/symbiflow-arch-defs-install-05d68df0.tar.xz
mkdir symbiflow 
tar -xJvf symbiflow-arch-defs-install-05d68df0.tar.xz --one-top-level=symbiflow/xc7/install
stat symbiflow/xc7/install/share/symbiflow/arch/xc7a100t_test
```
