### PR TITLE
Increase delay for `tty.usbmodem` on macOS.

### DIFF
--- a/litex/tools/litex_term.py
+++ b/litex/tools/litex_term.py
@@ -314,6 +314,9 @@ class LiteXTerm:
         if "ttyACM" in port:
             self.payload_length = sfl_payload_length
             self.delay          = 1e-4
+        elif "tty.usbmodem" in port:
+            self.payload_length = sfl_payload_length
+            self.delay          = 1e-3
         else:
             self.payload_length = 64
             self.delay          = 1e-5


### PR DESCRIPTION
**Problems**

On macOS USB CDC ACM, which appears as `/dev/tty.usbmodem*`,
somehow `lxterm` keeps failing to send a payload.

**Solution**

Increase delay.

It's very unknown why to me, however, probably macOS USB CDC ACM
driver implementation issue.

**Testing**

Tested on MacBook Air (2020, M1) for OrangeCrab (rev.0.2) target
with Linux on LiteX SoC bitstream build from current commit and
load prebuild Linux On LiteX image.