### PR TITLE
software/bios: add option to disable BIOS prompt

### DIFF
--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -91,6 +91,7 @@ int main(int i, char **c)
 	uart_init();
 #endif
 
+#ifndef CONFIG_SIM_DISABLE_BIOS_PROMPT
 	printf("\n");
 	printf("\e[1m        __   _ __      _  __\e[0m\n");
 	printf("\e[1m       / /  (_) /____ | |/_/\e[0m\n");
@@ -140,6 +141,7 @@ int main(int i, char **c)
 #endif
 #endif
 	printf("\n");
+#endif // CONFIG_SIM_DISABLE_BIOS_PROMPT
 
         sdr_ok = 1;
 


### PR DESCRIPTION
This allows to avoid a lot of unnecessary printing when running a Verilator simulation, saving a lot of time. It also omits the `crcbios()` check, which also seems unnecessary for simulation. It is useful for LPDDR4 simulation: https://github.com/antmicro/litedram/blob/9cb698360dc7f83f83a12eb64bed529d8802f973/litedram/phy/lpddr4/simsoc.py#L171