### PR TITLE
soc/integration/export Add constants to SVD export

### DIFF
--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -463,8 +463,9 @@ def get_csr_svd(soc, vendor="litex", name="soc", description=None):
             svd.append('            </interrupt>')
         svd.append('        </peripheral>')
     svd.append('    </peripherals>')
+    svd.append('    <vendorExtensions>')
+
     if len(soc.mem_regions) > 0:
-        svd.append('    <vendorExtensions>')
         svd.append('        <memoryRegions>')
         for region_name, region in soc.mem_regions.items():
             svd.append('            <memoryRegion>')
@@ -473,7 +474,13 @@ def get_csr_svd(soc, vendor="litex", name="soc", description=None):
             svd.append('                <size>0x{:08X}</size>'.format(region.size))
             svd.append('            </memoryRegion>')
         svd.append('        </memoryRegions>')
-        svd.append('    </vendorExtensions>')
+
+    svd.append('        <constants>')
+    for name, value in soc.constants.items():
+        svd.append('            <constant name="{}" value="{}" />'.format(name, value))
+    svd.append('        </constants>')
+
+    svd.append('    </vendorExtensions>')
     svd.append('</device>')
     return "\n".join(svd)
 


### PR DESCRIPTION
Currently both the json and csv exports contain the soc constants, but the svd export does not. When you need this information it currently means you have to export to multiple formats (as svd also contains e.g. register fields, which are not found in the other formats), which is a slight inconvenience.

This patch adds a ```<constants>``` section to the ```<vendorExtensions>``` svd element. For my current board, this results in the following export:

```xml
            <!-- ... -->
            <!-- Same as before -->
        </memoryRegions>
        <constants>
            <constant name="CONFIG_CLOCK_FREQUENCY" value="50000000" />
            <constant name="CONFIG_CPU_HAS_INTERRUPT" value="None" />
            <constant name="CONFIG_CPU_RESET_ADDR" value="0" />
            <constant name="CONFIG_CPU_TYPE_VEXRISCV" value="None" />
            <constant name="CONFIG_CPU_VARIANT_FULL" value="None" />
            <constant name="CONFIG_CPU_HUMAN_NAME" value="VexRiscv_Full" />
            <constant name="CONFIG_CPU_NOP" value="nop" />
            <constant name="CONFIG_WITH_BUILD_TIME" value="None" />
            <constant name="CONFIG_L2_SIZE" value="8192" />
            <constant name="CONFIG_CSR_DATA_WIDTH" value="8" />
            <constant name="CONFIG_CSR_ALIGNMENT" value="32" />
            <constant name="CONFIG_BUS_STANDARD" value="WISHBONE" />
            <constant name="CONFIG_BUS_DATA_WIDTH" value="32" />
            <constant name="CONFIG_BUS_ADDRESS_WIDTH" value="32" />
            <constant name="TIMER0_INTERRUPT" value="1" />
            <constant name="UART_INTERRUPT" value="0" />
        </constants>
    </vendorExtensions>
</device>
```