### PR TITLE
Allow selection of VexRiscv_Secure* from lxsim CLI

### DIFF
--- a/litex/soc/cores/cpu/vexriscv/core.py
+++ b/litex/soc/cores/cpu/vexriscv/core.py
@@ -34,6 +34,8 @@ CPU_VARIANTS = {
     "linux":            "VexRiscv_Linux",
     "linux+debug":      "VexRiscv_LinuxDebug",
     "linux+no-dsp":     "VexRiscv_LinuxNoDspFmax",
+    "secure":           "VexRiscv_Secure",
+    "secure+debug":     "VexRiscv_SecureDebug",
 }
 
 
@@ -58,6 +60,8 @@ GCC_FLAGS = {
     "linux":            "-march=rv32ima    -mabi=ilp32",
     "linux+debug":      "-march=rv32ima    -mabi=ilp32",
     "linux+no-dsp":     "-march=rv32ima    -mabi=ilp32",
+    "secure":           "-march=rv32ima    -mabi=ilp32",
+    "secure+debug":     "-march=rv32ima    -mabi=ilp32",
 }
 
 


### PR DESCRIPTION
The `VexRiscv_Secure` and `VexRiscv_SecureDebug` cores were added today in https://github.com/litex-hub/pythondata-cpu-vexriscv/pull/9.