### PR TITLE
Windows fixes for `litex_term`

### DIFF
--- a/litex/tools/litex_term.py
+++ b/litex/tools/litex_term.py
@@ -22,10 +22,14 @@ import telnetlib
 # Console ------------------------------------------------------------------------------------------
 
 if sys.platform == "win32":
+    import ctypes
     import msvcrt
     class Console:
         def configure(self):
-            pass
+            # https://stackoverflow.com/a/36760881
+            # ENABLE_VIRTUAL_TERMINAL_PROCESSING
+            kernel32 = ctypes.windll.kernel32
+            kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
 
         def unconfigure(self):
             pass

--- a/litex/tools/litex_term.py
+++ b/litex/tools/litex_term.py
@@ -17,7 +17,6 @@ import threading
 import multiprocessing
 import argparse
 import json
-import pty
 import telnetlib
 
 # Console ------------------------------------------------------------------------------------------
@@ -35,6 +34,7 @@ if sys.platform == "win32":
             return msvcrt.getch()
 else:
     import termios
+    import pty
     class Console:
         def __init__(self):
             self.fd = sys.stdin.fileno()
@@ -495,7 +495,10 @@ def main():
         print("[LXTERM] --no-crc is deprecated and now does nothing (CRC checking is now fast)")
     term = LiteXTerm(args.serial_boot, args.kernel, args.kernel_adr, args.images, args.flash)
 
-    bridge_cls = {"crossover": CrossoverUART, "jtag_uart": JTAGUART}.get(args.port, None)
+    if sys.platform == "win32":
+        bridge_cls = None
+    else:
+        bridge_cls = {"crossover": CrossoverUART, "jtag_uart": JTAGUART}.get(args.port, None)
     if bridge_cls is not None:
         bridge = bridge_cls()
         bridge.open()

--- a/litex/tools/litex_term.py
+++ b/litex/tools/litex_term.py
@@ -36,6 +36,42 @@ if sys.platform == "win32":
 
         def getkey(self):
             return msvcrt.getch()
+
+        # getch doesn't return Virtual Keycodes, but rather
+        # PS/2 Scan Codes. Keycodes starting with 0xE0 are
+        # worth handling.
+        def escape_char(self, b):
+            return b == b"\xe0"
+
+        def handle_escape(self, b):
+            # UP
+            if b == b"H":
+                return b"\x1b[A"
+            # DOWN
+            elif b == b"P":
+                return b"\x1b[B"
+            # LEFT
+            elif b == b"K":
+                return b"\x1b[D"
+            # RIGHT
+            elif b == b"M":
+                return b"\x1b[C"
+            # HOME
+            elif b == b"G":
+                return b"\x1b[H"
+            # END
+            elif b == b"O":
+                return b"\x1b[F"
+            # INSERT
+            elif b == b"R":
+                return b"\x1b[2~"
+            # DELETE
+            elif b == b"S":
+                return b"\x1b[3~"
+            else:
+                # Ignore remaining- TODO: Maybe handle ESC eventually?
+                return None
+
 else:
     import termios
     import pty
@@ -56,6 +92,12 @@ else:
 
         def getkey(self):
             return os.read(self.fd, 1)
+
+        def escape_char(self, b):
+            return False
+
+        def handle_escape(self, b):
+            return None
 
 # Crossover UART  ----------------------------------------------------------------------------------
 
@@ -449,6 +491,10 @@ class LiteXTerm:
                     self.stop()
                 elif b == b"\n":
                     self.port.write(b"\x0a")
+                elif self.console.escape_char(b):
+                    b = self.console.getkey()
+                    ansi_seq = self.console.handle_escape(b)
+                    self.port.write(ansi_seq)
                 else:
                     self.port.write(b)
         except:


### PR DESCRIPTION
* Avoid importing modules which don't exist on Windows.
* Set `ENABLE_VIRTUAL_TERMINAL_PROCESSING` flag when `litex_term` starts. This tells console processes which have not _already done so_ to interpret ANSI escape codes. Unfortunately it's inconsistent whether `ENABLE_VIRTUAL_TERMINAL_PROCESSING` is enabled on any given Windows console.
* `getch` works at a [lower level](https://wiki.osdev.org/PS/2_Keyboard) than other methods to capture the keyboard. While many chars can be passed to the serial port unmodified, some keys, such as those beginning `0xe0` are worth converting to ANSI equivalents such as "up", "down", "home", etc.