### PR TITLE
cpu/vexriscv_smp: Make sbt failures fatal

### DIFF
--- a/litex/soc/cores/cpu/vexriscv_smp/core.py
+++ b/litex/soc/cores/cpu/vexriscv_smp/core.py
@@ -206,7 +206,8 @@ class VexRiscvSMP(CPU):
         gen_args.append(f"--netlist-directory={vdir}")
 
         cmd = 'cd {path} && sbt "runMain vexriscv.demo.smp.VexRiscvLitexSmpClusterCmdGen {args}"'.format(path=os.path.join(vdir, "ext", "VexRiscv"), args=" ".join(gen_args))
-        os.system(cmd)
+        if os.system(cmd) != 0:
+            raise OSError('Failed to run sbt')
 
     def __init__(self, platform, variant):
         self.platform         = platform


### PR DESCRIPTION
When using a non-default VexRiscv cluster config, the netlist for that
config needs to be generated.  This requires sbt to be installed.
If sbt is missing, an error message is printed:

    sh: 1: sbt: not found

This message may easily be lost in the noise, as the build continues, and fails
later with:

    ERROR: Can't open input file `litex/pythondata-cpu-vexriscv-smp/pythondata_cpu_vexriscv_smp/verilog/VexRiscvLitexSmpCluster_Cc1_Iw32Is4096Iy1_Dw32Ds4096Dy1_Ood_Wm.v' for reading: No such file or directory

Make the root cause more visible by raising an OSError, and aborting the
build.

Signed-off-by: Geert Uytterhoeven <geert@linux-m68k.org>