### PR TITLE
Add SoC timer peripheral timer-uptime CLI parameter

### DIFF
--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -310,6 +310,9 @@ def soc_core_args(parser):
     # Timer parameters
     parser.add_argument("--no-timer", action="store_true",
                         help="Disable Timer (default=False)")
+    parser.add_argument("--timer-uptime", action="store_true",
+                        help="Add an uptime register to the timer (default=False)")
+
     # Controller parameters
     parser.add_argument("--no-ctrl", action="store_true",
                         help="Disable Controller (default=False)")


### PR DESCRIPTION
This allows enabling the uptime register in the timer core from the command line.

I've come to use the uptime feature quite frequently and having it available as a CLI parameter allows for easier CI integration.