### PR TITLE
fix a timing error in the S7 OPI block

### DIFF
--- a/litex/soc/cores/spi_opi.py
+++ b/litex/soc/cores/spi_opi.py
@@ -1393,7 +1393,7 @@ class S7SPIOPI(Module, AutoCSR, AutoDoc):
         ])
 
         self.comb += self.ecc_status.fields.ecc_error.eq(ecs_n)
-        self.comb += [
+        self.sync += [
             ecs_pulse.eq(ecs_n_delay & ~ecs_n), # falling edge -> positive pulse
             If(ecs_pulse,
                self.ecc_address.fields.ecc_address.eq(rom_addr),


### PR DESCRIPTION
should have no impact on normal operation, the path is
only for registering addresses that are correlated with
ECC errors as reported by the OPI device.