### PR TITLE
Change wording of demo README

### DIFF
--- a/litex/soc/software/demo/README.md
+++ b/litex/soc/software/demo/README.md
@@ -6,8 +6,10 @@ This directory provides a minimal bare metal demo app that demonstrates how to e
 [> Build
 --------
 
-Imagine you just build the Arty example design from LiteX-Boards, to build the demo app, run:
- `$ litex_bare_metal_demo --build-path=build/arty/`
+Imagine you just built the Arty example design from LiteX-Boards. Build the demo app as follows; where the build path is the path to the your previously built Arty build directory:
+```
+litex_bare_metal_demo --build-path=build/arty/
+```
 
 [> Load
 -------


### PR DESCRIPTION
Change wording of demo README to make it more clear what the process is
and how things related.  This should help the newcomer and it still
usefull for the triained.

Change the command example to be more copy paste friendly.

Fixes #814