### PR TITLE
Add 'lse' as a --synth-mode alternative with Radiant toolchain.

### DIFF
--- a/litex/build/lattice/radiant.py
+++ b/litex/build/lattice/radiant.py
@@ -121,12 +121,13 @@ def _build_pdc(named_sc, named_pc, clocks, vns, build_name):
 def _build_tcl(device, sources, vincpaths, build_name, pdc_file, synth_mode):
     tcl = []
     # Create project
+    syn = "lse" if synth_mode == "lse" else "synplify"
     tcl.append(" ".join([
         "prj_create",
         "-name \"{}\"".format(build_name),
         "-impl \"impl\"",
         "-dev {}".format(device),
-        "-synthesis \"synplify\""
+        "-synthesis \"" + syn + "\""
     ]))
 
     def tcl_path(path): return path.replace("\\", "/")


### PR DESCRIPTION
Lattice Radiant comes with two synthesis options, 'synplify' and 'lse'.

The LiteX Radiant toolchain uses 'synplify' by default, and allows it to be replaced with
'yosys' using option `--synth-mode 'yosys'`.   Since the `--synth-mode` option already exists, 
it seems to make sense to allow it to specify 'lse' as well, to give a third alternative.

Signed-off-by: Tim Callahan <tcal@google.com>