### PR TITLE
litex: soc: do not add the timestamp in the BIOS if it was disabled

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1061,6 +1061,7 @@ class LiteXSoC(SoC):
         self.check_if_exists(name)
         if with_build_time:
             identifier += " " + build_time()
+            self.add_config("HAS_TIMESTAMP")
         setattr(self.submodules, name, Identifier(identifier))
         self.csr.add(name + "_mem", use_loc_if_exists=True)
 

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -97,7 +97,9 @@ int main(int i, char **c)
 	printf(" (c) Copyright 2012-2020 Enjoy-Digital\n");
 	printf(" (c) Copyright 2007-2015 M-Labs\n");
 	printf("\n");
+#ifdef CONFIG_HAS_TIMESTAMP
 	printf(" BIOS built on "__DATE__" "__TIME__"\n");
+#endif
 	crcbios();
 	printf("\n");
 	printf(" Migen git sha1: "MIGEN_GIT_SHA1"\n");


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

The build time addition to the LiteX can be enabled with `with_build_time`.
The problem was that this functionality was not reflected in the BIOS source code, where the timestamp of the build time was added regardless of the `with_build_time` value.

This PR fixes this, allowing the user to disable the timestamp generation in the BIOS.

The main reason to do so is that the timestamp generates non-deterministic outputs, while in several cases, it is necessary to have stable and deterministic outputs, regardless of how small a difference is between two consecutive builds.