### PR TITLE
dts: Fix soc controller compatible

### DIFF
--- a/litex/tools/litex_json2dts.py
+++ b/litex/tools/litex_json2dts.py
@@ -139,7 +139,7 @@ def generate_dts(d):
 
     dts += """
             soc_ctrl0: soc_controller@{soc_ctrl_csr_base:x} {{
-                compatible = "litex,soc_controller";
+                compatible = "litex,soc-controller";
                 reg = <0x{soc_ctrl_csr_base:x} 0xc>;
                 status = "okay";
             }};


### PR DESCRIPTION
The version that landed upstream is spelt litex,soc-controller with a
dash instead of an underscore.

Signed-off-by: Joel Stanley <joel@jms.id.au>