### PR TITLE
soc/cpu/vexriscv-smp: add args to disable out of order or direct path to LiteDRAM

### DIFF
--- a/litex/soc/cores/cpu/vexriscv_smp/core.py
+++ b/litex/soc/cores/cpu/vexriscv_smp/core.py
@@ -47,6 +47,8 @@ class VexRiscvSMP(CPU):
     dcache_width   = 32
     icache_width   = 32
     aes_instruction = False
+    out_of_order_decoder = True
+    wishbone_memory = False
 
     @staticmethod
     def args_fill(parser):
@@ -60,7 +62,8 @@ class VexRiscvSMP(CPU):
         parser.add_argument("--icache-size",          default=None,        help="L1 instruction cache size in byte per CPU.")
         parser.add_argument("--icache-ways",          default=None,        help="L1 instruction cache ways per CPU")
         parser.add_argument("--aes-instruction",      default=None,        help="Enable AES instruction acceleration.")
-
+        parser.add_argument("--without-out-of-order-decoder", action='store_true',        help="Reduce area at cost of peripheral access speed")
+        parser.add_argument("--with-wishbone-memory"        , action='store_true',       help="Disable native litedram interface")
 
     @staticmethod
     def args_read(args):
@@ -82,6 +85,9 @@ class VexRiscvSMP(CPU):
         if(args.dcache_ways):          VexRiscvSMP.dcache_ways      = int(args.dcache_ways)
         if(args.icache_ways):          VexRiscvSMP.icache_ways      = int(args.icache_ways)
         if(args.aes_instruction):      VexRiscvSMP.aes_instruction  = bool(args.aes_instruction)
+        if(args.without_out_of_order_decoder): VexRiscvSMP.out_of_order_decoder  = False
+        if(args.with_wishbone_memory): VexRiscvSMP.wishbone_memory  = True
+
 
     @property
     def mem_map(self):
@@ -103,6 +109,7 @@ class VexRiscvSMP(CPU):
 
     @staticmethod
     def generate_cluster_name():
+        ldw = f"Ldw{VexRiscvSMP.litedram_width}"
         VexRiscvSMP.cluster_name = f"VexRiscvLitexSmpCluster_" \
         f"Cc{VexRiscvSMP.cpu_count}"    \
         "_" \
@@ -114,9 +121,11 @@ class VexRiscvSMP(CPU):
         f"Ds{VexRiscvSMP.dcache_size}"  \
         f"Dy{VexRiscvSMP.dcache_ways}"  \
         "_" \
-        f"Ldw{VexRiscvSMP.litedram_width}" \
+        f"{ldw if not VexRiscvSMP.wishbone_memory else ''}" \
         f"{'_Cdma' if VexRiscvSMP.coherent_dma else ''}" \
-        f"{'_Aes' if VexRiscvSMP.aes_instruction else ''}"
+        f"{'_Aes' if VexRiscvSMP.aes_instruction else ''}"\
+        f"{'_Ood' if VexRiscvSMP.out_of_order_decoder else ''}"\
+        f"{'_Wm' if VexRiscvSMP.wishbone_memory else ''}"
 
     @staticmethod
     def generate_default_configs():
@@ -192,9 +201,11 @@ class VexRiscvSMP(CPU):
         gen_args.append(f"--icache-ways={VexRiscvSMP.icache_ways}")
         gen_args.append(f"--litedram-width={VexRiscvSMP.litedram_width}")
         gen_args.append(f"--aes-instruction={VexRiscvSMP.aes_instruction}")
+        gen_args.append(f"--out-of-order-decoder={VexRiscvSMP.out_of_order_decoder}")
+        gen_args.append(f"--wishbone-memory={VexRiscvSMP.wishbone_memory}")
         gen_args.append(f"--netlist-name={VexRiscvSMP.cluster_name}")
         gen_args.append(f"--netlist-directory={vdir}")
-
+        
         cmd = 'cd {path} && sbt "runMain vexriscv.demo.smp.VexRiscvLitexSmpClusterCmdGen {args}"'.format(path=os.path.join(vdir, "ext", "VexRiscv"), args=" ".join(gen_args))
         os.system(cmd)
 
@@ -324,37 +335,38 @@ class VexRiscvSMP(CPU):
         VexRiscvSMP.generate_cluster_name()
 
         from litedram.common import LiteDRAMNativePort
-        ibus = LiteDRAMNativePort(mode="both", address_width=32, data_width=VexRiscvSMP.litedram_width)
-        dbus = LiteDRAMNativePort(mode="both", address_width=32, data_width=VexRiscvSMP.litedram_width)
-        self.memory_buses.append(ibus)
-        self.memory_buses.append(dbus)
-        self.cpu_params.update(
-            # Instruction Memory Bus (Master)
-            o_iBridge_dram_cmd_valid          = ibus.cmd.valid,
-            i_iBridge_dram_cmd_ready          = ibus.cmd.ready,
-            o_iBridge_dram_cmd_payload_we     = ibus.cmd.we,
-            o_iBridge_dram_cmd_payload_addr   = ibus.cmd.addr,
-            o_iBridge_dram_wdata_valid        = ibus.wdata.valid,
-            i_iBridge_dram_wdata_ready        = ibus.wdata.ready,
-            o_iBridge_dram_wdata_payload_data = ibus.wdata.data,
-            o_iBridge_dram_wdata_payload_we   = ibus.wdata.we,
-            i_iBridge_dram_rdata_valid        = ibus.rdata.valid,
-            o_iBridge_dram_rdata_ready        = ibus.rdata.ready,
-            i_iBridge_dram_rdata_payload_data = ibus.rdata.data,
+        if(not VexRiscvSMP.wishbone_memory):
+            ibus = LiteDRAMNativePort(mode="both", address_width=32, data_width=VexRiscvSMP.litedram_width)
+            dbus = LiteDRAMNativePort(mode="both", address_width=32, data_width=VexRiscvSMP.litedram_width)
+            self.memory_buses.append(ibus)
+            self.memory_buses.append(dbus)
+            self.cpu_params.update(
+                # Instruction Memory Bus (Master)
+                o_iBridge_dram_cmd_valid          = ibus.cmd.valid,
+                i_iBridge_dram_cmd_ready          = ibus.cmd.ready,
+                o_iBridge_dram_cmd_payload_we     = ibus.cmd.we,
+                o_iBridge_dram_cmd_payload_addr   = ibus.cmd.addr,
+                o_iBridge_dram_wdata_valid        = ibus.wdata.valid,
+                i_iBridge_dram_wdata_ready        = ibus.wdata.ready,
+                o_iBridge_dram_wdata_payload_data = ibus.wdata.data,
+                o_iBridge_dram_wdata_payload_we   = ibus.wdata.we,
+                i_iBridge_dram_rdata_valid        = ibus.rdata.valid,
+                o_iBridge_dram_rdata_ready        = ibus.rdata.ready,
+                i_iBridge_dram_rdata_payload_data = ibus.rdata.data,
 
-            # Data Memory Bus (Master)
-            o_dBridge_dram_cmd_valid          = dbus.cmd.valid,
-            i_dBridge_dram_cmd_ready          = dbus.cmd.ready,
-            o_dBridge_dram_cmd_payload_we     = dbus.cmd.we,
-            o_dBridge_dram_cmd_payload_addr   = dbus.cmd.addr,
-            o_dBridge_dram_wdata_valid        = dbus.wdata.valid,
-            i_dBridge_dram_wdata_ready        = dbus.wdata.ready,
-            o_dBridge_dram_wdata_payload_data = dbus.wdata.data,
-            o_dBridge_dram_wdata_payload_we   = dbus.wdata.we,
-            i_dBridge_dram_rdata_valid        = dbus.rdata.valid,
-            o_dBridge_dram_rdata_ready        = dbus.rdata.ready,
-            i_dBridge_dram_rdata_payload_data = dbus.rdata.data,
-        )
+                # Data Memory Bus (Master)
+                o_dBridge_dram_cmd_valid          = dbus.cmd.valid,
+                i_dBridge_dram_cmd_ready          = dbus.cmd.ready,
+                o_dBridge_dram_cmd_payload_we     = dbus.cmd.we,
+                o_dBridge_dram_cmd_payload_addr   = dbus.cmd.addr,
+                o_dBridge_dram_wdata_valid        = dbus.wdata.valid,
+                i_dBridge_dram_wdata_ready        = dbus.wdata.ready,
+                o_dBridge_dram_wdata_payload_data = dbus.wdata.data,
+                o_dBridge_dram_wdata_payload_we   = dbus.wdata.we,
+                i_dBridge_dram_rdata_valid        = dbus.rdata.valid,
+                o_dBridge_dram_rdata_ready        = dbus.rdata.ready,
+                i_dBridge_dram_rdata_payload_data = dbus.rdata.data,
+            )
 
     def do_finalize(self):
         assert hasattr(self, "reset_address")
@@ -362,3 +374,4 @@ class VexRiscvSMP(CPU):
 
         # Add verilog sources
         self.add_sources(self.platform)
+


### PR DESCRIPTION
- --without-out-of-order-decode: Disable out-of-order decoding, reducing resource usage but also performance.
- --with-wishbone-memory: Remove the direct memory path to LiteDRAM, reducing performance since accesses are done through the Peripheral Bus/L2 Cache but useful for boards without DRAM DM support (on some hardware, DM pins are grounded so can't be used).