### PR TITLE
soc/integration/export: Add CSR aliases for devices with suffix zero

### DIFF
--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -19,6 +19,7 @@
 import os
 import json
 import inspect
+import re
 from shutil import which
 from sysconfig import get_platform
 
@@ -257,6 +258,33 @@ def get_csr_header(regions, constants, csr_base=None, with_access_functions=True
                                 r += "\tuint32_t newword = " + field_name + "_replace(oldword, plain_value);\n"
                                 r += "\t" + reg_name + "_write(newword);\n"
                                 r += "}\n"
+
+            # Create alias for device with suffix zero
+            if re.fullmatch(".*[^\d]0", name):
+                alias = name[:-1]
+                r += "/* "+alias+" aliases */\n"
+                r += "#define CSR_{}_BASE CSR_{}_BASE\n".format(alias.upper(), name.upper())
+                for csr in region.obj:
+                    reg_name = name + "_" + csr.name
+                    alias_reg_name = alias + "_" + csr.name
+                    r += "#define CSR_{}_ADDR CSR_{}_ADDR\n".format(alias_reg_name.upper(), reg_name.upper())
+                    r += "#define CSR_{}_SIZE CSR_{}_SIZE\n".format(alias_reg_name.upper(), reg_name.upper())
+                    if with_access_functions:
+                        r += "#define {}_read {}_read\n".format(alias_reg_name, reg_name)
+                        if not getattr(csr, "read_only", False):
+                            r += "#define {}_write {}_write\n".format(alias_reg_name, reg_name)
+                    if hasattr(csr, "fields"):
+                        for field in csr.fields.fields:
+                            field_name = name + "_" + csr.name + "_" + field.name
+                            alias_field_name = alias + "_" + csr.name + "_" + field.name
+                            r += "#define CSR_{}_OFFSET CSR_{}_OFFSET\n".format(alias_field_name.upper(), field_name.upper())
+                            r += "#define CSR_{}_SIZE CSR_{}_SIZE\n".format(alias_field_name.upper(), field_name.upper())
+                            if with_access_functions:
+                                r += "#define {}_extract {}_extract\n".format(alias_field_name, field_name)
+                                r += "#define {}_read {}_read\n".format(alias_field_name, field_name)
+                                if not getattr(csr, "read_only", False):
+                                    r += "#define {}_replace {}_replace\n".format(alias_field_name, field_name)
+                                    r += "#define {}_write {}_write\n".format(alias_field_name, field_name)
 
     r += "\n#endif\n"
     return r


### PR DESCRIPTION
The LiteX BIOS checks for the presence of the various CSR_*_BASE
definitions to decide to include device support or not.  E.g. for I2C,
it checks for CSR_I2C_BASE.

However, linux-on-litex-vexriscv registers I2C masters using "i2c0"
instead of "i2c", in anticipation for future support for multiple I2C
busses.  As a consequence, CSR_I2C0_BASE is defined instead of
CSR_I2C_BASE, and LiteX BIOS is built without support for I2C.

Fix this by creating aliases for devices with suffix zero in the
generated CSR register definitions, so the LiteX BIOS will pick up the
presence of the corresponding device, and include support for it.

For now this is limited to the first instance of each type.

Signed-off-by: Geert Uytterhoeven <geert@linux-m68k.org>