### PR TITLE
Allow external software packages to be linked into the BIOS

### DIFF
--- a/litex/soc/software/bios/Makefile
+++ b/litex/soc/software/bios/Makefile
@@ -54,28 +54,17 @@ endif
 
 bios.elf: $(BIOS_DIRECTORY)/linker.ld $(OBJECTS)
 
+vpath %.a $(PACKAGES:%=../%)
 
-%.elf: ../libbase/crt0.o \
-	../libcompiler_rt/libcompiler_rt.a \
-	../libbase/libbase-nofloat.a \
-	../liblitedram/liblitedram.a \
-	../libliteeth/libliteeth.a \
-	../liblitespi/liblitespi.a \
-	../libfatfs/libfatfs.a \
-	../liblitesdcard/liblitesdcard.a \
-	../liblitesata/liblitesata.a
+%.elf: ../libbase/crt0.o $(LIBS:%=%.a)
 	$(CC) $(LDFLAGS) -T $(BIOS_DIRECTORY)/linker.ld -N -o $@ \
 		../libbase/crt0.o \
 		$(OBJECTS) \
-		-L../libcompiler_rt \
-		-L../libbase \
-		-L../liblitedram \
-		-L../libliteeth \
-		-L../liblitespi \
-		-L../libfatfs \
-		-L../liblitesdcard \
-		-L../liblitesata \
-		-llitedram -lliteeth -llitespi -lfatfs -llitesdcard -llitesata -lbase-nofloat -lcompiler_rt
+		$(PACKAGES:%=-L../%) \
+		-Wl,--whole-archive \
+		-Wl,--gc-sections \
+		$(LIBS:lib%=-l%) \
+
 
 ifneq ($(OS),Windows_NT)
 	chmod -x $@

--- a/litex/soc/software/bios/helpers.c
+++ b/litex/soc/software/bios/helpers.c
@@ -10,6 +10,7 @@
 #include "readline.h"
 #include "helpers.h"
 #include "command.h"
+#include "init.h"
 
 extern unsigned int _ftext, _edata_rom;
 
@@ -125,4 +126,11 @@ struct command_struct *command_dispatcher(char *command, int nb_params, char **p
 	}
 
 	return NULL;
+}
+
+void init_dispatcher(void)
+{
+	for (const init_func* fp = __bios_init_start; fp != __bios_init_end; fp++) {
+		(*fp)();
+	}
 }

--- a/litex/soc/software/bios/helpers.h
+++ b/litex/soc/software/bios/helpers.h
@@ -5,5 +5,6 @@ void dump_bytes(unsigned int *ptr, int count, unsigned long addr);
 void crcbios(void);
 int get_param(char *buf, char **cmd, char **params);
 struct command_struct *command_dispatcher(char *command, int nb_params, char **params);
+void init_dispatcher(void);
 
 #endif

--- a/litex/soc/software/bios/init.h
+++ b/litex/soc/software/bios/init.h
@@ -1,0 +1,10 @@
+#pragma once
+
+typedef void (*init_func)(void);
+
+extern init_func const __bios_init_start[];
+extern init_func const __bios_init_end[];
+
+#define define_init_func(f)                                           \
+    const init_func __bios_init_##f __attribute__((__used__)) \
+    __attribute__((__section__(".bios_init"))) = f

--- a/litex/soc/software/bios/linker.ld
+++ b/litex/soc/software/bios/linker.ld
@@ -41,6 +41,13 @@ SECTIONS
 		PROVIDE_HIDDEN (__bios_cmd_end = .);
 	} > rom
 
+	.init :
+	{
+		PROVIDE_HIDDEN (__bios_init_start = .);
+		KEEP(*(.bios_init))
+		PROVIDE_HIDDEN (__bios_init_end = .);
+	} > rom
+
 	.data :
 	{
 		. = ALIGN(8);

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -173,6 +173,8 @@ int main(int i, char **c)
 	video_framebuffer_dma_enable_write(1);
 #endif
 
+	init_dispatcher();
+
 	if(sdr_ok) {
 		printf("--============== \e[1mBoot\e[0m ==================--\n");
 		boot_sequence();


### PR DESCRIPTION
Hi, this is a set of two commits to allow external code to be linked into the BIOS, as a proposed starting point for #757.

The first commit modifies the builder and the BIOS Makefile to allow packages/libraries to be registered with the builder and passed through to the Makefile to get linked into the binary.

The second commit adds a registration mechanism for initialiation functions to the BIOS, following the same pattern used for command registration.

This has been successfully tested to link in hyperram initialization code without having to modify the litex repo.