### PR TITLE
correct the documentation for the ctrl reset register

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -652,7 +652,7 @@ class SoCController(Module, AutoCSR):
         with_errors   = True):
 
         if with_reset:
-            self._reset = CSRStorage(1, description="""Write a ``1`` to this register to reset the SoC.""")
+            self._reset = CSRStorage(1, description="""Any write to this register will reset the SoC.""")
         if with_scratch:
             self._scratch = CSRStorage(32, reset=0x12345678, description="""
                 Use this register as a scratch space to verify that software read/write accesses


### PR DESCRIPTION
@xobs pointed out to me today that the doc note on the CTRL reset register is incorrect.

As implemented, writing *anything* to the register triggers a reset as it is kicked off of the `.re` signal, and not the actual data signal itself.

Rather than change the behavior of the block to match the docs (which could cause compatibility issues elsewhere), this PR just fixes the doc string. Should be an easy review but wanted to clear it with @enjoy-digital instead of just merging it.
