### PR TITLE
software/bios: Add option to obtain IP address from DHCP server

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1367,7 +1367,7 @@ class LiteXSoC(SoC):
                 base_address = self.bus.regions["main_ram"].origin)
 
     # Add Ethernet ---------------------------------------------------------------------------------
-    def add_ethernet(self, name="ethmac", phy=None, phy_cd="eth", dynamic_ip=False, software_debug=False,
+    def add_ethernet(self, name="ethmac", phy=None, phy_cd="eth", dynamic_ip=False, with_dhcp=False, software_debug=False,
         nrxslots       = 2,
         ntxslots       = 2,
         with_timestamp = False):
@@ -1412,6 +1412,11 @@ class LiteXSoC(SoC):
         # Dynamic IP (if enabled).
         if dynamic_ip:
             self.add_constant("ETH_DYNAMIC_IP")
+
+        # Use DHCP to assigne IP address.
+        if with_dhcp:
+            assert(dynamic_ip)
+            self.add_constant("ETH_WITH_DHCP")
 
         # Software Debug
         if software_debug:

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -29,6 +29,7 @@
 
 #include <libliteeth/udp.h>
 #include <libliteeth/tftp.h>
+#include <libliteeth/dhcp_client.h>
 
 #include <liblitesdcard/spisdcard.h>
 #include <liblitesdcard/sdcard.h>
@@ -398,6 +399,15 @@ void set_mac_addr(const char * mac_address)
 		udp_set_mac(macadr);
 		printf("MAC address : %x:%x:%x:%x:%x:%x", macadr[0], macadr[1], macadr[2], macadr[3], macadr[4], macadr[5]);
 	}
+}
+
+#endif
+
+#ifdef ETH_WITH_DHCP
+
+void dhcp_get_ip(void)
+{
+        dhcp_resolve(macadr);
 }
 
 #endif

--- a/litex/soc/software/bios/boot.h
+++ b/litex/soc/software/bios/boot.h
@@ -4,6 +4,7 @@
 void set_local_ip(const char * ip_address);
 void set_remote_ip(const char * ip_address);
 void set_mac_addr(const char * mac_address);
+void dhcp_get_ip(void);
 
 void __attribute__((noreturn)) boot(unsigned long r1, unsigned long r2, unsigned long r3, unsigned long addr);
 int serialboot(void);

--- a/litex/soc/software/bios/cmds/cmd_liteeth.c
+++ b/litex/soc/software/bios/cmds/cmd_liteeth.c
@@ -193,3 +193,13 @@ static void eth_mac_addr_handler(int nb_params, char **params)
 }
 define_command(eth_mac_addr, eth_mac_addr_handler, "Set the mac address", LITEETH_CMDS);
 #endif
+
+/**
+ * Command "eth_dhcp"
+ *
+ * Get ip address from DHCP server.
+ *
+ */
+#ifdef ETH_WITH_DHCP
+define_command(eth_dhcp, dhcp_get_ip, "Use DHCP to get ip address", LITEETH_CMDS);
+#endif

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -69,6 +69,10 @@ static void boot_sequence(void)
 #ifdef CSR_ETHPHY_MODE_DETECTION_MODE_ADDR
 	eth_mode();
 #endif
+#ifdef ETH_WITH_DHCP
+	dhcp_get_ip();
+	printf("\n");
+#endif
 	netboot(0, NULL);
 #endif
 	printf("No boot medium found\n");

--- a/litex/soc/software/libliteeth/Makefile
+++ b/litex/soc/software/libliteeth/Makefile
@@ -1,7 +1,7 @@
 include ../include/generated/variables.mak
 include $(SOC_DIRECTORY)/software/common.mak
 
-OBJECTS=udp.o tftp.o mdio.o
+OBJECTS=udp.o tftp.o mdio.o dhcp_client.o
 
 all: libliteeth.a
 

--- a/litex/soc/software/libliteeth/dhcp_client.c
+++ b/litex/soc/software/libliteeth/dhcp_client.c
@@ -1,0 +1,171 @@
+#include <bios/boot.h>
+#include <inet.h>
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "dhcp_client.h"
+#include "dhcp_options.h"
+#include "udp.h"
+
+//#define DHCP_UDP_DEBUG
+
+/*Format of a DHCP message based on RFC2131(Page 8) */
+struct dhcp
+{
+        uint8_t  op;                                // Op code
+        uint8_t  htype;                             // Hardware address type
+        uint8_t  hlen;                              // Hardware address length
+        uint8_t  hops;                              // Relay agent
+        uint32_t xid;                               // Transaction ID
+        uint16_t secs;                              // Second elapsed
+        uint16_t flags;                             // Flags
+        uint32_t ciaddr;                            // Client IP adress(32 bits)
+        uint32_t yiaddr;                            // Client IP addres(32 bits)
+        uint32_t siaddr;                            // IP address of next server(32 bits)
+        uint32_t giaddr;                            // Relay agent IP address(32 bits)
+        unsigned char chaddr[16];                   // Client hardware address
+        unsigned char sname[64];                    // Optional server host name
+        unsigned char file[128];                    // Boot file name
+        uint32_t mcookie;                           // Magic cookie
+        unsigned char options[DHCP_OPTIONS_LEN];    // Optional parameters
+} __attribute__((packed));
+
+static uint8_t *packet_data;
+static struct dhcp dhcp_p;
+static int transfer_finished;
+static uint32_t offered_ip_address;
+
+static void rx_callback(uint32_t server_ip, uint16_t server_port, uint16_t dst_port, void *_data, unsigned int length)
+{
+        struct dhcp *data = _data;
+        if(dst_port != DHCP_PORT_CLIENT) return;
+
+        if(data->op == DHCP_TOFFER)
+        {
+                offered_ip_address = (data->yiaddr);
+                transfer_finished = 1;
+        }
+}
+
+static int fill_options(uint8_t *chunk, uint8_t code_option, void *data_option, uint8_t len_option)
+{
+        if(code_option == DHCP_OEND)
+        {
+                chunk[0] = DHCP_OEND;
+                return len_option;
+        }
+        chunk[0] = code_option;
+        chunk[1] = len_option;
+        memcpy(&chunk[2], data_option, len_option);
+        return len_option + (sizeof(uint8_t) << 1);
+}
+
+static void format_base(uint8_t *buff, struct dhcp *p, unsigned char * mc_addr)
+{
+        memset(p, 0, sizeof(struct dhcp));
+        p->op = 0x01;
+        p->htype = 0x01;
+        p->hlen = 0x06;
+        p->hops = 0x00;
+        p->xid = htonl(DHCP_XID);
+        p->secs = 0x0;
+        p->flags = 0x0;
+        p->ciaddr = IPTOINT(0, 0, 0, 0);
+        p->yiaddr = IPTOINT(0, 0, 0, 0);
+        p->siaddr = IPTOINT(0, 0, 0, 0);
+        p->giaddr = IPTOINT(0, 0, 0, 0);
+        memcpy(p->chaddr, mc_addr, DHCP_ADDR_LEN);
+        memset(p->sname, 0, 64);
+        memset(p->file, 0, 128);
+        p->mcookie = htonl(DHCP_COOKIE);
+}
+
+static int format_request(uint8_t *buff, struct dhcp *p, unsigned char* mc_addr)
+{
+        format_base(buff, p, mc_addr);
+        uint8_t option_tag = DHCP_TREQUEST;
+        int len = fill_options(&p->options[0], DHCP_OMESSAGE_TYPE, &option_tag, sizeof(option_tag));
+        len += fill_options(&p->options[len], DHCP_OREQUEST_IP , &offered_ip_address, sizeof(offered_ip_address));
+        len += fill_options(&p->options[len], DHCP_OEND, &option_tag, sizeof(option_tag));
+        memcpy(buff, p, sizeof(struct dhcp));
+        return sizeof(struct dhcp);
+}
+
+static int format_discovery(uint8_t *buff, struct dhcp *p, unsigned char* mc_addr)
+{
+        format_base(buff, p, mc_addr);
+        uint8_t option_tag = DHCP_TDISCOVER;
+        int len = fill_options(&p->options[0], DHCP_OMESSAGE_TYPE, &option_tag, sizeof(option_tag));
+        option_tag = DHCP_OEND;
+        len += fill_options(&p->options[len], DHCP_OEND, &option_tag, sizeof(option_tag));
+        memcpy(buff, p, sizeof(struct dhcp));
+        return sizeof(struct dhcp);
+}
+
+static int dhcp_dispatcher(uint8_t *buff, struct dhcp *p, unsigned char* mc_addr, uint16_t option)
+{
+        int message_len;
+        if(option == DHCP_TDISCOVER)
+                message_len = format_discovery(buff, p, mc_addr);
+        else if(option == DHCP_TREQUEST)
+                message_len = format_request(buff, p, mc_addr);
+        return message_len;
+}
+
+static int send_message(unsigned char * mc_addr, uint16_t type)
+{
+        for(int tries=5; tries > 0; --tries)
+        {
+                packet_data = udp_get_tx_buffer();
+                int len = dhcp_dispatcher(packet_data, &dhcp_p, mc_addr, type);
+                udp_send(DHCP_PORT_CLIENT, DHCP_PORT_SERVER, len);
+
+#ifdef DHCP_UDP_DEBUG
+                printf(">>>> UDP_Payload : %d\n", len);
+                for(int i=0; i<len; i++)
+                {
+                        if(i % 16 == 0)
+                                printf("\n %x :: ", i);
+                        printf(" %02x ", packet_data[i]);
+                }
+                printf("\n");
+#endif
+
+                for(int i=0; i<2000000; ++i)
+                {
+                        udp_service();
+                        if(transfer_finished)
+                        {
+                                transfer_finished = 0;
+                                return 1;
+                        }
+                }
+        }
+        return 0;
+}
+
+void dhcp_resolve(unsigned char * mc_addr)
+{
+        udp_start(mc_addr, IPTOINT(0, 0, 0, 0));
+        udp_arp_resolve(IPTOINT(255, 255, 255, 255));
+        udp_set_callback(rx_callback);
+
+        if(!send_message(mc_addr, DHCP_TDISCOVER))
+        {
+                printf("DHCP Server not found, Abort.");
+                udp_set_callback(NULL);
+                return;
+        }
+        if(!send_message(mc_addr, DHCP_TREQUEST))
+        {
+                printf("No Acknowledgement from DHCP server, Abort.");
+                udp_set_callback(NULL);
+                return;
+        }
+        char ip_resolved[15];
+        unsigned char *octets = (unsigned char *)&offered_ip_address;
+        snprintf(ip_resolved, sizeof(ip_resolved), "%d.%d.%d.%d", octets[0], octets[1], octets[2], octets[3]);
+        set_local_ip(ip_resolved);
+}

--- a/litex/soc/software/libliteeth/dhcp_client.h
+++ b/litex/soc/software/libliteeth/dhcp_client.h
@@ -1,0 +1,6 @@
+#ifndef __DHCP_H
+#define __DHCP_H
+
+void dhcp_resolve(unsigned char * mc_addr);
+
+#endif /* __DHCP_H */

--- a/litex/soc/software/libliteeth/dhcp_options.h
+++ b/litex/soc/software/libliteeth/dhcp_options.h
@@ -1,0 +1,28 @@
+#ifndef __DHCP_OPTIONS_H
+#define __DHCP_OPTIONS_H
+
+/* Available DHCP package types */
+
+#define DHCP_TDISCOVER        1
+#define DHCP_TOFFER           2
+#define DHCP_TREQUEST         3
+#define DHCP_TPACK     	      4
+
+/* Available DHCP package options */
+
+#define DHCP_OPAD             0
+#define DHCP_OREQUEST_IP      50
+#define DHCP_OMESSAGE_TYPE    53
+#define DHCP_OEND             255
+
+/* DHCP client general options */
+
+#define DHCP_PORT_CLIENT      68
+#define DHCP_PORT_SERVER      67
+#define DHCP_HARDWARE_LEN     6
+#define DHCP_OPTIONS_LEN      128
+#define DHCP_COOKIE           0x63825363
+#define DHCP_XID              0x21274A1D
+#define DHCP_ADDR_LEN         16
+
+#endif /* __DHCP_OPTIONS_H */

--- a/litex/soc/software/libliteeth/udp.c
+++ b/litex/soc/software/libliteeth/udp.c
@@ -241,6 +241,13 @@ int udp_arp_resolve(unsigned int ip)
 			if(cached_mac[i]) return 1;
 	}
 	cached_ip = ip;
+        /* Omit ARP request while Broadcasting */
+        if(cached_ip == IPTOINT(255,255,255,255)){
+                for(i=0;i<6;i++)
+                        cached_mac[i] = broadcast[i];
+		return 1;
+	}
+
 	for(i=0;i<6;i++)
 		cached_mac[i] = 0;
 
@@ -377,7 +384,8 @@ static void process_ip(void)
 	// check disabled for QEMU compatibility
 	//if(ntohs(rxbuffer->frame.contents.udp.ip.fragment_offset) != IP_DONT_FRAGMENT) return;
 	if(udp_ip->ip.proto != IP_PROTO_UDP) return;
-	if(ntohl(udp_ip->ip.dst_ip) != my_ip) return;
+	// Check isn't neeeded when we use DHCP client(my_ip = 0.0.0.0)
+	if((ntohl(udp_ip->ip.dst_ip) != my_ip) && my_ip != 0) return;
 	if(ntohs(udp_ip->udp.length) < sizeof(struct udp_header)) return;
 
 	if(rx_callback)


### PR DESCRIPTION
That PR allows to obtain IP address automatically from DHCP server using `eth_dhcp` command.
That command is only available when with_dhcp argument is set in litex/soc/integration/soc.py.
`dhcp_get_ip` function in litex/soc/software/bios/boot.c invokes `dhcp_resolve` function with MAC address as parameter.
That PR is associated with litex-hub/litex-boards#206.
