### PR TITLE
build/xilinx/symbiflow: fix bitstream_device select

### DIFF
--- a/litex/build/xilinx/symbiflow.py
+++ b/litex/build/xilinx/symbiflow.py
@@ -116,11 +116,11 @@ class SymbiflowToolchain:
                 raise ValueError(f"symbiflow_device is not specified")
         if not self.bitstream_device:
             try:
-                arch = re.match('xc7a[0-9]*t', platform.device).group(0)
+                # bitstream_device points to a directory in prjxray database
+                # available bitstream_devices: artix7, kintex7, zynq7
                 self.bitstream_device = {
-                    "xc7a35t": "artix7",
-                    "xc7a200t": "artix7_200t"
-                }[arch]
+                    "xc7a": "artix7", # xc7a35t, xc7a50t, xc7a100t, xc7a200t
+                }[platform.device[:4]]
             except KeyError:
                 raise ValueError(f"Unsupported device: {platform.device}")
         # FIXME: prjxray-db doesn't have xc7a35ticsg324-1L - use closest replacement


### PR DESCRIPTION
Signed-off-by: Jan Kowalewski <jkowalewski@antmicro.com>

There was a change that was added mistakenly to xc7a200t support in the other PR. I reverted this change regarding bitstream_device and added a proper comment to avoid such mistake in future.