### PR TITLE
Fix syntax error preventing to use CSRField.

### DIFF
--- a/litex/soc/interconnect/csr.py
+++ b/litex/soc/interconnect/csr.py
@@ -190,7 +190,7 @@ class CSRField(Signal):
     """
 
     def __init__(self, name, size=1, offset=None, reset=0, description=None, pulse=False, access=None, values=None):
-        assert access is None or (access in CSRAccess.values())
+        assert access is None or (access in CSRAccess)
         self.name        = name
         self.size        = size
         self.offset      = offset


### PR DESCRIPTION
This PR fixes this error when using CSRField in a design.

``` python-traceback
Traceback (most recent call last):
...
  File "mydesign.py", line 65, in __init__
    CSRField("myfieldname", size=2, reset=1, access=CSRAccess.ReadWrite, description="My description"),
  File ".../litex/litex/soc/interconnect/csr.py", line 193, in __init__
    assert access is None or (access in CSRAccess.values())
  File "/usr/lib/python3.8/enum.py", line 346, in __getattr__
    raise AttributeError(name) from None
AttributeError: values
```
