### PR TITLE
software/liblitespi: Remove manual mode control.

### DIFF
--- a/litex/soc/software/liblitespi/spiflash.c
+++ b/litex/soc/software/liblitespi/spiflash.c
@@ -17,16 +17,6 @@
 #define DEBUG	0
 #define USER_DEFINED_DUMMY_BITS	0
 
-static spi_mode spi_get_mode(void)
-{
-	return (spi_mode)spiflash_mmap_cfg_read();
-}
-
-static void spi_set_mode(spi_mode mode)
-{
-	spiflash_mmap_cfg_write((unsigned char)mode);
-}
-
 int spiflash_freq_init(void)
 {
 	unsigned int lowest_div = spiflash_phy_clk_divisor_read();
@@ -36,10 +26,6 @@ int spiflash_freq_init(void)
 #if DEBUG
 	printf("Testing against CRC32: %08x\n\r", crc);
 #endif
-
-	if(spi_get_mode() != SPI_MODE_MMAP) {
-		spi_set_mode(SPI_MODE_MMAP);
-	}
 
 	/* Check if block is erased (filled with 0xFF) */
 	if(crc == CRC32_ERASED_FLASH) {

--- a/litex/soc/software/liblitespi/spiflash.h
+++ b/litex/soc/software/liblitespi/spiflash.h
@@ -6,11 +6,6 @@
 #define SPI_FLASH_BLOCK_SIZE	256
 #define CRC32_ERASED_FLASH	0xFEA8A821
 
-typedef enum {
-	SPI_MODE_MMAP = 0,
-	SPI_MODE_MASTER = 1,
-} spi_mode;
-
 int spiflash_freq_init(void);
 void spiflash_dummy_bits_setup(unsigned int dummy_bits);
 void spiflash_init(void);


### PR DESCRIPTION
An upcoming PR for https://github.com/litex-hub/litespi/issues/46 is adding automatic arbitration between MMIO and master cores, so the CSR for manual control is being removed.

In existing gateware, mode defaults to MMIO, so in most cases this check does not matter anyway.