### PR TITLE
json2dts.py: fix mac0 reg property style for consistency

### DIFF
--- a/litex/tools/litex_json2dts.py
+++ b/litex/tools/litex_json2dts.py
@@ -198,9 +198,10 @@ def generate_dts(d, initrd_start=None, initrd_size=None, polling=False):
         dts += """
             mac0: mac@{ethmac_csr_base:x} {{
                 compatible = "litex,liteeth";
-                reg = <0x{ethmac_csr_base:x} 0x7c>,
-                      <0x{ethphy_csr_base:x} 0x0a>,
-                      <0x{ethmac_mem_base:x} 0x{ethmac_mem_size:x}>;
+                reg = <
+                    0x{ethmac_csr_base:x} 0x7c
+                    0x{ethphy_csr_base:x} 0x0a
+                    0x{ethmac_mem_base:x} 0x{ethmac_mem_size:x}>;
                 tx-fifo-depth = <{ethmac_tx_slots}>;
                 rx-fifo-depth = <{ethmac_rx_slots}>;
                 {ethmac_interrupt}


### PR DESCRIPTION
Assuming "#[address|size]-cells = <1>", both of the following are
equivalent:

	reg = <start1 size1>, <start2 size2>, ..., <startN sizeN>;

	reg = <start1 size1 start2 size2 ... startN sizeN>;

The second form appears more widely used and popular, including in
the output of json2dts.py, with the exception of the mac0 node, which
uses the first form. This patch makes output generated for mac0
consistent with that for other DT nodes.