### PR TITLE
add a hook for activating the GSR inside the STARTUPE2 block for spi_opi

### DIFF
--- a/litex/soc/cores/spi_opi.py
+++ b/litex/soc/cores/spi_opi.py
@@ -27,6 +27,7 @@ class S7SPIOPI(Module, AutoCSR, AutoDoc):
         self.iddr_name = iddr_name
         self.cipo_name = cipo_name
         self.spiread = spiread
+        self.gsr = Signal()
 
         self.dq = dq = TSTriple(7) # dq[0] is special because it is also copi
         self.dq_copi = dq_copi = TSTriple(1) # this has similar structure but an independent "oe" signal
@@ -289,7 +290,7 @@ class S7SPIOPI(Module, AutoCSR, AutoDoc):
             # De-activate the CCLK interface, parallel it with a GPIO
             Instance("STARTUPE2",
                 i_CLK       = 0,
-                i_GSR       = 0,
+                i_GSR       = self.gsr,
                 i_GTS       = 0,
                 i_KEYCLEARB = 0,
                 i_PACK      = 0,


### PR DESCRIPTION
This is just exposing a signal to assist with SoC integration, the change should be neutral to all other designs so I'm going to go ahead and just merge it after making the request.
