### PR TITLE
Remove implicit dependency of LiteX BIOS on LiteX timer peripheral

### DIFF
--- a/litex/soc/cores/cpu/microwatt/irq.h
+++ b/litex/soc/cores/cpu/microwatt/irq.h
@@ -12,6 +12,8 @@ extern "C" {
 #include <generated/soc.h>
 #include <generated/mem.h>
 
+#include <ppc/ppc64_asm.h>
+
 #ifdef CONFIG_CPU_HAS_INTERRUPT
 
 // Address of exception / IRQ handler routine
@@ -63,30 +65,6 @@ static inline uint32_t xics_ics_read_xive(int irq_number)
 static inline void xics_ics_write_xive(int irq_number, uint32_t priority)
 {
 	*((uint32_t*)(XICSICS_BASE + 0x800 + (irq_number << 2))) = bswap32(priority);
-}
-
-static inline void mtmsrd(uint64_t val)
-{
-	__asm__ volatile("mtmsrd %0" : : "r" (val) : "memory");
-}
-
-static inline uint64_t mfmsr(void)
-{
-	uint64_t rval;
-	__asm__ volatile("mfmsr %0" : "=r" (rval) : : "memory");
-	return rval;
-}
-
-static inline void mtdec(uint64_t val)
-{
-	__asm__ volatile("mtdec %0" : : "r" (val) : "memory");
-}
-
-static inline uint64_t mfdec(void)
-{
-	uint64_t rval;
-	__asm__ volatile("mfdec %0" : "=r" (rval) : : "memory");
-	return rval;
 }
 
 static inline unsigned int irq_getie(void)

--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -14,6 +14,7 @@
 # This file is Copyright (c) 2015 whitequark <whitequark@whitequark.org>
 # This file is Copyright (c) 2018 William D. Jones <thor0505@comcast.net>
 # This file is Copyright (c) 2020 Piotr Esden-Tempski <piotr@esden.net>
+# This file is Copyright (c) 2021 Raptor Engineering, LLC <sales@raptorengineering.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
 import os
@@ -88,6 +89,7 @@ def get_cpu_mak(cpu, compile_software):
 
     # return informations
     return [
+        ("ARCHITECTURE", select_triple(triple).split("-")[0]),
         ("TRIPLE", select_triple(triple)),
         ("CPU", cpu.name),
         ("CPUFLAGS", flags),

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -16,6 +16,7 @@
 #include <crc.h>
 #include <string.h>
 #include <irq.h>
+#include <lxtimer.h>
 
 #include <generated/mem.h>
 #include <generated/csr.h>
@@ -106,17 +107,17 @@ static int check_ack(void)
 	int recognized;
 	static const char str[SFL_MAGIC_LEN] = SFL_MAGIC_ACK;
 
-	timer0_en_write(0);
-	timer0_reload_write(0);
+	lxtimer_en_write(0);
+	lxtimer_reload_write(0);
 #ifndef CONFIG_DISABLE_DELAYS
-	timer0_load_write(CONFIG_CLOCK_FREQUENCY/4);
+	lxtimer_load_write(CONFIG_CLOCK_FREQUENCY/4);
 #else
-	timer0_load_write(0);
+	lxtimer_load_write(0);
 #endif
-	timer0_en_write(1);
-	timer0_update_value_write(1);
+	lxtimer_en_write(1);
+	lxtimer_update_value_write(1);
 	recognized = 0;
-	while(timer0_value_read()) {
+	while(lxtimer_value_read()) {
 		if(uart_read_nonblock()) {
 			char c;
 			c = uart_read();
@@ -133,7 +134,7 @@ static int check_ack(void)
 					recognized = 0;
 			}
 		}
-		timer0_update_value_write(1);
+		lxtimer_update_value_write(1);
 	}
 	return ACK_TIMEOUT;
 }

--- a/litex/soc/software/bios/cmds/cmd_bios.c
+++ b/litex/soc/software/bios/cmds/cmd_bios.c
@@ -67,8 +67,8 @@ static void uptime_handler(int nb_params, char **params)
 {
 	unsigned long uptime;
 
-	timer0_uptime_latch_write(1);
-	uptime = timer0_uptime_cycles_read();
+	lxtimer_uptime_latch_write(1);
+	uptime = lxtimer_uptime_cycles_read();
 	printf("Uptime: %ld sys_clk cycles / %ld seconds",
 		uptime,
 		uptime/CONFIG_CLOCK_FREQUENCY

--- a/litex/soc/software/bios/isr.c
+++ b/litex/soc/software/bios/isr.c
@@ -6,11 +6,16 @@
 
 #include <generated/csr.h>
 #include <generated/soc.h>
+#include <lxtimer.h>
 #include <irq.h>
 #include <uart.h>
 #include <stdio.h>
 
-#if defined(__microwatt__)
+#if defined(__PPC64__)
+#ifdef _PPCTIME_H_
+#define USE_DEC_AS_TIMER0 1
+#endif
+
 void isr(uint64_t vec);
 void isr_dec(void);
 #else
@@ -138,11 +143,18 @@ void isr(uint64_t vec)
 	}
 }
 
+#if (USE_DEC_AS_TIMER0)
+void isr_dec(void)
+{
+	ppc_arch_timer_isr_dec();
+}
+#else
 void isr_dec(void)
 {
 	//  For now, just set DEC back to a large enough value to slow the flood of DEC-initiated timer interrupts
 	mtdec(0x000000000ffffff);
 }
+#endif
 
 #else
 void isr(void)

--- a/litex/soc/software/include/base/lxtimer.h
+++ b/litex/soc/software/include/base/lxtimer.h
@@ -1,0 +1,47 @@
+/*
+ * LiteX timer abstraction layer
+ * Copyright (C) 2021 Raptor Engineering, LLC <sales@raptorengineering.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _LXTIMER_H_
+#define _LXTIMER_H_
+
+#include <generated/csr.h>
+
+static inline void lxtimer_load_write(uint32_t v) {
+	timer0_load_write(v);
+}
+
+static inline void lxtimer_reload_write(uint32_t v) {
+	timer0_reload_write(v);
+}
+
+static inline uint32_t lxtimer_reload_read(void) {
+	return timer0_reload_read();
+}
+
+static inline void lxtimer_en_write(uint8_t v) {
+	timer0_en_write(v);
+}
+
+static inline void lxtimer_update_value_write(uint8_t v) {
+	timer0_update_value_write(v);
+}
+
+static inline uint32_t lxtimer_value_read(void) {
+	return timer0_value_read();
+}
+
+#endif // _LXTIMER_H_

--- a/litex/soc/software/include/base/lxtimer.h
+++ b/litex/soc/software/include/base/lxtimer.h
@@ -18,6 +18,35 @@
 #ifndef _LXTIMER_H_
 #define _LXTIMER_H_
 
+#ifdef __PPC64__
+
+#include <ppc/timer.h>
+
+static inline void lxtimer_load_write(uint32_t v) {
+	ppc_arch_timer_load_write(v);
+}
+
+static inline void lxtimer_reload_write(uint32_t v) {
+	ppc_arch_timer_reload_write(v);
+}
+
+static inline uint32_t lxtimer_reload_read(void) {
+	return ppc_arch_timer_reload_read();
+}
+
+static inline void lxtimer_en_write(uint8_t v) {
+	ppc_arch_timer_en_write(v);
+}
+
+static inline void lxtimer_update_value_write(uint8_t v) {
+	ppc_arch_timer_update_value_write(v);
+}
+
+static inline uint32_t lxtimer_value_read(void) {
+	return ppc_arch_timer_value_read();
+}
+#else
+
 #include <generated/csr.h>
 
 static inline void lxtimer_load_write(uint32_t v) {
@@ -43,5 +72,6 @@ static inline void lxtimer_update_value_write(uint8_t v) {
 static inline uint32_t lxtimer_value_read(void) {
 	return timer0_value_read();
 }
+#endif
 
 #endif // _LXTIMER_H_

--- a/litex/soc/software/include/base/ppc/ppc64_asm.h
+++ b/litex/soc/software/include/base/ppc/ppc64_asm.h
@@ -1,0 +1,47 @@
+/*
+ * OpenPOWER Common Assembly Interfaces
+ * Copyright (C) 2021 Raptor Engineering, LLC <sales@raptorengineering.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _PPC64_ASM_H_
+#define _PPC64_ASM_H_
+
+#include <stdint.h>
+
+static inline void mtmsrd(uint64_t val)
+{
+	__asm__ volatile("mtmsrd %0" : : "r" (val) : "memory");
+}
+
+static inline uint64_t mfmsr(void)
+{
+	uint64_t rval;
+	__asm__ volatile("mfmsr %0" : "=r" (rval) : : "memory");
+	return rval;
+}
+
+static inline void mtdec(uint64_t val)
+{
+	__asm__ volatile("mtdec %0" : : "r" (val) : "memory");
+}
+
+static inline uint64_t mfdec(void)
+{
+	uint64_t rval;
+	__asm__ volatile("mfdec %0" : "=r" (rval) : : "memory");
+	return rval;
+}
+
+#endif // _PPC64_ASM_H_

--- a/litex/soc/software/include/base/ppc/timer.h
+++ b/litex/soc/software/include/base/ppc/timer.h
@@ -1,0 +1,33 @@
+/*
+ * OpenPOWER Timer Interface
+ * Copyright (C) 2021 Raptor Engineering, LLC <sales@raptorengineering.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _PPCTIME_H_
+#define _PPCTIME_H_
+
+#include <stdint.h>
+#include <ppc/ppc64_asm.h>
+
+void ppc_arch_timer_load_write(uint32_t v);
+void ppc_arch_timer_reload_write(uint32_t v);
+uint32_t ppc_arch_timer_reload_read(void);
+void ppc_arch_timer_en_write(uint8_t v);
+void ppc_arch_timer_update_value_write(uint8_t v);
+uint32_t ppc_arch_timer_value_read(void);
+
+void ppc_arch_timer_isr_dec(void);
+
+#endif // _PPCTIME_H_

--- a/litex/soc/software/include/base/ppctime.h
+++ b/litex/soc/software/include/base/ppctime.h
@@ -1,0 +1,96 @@
+/*
+ * OpenPOWER Timer Interface
+ * Copyright (C) 2021 Raptor Engineering, LLC <sales@raptorengineering.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _PPCTIME_H_
+#define _PPCTIME_H_
+
+#include <stdint.h>
+#include <ppc64_asm.h>
+
+extern uint32_t ppc64_dec_timer_enabled;
+extern uint32_t ppc64_dec_timer_single_shot_fired;
+extern uint32_t ppc64_dec_timer_reload_enabled;
+extern uint32_t ppc64_dec_timer_oneshot_value;
+extern uint32_t ppc64_dec_timer_reload_value;
+extern uint32_t ppc64_dec_timer_latched_value;
+
+static inline void ppc_arch_timer_load_write(uint32_t v) {
+	ppc64_dec_timer_reload_enabled = 0;
+	ppc64_dec_timer_oneshot_value = v;
+	if (v) {
+		ppc64_dec_timer_single_shot_fired = 0;
+	}
+}
+
+static inline void ppc_arch_timer_reload_write(uint32_t v) {
+	if (v) {
+		ppc64_dec_timer_reload_enabled = 1;
+		ppc64_dec_timer_reload_value = v;
+	}
+	else {
+		ppc64_dec_timer_reload_enabled = 0;
+	}
+}
+
+static inline uint32_t ppc_arch_timer_reload_read(void) {
+	return ppc64_dec_timer_reload_value;
+}
+
+static inline void ppc_arch_timer_en_write(uint8_t v) {
+	if (v) {
+		ppc64_dec_timer_enabled = 1;
+		if (ppc64_dec_timer_reload_enabled) {
+			mtdec(ppc64_dec_timer_reload_value);
+		}
+		else {
+			mtdec(ppc64_dec_timer_oneshot_value);
+		}
+	}
+	else {
+		ppc64_dec_timer_enabled = 0;
+	}
+}
+
+static inline void ppc_arch_timer_update_value_write(uint8_t v) {
+	ppc64_dec_timer_latched_value = mfdec();
+}
+
+static inline uint32_t ppc_arch_timer_value_read(void) {
+	int64_t value = mfdec();
+	if ((value < 0) || (ppc64_dec_timer_single_shot_fired)) {
+		// Overflow -- the timer expired and is now counting upward from negative values
+		value = 0;
+	}
+
+	if (ppc64_dec_timer_enabled) {
+		if (value == 0) {
+			if (ppc64_dec_timer_reload_enabled) {
+				// Reload timer
+				mtdec(ppc64_dec_timer_reload_value);
+			}
+			else {
+				// Lock timer value at zero
+				mtdec(0);
+				ppc64_dec_timer_single_shot_fired = 1;
+			}
+		}
+	}
+
+	return value;
+}
+
+#endif // _PPCTIME_H_

--- a/litex/soc/software/libbase/Makefile
+++ b/litex/soc/software/libbase/Makefile
@@ -21,6 +21,11 @@ OBJECTS = exception.o \
 	memtest.o         \
 	sim_debug.o
 
+
+ifeq ($(ARCHITECTURE),powerpc64le)
+	OBJECTS += arch_ppc_timer.o
+endif
+
 all: crt0.o libbase.a libbase-nofloat.a
 
 libbase.a: $(OBJECTS) vsnprintf.o

--- a/litex/soc/software/libbase/memtest.c
+++ b/litex/soc/software/libbase/memtest.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <lfsr.h>
 #include <system.h>
+#include <lxtimer.h>
 
 #include <generated/soc.h>
 #include <generated/csr.h>
@@ -229,20 +230,20 @@ void memspeed(unsigned int *addr, unsigned long size, bool read_only)
 	printf(")...\n");
 
 	/* Init timer */
-	timer0_en_write(0);
-	timer0_reload_write(0);
-	timer0_load_write(0xffffffff);
-	timer0_en_write(1);
+	lxtimer_en_write(0);
+	lxtimer_reload_write(0);
+	lxtimer_load_write(0xffffffff);
+	lxtimer_en_write(1);
 
 	/* Measure Write speed */
 	if (!read_only) {
-		timer0_update_value_write(1);
-		start = timer0_value_read();
+		lxtimer_update_value_write(1);
+		start = lxtimer_value_read();
 		for(i = 0; i < size/sz; i++) {
 			array[i] = -1ul;
 		}
-		timer0_update_value_write(1);
-		end = timer0_value_read();
+		lxtimer_update_value_write(1);
+		end = lxtimer_value_read();
 		uint64_t numerator   = ((uint64_t)size)*((uint64_t)CONFIG_CLOCK_FREQUENCY);
 		uint64_t denominator = ((uint64_t)start - (uint64_t)end);
 		write_speed = numerator/denominator;
@@ -256,14 +257,14 @@ void memspeed(unsigned int *addr, unsigned long size, bool read_only)
 	flush_l2_cache();
 
 	/* Measure Read speed */
-	timer0_en_write(1);
-	timer0_update_value_write(1);
-	start = timer0_value_read();
+	lxtimer_en_write(1);
+	lxtimer_update_value_write(1);
+	start = lxtimer_value_read();
 	for(i = 0; i < size/sz; i++) {
 		data = array[i];
 	}
-	timer0_update_value_write(1);
-	end = timer0_value_read();
+	lxtimer_update_value_write(1);
+	end = lxtimer_value_read();
 	uint64_t numerator   = ((uint64_t)size)*((uint64_t)CONFIG_CLOCK_FREQUENCY);
 	uint64_t denominator = ((uint64_t)start - (uint64_t)end);
 	read_speed = numerator/denominator;

--- a/litex/soc/software/libbase/system.c
+++ b/litex/soc/software/libbase/system.c
@@ -2,6 +2,7 @@
 #include <uart.h>
 
 #include <system.h>
+#include <lxtimer.h>
 #include <generated/mem.h>
 #include <generated/csr.h>
 
@@ -17,20 +18,20 @@ void flush_l2_cache(void)
 
 void busy_wait(unsigned int ms)
 {
-	timer0_en_write(0);
-	timer0_reload_write(0);
-	timer0_load_write(CONFIG_CLOCK_FREQUENCY/1000*ms);
-	timer0_en_write(1);
-	timer0_update_value_write(1);
-	while(timer0_value_read()) timer0_update_value_write(1);
+	lxtimer_en_write(0);
+	lxtimer_reload_write(0);
+	lxtimer_load_write(CONFIG_CLOCK_FREQUENCY/1000*ms);
+	lxtimer_en_write(1);
+	lxtimer_update_value_write(1);
+	while(lxtimer_value_read()) lxtimer_update_value_write(1);
 }
 
 void busy_wait_us(unsigned int us)
 {
-	timer0_en_write(0);
-	timer0_reload_write(0);
-	timer0_load_write(CONFIG_CLOCK_FREQUENCY/1000000*us);
-	timer0_en_write(1);
-	timer0_update_value_write(1);
-	while(timer0_value_read()) timer0_update_value_write(1);
+	lxtimer_en_write(0);
+	lxtimer_reload_write(0);
+	lxtimer_load_write(CONFIG_CLOCK_FREQUENCY/1000000*us);
+	lxtimer_en_write(1);
+	lxtimer_update_value_write(1);
+	while(lxtimer_value_read()) lxtimer_update_value_write(1);
 }

--- a/litex/soc/software/libbase/time.c
+++ b/litex/soc/software/libbase/time.c
@@ -1,30 +1,31 @@
 #include <generated/csr.h>
+#include <lxtimer.h>
 #include <time.h>
 
 void time_init(void)
 {
 	int t;
 
-	timer0_en_write(0);
+	lxtimer_en_write(0);
 	t = 2*CONFIG_CLOCK_FREQUENCY;
-	timer0_reload_write(t);
-	timer0_load_write(t);
-	timer0_en_write(1);
+	lxtimer_reload_write(t);
+	lxtimer_load_write(t);
+	lxtimer_en_write(1);
 }
 
 int elapsed(int *last_event, int period)
 {
 	int t, dt;
 
-	timer0_update_value_write(1);
-	t = timer0_reload_read() - timer0_value_read();
+	lxtimer_update_value_write(1);
+	t = lxtimer_reload_read() - lxtimer_value_read();
 	if(period < 0) {
 		*last_event = t;
 		return 1;
 	}
 	dt = t - *last_event;
 	if(dt < 0)
-		dt += timer0_reload_read();
+		dt += lxtimer_reload_read();
 	if((dt > period) || (dt < 0)) {
 		*last_event = t;
 		return 1;


### PR DESCRIPTION
On certain higher-spec CPU architectures, such as POWER-compliant CPUs, the LiteX timer peripheral is redundant and uses FPGA die area that may be desired for other logic.  The LiteX BIOS however attempts to directly access the `timer0` peripheral, leading to build failures when the timer is removed.

Add a timer abstraction layer and enable timer-free builds of LiteX for POWER-based (e.g. Microwatt) projects.