### PR TITLE
Lattice Crosslink NX: Fix clock port names in SDR{in/out} Impl

### DIFF
--- a/litex/build/lattice/common.py
+++ b/litex/build/lattice/common.py
@@ -196,7 +196,7 @@ class LatticeNXAsyncResetSynchronizer:
 class LatticeNXSDRInputImpl(Module):
     def __init__(self, i, o, clk):
         self.specials += Instance("IFD1P3BX",
-            i_SCLK = clk,
+            i_CK = clk,
             i_PD   = 0,
             i_SP   = 1,
             i_D    = i,
@@ -213,7 +213,7 @@ class LatticeNXSDRInput:
 class LatticeNXSDROutputImpl(Module):
     def __init__(self, i, o, clk):
         self.specials += Instance("OFD1P3BX",
-            i_SCLK = clk,
+            i_CK = clk,
             i_PD   = 0,
             i_SP   = 1,
             i_D    = i,


### PR DESCRIPTION
This PR fixes `IFD1P3BX` and `OFD1P3BX` black boxes instantiation for Lattice Crosslink NX flow. Both Yosys and Radiant define those as:

```
module OFD1P3BX (...);
    parameter GSR = "ENABLED";
    input D;
    input SP;
    input CK;
    input PD;
    output Q;
endmodule

module OFD1P3DX (...);
    parameter GSR = "ENABLED";
    input D;
    input SP;
    input CK;
    input CD;
    output Q;
endmodule
```