### PR TITLE
soc/interconnect/axi: fix valid signal in connect_to_pads for axi lite

### DIFF
--- a/litex/soc/interconnect/axi.py
+++ b/litex/soc/interconnect/axi.py
@@ -92,10 +92,10 @@ def connect_to_pads(bus, pads, mode="master", axi_full=False):
     }
     for channel, mode in channel_modes.items():
         ch = getattr(bus, channel)
-        for name, width in (
-            [("valid", 1)] +
-            [("last",  1)] if (ch in ["w", "r"] and axi_full) else [] +
-            ch.description.payload_layout):
+        sig_list = [("valid", 1)] + ch.description.payload_layout
+        if ch in ["w", "r"] and axi_full:
+            sig_list += [("last",  1)]
+        for name, width in sig_list:
             sig  = getattr(ch, name)
             pad  = getattr(pads, channel + name)
             if mode == "master":


### PR DESCRIPTION
The code here https://github.com/enjoy-digital/litex/blob/master/litex/soc/interconnect/axi.py#L96 is obscure enough to disable the 'valid' signal when axi_full is False:

```
        for name, width in (
            [("valid", 1)] +
            [("last",  1)] if (ch in ["w", "r"] and axi_full) else [] +
            ch.description.payload_layout):
```