### PR TITLE
build/xilinx/vivado.py: Allow a tcl script to be added as ip

### DIFF
--- a/litex/build/xilinx/vivado.py
+++ b/litex/build/xilinx/vivado.py
@@ -171,15 +171,18 @@ class XilinxVivadoToolchain:
         # Add IPs
         tcl.append("\n# Add IPs\n")
         for filename, disable_constraints in platform.ips.items():
-            filename_tcl = "{" + filename + "}"
-            ip = os.path.splitext(os.path.basename(filename))[0]
-            tcl.append("read_ip " + filename_tcl)
-            tcl.append("upgrade_ip [get_ips {}]".format(ip))
-            tcl.append("generate_target all [get_ips {}]".format(ip))
-            tcl.append("synth_ip [get_ips {}] -force".format(ip))
-            tcl.append("get_files -all -of_objects [get_files {}]".format(filename_tcl))
-            if disable_constraints:
-                tcl.append("set_property is_enabled false [get_files -of_objects [get_files {}] -filter {{FILE_TYPE == XDC}}]".format(filename_tcl))
+            if filename.endswith("tcl"):
+                tcl += open(filename, "r").read().splitlines()
+            else:
+                filename_tcl = "{" + filename + "}"
+                ip = os.path.splitext(os.path.basename(filename))[0]
+                tcl.append("read_ip " + filename_tcl)
+                tcl.append("upgrade_ip [get_ips {}]".format(ip))
+                tcl.append("generate_target all [get_ips {}]".format(ip))
+                tcl.append("synth_ip [get_ips {}] -force".format(ip))
+                tcl.append("get_files -all -of_objects [get_files {}]".format(filename_tcl))
+                if disable_constraints:
+                    tcl.append("set_property is_enabled false [get_files -of_objects [get_files {}] -filter {{FILE_TYPE== XDC}}]".format(filename_tcl))
 
         # Add constraints
         tcl.append("\n# Add constraints\n")


### PR DESCRIPTION
These tcl scripts tend to generate .xci's on the fly. The tcl script is typcially a set of commands from vivado ip generation software (found in vivado.jou, or the vivado console).

Perhaps should be made available upstream to (n)-migen at some point.