### PR TITLE
Fix interrupt issue with ethernet on recent Linux-On-Litex-Vexriscv/SMP

### DIFF
--- a/litex/tools/litex_json2dts.py
+++ b/litex/tools/litex_json2dts.py
@@ -28,7 +28,6 @@ def generate_dts(d, initrd_start=None, initrd_size=None, polling=False):
 / {
         #address-cells = <1>;
         #size-cells    = <1>;
-        interrupt-parent = <&intc0>;
 
 """
 
@@ -151,6 +150,7 @@ def generate_dts(d, initrd_start=None, initrd_size=None, polling=False):
             #size-cells    = <1>;
             bus-frequency  = <{sys_clk_freq}>;
             compatible = "simple-bus";
+            interrupt-parent = <&intc0>;
             ranges;
 """.format(sys_clk_freq=d["constants"]["config_clock_frequency"])
 


### PR DESCRIPTION
It seems an overreaching 'interrupt-parent' caused trouble to interrupt routing
This moves 'interrupt-parent' to devices with interrupts only.

Symptoms are `plic` saying 'cpu%d: parent irq not available' and ethernet not working (and the interrupt not shown in /proc/interrupts).

This might solve https://github.com/litex-hub/linux-on-litex-vexriscv/issues/178 and https://github.com/enjoy-digital/liteeth/issues/62 as they look very similar to the issue I encountered -> mentioning @zguig52 @geertu @Chgavilana @enjoy-digital