### PR TITLE
doc: Fix doc build with Sphinx v1.x

### DIFF
--- a/litex/soc/doc/__init__.py
+++ b/litex/soc/doc/__init__.py
@@ -28,6 +28,7 @@ offline_skin_js_path = "https://wavedrom.com/skins/default.js"
 offline_wavedrom_js_path = "https://wavedrom.com/WaveDrom.js"
 html_theme = 'alabaster'
 html_static_path = ['_static']
+master_doc = 'index'
 """
 
 def generate_svd(soc, buildpath, filename=None, name="soc", **kwargs):


### PR DESCRIPTION
When building the linux-on-litex-vexriscv documentation with Sphinx
v1.8.5:

    Sphinx error:
    master file linux-on-litex-vexriscv/build/orangecrab/doc/contents.rst not found

The default value of "master_doc" was changed from "contents" to "index"
in Sphinx v2[1].  As the LiteX doc system creates "index.rst", it thus
fails to build with Sphinx v1.x.

Explicitly configure "master_doc" to "index", to make it work with all
versions of Sphinx, regardless of the default.

[1] https://www.sphinx-doc.org/ca/latest/usage/configuration.html?highlight=master_doc

Signed-off-by: Geert Uytterhoeven <geert@linux-m68k.org>