### PR TITLE
cpu/mor1kx: Add initial SMP support to cpu core

### DIFF
--- a/litex/soc/cores/cpu/mor1kx/core.py
+++ b/litex/soc/cores/cpu/mor1kx/core.py
@@ -15,7 +15,8 @@ from litex import get_data_mod
 from litex.soc.interconnect import wishbone
 from litex.soc.cores.cpu import CPU
 
-CPU_VARIANTS = ["standard", "standard+fpu", "linux", "linux+fpu"]
+CPU_VARIANTS = ["standard", "standard+fpu", "linux", "linux+fpu",
+                "linux+smp", "linux+smp+fpu"]
 
 
 class MOR1KX(CPU):
@@ -112,6 +113,11 @@ class MOR1KX(CPU):
             p_IBUS_WB_TYPE              = "B3_REGISTERED_FEEDBACK",
             p_DBUS_WB_TYPE              = "B3_REGISTERED_FEEDBACK",
         )
+
+        if "smp" in variant:
+           cpu_args.update(
+               p_OPTION_RF_NUM_SHADOW_GPR = 1,
+           )
 
         if "fpu" in variant:
             cpu_args.update(


### PR DESCRIPTION
In order for mor1kx to run an SMP kernel shadow registers must be
enabled.  This patch adds two new variants:

 - linux+smp - basic linux + smp support
 - linux+smp+fpu - linux with FPU and smp support