### PR TITLE
Change misleading comment about ModuleDoc.

### DIFF
--- a/litex/soc/integration/doc.py
+++ b/litex/soc/integration/doc.py
@@ -24,7 +24,7 @@ class ModuleDoc(DUID):
     first section of your class' module documentation
     2. Add a :obj:`ModuleDoc` object to your class and inherit from :obj:`AutoDoc`.
 
-    If you inherit from :obj:`ModuleDoc`, then there is no need to call ``__init__()``
+    If you inherit from :obj:`ModuleDoc`, you still need to call ``ModuleDoc.__init__(self)``.
 
     Synopsis
     --------


### PR DESCRIPTION
Not calling `ModuleDoc.__init__(self)` causes `duid` to be unset and exceptions like this (see https://github.com/gregdavill/valentyusb/pull/1 ).

Traceback (most recent call last):
  File "mydesign.py", line 299, in <module>
    main()
  File "mydesign.py", line 292, in main
    generate_docs(soc, "build/"+target+"/documentation")
  File ".../litex/litex/litex/soc/doc/__init__.py", line 98, in generate_docs
    documented_region = DocumentedCSRRegion(
  File ".../litex/litex/litex/soc/doc/csr.py", line 80, in __init__
    docs = module.get_module_documentation()
  File ".../litex/litex/litex/soc/integration/doc.py", line 141, in gatherer
    return sorted(r, key=lambda x: x.duid)
  File ".../litex/litex/litex/soc/integration/doc.py", line 141, in <lambda>
    return sorted(r, key=lambda x: x.duid)
  File ".../litex/migen/migen/fhdl/module.py", line 136, in __getattr__
    raise AttributeError("'"+self.__class__.__name__+"' object has no attribute '"+name+"'")
AttributeError: 'CDCUsbPHY' object has no attribute 'duid'

## Acknowledgement

Thanks for zyp on #litex for hints. As zyp wrote: "unless there is a better way to solve it".
