### PR TITLE
tools/litex_json2dts: Miscellaneous fixes and improvements

### DIFF
--- a/litex/tools/litex_json2dts.py
+++ b/litex/tools/litex_json2dts.py
@@ -183,9 +183,9 @@ def generate_dts(d):
         dts += """
                 mac0: mac@{ethmac_csr_base:x} {{
                         compatible = "litex,liteeth";
-                        reg = <0x{ethmac_csr_base:x} 0x7c
-                               0x{ethphy_csr_base:x} 0x0a
-                               0x{ethmac_mem_base:x} 0x2000>;
+                        reg = <0x{ethmac_csr_base:x} 0x7c>,
+                              <0x{ethphy_csr_base:x} 0x0a>,
+                              <0x{ethmac_mem_base:x} 0x2000>;
                         tx-fifo-depth = <{ethmac_tx_slots}>;
                         rx-fifo-depth = <{ethmac_rx_slots}>;
                 }};

--- a/litex/tools/litex_json2dts.py
+++ b/litex/tools/litex_json2dts.py
@@ -184,8 +184,8 @@ def generate_dts(d):
                 mac0: mac@{ethmac_csr_base:x} {{
                         compatible = "litex,liteeth";
                         reg = <0x{ethmac_csr_base:x} 0x7c
-                                0x{ethphy_csr_base:x} 0x0a
-                                0x{ethmac_mem_base:x} 0x2000>;
+                               0x{ethphy_csr_base:x} 0x0a
+                               0x{ethmac_mem_base:x} 0x2000>;
                         tx-fifo-depth = <{ethmac_tx_slots}>;
                         rx-fifo-depth = <{ethmac_rx_slots}>;
                 }};
@@ -273,8 +273,8 @@ def generate_dts(d):
 
         dts += """
                 litespiflash: spiflash@{spiflash_csr_base:x} {{
-                            #address-cells = <1>;
-                            #size-cells    = <1>;
+                        #address-cells = <1>;
+                        #size-cells    = <1>;
                         compatible = "litex,spiflash";
                         reg = <0x{spiflash_csr_base:x} 0x100>;
                         flash: flash@0 {{
@@ -306,10 +306,10 @@ def generate_dts(d):
 
                         mmc-slot@0 {{
                                 compatible = "mmc-spi-slot";
-                            reg = <0>;
+                                reg = <0>;
                                 voltage-ranges = <3300 3300>;
                                 spi-max-frequency = <1500000>;
-                            status = "okay";
+                                status = "okay";
                         }};
                 }};
 """.format(spisdcard_csr_base=d["csr_bases"]["spisdcard"])
@@ -408,7 +408,7 @@ def generate_dts(d):
         return """
                         CLKOUT{clkout_nr}: CLKOUT{clkout_nr} {{
                                 compatible = "litex,clk";
-                                #clock-cells =	<0>;
+                                #clock-cells = <0>;
                                 clock-output-names = "CLKOUT{clkout_nr}";
                                 reg = <{clkout_nr}>;
                                 litex,clock-frequency = <{clk_f}>;

--- a/litex/tools/litex_json2dts.py
+++ b/litex/tools/litex_json2dts.py
@@ -254,7 +254,7 @@ def generate_dts(d):
                         litespi,num-cs = <1>;
 
                         #address-cells = <1>;
-                        #size-cells    = <1>;
+                        #size-cells    = <0>;
 
                         spidev0: spidev@0 {{
                                 compatible = "linux,spidev";
@@ -302,7 +302,7 @@ def generate_dts(d):
                         litespi,num-cs = <1>;
 
                         #address-cells = <1>;
-                        #size-cells    = <1>;
+                        #size-cells    = <0>;
 
                         mmc-slot@0 {{
                                 compatible = "mmc-spi-slot";


### PR DESCRIPTION
This is a set of miscellaneous fixes and improvements for the
automatic generation of DTS from JSON:

  - tools/litex_json2dts: Fix SPI bus #size-cells
  - tools/litex_json2dts: Fix DTS indentation
  - tools/litex_json2dts: Group tuples in liteeth reg property

The last change is untested, due to lack of liteeth hardware.
Thanks!