### PR TITLE
RFC -- don't apply -- JTAG support for ECP5 (experimental)

### DIFF
--- a/litex/soc/cores/jtag.py
+++ b/litex/soc/cores/jtag.py
@@ -85,6 +85,41 @@ class USJTAG(XilinxJTAG):
     def __init__(self, *args, **kwargs):
         XilinxJTAG.__init__(self, primitive="BSCANE2", *args, **kwargs)
 
+# ECP5 JTAG ----------------------------------------------------------------------------------------
+
+class ECP5JTAG(Module):
+    def __init__(self):
+        self.reset   = Signal()
+        self.capture = Signal()
+        self.shift   = Signal()
+        self.update  = Signal()
+
+        self.tck = Signal()
+        self.tdi = Signal()
+        self.tdo = Signal()
+
+        jce1 = Signal()
+        jce2 = Signal()
+        rst_n = Signal()
+
+        # # #
+
+        self.comb += self.capture.eq(jce1 | jce2)
+        self.comb += self.reset.eq(~rst_n)
+
+        self.specials += Instance("JTAGG",
+            o_JRSTN   = rst_n,
+            o_JSHIFT  = self.shift,
+            o_JUPDATE = self.update,
+
+            o_JTCK  = self.tck,
+            o_JTDI  = self.tdi,
+            o_JCE1  = jce1,
+            o_JCE2  = jce2,
+            i_JTDO1 = self.tdo,
+            i_JTDO2 = self.tdo,
+        )
+
 # JTAG PHY -----------------------------------------------------------------------------------------
 
 class JTAGPHY(Module):
@@ -123,6 +158,8 @@ class JTAGPHY(Module):
                 jtag = S7JTAG()
             elif device[:4] in ["xcku", "xcvu"]:
                 jtag = USJTAG()
+            elif device[:6] == "LFE5UM":
+                jtag = ECP5JTAG()
             else:
                 raise NotImplementedError
             self.submodules.jtag = jtag


### PR DESCRIPTION
I'm trying to use it with `litex_server_ecp5 --jtag --jtag-config /usr/share/trellis/misc/openocd/trellisboard.cfg` after applying the following openocd patch (thanks @daveshah1):

```
diff --git a/litex/build/openocd.py b/litex/build/openocd.py
index 5f392d31..4f636ee1 100644
--- a/litex/build/openocd.py
+++ b/litex/build/openocd.py
@@ -139,8 +139,8 @@ proc jtagstream_serve {tap port} {
         write_to_file("stream.cfg", cfg)
         script = "; ".join([
             "init",
-            "irscan $_CHIPNAME.tap $_USER1",
-            "jtagstream_serve $_CHIPNAME.tap {:d}".format(port),
+            "irscan ecp5.tap 0x32",
+            "jtagstream_serve ecp5.tap {:d}".format(port),
             "exit",
         ])
         config = self.find_config()
```

I build with

```
litex-boards/litex_boards/targets/trellisboard.py --build \
    --cpu-type rocket --cpu-variant linuxq --sys-clk-freq 50e6 \
    --with-ethernet --with-sdcard --integrated-rom-size 0x10000 \
    --with-analyzer --csr-csv csr.csv
```

after applying [litex-trellisboard-analyzer.patch.txt](https://github.com/enjoy-digital/litex/files/5913527/litex-trellisboard-analyzer.patch.txt) to `targets/trellisboard.py` in `litex-boards`.

I'm probably misusing `JTAGG` in horrible ways due to its behavior being mostly undocumented by Lattice...
