### PR TITLE
litex_sim: fix old name: get_cl_cw -> get_default_cl_cwl

### DIFF
--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -114,7 +114,7 @@ def get_sdram_phy_settings(memtype, data_width, clk_freq):
     elif memtype in ["DDR2", "DDR3"]:
         # Settings from s7ddrphy
         tck             = 2/(2*nphases*clk_freq)
-        cl, cwl         = get_cl_cw(memtype, tck)
+        cl, cwl         = get_default_cl_cwl(memtype, tck)
         cl_sys_latency  = get_sys_latency(nphases, cl)
         cwl_sys_latency = get_sys_latency(nphases, cwl)
         rdphase         = get_sys_phase(nphases, cl_sys_latency, cl)
@@ -124,7 +124,7 @@ def get_sdram_phy_settings(memtype, data_width, clk_freq):
     elif memtype == "DDR4":
         # Settings from usddrphy
         tck             = 2/(2*nphases*clk_freq)
-        cl, cwl         = get_cl_cw(memtype, tck)
+        cl, cwl         = get_default_cl_cwl(memtype, tck)
         cl_sys_latency  = get_sys_latency(nphases, cl)
         cwl_sys_latency = get_sys_latency(nphases, cwl)
         rdphase         = get_sys_phase(nphases, cl_sys_latency, cl)


### PR DESCRIPTION
The old name hasn't been updated to the new one: https://github.com/enjoy-digital/litedram/blob/master/litedram/common.py#L29