### PR TITLE
build/xilinx/symbiflow: drop IDELAYCTRL if declared without IDELAYE2

### DIFF
--- a/litex/build/xilinx/symbiflow.py
+++ b/litex/build/xilinx/symbiflow.py
@@ -208,9 +208,22 @@ class SymbiflowToolchain:
         platform.finalize(fragment)
 
         # Symbiflow-specific fixes
+        idelayctrl_num = 0
+        idelaye2_num = 0
+        idelayctrl = None
         for instance in fragment.specials:
+            if hasattr(instance, "name_override"):
+                if "IDELAYCTRL" == instance.name_override:
+                    idelayctrl_num += 1
+                    idelayctrl = instance
+                if "IDELAYE2" == instance.name_override:
+                    idelaye2_num += 1
             if isinstance(instance, Instance):
                 self._fix_instance(instance)
+        if idelayctrl_num == 1 and idelaye2_num == 0:
+            # Drop IDELAYCTRL submodule from target because it won't be used
+            # without IDELAYE2 anyways
+            fragment.specials.remove(idelayctrl)
 
         # Generate timing constraints
         self._build_clock_constraints(platform)


### PR DESCRIPTION
Signed-off-by: Jan Kowalewski <jkowalewski@antmicro.com>

In xilinx targets in litex-boards there is the `IDELAYCTRL` declared by default, in SymbiFlow it is assumed that the number of `IDELAYCTRL` and `IDELAYE2` is the same, thus single `IDELAYCTRL` without any `IDELAYE2` results in an error. However according to dcp generated from Vivado, declaring only `IDELAYCTRL` without any corresponding `IDELAYE2` results in dropping the `IDELAYCTRL` (it is not placed). This PR adds dropping functionality when we have a similar situation using SymbiFlow toolchain.