### PR TITLE
bios: add command returning card-detect pin status

### DIFF
--- a/litex/soc/software/bios/cmds/cmd_litesdcard.c
+++ b/litex/soc/software/bios/cmds/cmd_litesdcard.c
@@ -11,6 +11,22 @@
 #include "../helpers.h"
 
 /**
+ * Command "sdcard_detect"
+ *
+ * Detect SDcard
+ *
+ */
+#ifdef CSR_SDPHY_BASE
+static void sdcard_detect_handler(int nb_params, char **params)
+{
+	uint8_t cd = sdphy_card_detect_read();
+	printf("SDCard %sinserted.\n", cd ? "not " : "");
+}
+
+define_command(sdcard_detect, sdcard_detect_handler, "Detect SDCard", LITESDCARD_CMDS);
+#endif
+
+/**
  * Command "sdcard_init"
  *
  * Initialize SDcard


### PR DESCRIPTION
low priority, I just wanted to convince myself that this pin works in bare-metal, and figured now that I created the bios command, might as well share it. Feel free to ignore if it comes off as more "spammy" than useful :)