### PR TITLE
soc/integration: generate and add list of peripherals

### DIFF
--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -528,6 +528,6 @@ def get_peripherals(csr_regions={}, constants={}, mem_regions={}):
         r += "\n"
 
     for name, region in mem_regions.items():
-        r += "name: {},base: 0x{:08x},length: {},type: {},\n\n".format(name, region.origin, region.length, region.type)
+        r += "name: {},base: 0x{:08x},length: {},type: {},\n\n".format(name, region.origin, region.size, region.mode)
 
     return r

--- a/litex/soc/software/bios/Makefile
+++ b/litex/soc/software/bios/Makefile
@@ -38,6 +38,10 @@ else
 OBJECTS += readline.o
 endif
 
+ifdef PERIPHERALS
+OBJECTS += peripherals.o
+endif
+
 all: bios.bin
 	$(PYTHON) -m litex.soc.software.memusage bios.elf $(CURDIR)/../include/generated/regions.ld $(TRIPLE)
 

--- a/litex/soc/software/bios/linker.ld
+++ b/litex/soc/software/bios/linker.ld
@@ -76,7 +76,10 @@ SECTIONS
 		*(.eh_frame)
 		*(.comment)
 	}
+
+	INCLUDE generated/peripherals.ld
 }
+
 
 PROVIDE(_fstack = ORIGIN(sram) + LENGTH(sram) - 8);
 


### PR DESCRIPTION
This PR adds `--generate-peripherals` parameter. Using that parameter causes generating a list of peripherals in the csv format which is then changed into an array in C (using xxd). The array is being added by the linker script but instead of just adding it to the ROM, there's being added peripherals_rom right after the ROM (`self.soc.mem_regions['rom'].origin + 2**log2_int(self.soc.mem_regions['rom'].size, False)`) to put the array in. The peripherals_rom size matches the array size. In future, there could be an option to put that new peripherals_rom in a specific place but currently, setting an address was causing problems with the ROM resizing. 

The main aim for now is checking if a DTS is correct if it comes from other build then the binary itself but there are also possible other use cases.