### PR TITLE
litespi: fix cs handling for bulk transfers

### DIFF
--- a/test/test_spi.py
+++ b/test/test_spi.py
@@ -69,12 +69,14 @@ class TestSPI(unittest.TestCase):
                 yield
             yield dut.master.mosi.eq(0xdeadbeef)
             yield dut.master.length.eq(32)
+            yield dut.master.cs.eq(1)
             yield dut.master.start.eq(1)
             yield
             yield dut.master.start.eq(0)
             yield
             while (yield dut.master.done) == 0:
                 yield
+            yield dut.master.cs.eq(0)
             yield
             self.assertEqual(hex((yield dut.master.miso)), hex(0x12345678))
 


### PR DESCRIPTION
For bulk transfers it is essential to keep cs asserted for all
transfers in a block. CS register must directly drive the cs pin
for the software to be able to control the CS pin.

Linux driver related changes are in https://github.com/litex-hub/linux/pull/4.