### PR TITLE
Add CFU integration

### DIFF
--- a/litex/soc/cores/cpu/vexriscv/core.py
+++ b/litex/soc/cores/cpu/vexriscv/core.py
@@ -31,7 +31,9 @@ CPU_VARIANTS = {
     "imac":             "VexRiscv_IMAC",
     "imac+debug":       "VexRiscv_IMACDebug",
     "full":             "VexRiscv_Full",
+    "full+cfu":         "VexRiscv_FullCfu",
     "full+debug":       "VexRiscv_FullDebug",
+    "full+cfu+debug":   "VexRiscv_FullCfuDebug",
     "linux":            "VexRiscv_Linux",
     "linux+debug":      "VexRiscv_LinuxDebug",
     "linux+no-dsp":     "VexRiscv_LinuxNoDspFmax",
@@ -58,7 +60,9 @@ GCC_FLAGS = {
     "imac":             "-march=rv32imac   -mabi=ilp32",
     "imac+debug":       "-march=rv32imac   -mabi=ilp32",
     "full":             "-march=rv32im     -mabi=ilp32",
+    "full+cfu":         "-march=rv32im     -mabi=ilp32",
     "full+debug":       "-march=rv32im     -mabi=ilp32",
+    "full+cfu+debug":   "-march=rv32im     -mabi=ilp32",
     "linux":            "-march=rv32ima    -mabi=ilp32",
     "linux+debug":      "-march=rv32ima    -mabi=ilp32",
     "linux+no-dsp":     "-march=rv32ima    -mabi=ilp32",
@@ -277,6 +281,59 @@ class VexRiscv(CPU, AutoCSR):
     def use_external_variant(self, variant_filename):
         self.external_variant = True
         self.platform.add_source(variant_filename)
+
+    def add_cfu(self, cfu_filename):
+        cfu_bus_layout = [
+            ("cmd", [
+                ("valid", 1),
+                ("ready", 1),
+                ("payload", [
+                    ("function_id", 10),
+                    ("inputs_0", 32),
+                    ("inputs_1", 32),
+                ]),
+            ]),
+            ("rsp", [
+                ("valid", 1),
+                ("ready", 1),
+                ("payload", [
+                    ("response_ok", 1),
+                    ("outputs_0", 32),
+                ]),
+            ]),
+        ]
+
+        # CFU Bus.
+        self.cfu_bus = cfu_bus = Record(cfu_bus_layout)
+
+        # Add CFU.
+        self.specials += Instance("Cfu",
+            i_cmd_valid                = cfu_bus.cmd.valid,
+            o_cmd_ready                = cfu_bus.cmd.ready,
+            i_cmd_payload_function_id  = cfu_bus.cmd.payload.function_id,
+            i_cmd_payload_inputs_0     = cfu_bus.cmd.payload.inputs_0,
+            i_cmd_payload_inputs_1     = cfu_bus.cmd.payload.inputs_1,
+            o_rsp_valid                = cfu_bus.rsp.valid,
+            i_rsp_ready                = cfu_bus.rsp.ready,
+            o_rsp_payload_response_ok  = cfu_bus.rsp.payload.response_ok,
+            o_rsp_payload_outputs_0    = cfu_bus.rsp.payload.outputs_0,
+            i_clk                      = ClockSignal(),
+            i_reset                    = ResetSignal(),
+        )
+        self.platform.add_source(cfu_filename)
+
+        # Connect CFU to CPU.
+        self.cpu_params.update(
+            o_CfuPlugin_bus_cmd_valid                = cfu_bus.cmd.valid,
+            i_CfuPlugin_bus_cmd_ready                = cfu_bus.cmd.ready,
+            o_CfuPlugin_bus_cmd_payload_function_id  = cfu_bus.cmd.payload.function_id,
+            o_CfuPlugin_bus_cmd_payload_inputs_0     = cfu_bus.cmd.payload.inputs_0,
+            o_CfuPlugin_bus_cmd_payload_inputs_1     = cfu_bus.cmd.payload.inputs_1,
+            i_CfuPlugin_bus_rsp_valid                = cfu_bus.rsp.valid,
+            o_CfuPlugin_bus_rsp_ready                = cfu_bus.rsp.ready,
+            i_CfuPlugin_bus_rsp_payload_response_ok  = cfu_bus.rsp.payload.response_ok,
+            i_CfuPlugin_bus_rsp_payload_outputs_0    = cfu_bus.rsp.payload.outputs_0,
+        )
 
     def do_finalize(self):
         assert hasattr(self, "reset_address")

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -70,6 +70,8 @@ class SoCCore(LiteXSoC):
         cpu_reset_address        = None,
         cpu_variant              = None,
         cpu_cls                  = None,
+        # CFU parameters
+        cfu_filename             = None,
         # ROM parameters
         integrated_rom_size      = 0,
         integrated_rom_mode      = "r",
@@ -190,6 +192,11 @@ class SoCCore(LiteXSoC):
             if timer_uptime:
                 self.timer0.add_uptime()
 
+        # Add CFU
+        if cfu_filename:
+            assert(cpu_type == "vexriscv")
+            self.cpu.add_cfu(cfu_filename=cfu_filename)
+
     # Methods --------------------------------------------------------------------------------------
 
     def add_interrupt(self, interrupt_name, interrupt_id=None, use_loc_if_exists=False):
@@ -301,6 +308,9 @@ def soc_core_args(parser):
 
     # L2 Cache
     parser.add_argument("--l2-size",           default=8192, type=auto_int, help="L2 cache size (default=8192).")
+
+    # CFU
+    parser.add_argument("--cfu-filename",      default=None,                help="CFU verilog filename.")
 
 def soc_core_argdict(args):
     r = dict()


### PR DESCRIPTION
Following issue #883 I've added `add_cfu()` function that provides support for [CfuPlugin](https://github.com/SpinalHDL/VexRiscv/blob/master/src/main/scala/vexriscv/plugin/CfuPlugin.scala) provided by SpinalHDL for VexRiscv CPU.

You can add CFU verilog filename via argument `--cfu-filename`. I have tested it on Arty A7 with software generated in [CFU-Playground](https://github.com/google/CFU-Playground/tree/main/proj/example_cfu_v) by executing `make software`.