### PR TITLE
Add support for xcompiler on Alpine 3.13

### DIFF
--- a/litex/soc/cores/cpu/__init__.py
+++ b/litex/soc/cores/cpu/__init__.py
@@ -44,6 +44,7 @@ CPU_GCC_TRIPLE_RISCV32 = (
     "riscv64-elf",
     "riscv32-elf",
     "riscv-none-embed",
+    "riscv-none-elf",
     "riscv64-linux",
     "riscv64-linux-gnu",
     "riscv-sifive-elf",


### PR DESCRIPTION
Problem: xcompiler on Alpine 3.13 was not found 

Solution is to add "riscv-none-elf-gcc":

1. Add Edge to your repositories:
$ echo -e "http://dl-cdn.alpinelinux.org/alpine/edge/main\nhttp://dl-cdn.alpinelinux.org/alpine/edge/testing\nhttp://dl-cdn.alpine
linux.org/alpine/edge/community" >> /etc/apk/repositories
$ apk update
$ apk add gcc-riscv-none-elf
2. The xcompiler should be found at:
$ which riscv-none-elf-gcc
/usr/bin/riscv-none-elf-gcc