### PR TITLE
symbiflow: restore add_false_path_constraint

### DIFF
--- a/litex/build/xilinx/symbiflow.py
+++ b/litex/build/xilinx/symbiflow.py
@@ -242,6 +242,9 @@ class SymbiflowToolchain:
                     .format(self.clocks[clk], period))
         self.clocks[clk] = period
 
+    def add_false_path_constraint(self, platform, from_, to):
+        # FIXME: false path constraints are currently not supported by the symbiflow toolchain
+        return
 
 def symbiflow_build_args(parser):
     pass


### PR DESCRIPTION
Restore the  `add_false_path_constraint` method to fix SymbiflowToolchain class API.
This fixes the bitstream generation when the created SoC uses LiteEth. Otherwise the build will fail on:
```
  File "/media/rwinkler/hdd/Projects/.direnv/conda/envs/xc7/lib/python3.9/site-packages/litex/build/xilinx/platform.py", line 66, in add_false_path_constraint
    self.toolchain.add_false_path_constraint(self, from_, to)
AttributeError: 'SymbiflowToolchain' object has no attribute 'add_false_path_constraint'
```

