### PR TITLE
integration/soc: Wire up the sdirq to the CPU

### DIFF
--- a/litex/tools/litex_json2dts.py
+++ b/litex/tools/litex_json2dts.py
@@ -283,8 +283,10 @@ def generate_dts(d, initrd_start=None, initrd_size=None, polling=False):
                 reg = <0x{sdphy_csr_base:x} 0x100>,
                       <0x{sdcore_csr_base:x} 0x100>,
                       <0x{sdblock2mem:x} 0x100>,
-                      <0x{sdmem2block:x} 0x100>;
+                      <0x{sdmem2block:x} 0x100>,
+                      <0x{sdirq:x} 0x100>;
                 bus-width = <0x04>;
+                {sdirq_interrupt}
                 status = "okay";
             }};
 """.format(
@@ -292,7 +294,9 @@ def generate_dts(d, initrd_start=None, initrd_size=None, polling=False):
         sdphy_csr_base  = d["csr_bases"]["sdphy"],
         sdcore_csr_base = d["csr_bases"]["sdcore"],
         sdblock2mem     = d["csr_bases"]["sdblock2mem"],
-        sdmem2block     = d["csr_bases"]["sdmem2block"]
+        sdmem2block     = d["csr_bases"]["sdmem2block"],
+        sdirq           = d["csr_bases"]["sdirq"],
+        sdirq_interrupt = "" if polling else "interrupts = <{}>;".format(d["constants"]["sdirq_interrupt"])
 )
     # Leds -----------------------------------------------------------------------------------------
 


### PR DESCRIPTION
I am working on testing out the patches from:
 https://github.com/litex-hub/linux/pull/8

These linux patches take advantage of the sdcard interrupt to track when
transfers finish.  However, it seems the interrupt is not being
connected to the CPU.

This patch does that by allowing us to directly register an
EventManager module with the irq handler.