### PR TITLE
Use asynchronous transfers when loading kernel

### DIFF
--- a/litex/soc/software/bios/sfl.h
+++ b/litex/soc/software/bios/sfl.h
@@ -15,6 +15,8 @@ struct sfl_frame {
 	unsigned char payload[255];
 } __attribute__((packed));
 
+#define SFL_VERSION 2
+
 /* General commands */
 #define SFL_CMD_ABORT		0x00
 #define SFL_CMD_LOAD		0x01
@@ -22,11 +24,26 @@ struct sfl_frame {
 #define SFL_CMD_LOAD_NO_CRC	0x03
 #define SFL_CMD_FLASH		0x04
 #define SFL_CMD_REBOOT		0x05
+/* Commands available from version 2 */
+#define SFL_CMD_VERSION		0x06
+#define SFL_CMD_LOAD_ASYNC	0x07
+#define SFL_CMD_RESYNC		0x08
+
+#define SFL_MAX_CMD         SFL_CMD_RESYNC
 
 /* Replies */
 #define SFL_ACK_SUCCESS		'K'
 #define SFL_ACK_CRCERROR	'C'
 #define SFL_ACK_UNKNOWN		'U'
 #define SFL_ACK_ERROR		'E'
+/* Followed by a 1 byte version number if the protocol version is at least 2.
+ * Otherwise SFL_ACK_UNKNOWN will be returned instead. */
+#define SFL_ACK_VERSION		'V'
+/* Followed by a 4 byte big endian address that needs to be resent via
+ * LOAD_ASYNC. */
+#define SFL_ACK_RESEND		'R'
+/* Followed by a 4 byte big endian address that was successfully loaded via
+ * LOAD_ASYNC. */
+#define SFL_ACK_ASYNC		'A'
 
 #endif /* __SFL_H */


### PR DESCRIPTION
I observed that loading a 427KB kernel took about 2 minutes, so I
switched to using 4Mbit serial and it still took about 2 minutes. This
change fixes that by allowing load requests to continue while awaiting
confirmation that the CRC was valid and the load succeeded.

Prior to this change, with serial speed set to 4Mbits and CRC checking
enabled, a 427KB file would take 116 seconds to load.

With this change, it now takes 1.1 seconds.

I tested by randomly changing, deleting or inserting a byte of the
output stream.

I've attempted to keep the communication protocol backwards compatible.
So old versions of litex_term should still work with new BIOS code and
vice versa.

I also increased the size of the payload size in litex_term to match the
buffer size that already existed in the BIOS.