### PR TITLE
More precise memory performance test.

### DIFF
--- a/litex/soc/software/libbase/memtest.c
+++ b/litex/soc/software/libbase/memtest.c
@@ -185,7 +185,7 @@ void memspeed(unsigned int *addr, unsigned long size, bool read_only)
 	__attribute__((unused)) unsigned long data;
 	const unsigned int sz = sizeof(unsigned long);
 
-	printf("Memspeed at 0x%p...\n", addr);
+	printf("Memspeed at 0x%p size 0x%x (%u read or write operations), read_only? %s...\n", addr, size, (size/sz), read_only?"true":"false");
 
 	/* init timer */
 	timer0_en_write(0);
@@ -232,7 +232,7 @@ int memtest(unsigned int *addr, unsigned long maxsize)
 	unsigned long addr_size = MEMTEST_ADDR_SIZE < maxsize ? MEMTEST_ADDR_SIZE : maxsize;
 	unsigned long data_size = MEMTEST_DATA_SIZE < maxsize ? MEMTEST_DATA_SIZE : maxsize;
 
-	printf("Memtest at 0x%p...\n", addr);
+	printf("Memtest at 0x%p size 0x%x...\n", addr, maxsize);
 
 	bus_errors  = memtest_bus(addr, bus_size);
 	addr_errors = memtest_addr(addr, addr_size, MEMTEST_ADDR_RANDOM);

--- a/litex/soc/software/libbase/memtest.c
+++ b/litex/soc/software/libbase/memtest.c
@@ -179,7 +179,7 @@ void memspeed(unsigned int *addr, unsigned long size, bool read_only)
 {
 	volatile unsigned long *array = (unsigned long *)addr;
 	int i;
-	unsigned int start, end;
+	uint32_t start, end;
 	unsigned long write_speed = 0;
 	unsigned long read_speed;
 	__attribute__((unused)) unsigned long data;
@@ -202,8 +202,10 @@ void memspeed(unsigned int *addr, unsigned long size, bool read_only)
 		}
 		timer0_update_value_write(1);
 		end = timer0_value_read();
-		write_speed = (size*(CONFIG_CLOCK_FREQUENCY/1000000))/(start - end);
-		printf("  Write: %ldMiB/s\n", write_speed);
+		uint64_t numerator = ((uint64_t)size)*((uint64_t)CONFIG_CLOCK_FREQUENCY);
+		uint64_t denominator = ((uint64_t)start - (uint64_t)end);
+		write_speed = numerator/denominator;
+		printf("  Write speed: %lub/s\n", write_speed);
 	}
 
 	/* flush CPU and L2 caches */
@@ -221,8 +223,10 @@ void memspeed(unsigned int *addr, unsigned long size, bool read_only)
 	}
 	timer0_update_value_write(1);
 	end = timer0_value_read();
-	read_speed = (size*(CONFIG_CLOCK_FREQUENCY/1000000))/(start - end);
-	printf("  Read:  %ldMiB/s\n", read_speed);
+	uint64_t numerator = ((uint64_t)size)*((uint64_t)CONFIG_CLOCK_FREQUENCY);
+	uint64_t denominator = ((uint64_t)start - (uint64_t)end);
+	read_speed = numerator/denominator;
+	printf("  Read speed:  %lub/s\n", read_speed);
 }
 
 int memtest(unsigned int *addr, unsigned long maxsize)

--- a/litex/soc/software/libbase/memtest.c
+++ b/litex/soc/software/libbase/memtest.c
@@ -203,8 +203,8 @@ void memspeed(unsigned int *addr, unsigned long size, bool read_only)
 		timer0_update_value_write(1);
 		end = timer0_value_read();
 		write_speed = (size*(CONFIG_CLOCK_FREQUENCY/1000000))/(start - end);
+		printf("  Write: %ldMiB/s\n", write_speed);
 	}
-	printf("  Write: %ldMiB/s\n", write_speed);
 
 	/* flush CPU and L2 caches */
 	flush_cpu_dcache();


### PR DESCRIPTION
On mem_speed, confirm parameters on terminal output.
Show speeds in bytes per second.

Rationale:
    
* Forcing megabytes per second for everyone does not make sense and clamps less-than-1MB/s to zero.
* Showing bytes per second allows to distinguish between low performance and a performance measurement bug.
* Anyway previous code claims speeds were in MiB/s, they were not, actually MB/s.
