### PR TITLE
Fix gtkwave.py to be compatible with python 3.6

### DIFF
--- a/litex/build/sim/gtkwave.py
+++ b/litex/build/sim/gtkwave.py
@@ -96,7 +96,7 @@ class GTKWSave:
         return prefix[:last_underscore + 1]
 
     def group(self,
-            signals: list[Signal],
+            signals: Sequence[Signal],
             group_name: str = None,
             alias: bool = True,
             closed: bool = True,

--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -472,8 +472,6 @@ def main():
         if args.with_analyzer:
             soc.analyzer.export_csv(vns, "analyzer.csv")
         if args.gtkwave_savefile:
-            if sys.version_info[1] < 7:
-                raise OSError("--gtkwave-savefile option only supported for python 3.7+.")
             generate_gtkw_savefile(builder, vns, args.trace_fst)
 
 if __name__ == "__main__":


### PR DESCRIPTION
@enjoy-digital As you mentioned in https://github.com/enjoy-digital/litex/pull/795#issuecomment-771490085 I tested this with the [vermin](https://github.com/netromdk/vermin) tool and it was actually requiring Python 3.9 which seemed weird (I'm using 3.9 so I didn't notice). But it came out that it only required a minimal change to be compatible with older versions. I tested with Python 3.6 and it worked. It should probably also work with Python 3.5, but I haven't tested.