### PR TITLE
integration/soc_core: Increase default ROM size to 128K

### DIFF
--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -270,7 +270,7 @@ def soc_core_args(parser):
     parser.add_argument("--no-ctrl", action="store_true", help="Disable Controller (default=False).")
 
     # ROM parameters
-    parser.add_argument("--integrated-rom-size", default=0x10000, type=auto_int, help="Size/Enable the integrated (BIOS) ROM (default=64KB, automatically resized to BIOS size when smaller).")
+    parser.add_argument("--integrated-rom-size", default=0x20000, type=auto_int, help="Size/Enable the integrated (BIOS) ROM (default=128KB, automatically resized to BIOS size when smaller).")
     parser.add_argument("--integrated-rom-file", default=None,    type=str,      help="Integrated (BIOS) ROM binary file.")
 
     # SRAM parameters


### PR DESCRIPTION
With recent BIOS changes the default rom size on the mor1kx built just
passes over the 64k boundary and the build fails.  Since the 128K
default is a soft limit and the ROM gets resized to the actual ROM
requirements this should be relatively safe.

Note, that if a RW rom is configured the full 128kb will be allocated.

Fixes: #893