### PR TITLE
Fix yosys read command for SystemVerilog sources

### DIFF
--- a/litex/build/lattice/icestorm.py
+++ b/litex/build/lattice/icestorm.py
@@ -56,6 +56,9 @@ def _yosys_import_sources(platform):
     for path in platform.verilog_include_paths:
         includes += " -I" + path
     for filename, language, library in platform.sources:
+        # yosys has no such function read_systemverilog
+        if language == "systemverilog":
+            language = "verilog -sv"
         reads.append("read_{}{} {}".format(
             language, includes, filename))
     return "\n".join(reads)

--- a/litex/build/lattice/oxide.py
+++ b/litex/build/lattice/oxide.py
@@ -37,6 +37,9 @@ def _yosys_import_sources(platform):
     for path in platform.verilog_include_paths:
         includes += " -I" + path
     for filename, language, library in platform.sources:
+        # yosys has no such function read_systemverilog
+        if language == "systemverilog":
+            language = "verilog -sv"
         reads.append("read_{}{} {}".format(
             language, includes, filename))
     return "\n".join(reads)

--- a/litex/build/lattice/trellis.py
+++ b/litex/build/lattice/trellis.py
@@ -67,6 +67,9 @@ def _yosys_import_sources(platform):
     for path in platform.verilog_include_paths:
         includes += " -I" + path
     for filename, language, library in platform.sources:
+        # yosys has no such function read_systemverilog
+        if language == "systemverilog":
+            language = "verilog -sv"
         reads.append("read_{}{} {}".format(
             language, includes, filename))
     return "\n".join(reads)


### PR DESCRIPTION
This is a fix for https://github.com/enjoy-digital/litex/issues/870 -- the generic map to create yosys commands generates an invalid command, `read_systemverilog` when importing SystemVerilog sources.  The correct command is `read_verilog -sv`. 