### PR TITLE
Display more precision in BIOS mem_speed test.

### DIFF
--- a/litex/soc/software/libbase/memtest.c
+++ b/litex/soc/software/libbase/memtest.c
@@ -162,11 +162,11 @@ int memtest_addr(unsigned int *addr, unsigned long size, int random)
 }
 
 static void print_size(unsigned long size) {
-	if (size < KIB)
+	if (size < 10*KIB)
 		printf("%luB", size);
-	else if (size < MIB)
+	else if (size < 10*MIB)
 		printf("%luKiB", size/KIB);
-	else if (size < GIB)
+	else if (size < 10*GIB)
 		printf("%luMiB", size/MIB);
 	else
 		printf("%luGiB", size/GIB);

--- a/litex/soc/software/libbase/memtest.c
+++ b/litex/soc/software/libbase/memtest.c
@@ -166,7 +166,7 @@ static void print_size(unsigned long size) {
 		printf("%luB", size);
 	else if (size < 10*MIB)
 		printf("%luKiB", size/KIB);
-	else if (size < 10*GIB)
+	else if (size < GIB)
 		printf("%luMiB", size/MIB);
 	else
 		printf("%luGiB", size/GIB);


### PR DESCRIPTION
Rather than jumping from "999KiB/s" to "1MiB/s",
where 1MiB/s could be anywhere from 1.00 to 1.99 MiB/s,
instead go up to "9999KiB/s" and then "10MiB/s", to always
provide at least two significant digits of accuracy.

Signed-off-by: Tim Callahan <tcal@google.com>