### PR TITLE
software/liblitespi: Fix speed test.

### DIFF
--- a/litex/soc/software/liblitespi/spiflash.c
+++ b/litex/soc/software/liblitespi/spiflash.c
@@ -47,12 +47,11 @@ int spiflash_freq_init(void)
 		return -1;
 	}
 
-	for(int i = lowest_div; (crc == crc_test) && (i >= 0); i--) {
-		lowest_div = i;
-		spiflash_phy_clk_divisor_write((uint32_t)i);
+	while((crc == crc_test) && (lowest_div-- > 0)) {
+		spiflash_phy_clk_divisor_write((uint32_t)lowest_div);
 		crc_test = crc32((unsigned char *)SPIFLASH_BASE, SPI_FLASH_BLOCK_SIZE);
 #if DEBUG
-		printf("[DIV: %d] %08x\n\r", i, crc_test);
+		printf("[DIV: %d] %08x\n\r", lowest_div, crc_test);
 #endif
 	}
 	lowest_div++;


### PR DESCRIPTION
Before this patch, the loop would finish with `lowest_div` either set to the first failing value
or 0 even if it succeeded with 0. Fix it so that if all tests pass, it’ll end up being -1 before
the incrementation.

This patch also skips retesting the original value. If the retest failed, `lowest_div` would be incremented past the original value and could potentially wrap around.