### PR TITLE
Force SymbiFlow 'make' to be non-parallel.

### DIFF
--- a/litex/build/xilinx/symbiflow.py
+++ b/litex/build/xilinx/symbiflow.py
@@ -73,7 +73,7 @@ class _MakefileGenerator:
 
 
 def _run_make():
-    make_cmd = ["make"]
+    make_cmd = ["make", "-j1"]
 
     if which("symbiflow_synth") is None:
         msg = "Unable to find Symbiflow toolchain, please:\n"


### PR DESCRIPTION
Fixes #944 .

Signed-off-by: Tim Callahan <tcal@google.com>