### PR TITLE
resolve issue #862 add description to soc.svd

### DIFF
--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -33,6 +33,10 @@ from litex.soc.doc.module import gather_submodules, ModuleNotDocumented, Documen
 from litex.soc.doc.csr import DocumentedCSRRegion
 from litex.soc.interconnect.csr import _CompoundCSR
 
+# for generating a timestamp in the description field, if none is otherwise given
+import datetime
+import time
+
 # CPU files ----------------------------------------------------------------------------------------
 
 def get_cpu_mak(cpu, compile_software):
@@ -398,8 +402,6 @@ def get_csr_svd(soc, vendor="litex", name="soc", description=None):
     if description is not None:
         svd.append('    <description><![CDATA[{}]]></description>'.format(reflow(description)))
     else:
-        import datetime
-        import time
         fmt = "%Y-%m-%d %H:%M:%S"
         build_time = datetime.datetime.fromtimestamp(time.time()).strftime(fmt)
         svd.append('    <description><![CDATA[{}]]></description>'.format(reflow("Litex SoC " + build_time)))

--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -397,6 +397,12 @@ def get_csr_svd(soc, vendor="litex", name="soc", description=None):
     svd.append('    <name>{}</name>'.format(name.upper()))
     if description is not None:
         svd.append('    <description><![CDATA[{}]]></description>'.format(reflow(description)))
+    else:
+        import datetime
+        import time
+        fmt = "%Y-%m-%d %H:%M:%S"
+        build_time = datetime.datetime.fromtimestamp(time.time()).strftime(fmt)
+        svd.append('    <description><![CDATA[{}]]></description>'.format(reflow("Litex SoC " + build_time)))
     svd.append('')
     svd.append('    <addressUnitBits>8</addressUnitBits>')
     svd.append('    <width>32</width>')


### PR DESCRIPTION
This fixes issue #862.

The root cause is that with no description provided it simply would
not put out a description tag, which breaks compatibility with
other programs.

Insert a somewhat useful default description including a timestamp
and the words "LiteX SoC".