### PR TITLE
extend builder to take custom bios options

### DIFF
--- a/litex/soc/software/demo/demo.py
+++ b/litex/soc/software/demo/demo.py
@@ -12,7 +12,9 @@ from distutils.dir_util import copy_tree
 
 def main():
     parser = argparse.ArgumentParser(description="LiteX Bare Metal Demo App.")
-    parser.add_argument("--build-path", help="Target's build path.", required=True)
+    parser.add_argument("--build-path", help="Target's build path (eg ./build/board_name/)." + \
+        "Note: this tool needs to be invoked from the project directory " + \
+        "(the directory containing the build/ subdirectory)", required=True)
     args = parser.parse_args()
 
     # Create demo directory


### PR DESCRIPTION
Hello I had the problem that I could not customize the bios to
use different IP addresses. This is a general solution which
allows to insert custom variables into the makefile,
which solves that problem.