### PR TITLE
Add get_ios for full AXI and add missing signals in connect_to_pads

### DIFF
--- a/litex/soc/interconnect/axi.py
+++ b/litex/soc/interconnect/axi.py
@@ -142,6 +142,19 @@ class AXIInterface:
     def connect_to_pads(self, pads, mode="master"):
         return connect_to_pads(self, pads, mode)
 
+    def get_ios(self, bus_name="wb"):
+        subsignals = []
+        for channel in ["aw", "w", "b", "ar", "r"]:
+            for name in ["valid", "ready"]:
+                subsignals.append(Subsignal(channel + name, Pins(1)))
+            for name, width in getattr(self, channel).description.payload_layout:
+                subsignals.append(Subsignal(channel + name, Pins(width)))
+
+        subsignals.append(Subsignal("rlast", Pins(1)))
+        subsignals.append(Subsignal("wlast", Pins(1)))
+        ios = [(bus_name , 0) + tuple(subsignals)]
+        return ios
+
     def connect(self, slave, **kwargs):
         return _connect_axi(self, slave, **kwargs)
 

--- a/litex/soc/interconnect/axi.py
+++ b/litex/soc/interconnect/axi.py
@@ -140,7 +140,16 @@ class AXIInterface:
         self.r  = stream.Endpoint(r_description(data_width, id_width))
 
     def connect_to_pads(self, pads, mode="master"):
-        return connect_to_pads(self, pads, mode)
+        r = connect_to_pads(self, pads, mode)
+
+        if mode == "master":
+            r.append(pads.wlast.eq(self.w.last))
+            r.append(self.r.last.eq(pads.rlast))
+        else:
+            r.append(pads.rlast.eq(self.r.last))
+            r.append(self.w.last.eq(pads.wlast))
+
+        return r
 
     def get_ios(self, bus_name="wb"):
         subsignals = []


### PR DESCRIPTION
This PR adds `get_ios` method for full AXI bus and also adds connections for `wlast` and `rlast` signals in `connect_to_pads`