### PR TITLE
Add flash method to openFPGALoader class

### DIFF
--- a/litex/build/openfpgaloader.py
+++ b/litex/build/openfpgaloader.py
@@ -15,8 +15,13 @@ class OpenFPGALoader(GenericProgrammer):
     def __init__(self, board):
         self.board = board
 
-    def load_bitstream(self, bitstream_file, flash=False):
+    def load_bitstream(self, bitstream_file):
         cmd = ["openFPGALoader", "--board", self.board, "--bitstream", bitstream_file]
-        if flash:
-            cmd.append("--write-flash")
+        self.call(cmd)
+
+    def flash(self, address, data_file):
+        cmd = ["openFPGALoader", "--board", self.board, "--write-flash", "--bitstream", data_file]
+        if address:
+            cmd.append("--offset")
+            cmd.append(address)
         self.call(cmd)


### PR DESCRIPTION
This is needed to support with generic_programmer usage (needed for linux-on-litex-vexriscv) + add offset/address support for firmware load:
https://github.com/litex-hub/linux-on-litex-vexriscv/issues/189