### PR TITLE
bios: support passing tftp filename to the 'netboot' command

### DIFF
--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -487,9 +487,13 @@ static void netboot_from_bin(const char * filename, unsigned int ip, unsigned sh
 	boot(0, 0, 0, MAIN_RAM_BASE);
 }
 
-void netboot(void)
+void netboot(int nb_params, char **params)
 {
 	unsigned int ip;
+	char * filename = NULL;
+
+	if (nb_params > 0 )
+		filename = params[0];
 
 	printf("Booting from network...\n");
 
@@ -499,13 +503,18 @@ void netboot(void)
 	ip = IPTOINT(remote_ip[0], remote_ip[1], remote_ip[2], remote_ip[3]);
 	udp_start(macadr, IPTOINT(local_ip[0], local_ip[1], local_ip[2], local_ip[3]));
 
-	/* Boot from boot.json */
-	printf("Booting from boot.json...\n");
-	netboot_from_json("boot.json", ip, TFTP_SERVER_PORT);
+	if (filename) {
+		printf("Booting from %s (JSON)...\n", filename);
+		netboot_from_json(filename, ip, TFTP_SERVER_PORT);
+	} else {
+		/* Boot from boot.json */
+		printf("Booting from boot.json...\n");
+		netboot_from_json("boot.json", ip, TFTP_SERVER_PORT);
 
-	/* Boot from boot.bin */
-	printf("Booting from boot.bin...\n");
-	netboot_from_bin("boot.bin", ip, TFTP_SERVER_PORT);
+		/* Boot from boot.bin */
+		printf("Booting from boot.bin...\n");
+		netboot_from_bin("boot.bin", ip, TFTP_SERVER_PORT);
+	}
 
 	/* Boot failed if we are here... */
 	printf("Network boot failed.\n");

--- a/litex/soc/software/bios/boot.h
+++ b/litex/soc/software/bios/boot.h
@@ -7,7 +7,7 @@ void set_mac_addr(const char * mac_address);
 
 void __attribute__((noreturn)) boot(unsigned long r1, unsigned long r2, unsigned long r3, unsigned long addr);
 int serialboot(void);
-void netboot(void);
+void netboot(int nb_params, char **params);
 void flashboot(void);
 void romboot(void);
 void sdcardboot(void);

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -69,7 +69,7 @@ static void boot_sequence(void)
 #ifdef CSR_ETHPHY_MODE_DETECTION_MODE_ADDR
 	eth_mode();
 #endif
-	netboot();
+	netboot(0, NULL);
 #endif
 	printf("No boot medium found\n");
 }


### PR DESCRIPTION
Combined with the dynamic IP configuration, this makes it possible to use a shared TFTP server, as every developer can use their own boot.json file.

```
litex> eth_remote_ip 192.168.8.13

Remote IP: 192.168.8.13
litex> eth_local_ip 192.168.8.254

Local IP: 192.168.8.254
litex> netboot jlu-boot.json

Booting from network...
Local IP: 192.168.8.254
Remote IP: 192.168.8.13
Booting from jlu-boot.json (JSON)...
Copying jlu-Image-ecpix5.bin to 0x40000000... (6903848 bytes)
Copying jlu-rv32.dtb to 0x40ef0000... (2401 bytes)
Copying jlu-ecpix5.cpio to 0x41000000... (6135296 bytes)
Copying jlu-fw_jump.bin to 0x40f00000... (49636 bytes)
Executing booted program at 0x40f00000
```