### PR TITLE
Use riscv32 gcc triples for picorv32- superset of riscv64 triples.

### DIFF
--- a/litex/soc/cores/cpu/picorv32/core.py
+++ b/litex/soc/cores/cpu/picorv32/core.py
@@ -14,7 +14,7 @@ from migen import *
 
 from litex import get_data_mod
 from litex.soc.interconnect import wishbone
-from litex.soc.cores.cpu import CPU, CPU_GCC_TRIPLE_RISCV64
+from litex.soc.cores.cpu import CPU, CPU_GCC_TRIPLE_RISCV32
 
 
 CPU_VARIANTS = ["minimal", "standard"]
@@ -38,7 +38,7 @@ class PicoRV32(CPU):
     variants             = CPU_VARIANTS
     data_width           = 32
     endianness           = "little"
-    gcc_triple           = CPU_GCC_TRIPLE_RISCV64
+    gcc_triple           = CPU_GCC_TRIPLE_RISCV32
     linker_output_format = "elf32-littleriscv"
     nop                  = "nop"
     io_regions           = {0x80000000: 0x80000000} # origin, length


### PR DESCRIPTION
Self-explanatory. Can confirm a working CPU and BIOS on OrangeCrab using the following invocation in `litex-boards`:

```
python3 litex_boards/targets/orangecrab.py --cpu-type=picorv32 --l2-size=0 --integrated-main-ram-size=32768 --build
```
