### PR TITLE
software/libbase: fix %lld and %llu in printf functions

### DIFF
--- a/litex/soc/software/include/base/stdlib.h
+++ b/litex/soc/software/include/base/stdlib.h
@@ -57,7 +57,7 @@ static inline int atoi(const char *nptr) {
 static inline long atol(const char *nptr) {
 	return (long)atoi(nptr);
 }
-char *number(char *buf, char *end, unsigned long num, int base, int size, int precision, int type);
+char *number(char *buf, char *end, unsigned long long num, int base, int size, int precision, int type);
 
 #define   RAND_MAX        2147483647
 

--- a/litex/soc/software/libbase/libc.c
+++ b/litex/soc/software/libbase/libc.c
@@ -424,7 +424,7 @@ int skip_atoi(const char **s)
 	return i;
 }
 
-char *number(char *buf, char *end, unsigned long num, int base, int size, int precision, int type)
+char *number(char *buf, char *end, unsigned long long num, int base, int size, int precision, int type)
 {
 	char c,sign,tmp[66];
 	const char *digits;


### PR DESCRIPTION
The vsnprintf() function would correctly interpret %lld and %llu
arguments as "long long" width, but the number() helper function only
accept "long" so the value would be truncated and then printed
incorrectly.

Widen the argument to number() to accommodate up to "long long".