### PR TITLE
integration/soc/add_sdcard: Add an interrupt for command completion

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1550,11 +1550,13 @@ class LiteXSoC(SoC):
         self.sdirq.card_detect   = EventSourcePulse(description="SDCard has been ejected/inserted.")
         self.sdirq.block2mem_dma = EventSourcePulse(description="Block2Mem DMA terminated.")
         self.sdirq.mem2block_dma = EventSourcePulse(description="Mem2Block DMA terminated.")
+        self.sdirq.cmd_done      = EventSourceLevel(description="Command completed.")
         self.sdirq.finalize()
         self.comb += [
             self.sdirq.card_detect.trigger.eq(self.sdphy.card_detect_irq),
             self.sdirq.block2mem_dma.trigger.eq(self.sdblock2mem.irq),
             self.sdirq.mem2block_dma.trigger.eq(self.sdmem2block.irq),
+            self.sdirq.cmd_done.trigger.eq(self.sdcore.cmd_done)
         ]
 
         # Debug.


### PR DESCRIPTION
This is useful for long-running commands generally and in particular
for those without any data transfer, such as erase.  It is a
level-sensitive interrupt because that makes it a little harder to
lose interrupts due to incorrect programming.

Signed-off-by: Paul Mackerras <paulus@ozlabs.org>