### PR TITLE
Fix compile error when FST traces are enabled on macOS.

### DIFF
--- a/litex/build/sim/core/Makefile
+++ b/litex/build/sim/core/Makefile
@@ -7,10 +7,11 @@ ifeq ($(UNAME_S),Darwin)
 	LDFLAGS += -lpthread -ljson-c -lm -lstdc++ -ldl -levent
 else
 	CC ?= gcc
-	CFLAGS += -Wall -$(OPT_LEVEL) -ggdb $(if $(COVERAGE), -DVM_COVERAGE) $(if $(TRACE_FST), -DTRACE_FST)
+	CFLAGS += -ggdb
 	LDFLAGS += -lpthread -Wl,--no-as-needed -ljson-c -lm -lstdc++ -Wl,--no-as-needed -ldl -levent
 endif
 
+CFLAGS += -Wall -$(OPT_LEVEL) $(if $(COVERAGE), -DVM_COVERAGE) $(if $(TRACE_FST), -DTRACE_FST)
 
 CC_SRCS ?= "--cc sim.v"
 


### PR DESCRIPTION
Compile options should be the same for all platforms.