### PR TITLE
mor1kx: Enable rotate, fpu and sign extensions under linux

### DIFF
--- a/litex/soc/cores/cpu/mor1kx/core.py
+++ b/litex/soc/cores/cpu/mor1kx/core.py
@@ -50,6 +50,7 @@ class MOR1KX(CPU):
     def gcc_flags(self):
         flags =  "-mhard-mul "
         flags += "-mhard-div "
+        flags += "-mcmov "
         flags += "-D__mor1kx__ "
 
         if "linux" in self.variant:

--- a/litex/soc/cores/cpu/mor1kx/core.py
+++ b/litex/soc/cores/cpu/mor1kx/core.py
@@ -15,7 +15,7 @@ from litex import get_data_mod
 from litex.soc.interconnect import wishbone
 from litex.soc.cores.cpu import CPU
 
-CPU_VARIANTS = ["standard", "linux"]
+CPU_VARIANTS = ["standard", "standard+fpu", "linux", "linux+fpu"]
 
 
 class MOR1KX(CPU):
@@ -51,6 +51,11 @@ class MOR1KX(CPU):
         flags =  "-mhard-mul "
         flags += "-mhard-div "
         flags += "-D__mor1kx__ "
+
+        if "linux" in self.variant:
+            flags += "-mror "
+            flags += "-msext "
+
         return flags
 
     @property
@@ -77,7 +82,7 @@ class MOR1KX(CPU):
         self.memory_buses = []
 
 
-        if variant == "linux":
+        if "linux" in variant:
             self.mem_map = self.mem_map_linux
 
         # # #
@@ -107,7 +112,12 @@ class MOR1KX(CPU):
             p_DBUS_WB_TYPE              = "B3_REGISTERED_FEEDBACK",
         )
 
-        if variant == "linux":
+        if "fpu" in variant:
+            cpu_args.update(
+                p_FEATURE_FPU = "ENABLED",
+            )
+
+        if "linux" in variant:
             cpu_args.update(
                 # Linux needs the memory management units.
                 p_FEATURE_IMMU  = "ENABLED",
@@ -115,6 +125,8 @@ class MOR1KX(CPU):
                 # FIXME: Currently we need the or1k timer when we should be
                 # using the litex timer.
                 p_FEATURE_TIMER = "ENABLED",
+                p_FEATURE_ROR = "ENABLED",
+                p_FEATURE_EXT = "ENABLED",
             )
             # FIXME: Check if these are needed?
             use_defaults = (


### PR DESCRIPTION
My thought is that if we are running linux the FPGA should be able to
handle these extra instruction's footprint.  Also, since we are running
on linux there may be any kind of software running on the CPU, so allow
handling these instructions.

But really, I am running GLIBC tests and they run faster with this
enabled.