### PR TITLE
Make memtest_data more configurable

### DIFF
--- a/litex/soc/software/include/base/memtest.h
+++ b/litex/soc/software/include/base/memtest.h
@@ -3,10 +3,22 @@
 
 #include <stdbool.h>
 
+// Called when an error is encountered. Can return non-zero to stop the memtest.
+// `arg` can be used to pass arbitrary data to the callback via `memtest_config.arg`.
+typedef int (*on_error_callback)(unsigned int addr, unsigned int rdata, unsigned int refdata, void *arg);
+
+// Optional memtest configuration. If NULL, then we default to progress=1, read_only=0.
+struct memtest_config {
+	int show_progress;
+	int read_only;
+	on_error_callback on_error;
+	void *arg;
+};
+
 int memtest_access(unsigned int *addr);
 int memtest_bus(unsigned int *addr, unsigned long size);
 int memtest_addr(unsigned int *addr, unsigned long size, int random);
-int memtest_data(unsigned int *addr, unsigned long size, int random);
+int memtest_data(unsigned int *addr, unsigned long size, int random, struct memtest_config *config);
 
 void memspeed(unsigned int *addr, unsigned long size, bool read_only);
 int memtest(unsigned int *addr, unsigned long maxsize);

--- a/litex/soc/software/libbase/memtest.c
+++ b/litex/soc/software/libbase/memtest.c
@@ -11,6 +11,11 @@
 //#define MEMTEST_DATA_DEBUG
 //#define MEMTEST_ADDR_DEBUG
 
+// Limits the number of errors printed, so that we can still access bios console
+#ifndef MEMTEST_DEBUG_MAX_ERRORS
+#define MEMTEST_DEBUG_MAX_ERRORS 400
+#endif
+
 #define KIB 1024
 #define MIB (KIB*1024)
 #define GIB (MIB*1024)
@@ -85,7 +90,8 @@ int memtest_bus(unsigned int *addr, unsigned long size)
 		if(rdata != ONEZERO) {
 			errors++;
 #ifdef MEMTEST_BUS_DEBUG
-			printf("memtest_bus error @ %p: 0x%08x vs 0x%08x\n", addr + i, rdata, ONEZERO);
+			if (MEMTEST_DEBUG_MAX_ERRORS < 0 || errors <= MEMTEST_DEBUG_MAX_ERRORS)
+				printf("memtest_bus error @ %p: 0x%08x vs 0x%08x\n", addr + i, rdata, ONEZERO);
 #endif
 		}
 	}
@@ -105,7 +111,8 @@ int memtest_bus(unsigned int *addr, unsigned long size)
 		if(rdata != ZEROONE) {
 			errors++;
 #ifdef MEMTEST_BUS_DEBUG
-			printf("memtest_bus error @ %p:: 0x%08x vs 0x%08x\n", addr + i, rdata, ZEROONE);
+			if (MEMTEST_DEBUG_MAX_ERRORS < 0 || errors <= MEMTEST_DEBUG_MAX_ERRORS)
+				printf("memtest_bus error @ %p:: 0x%08x vs 0x%08x\n", addr + i, rdata, ZEROONE);
 #endif
 		}
 	}
@@ -141,7 +148,8 @@ int memtest_addr(unsigned int *addr, unsigned long size, int random)
 		if(rdata != i) {
 			errors++;
 #ifdef MEMTEST_ADDR_DEBUG
-			printf("memtest_addr error @ %p: 0x%08x vs 0x%08x\n", addr + i, rdata, i);
+			if (MEMTEST_DEBUG_MAX_ERRORS < 0 || errors <= MEMTEST_DEBUG_MAX_ERRORS)
+				printf("memtest_addr error @ %p: 0x%08x vs 0x%08x\n", addr + i, rdata, i);
 #endif
 		}
 	}
@@ -213,7 +221,8 @@ int memtest_data(unsigned int *addr, unsigned long size, int random, struct memt
 					return errors;
 			}
 #ifdef MEMTEST_DATA_DEBUG
-			printf("memtest_data error @ %p: 0x%08x vs 0x%08x\n", addr + i, rdata, seed_32);
+			if (MEMTEST_DEBUG_MAX_ERRORS < 0 || errors <= MEMTEST_DEBUG_MAX_ERRORS)
+				printf("memtest_data error @ %p: 0x%08x vs 0x%08x\n", addr + i, rdata, seed_32);
 #endif
 		}
 		if (i%0x8000 == 0 && progress)


### PR DESCRIPTION
This PR introduces some additional features to `memtest_data`.
These changes are required for the follow-up PR that adds utilities to help in debugging DRAM issues: https://github.com/enjoy-digital/litex/pull/917

**Config**

`memtest_data` can take an optional parameter with `struct memtest_config *`. When passing NULL `memtest_data` works as before. The config parameter allows to:
* disable progress using `config.show_progress=0`
* disable writing to memory and only read data (`config.read_only=1`), this can be useful when debugging memory issues to test whether errors occur when writing or when reading (reading multiple times we check if we always get the same errors
* allow arbitrary callback when an error is encountered

The callback can take a pointer to arbitrary state via `config.arg`.

Example usage (does not make much sense, but illustrates possibilities) - first fill memory by doing regular memtest, then run a read-only memtest which will stop when an error at 0x00010000 is found.
```c
static int stop_on_bit(
	unsigned int addr, unsigned int rdata, unsigned int refdata, void *arg)
{
	unsinged int bit = (unsinged int) arg;
	struct memory_error error = {
		.addr = addr,
		.data = rdata,
		.ref = refdata,
	};
	return (rdata ^ refdata) == bit ? 1 : 0;
}

void foo() {
	memtest_data((unsigned int *) MAIN_RAM_BASE, SDRAM_MEMTEST_SIZE, 1, NULL);

	struct memtest_config config = {
		.show_progress = 0,
		.read_only = 1,
		.on_error = stop_on_bit,
		.arg = (void *) 0x00010000,
	};

	memtest_data((unsigned int *) MAIN_RAM_BASE, SDRAM_MEMTEST_SIZE, 1, &config);
}
```

**Additional defines**

Two following commits introduce two additional `#define`s:
* `MEMTEST_DEBUG_MAX_ERRORS` limits number of errors printed up to a maximum count, this way when memtest fails completely we won't be stuck with BIOS printing errors for each access (which takes very long and we cannot use the BIOS console)
* `MEMTEST_DATA_RETRIES` can optionally make `memtest_data` retry reading the memory when an error is encountered; this is again helpful for debugging memory issues, as it is a simple way of checking whether errors occur when writing to memory or when reading (when error dissappears after a few retries, then it's most likely issue during reads)