### PR TITLE
Add interrupt only if interrupts are supported

### DIFF
--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -192,7 +192,8 @@ class SoCCore(LiteXSoC):
     # Methods --------------------------------------------------------------------------------------
 
     def add_interrupt(self, interrupt_name, interrupt_id=None, use_loc_if_exists=False):
-        self.irq.add(interrupt_name, interrupt_id, use_loc_if_exists=use_loc_if_exists)
+        if hasattr(self.cpu, "interrupt"):
+            self.irq.add(interrupt_name, interrupt_id, use_loc_if_exists=use_loc_if_exists)
 
     def add_csr(self, csr_name, csr_id=None, use_loc_if_exists=False):
         self.csr.add(csr_name, csr_id, use_loc_if_exists=use_loc_if_exists)


### PR DESCRIPTION
This check exists in other parts of the code, so I don't see any reasons to not have it here. This check prevents adding an irq entry (and generating interrupt entries in SVD) for cores that don't support interrupts.