### PR TITLE
cores/cpu/zynq7000: fix axi hp slave registration

### DIFF
--- a/litex/soc/cores/cpu/zynq7000/core.py
+++ b/litex/soc/cores/cpu/zynq7000/core.py
@@ -215,7 +215,7 @@ class Zynq7000(CPU):
         assert len(self.axi_hp_slaves) < 4
         n       = len(self.axi_hp_slaves)
         axi_hpn = axi.AXIInterface(data_width=64, address_width=32, id_width=6)
-        self.axi_hp_masters.append(axi_hpn)
+        self.axi_hp_slaves.append(axi_hpn)
         self.cpu_params.update({
             # AXI HP0 clk
             f"i_S_AXI_HP{n}_ACLK"    : ClockSignal("ps7"),


### PR DESCRIPTION
Zynq HP AXI ports are slaves, not masters - see the lines right above.