### PR TITLE
soc/software: link with compiler instead of ld

### DIFF
--- a/litex/soc/software/bios/Makefile
+++ b/litex/soc/software/bios/Makefile
@@ -64,7 +64,7 @@ bios.elf: $(BIOS_DIRECTORY)/linker.ld $(OBJECTS)
 	../libfatfs/libfatfs.a \
 	../liblitesdcard/liblitesdcard.a \
 	../liblitesata/liblitesata.a
-	$(LD) $(LDFLAGS) -T $(BIOS_DIRECTORY)/linker.ld -N -o $@ \
+	$(CC) $(LDFLAGS) -T $(BIOS_DIRECTORY)/linker.ld -N -o $@ \
 		../libbase/crt0.o \
 		$(OBJECTS) \
 		-L../libcompiler_rt \

--- a/litex/soc/software/demo/Makefile
+++ b/litex/soc/software/demo/Makefile
@@ -18,7 +18,7 @@ all: demo.bin
 	chmod -x $@
 
 demo.elf: $(OBJECTS)
-	$(LD) $(LDFLAGS) \
+	$(CC) $(LDFLAGS) \
 		-T linker.ld \
 		-N -o $@ \
 		$(BUILD_DIR)/software/libbase/crt0.o \


### PR DESCRIPTION
The linker does not actually recognise -nodefaultlibs, that is a compiler
option.

Prior to binutils 2.36, ld treated -nodefaultlibs as a string of short
options and ignored them as unrecognised. Starting from binutils 2.36, it
reports an error instead:

    riscv64-unknown-elf-ld: Error: unable to disambiguate: -nodefaultlibs (did you mean --nodefaultlibs ?)

See also: https://sourceware.org/bugzilla/show_bug.cgi?id=27050

Fixes #825.