### PR TITLE
Fix base_address for LiteDRAMWishbone2Native

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1326,7 +1326,7 @@ class LiteXSoC(SoC):
                         self.submodules += LiteDRAMWishbone2Native(
                             wishbone     = litedram_wb,
                             port         = port,
-                            base_address = origin)
+                            base_address = self.bus.regions["main_ram"].origin)
                         self.submodules += wishbone.Converter(mem_wb, litedram_wb)
                 # Check if bus is a Native bus and connect it.
                 if isinstance(mem_bus, LiteDRAMNativePort):


### PR DESCRIPTION
I tried using rocket on the ulx3s which has a 16bit dram bus and therefore uses the adapter.
With the latest litex version this fails.
It's probably caused by https://github.com/litex-hub/litex-boards/commit/ba01776

**Log**
```
INFO:SoC:Converting MEM data width: 16 to 64 via Wishbone
Traceback (most recent call last):
  File "../litex/litex-boards/litex_boards/targets/radiona_ulx3s.py", line 202, in <module>
    main()
  File "../litex/litex-boards/litex_boards/targets/radiona_ulx3s.py", line 171, in main
    soc = BaseSoC(
  File "../litex/litex-boards/litex_boards/targets/radiona_ulx3s.py", line 115, in __init__
    self.add_sdram("sdram",
  File "/home/martin/coding/litex/litex/litex/soc/integration/soc.py", line 1326, in add_sdram
    self.submodules += LiteDRAMWishbone2Native(
  File "/home/martin/coding/litex/litedram/litedram/frontend/wishbone.py", line 42, in __init__
    offset  = base_address >> log2_int(port.data_width//8)
TypeError: unsupported operand type(s) for >>: 'NoneType' and 'int'
```