### PR TITLE
Add ECPDAP programmer

### DIFF
--- a/litex/build/lattice/programmer.py
+++ b/litex/build/lattice/programmer.py
@@ -147,3 +147,30 @@ class UJProg(GenericProgrammer):
 
     def load_bitstream(self, bitstream_file):
         self.call(["ujprog", bitstream_file])
+
+# EcpDapProgrammer -------------------------------------------------------------------------------
+
+class EcpDapProgrammer(GenericProgrammer):
+    """ECPDAP allows you to program ECP5 FPGAs and attached SPI flash using CMSIS-DAP probes in JTAG mode.
+
+    You can get `ecpdap` here: https://github.com/adamgreig/ecpdap
+    """
+    needs_bitreverse = False
+
+    def __init__(self, frequency=8_000_000):
+        self.frequency_khz = frequency // 1000
+
+    def flash(self, address, bitstream_file):
+        self.call(["ecpdap",
+            "flash", "write",
+            "--freq", str(self.frequency_khz),
+            "--offset", str(address),
+            bitstream_file
+        ])
+
+    def load_bitstream(self, bitstream_file):
+        self.call(["ecpdap",
+            "program",
+            "--freq", str(self.frequency_khz),
+            bitstream_file
+        ])


### PR DESCRIPTION
Useful for [Colorlight i5 extension board](https://github.com/wuxx/Colorlight-FPGA-Projects) as well as for other ECP5 boards with a separate external CMSIS-DAP compatible debug probe.