### PR TITLE
Add initial core test for Timer

### DIFF
--- a/test/test_timer.py
+++ b/test/test_timer.py
@@ -1,0 +1,63 @@
+import unittest
+
+from migen import *
+
+from litex.soc.cores.timer import Timer
+
+class TestTimer(unittest.TestCase):
+    def test_one_shot_software_polling(self):
+        def generator(timer):
+            clock_cycles = 25
+            yield from timer._en.write(0)
+            yield from timer._load.write(clock_cycles)
+            yield from timer._reload.write(0)
+            yield from timer._en.write(1)
+            yield from timer._update_value.write(1)
+            yield
+            self.assertTrue((yield timer._value.status) > 0)
+            while (yield timer._value.status) > 0:
+                yield from timer._update_value.write(1)
+            yield
+            self.assertEqual((yield timer._value.status), 0)
+
+        timer = Timer()
+        run_simulation(timer, generator(timer))
+
+    def test_periodic_timer_software_polling(self):
+        def generator(timer):
+            clock_cycles = 25
+            yield from timer._en.write(0)
+            yield from timer._load.write(0)
+            yield from timer._reload.write(clock_cycles)
+            yield from timer._en.write(1)
+            yield from timer._update_value.write(1)
+            yield
+            self.assertTrue((yield timer._value.status) > 0)
+            while (yield timer._value.status) > 0:
+                yield from timer._update_value.write(1)
+            yield
+            # Ensure that the timer reloads
+            self.assertEqual((yield timer._value.status), clock_cycles)
+
+        timer = Timer()
+        run_simulation(timer, generator(timer))
+
+    def test_one_shot_timer_interrupts(self):
+        def generator(timer):
+            clock_cycles = 25
+            yield from timer._en.write(0)
+            yield from timer._load.write(clock_cycles)
+            yield from timer._reload.write(0)
+            yield from timer.ev.enable.write(1)
+
+            self.assertEqual(1, (yield timer.ev.zero.trigger))
+
+            yield from timer._en.write(1)
+
+            while (yield timer.ev.zero.trigger != 0) and clock_cycles >= -5:
+                yield
+                clock_cycles -= 1
+            self.assertEqual(0, (yield timer.ev.zero.trigger))
+
+        timer = Timer()
+        run_simulation(timer, generator(timer))


### PR DESCRIPTION
I was debugging some issues I was having with the `Timer` core, and since I couldn't find any existing tests I wrote some to help understand the timer behavior. Thought I'd pass them along in case they're helpful!

I covered the 3 main timer use modes:

- One shot timer
- Periodic timer
- Interrupt driven timer

I'm still new to migen / Litex, so let me know if there's anything that needs some cleanup.