### PR TITLE
builder.py: Add -j 4 to make command

### DIFF
--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -187,7 +187,7 @@ class Builder:
                 dst_dir = os.path.join(self.software_dir, name)
                 makefile = os.path.join(src_dir, "Makefile")
                 if self.compile_software:
-                    subprocess.check_call(["make", "-C", dst_dir, "-f", makefile])
+                    subprocess.check_call(["make", "-j", "4", "-C", dst_dir, "-f", makefile])
 
     def _initialize_rom_software(self):
         bios_file = os.path.join(self.software_dir, "bios", "bios.bin")


### PR DESCRIPTION
Execute make with -j 4, causing it to execute up to 4 compilations
concurrently. The decrease in build times is significant in cases where
no synthesis is required, such as when building a verilator simulation.

4 concurrent jobs was chosen as a conservative setting even for slightly
older machines.