### PR TITLE
software/lib*: address gcc warnings

### DIFF
--- a/litex/soc/software/libbase/memtest.c
+++ b/litex/soc/software/libbase/memtest.c
@@ -233,7 +233,7 @@ int memtest_data(unsigned int *addr, unsigned long size, int random, struct memt
 			errors++;
 			if (config != NULL && config->on_error != NULL) {
 				// call the handler, if non-zero status is returned finish now
-				if (config->on_error((unsigned int) (addr + i), rdata, seed_32, config->arg) != 0)
+				if (config->on_error((unsigned long) (addr + i), rdata, seed_32, config->arg) != 0)
 					return errors;
 			}
 #ifdef MEMTEST_DATA_DEBUG

--- a/litex/soc/software/liblitedram/sdram.c
+++ b/litex/soc/software/liblitedram/sdram.c
@@ -39,7 +39,7 @@
 #define max(x, y) (((x) > (y)) ? (x) : (y))
 #define min(x, y) (((x) < (y)) ? (x) : (y))
 
-__attribute__((unused)) static void cdelay(int i)
+__attribute__((unused)) void cdelay(int i)
 {
 #ifndef CONFIG_DISABLE_DELAYS
 	while(i > 0) {


### PR DESCRIPTION
Fix gcc warnings: use 'unsigned long' to represent memory addresses,
and remove 'static' from the definition of 'cdelay()', as it is called
from multiple C files.