### PR TITLE
build/DFUProg: Allow to specify alt interface and to not reboot

### DIFF
--- a/litex/build/dfu.py
+++ b/litex/build/dfu.py
@@ -14,11 +14,18 @@ from litex.build.generic_programmer import GenericProgrammer
 class DFUProg(GenericProgrammer):
     needs_bitreverse = False
 
-    def __init__(self, vid, pid):
+    def __init__(self, vid, pid, alt=None):
         self.vid = vid
         self.pid = pid
+        self.alt = alt
 
-    def load_bitstream(self, bitstream_file):
+    def load_bitstream(self, bitstream_file, reset=True):
         subprocess.call(["cp", bitstream_file, bitstream_file + ".dfu"])
         subprocess.call(["dfu-suffix", "-v", self.vid, "-p", self.pid, "-a", bitstream_file + ".dfu"])
-        subprocess.call(["dfu-util", "--download", bitstream_file + ".dfu", "-R"])
+
+        flash_cmd = ["dfu-util", "--download", bitstream_file + ".dfu"]
+        if reset:
+            flash_cmd.append("-R")
+        if self.alt is not None:
+            flash_cmd.extend(["-a", str(self.alt)])
+        subprocess.call(flash_cmd)


### PR DESCRIPTION
Some targets have multiple alt settings for DFU for different zone
of the flash. Allowing to specify which one to flash and not
rebooting immediately allows to flash several of them at once.

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>