### PR TITLE
don't add pins without pad location in constraints file

### DIFF
--- a/litex/build/generic_platform.py
+++ b/litex/build/generic_platform.py
@@ -8,6 +8,7 @@
 
 import sys
 import os
+import re
 
 from migen.fhdl.structure import Signal, Cat
 from migen.genlib.record import Record
@@ -395,7 +396,8 @@ class GenericPlatform:
         # resolve signal names in constraints
         sc = self.constraint_manager.get_sig_constraints()
         named_sc = [(vns.get_name(sig), pins, others, resource)
-                    for sig, pins, others, resource in sc]
+                    for sig, pins, others, resource in sc
+                        if not re.match(r"^X+$", ''.join(pins))]
         # resolve signal names in platform commands
         pc = self.constraint_manager.get_platform_commands()
         named_pc = []


### PR DESCRIPTION
When a Pins is defined at the platform level with only a size instead of one (or more) pad location resulting constraints file contains X instead of pad name.
Most of the time Pins have pad name, but with xc7z platforms when the zynq is used, PS signals (RAM, USB, clk and reset, ...) must be present at the top hdl level.
For this case xdc file contains LOC X and vivado produces critical warnings like:
```
CRITICAL WARNING: [Common 17-69] Command failed: 'X' is not a valid site or package pin name. [/somewhere/build/board/gateware/board.xdc:xxx]
```
Correct pad name for PS side are not required (and provided by another xdc produces by xci or create_ip).

This PR add a test to drop signals where pin name match 'X', so the xdc is not filled with them.