### PR TITLE
Add options to save and print environment variables to Flash persistent storage 

### DIFF
--- a/litex/soc/software/bios/boot.h
+++ b/litex/soc/software/bios/boot.h
@@ -4,6 +4,7 @@
 void set_local_ip(const char * ip_address);
 void set_remote_ip(const char * ip_address);
 void set_mac_addr(const char * mac_address);
+void set_tftpserver_port(unsigned port_address);
 
 void __attribute__((noreturn)) boot(unsigned long r1, unsigned long r2, unsigned long r3, unsigned long addr);
 int serialboot(void);
@@ -12,5 +13,7 @@ void flashboot(void);
 void romboot(void);
 void sdcardboot(void);
 void sataboot(void);
+int init_env_from_flash(void);
+int get_env_params(char * base_env_params, unsigned int size);
 
 #endif /* __BOOT_H */

--- a/litex/soc/software/bios/cmds/cmd_liteeth.c
+++ b/litex/soc/software/bios/cmds/cmd_liteeth.c
@@ -193,3 +193,28 @@ static void eth_mac_addr_handler(int nb_params, char **params)
 }
 define_command(eth_mac_addr, eth_mac_addr_handler, "Set the mac address", LITEETH_CMDS);
 #endif
+
+/**
+ * Command "tftp_server_port"
+ *
+ * Set TFTP server port.
+ *
+ */
+#ifdef ETH_DYNAMIC_IP
+static void tftp_server_port_handler(int nb_params, char **params)
+{
+	if (nb_params != 1)
+	{
+		printf("tftp_server_port <port>");
+		return;
+	}
+	int port_address = atoi(params[0]);
+	if (port_address < 0)
+	{
+	printf("Incorrect port number \n");
+	return;
+	}
+	set_tftpserver_port(port_address);
+}
+define_command(tftp_server_port, tftp_server_port_handler, "Set the TFTP server port", LITEETH_CMDS);
+#endif

--- a/litex/soc/software/bios/cmds/cmd_spiflash.c
+++ b/litex/soc/software/bios/cmds/cmd_spiflash.c
@@ -2,11 +2,15 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <generated/csr.h>
 
 #include "../command.h"
 #include "../helpers.h"
+#include <spiflash.h>
+#include <jsmn_helpers.h>
+#include <bios/boot.h>
 
 /**
  * Command "flash_write"
@@ -73,3 +77,68 @@ static void flash_erase_handler(int nb_params, char **params)
 define_command(flash_erase, flash_erase_handler, "Erase whole flash", SPIFLASH_CMDS);
 #endif
 
+/**
+ * Command "flash_save_env"
+ *
+ * Save environment parameters to SPI Flash storage
+ *
+ */
+#if (defined CSR_SPIFLASH_BASE && defined SPIFLASH_PAGE_SIZE && defined FLASH_SAVE_ENV)
+static void flash_save_env_handler(int nb_params, char **params)
+{
+	char base_env_params[ENV_VAR_SIZE];
+	memset(base_env_params, 0, sizeof(base_env_params));
+	unsigned int addr;
+	char *c;
+	if (nb_params > 1)
+	{
+		printf("flash_save_env <address>");
+		return;
+	}
+	if(nb_params == 0)
+		addr = (unsigned int)FLASH_ENV_ADDRESS;
+	else
+	{
+		addr = strtoul(params[0], &c, 0);
+		if (*c != 0)
+		{
+			printf("Incorrect address");
+			return;
+		}
+	}
+	erase_flash_subsector(addr);
+	get_env_params(base_env_params, sizeof(base_env_params)); /*Getting environment parameters in JSON format*/
+	print_tokens(base_env_params, NULL);
+	write_to_flash(addr, (const unsigned char *)base_env_params, sizeof(base_env_params));
+}
+
+define_command(flash_save_env, flash_save_env_handler, "Save environment parameters to flash storage ", SPIFLASH_CMDS);
+#endif
+
+/**
+ * Command "flash_show_env"
+ *
+ * Print environment parameters from flash storage
+ *
+ */
+#if (defined CSR_SPIFLASH_BASE && defined SPIFLASH_PAGE_SIZE && defined FLASH_SAVE_ENV)
+static void flash_show_env_handler(int nb_params, char **params)
+{
+	char flash_buffer[ENV_VAR_SIZE];
+	memset(flash_buffer, 0, sizeof(flash_buffer));
+	memcpy((void *)flash_buffer, (void *)FLASH_ENV_ADDRESS, ENV_VAR_SIZE);
+	if(nb_params == 0)
+	{
+		printf("Printing all environment variables...\n");
+		print_tokens(flash_buffer, NULL);
+	}
+	else if(nb_params == 1)
+	{
+		print_tokens(flash_buffer, params[0]);
+	}
+	else
+		printf("flash_show_env <token> ");
+}
+
+define_command(flash_show_env, flash_show_env_handler, "Print environment parameters from flash", SPIFLASH_CMDS);
+#endif

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -49,6 +49,10 @@
 
 static void boot_sequence(void)
 {
+#ifdef FLASH_SAVE_ENV
+	if (init_env_from_flash() == -1)
+		printf("Failed to get initialization parameters from Flash memory\n");
+#endif
 #ifdef CSR_UART_BASE
 	if (serialboot() == 0)
 		return;

--- a/litex/soc/software/include/base/jsmn_helpers.h
+++ b/litex/soc/software/include/base/jsmn_helpers.h
@@ -1,0 +1,10 @@
+#ifndef __JSMN_HELPERS_H__
+#define __JSMN_HELEPRS_H__
+
+#define JSMN_HEADER
+#include "jsmn.h"
+
+int print_tokens(char *json_buffer, const char *searched);
+int json_token_check(const char *json_buffer, jsmntok_t *token, const char *searched);
+
+#endif

--- a/litex/soc/software/include/base/spiflash.h
+++ b/litex/soc/software/include/base/spiflash.h
@@ -1,8 +1,13 @@
 #ifndef __SPIFLASH_H
 #define __SPIFLASH_H
 
+#define FLASH_ENV_ADDRESS 16777216
+#define ENV_VAR_SIZE 1024
+#define JSMN_TOKEN_SIZE 10
+
 void write_to_flash_page(unsigned int addr, const unsigned char *c, unsigned int len);
 void erase_flash_sector(unsigned int addr);
+void erase_flash_subsector(unsigned int addr);
 void erase_flash(void);
 void write_to_flash(unsigned int addr, const unsigned char *c, unsigned int len);
 

--- a/litex/soc/software/libbase/Makefile
+++ b/litex/soc/software/libbase/Makefile
@@ -19,7 +19,8 @@ OBJECTS = exception.o \
 	div64.o           \
 	progress.o        \
 	memtest.o         \
-	sim_debug.o
+	sim_debug.o       \
+	jsmn_helpers.o
 
 all: crt0.o libbase.a libbase-nofloat.a
 

--- a/litex/soc/software/libbase/jsmn_helpers.c
+++ b/litex/soc/software/libbase/jsmn_helpers.c
@@ -1,0 +1,39 @@
+#include <jsmn_helpers.h>
+#include <string.h>
+#include <stdio.h>
+#include <spiflash.h>
+
+int json_token_check(const char *json_buffer, jsmntok_t *token, const char *searched)
+{
+	if ((int)strlen(searched) == token->end - token->start && strncmp(json_buffer + token->start, searched, token->end - token->start) == 0)
+	{
+		return 0; //Token found
+	}
+	return -1;
+}
+
+int print_tokens(char *json_buffer, const char *searched)
+{
+	int token_count;
+	jsmn_parser parser;
+	jsmntok_t tokens[JSMN_TOKEN_SIZE]; /* No more than JSMN_TOKEN_SIZE tokens */
+	jsmn_init(&parser);
+	token_count = jsmn_parse(&parser, json_buffer, strlen(json_buffer), tokens, sizeof(tokens) / sizeof(tokens[0]));
+	if (token_count < 0)
+	{
+		printf("Failed to parse JSON\n");
+		return -1;
+	}
+	for (unsigned i = 1; i < token_count; i++)
+	{
+		if(searched == NULL)
+			printf("%.*s: %.*s\n",tokens[i].end - tokens[i].start, json_buffer + tokens[i].start ,tokens[i + 1].end - tokens[i + 1].start, json_buffer + tokens[i + 1].start);
+		else if(json_token_check(json_buffer, &tokens[i], searched) == 0)
+		{
+			printf("%.*s: %.*s\n",tokens[i].end - tokens[i].start, json_buffer + tokens[i].start ,tokens[i + 1].end - tokens[i + 1].start, json_buffer + tokens[i + 1].start);
+			return 0;
+		}
+		++i;
+	}
+	return 0;
+}


### PR DESCRIPTION
That Merge Request allows to:
- Print the environment variable from Flash persistent storage using **flash_show_env** bios command. Without argument, command lists all available environment variables. 
- Save the environment variables to the specified memory location using **flash_save_env** bios command. Without argument in command, saves variables to the memory address based on the default FLASH_OFFSET macro.
-  Sets any number greater than 0 as the port of the tftp server using **tftp_server_port** command.

Adds to functionality:
- get_env_params function in bios/boot.c to convert environment variables(data types) to token boundaries in JSON string.
- json_token_check function in libbase/jsmn_helpers.c to check presence of given token in JSON format string.
- erase_flash_subsector function in libbase/spiflash.c to erase given subsector.
- init_env_from_flash function in bios/boot.c to initialization of our environment variables at startup.

That PR is associated with litex-hub/litex-boards#228