### PR TITLE
integration/export: allow manually specifying toolchain triple.

### DIFF
--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -64,6 +64,9 @@ def get_cpu_mak(cpu, compile_software):
         r = None
         if not isinstance(triple, tuple):
             triple = (triple,)
+        override = os.getenv( "TRIPLE" )
+        if override:
+            triple = (override,) + triple
         p = get_platform()
         for i in range(len(triple)):
             t = triple[i]


### PR DESCRIPTION
If the environment variable TRIPLE is defined, use its value as the highest priority candidate.  Useful for testing new cross-compilers, or selecting among toolchains in a different priority than the built-in list.