### PR TITLE
Use add_etherbone in simulation

### DIFF
--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -262,15 +262,11 @@ class SimSoC(SoCCore):
         elif with_etherbone:
             # Ethernet PHY
             self.submodules.ethphy = LiteEthPHYModel(self.platform.request("eth", 0)) # FIXME
-            # Ethernet Core
-            ethcore = LiteEthUDPIPCore(self.ethphy,
-                mac_address = etherbone_mac_address,
+            self.add_etherbone(
+                phy         = self.ethphy,
                 ip_address  = etherbone_ip_address,
-                clk_freq    = sys_clk_freq)
-            self.submodules.ethcore = ethcore
-            # Etherbone
-            self.submodules.etherbone = LiteEthEtherbone(self.ethcore.udp, 1234, mode="master")
-            self.add_wb_master(self.etherbone.wishbone.bus)
+                mac_address = etherbone_mac_address
+            )
 
         # Analyzer ---------------------------------------------------------------------------------
         if with_analyzer:


### PR DESCRIPTION
**Describe the bug**
Running the https://github.com/enjoy-digital/litex/wiki/Use-LiteScope-To-Debug-A-SoC#use-the-analyzer tutorial from the wiki leads to errors on the most recent version of litex.

**To Reproduce**
Run `litex_sim --with-etherbone --with-analyzer` followed by `litex_server --udp --udp-ip=192.168.1.51` like the tutorial says.

**Expected behavior**
The litex server connects to the simulation.

**Log output**
```
litex_server --udp --udp-ip=192.168.1.51
[CommUDP] ip: 192.168.1.51 / port: 1234 / tcp port: 1234
Traceback (most recent call last):
  File "/home/martin/coding/litex/litex/litex/tools/remote/comm_udp.py", line 48, in probe
    datas, dummy = self.socket.recvfrom(8192)
socket.timeout: timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/martin/.local/bin/litex_server", line 11, in <module>
    load_entry_point('litex', 'console_scripts', 'litex_server')()
  File "/home/martin/coding/litex/litex/litex/tools/litex_server.py", line 270, in main
    server.open()
  File "/home/martin/coding/litex/litex/litex/tools/litex_server.py", line 90, in open
    self.comm.open()
  File "/home/martin/coding/litex/litex/litex/tools/remote/comm_udp.py", line 31, in open
    self.probe(self.server, self.port)
  File "/home/martin/coding/litex/litex/litex/tools/remote/comm_udp.py", line 56, in probe
    raise Exception(f"Unable to probe Etherbone server at {self.server}.")
Exception: Unable to probe Etherbone server at 192.168.1.51.
```

**Proposed Solution**
This pull request which is based on https://github.com/enjoy-digital/litex/wiki/Use-Host-Bridge-to-control-debug-a-SoC#add-an-ethernet-bridge-to-your-soc and makes litex server and simulation connect successfully.

**Environment:**
 - Litex: 5fd215fe3a16b8f604fa2d61f49e03d89bc28007
 - OS: Ubuntu 20.04