### PR TITLE
liteeth: support hardware timestamping

### DIFF
--- a/litex/soc/cores/timer.py
+++ b/litex/soc/cores/timer.py
@@ -92,6 +92,6 @@ class Timer(Module, AutoCSR, ModuleDoc):
 
         # # #
 
-        uptime_cycles = Signal(width, reset_less=True)
-        self.sync += uptime_cycles.eq(uptime_cycles + 1)
-        self.sync += If(self._uptime_latch.re, self._uptime_cycles.status.eq(uptime_cycles))
+        self.uptime_cycles = Signal(width, reset_less=True)
+        self.sync += self.uptime_cycles.eq(self.uptime_cycles + 1)
+        self.sync += If(self._uptime_latch.re, self._uptime_cycles.status.eq(self.uptime_cycles))

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1346,7 +1346,7 @@ class LiteXSoC(SoC):
                 base_address = self.bus.regions["main_ram"].origin)
 
     # Add Ethernet ---------------------------------------------------------------------------------
-    def add_ethernet(self, name="ethmac", phy=None, phy_cd="eth", software_debug=False):
+    def add_ethernet(self, name="ethmac", phy=None, phy_cd="eth", software_debug=False, timestamp_source=None):
         # Imports
         from liteeth.mac import LiteEthMAC
 
@@ -1356,7 +1356,9 @@ class LiteXSoC(SoC):
             dw                = 32,
             interface         = "wishbone",
             endianness        = self.cpu.endianness,
-            with_preamble_crc = not software_debug)
+            with_preamble_crc = not software_debug,
+            timestamp_source  = timestamp_source,
+        )
         ethmac = ClockDomainsRenamer({
             "eth_tx": phy_cd + "_tx",
             "eth_rx": phy_cd + "_rx"})(ethmac)


### PR DESCRIPTION
This is a companion PR to https://github.com/enjoy-digital/liteeth/pull/59, which introduces hardware timestamping functionality for RX and TX packets in LiteEth. This is useful for time-critical applications such as IEEE 1588 Precision Time Protocol and Time Sensitive Networking.

This PR
- makes the Timer's `uptime_cycles` signal an accessible member on the Timer class, as it might be a popular timestamp source for the LiteEth MAC
- supports passing a timestamp signal into an SoC's `add_ethernet` method. This makes it possible to wire up a hardware-timestamping ethernet interface in a single method call:

  ```python
  self.add_ethernet(phy=self.ethphy, timestamp_source=self.timer0.uptime_cycles)
  ```