### PR TITLE
software/demo: Drop bogus "the" in README

### DIFF
--- a/litex/soc/software/demo/README.md
+++ b/litex/soc/software/demo/README.md
@@ -6,7 +6,7 @@ This directory provides a minimal bare metal demo app that demonstrates how to e
 [> Build
 --------
 
-Imagine you just built the Arty example design from LiteX-Boards. Build the demo app as follows; where the build path is the path to the your previously built Arty build directory:
+Imagine you just built the Arty example design from LiteX-Boards. Build the demo app as follows; where the build path is the path to your previously built Arty build directory:
 ```
 litex_bare_metal_demo --build-path=build/arty/
 ```


### PR DESCRIPTION
Fixes: e7e28f2438c2b933 ("Change wording of demo README")
Signed-off-by: Geert Uytterhoeven <geert@linux-m68k.org>