### PR TITLE
Replace deprecated inspect.getargspec with inspect.getfullargspec.

### DIFF
--- a/litex/compat/soc_sdram.py
+++ b/litex/compat/soc_sdram.py
@@ -58,7 +58,7 @@ def soc_sdram_args(parser):
 
 def soc_sdram_argdict(args):
     r = soc_core_argdict(args)
-    for a in inspect.getargspec(SoCSDRAM.__init__).args:
+    for a in inspect.getfullargspec(SoCSDRAM.__init__).args:
         if a not in ["self", "platform", "clk_freq"]:
             arg = getattr(args, a, None)
             if arg is not None:

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -337,7 +337,7 @@ def soc_core_args(parser):
 
 def soc_core_argdict(args):
     r = dict()
-    for a in inspect.getargspec(SoCCore.__init__).args:
+    for a in inspect.getfullargspec(SoCCore.__init__).args:
         if a not in ["self", "platform"]:
             if a in ["with_uart", "with_timer", "with_ctrl"]:
                 arg = not getattr(args, a.replace("with", "no"), True)


### PR DESCRIPTION
The [inspect.getargspec](https://docs.python.org/3/library/inspect.html#inspect.getargspec) function has been deprecated since Python 3.0. For the use case in LiteX (referencing the .args part), [inspec.getfullargspec](https://docs.python.org/3/library/inspect.html#inspect.getfullargspec) is a non-deprecated, drop-in replacement (shown by the source code [here](https://github.com/python/cpython/blob/3.9/Lib/inspect.py#L1120)).