### PR TITLE
software/liblitesdcard: Tell the controller when to wait while the card is busy

### DIFF
--- a/litex/soc/software/liblitesdcard/sdcard.c
+++ b/litex/soc/software/liblitesdcard/sdcard.c
@@ -164,7 +164,7 @@ int sdcard_app_send_op_cond(int hcs) {
 #ifdef SDCARD_DEBUG
 	printf("ACMD41: APP_SEND_OP_COND, arg: %08x\n", arg);
 #endif
-	return sdcard_send_command(arg, 41, SDCARD_CTRL_RESPONSE_SHORT);
+	return sdcard_send_command(arg, 41, SDCARD_CTRL_RESPONSE_SHORT_BUSY);
 }
 
 int sdcard_all_send_cid(void) {
@@ -199,7 +199,7 @@ int sdcard_select_card(uint16_t rca) {
 #ifdef SDCARD_DEBUG
 	printf("CMD7: SELECT_CARD\n");
 #endif
-	return sdcard_send_command(rca << 16, 7, SDCARD_CTRL_RESPONSE_SHORT);
+	return sdcard_send_command(rca << 16, 7, SDCARD_CTRL_RESPONSE_SHORT_BUSY);
 }
 
 int sdcard_app_set_bus_width(void) {
@@ -296,7 +296,7 @@ int sdcard_stop_transmission(void) {
 #ifdef SDCARD_DEBUG
 	printf("CMD12: STOP_TRANSMISSION\n");
 #endif
-	return sdcard_send_command(0, 12, SDCARD_CTRL_RESPONSE_SHORT);
+	return sdcard_send_command(0, 12, SDCARD_CTRL_RESPONSE_SHORT_BUSY);
 }
 
 int sdcard_send_status(uint16_t rca) {

--- a/litex/soc/software/liblitesdcard/sdcard.h
+++ b/litex/soc/software/liblitesdcard/sdcard.h
@@ -52,6 +52,11 @@
 #define SDCARD_CTRL_RESPONSE_SHORT 1
 #define SDCARD_CTRL_RESPONSE_LONG  2
 
+#define SDCARD_CTRL_RESPONSE_BUSY  4
+
+#define SDCARD_CTRL_RESPONSE_SHORT_BUSY (SDCARD_CTRL_RESPONSE_SHORT | \
+					 SDCARD_CTRL_RESPONSE_BUSY)
+
 /*-----------------------------------------------------------------------*/
 /* SDCard command helpers                                                */
 /*-----------------------------------------------------------------------*/


### PR DESCRIPTION
Bit 2 of the command register now tells the controller to wait while
the card is indicating that it is busy (by pulling the DAT0 line low).
The card can do this for commands 7 and 12 and app command 41 (and
also for commands 20, 28, 29, 38 and 43, but we don't use those here.)

This sets bit 2 for those commands.

Signed-off-by: Paul Mackerras <paulus@ozlabs.org>