### PR TITLE
Spartan 6 Support

### DIFF
--- a/litex/soc/cores/clock/xilinx_s6.py
+++ b/litex/soc/cores/clock/xilinx_s6.py
@@ -37,7 +37,6 @@ class S6PLL(XilinxClocking):
             p_BANDWIDTH      = "OPTIMIZED",
             p_COMPENSATION   = "INTERNAL",
             i_RST            = self.reset,
-            i_PWRDWN         = self.power_down,
             o_LOCKED         = self.locked,
 
             # VCO.


### PR DESCRIPTION
I was trying to build for a spartan 6 board and discovered that a patch a while back added in a flag to the clocking that just doesn't exist on the S6PLL. I feel like just removing the line linking it through seems a little excessive, but I can't see anything in any of the datasheets that would suggest that there's support for this.
With that said, this change allows the s6 boards to build again. Tested with building using ISE 14.7 against the panologic g2 target.