### PR TITLE
fixes for boot and (single-block, cmd17-only) Linux driver

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1480,7 +1480,7 @@ class LiteXSoC(SoC):
             sdcard_pads = self.platform.request(name)
 
         # Core
-        self.submodules.sdphy  = SDPHY(sdcard_pads, self.platform.device, self.clk_freq)
+        self.submodules.sdphy  = SDPHY(sdcard_pads, self.platform.device, self.clk_freq, cmd_timeout=10e-1, data_timeout=10e-1)
         self.submodules.sdcore = SDCore(self.sdphy)
         self.csr.add("sdphy", use_loc_if_exists=True)
         self.csr.add("sdcore", use_loc_if_exists=True)

--- a/litex/soc/software/liblitesdcard/sdcard.c
+++ b/litex/soc/software/liblitesdcard/sdcard.c
@@ -106,6 +106,7 @@ void sdcard_set_clk_freq(uint32_t clk_freq, int show) {
 	uint32_t divider;
 	divider = clk_freq ? CONFIG_CLOCK_FREQUENCY/clk_freq : 256;
 	divider = pow2_round_up(divider);
+	divider <<= 1; /* NOTE: workaround for occasional sdcardboot failure */
 	divider = min(max(divider, 2), 256);
 #ifdef SDCARD_DEBUG
 	show = 1;


### PR DESCRIPTION
With the current sdcard clocking, when building a rocket-litex system at exactly 50 MHz, when 12.5 or 25 MHz are requested, it is possible to obtain those frequencies by using an exact power-of-two divisor for the sdclock (4 and 2, respectively). However, when driven at the full 25 MHz during `sdcardboot`, data transfer from the sdcard hangs. The first patch adds an additional halving of the sdclock frequency to ensure the sdclock frequency is never ***too*** fast for `sdcardboot`.

The second patch allows the current single-block-at-a-time (cmd17-only) Linux driver to avoid running into command timeouts when e.g., `dd`-ing a large file to `/dev/null` from the mounted sdcard. This doesn't help enable multi-block (cmd18) transfers without timeouts, but I will open a separate issue to keep track of those debugging efforts.