### PR TITLE
Vexriscv "lite" uses "--mulDiv true", so enable "mul" instructions.

### DIFF
--- a/litex/soc/cores/cpu/vexriscv/core.py
+++ b/litex/soc/cores/cpu/vexriscv/core.py
@@ -49,8 +49,8 @@ GCC_FLAGS = {
     #                               imacfd
     "minimal":          "-march=rv32i      -mabi=ilp32",
     "minimal+debug":    "-march=rv32i      -mabi=ilp32",
-    "lite":             "-march=rv32i      -mabi=ilp32",
-    "lite+debug":       "-march=rv32i      -mabi=ilp32",
+    "lite":             "-march=rv32im     -mabi=ilp32",
+    "lite+debug":       "-march=rv32im     -mabi=ilp32",
     "standard":         "-march=rv32im     -mabi=ilp32",
     "standard+debug":   "-march=rv32im     -mabi=ilp32",
     "imac":             "-march=rv32imac   -mabi=ilp32",


### PR DESCRIPTION
This is the Makefile that builds VexRiscv_Lite.v:   
https://github.com/litex-hub/pythondata-cpu-vexriscv/blob/master/pythondata_cpu_vexriscv/verilog/Makefile#L11

`--mulDiv true` is specified, so the "Lite" CPU supports the "m" extension.  Same with "LiteDebug".

We will pick up some free performance by enabling the compiler to generate "mul" instructions.

Signed-off-by: Tim Callahan <tcal@google.com>