### PR TITLE
add the following modification

### DIFF
--- a/litex/soc/cores/video.py
+++ b/litex/soc/cores/video.py
@@ -112,6 +112,17 @@ video_timings = {
         "v_sync_offset" : 4,
         "v_sync_width"  : 5,
     },
+    "1024x600@60Hz": {
+        "pix_clk"        : 49e6,
+        "h_active"       : 1024,
+        "h_blanking"     : 288,
+        "h_sync_offset"  : 270,
+        "h_sync_width"   : 13,
+        "v_active"       : 600,
+        "v_blanking"     : 22,
+        "v_sync_offset"  : 17,
+        "v_sync_width"   : 3,
+    },
 }
 
 # Video Timing Generator ---------------------------------------------------------------------------

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1701,7 +1701,7 @@ class LiteXSoC(SoC):
         self.comb += vt.source.connect(phy.sink)
 
     # Add Video Framebuffer ------------------------------------------------------------------------
-    def add_video_framebuffer(self, name="video_framebuffer", phy=None, timings="800x600@60Hz", clock_domain="sys"):
+    def add_video_framebuffer(self, name="video_framebuffer", base=0x4f000000, phy=None, timings="800x600@60Hz", clock_domain="sys"):
         # Imports.
         from litex.soc.cores.video import VideoTimingGenerator, VideoFrameBuffer
 
@@ -1711,7 +1711,7 @@ class LiteXSoC(SoC):
         setattr(self.submodules, f"{name}_vtg", vtg)
 
         # Video FrameBuffer.
-        base = self.mem_map.get(name, 0x40c00000)
+        base = self.mem_map.get(name, base)
         hres = int(timings.split("@")[0].split("x")[0])
         vres = int(timings.split("@")[0].split("x")[1])
         vfb = VideoFrameBuffer(self.sdram.crossbar.get_port(),

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -167,10 +167,15 @@ int main(int i, char **c)
 
 #ifdef CSR_VIDEO_FRAMEBUFFER_BASE
 	/* Initialize Video Framebuffer FIXME: Move */
+	unsigned char *fb_ptr = NULL;
+	unsigned int fb_len = 0;
 	video_framebuffer_vtg_enable_write(0);
 	video_framebuffer_dma_enable_write(0);
 	video_framebuffer_vtg_enable_write(1);
 	video_framebuffer_dma_enable_write(1);
+	fb_ptr = (unsigned char *)VIDEO_FRAMEBUFFER_BASE;
+	fb_len = VIDEO_FRAMEBUFFER_HRES * VIDEO_FRAMEBUFFER_VRES * 4;
+	memset(fb_ptr, 0x00, fb_len);
 #endif
 
 	if(sdr_ok) {

--- a/litex/tools/litex_json2dts.py
+++ b/litex/tools/litex_json2dts.py
@@ -379,7 +379,7 @@ def generate_dts(d, initrd_start=None, initrd_size=None, polling=False):
         framebuffer_width  = d["constants"]["video_framebuffer_hres"]
         framebuffer_height = d["constants"]["video_framebuffer_vres"]
         dts += """
-            framebuffer0: framebuffer@f0000000 {{
+            framebuffer0: framebuffer@{framebuffer_base:x} {{
                 compatible = "simple-framebuffer";
                 reg = <0x{framebuffer_base:x} 0x{framebuffer_size:x}>;
                 width = <{framebuffer_width}>;


### PR DESCRIPTION
Dear Sir:

I had done the following modification.
1. add wave share 7" hdmi lcd monitor video setting in litex/soc/cores/video.py.
2. add video framebuffer memory base in add_video_framebuffer() to make config easier in litex/soc/integration/soc.py.
3. add video framebuffer memory clear code in main() in litex/soc/software/bios/main.c.
4. add simple progress indication during sd card boot flow in init_progression_bar() / show_progress() in litex/soc/software/libbase/progress.c.
5. change fixed video framebuffer memory base to the base of add_video_framebuffer() in litex/tools/litex_json2dts.py.

If it is ok, please add these modification. Many Thanks.

BR, Sanada