### PR TITLE
cores/clock/ecp5: Add dynamic phase adjustment signals.

### DIFF
--- a/litex/soc/cores/clock/lattice_ecp5.py
+++ b/litex/soc/cores/clock/lattice_ecp5.py
@@ -32,6 +32,11 @@ class ECP5PLL(Module):
         self.config     = {}
         self.params     = {}
 
+        self.phase_sel  = Signal(2)
+        self.phase_dir  = Signal()
+        self.phase_step = Signal()
+        self.phase_load = Signal()
+
     def register_clkin(self, clkin, freq):
         (clki_freq_min, clki_freq_max) = self.clki_freq_range
         assert freq >= clki_freq_min
@@ -108,6 +113,14 @@ class ECP5PLL(Module):
             p_CLKOS3_CPHASE = 23,
             p_CLKFB_DIV     = config["clkfb_div"],
             p_CLKI_DIV      = config["clki_div"],
+
+            p_DPHASE_SOURCE = "ENABLED",
+
+            i_PHASESEL0     = self.phase_sel[0],
+            i_PHASESEL1     = self.phase_sel[1],
+            i_PHASEDIR      = self.phase_dir,
+            i_PHASESTEP     = self.phase_step,
+            i_PHASELOADREG  = self.phase_load,
         )
         self.comb += self.locked.eq(locked & ~self.reset)
         for n, (clk, f, p, m) in sorted(self.clkouts.items()):


### PR DESCRIPTION
I'd like to upstream this change by @gregdavill, extracted from https://github.com/gregdavill/DiVA-firmware/blob/main/gateware/rtl/ecp5_dynamic_pll.py.