### PR TITLE
software/liblitedram: fix error in window centering

### DIFF
--- a/litex/soc/software/liblitedram/sdram.c
+++ b/litex/soc/software/liblitedram/sdram.c
@@ -878,7 +878,7 @@ static void sdram_leveling_center_module(
 	}
 
 	/* Extend the range if it wraps around */
-	if (delay_min_next > 0) {
+	if (delay_min_next > delay_max) {
 		delay_min = delay_min_next;
 		delay_max += SDRAM_PHY_DELAYS;
 	}


### PR DESCRIPTION
This should fix the problem in https://github.com/enjoy-digital/litex/issues/890.
The problem was that max delay was ending up exactly on 32 and the wrapping logic was incorrect in that case.

I did some tests outside of Litex using the following implementation 
[sdram_leveling_center_module.zip](https://github.com/enjoy-digital/litex/files/6375271/sdram_leveling_center_module.zip) and with the fix included I now get the following results:
```
Range 0-9:
m0: |11111111100000000000000000000000| delays: 04+-04
Range 5-25:
m0: |00000111111111111111111110000000| delays: 15+-10
Range 19-32:
m0: |00000000000000000001111111111111| delays: 25+-06
Range 18-31:
m0: |00000000000000000011111111111110| delays: 24+-06
Range 30-6:
m0: |11111100000000000000000000000011| delays: 02+-04
```

