### PR TITLE
ECP5PLL: implement 4-output solver

### DIFF
--- a/litex/soc/cores/clock/lattice_ecp5.py
+++ b/litex/soc/cores/clock/lattice_ecp5.py
@@ -25,6 +25,7 @@ class ECP5PLL(Module):
         self.logger.info("Creating ECP5PLL.")
         self.reset      = Signal()
         self.locked     = Signal()
+        self.stdby      = Signal()
         self.clkin_freq = None
         self.vcxo_freq  = None
         self.nclkouts   = 0
@@ -117,6 +118,7 @@ class ECP5PLL(Module):
                 ("MFG_GMCREF_SEL",         "2")],
             i_RST           = self.reset,
             i_CLKI          = self.clkin,
+            i_STDBY         = self.stdby,
             o_LOCK          = locked,
             p_FEEDBK_PATH   = "INT_OS3", # CLKOS3 reserved for feedback with div=1.
             p_CLKOS3_ENABLE = "ENABLED",

--- a/test/test_clock.py
+++ b/test/test_clock.py
@@ -117,7 +117,8 @@ class TestClock(unittest.TestCase):
         pll = ECP5PLL()
         pll.register_clkin(Signal(), 100e6)
         for i in range(pll.nclkouts_max):
-            pll.create_clkout(ClockDomain("clkout{}".format(i)), 200e6)
+            pll.create_clkout(ClockDomain("clkout{}".format(i)), 200e6, uses_dpa=(i != 0))
+        pll.expose_dpa()
         pll.compute_config()
 
     # Lattice / NX


### PR DESCRIPTION
Reimplement the configuration loop to allow all 4 outputs to be used by the user, if one of them is suitable for use as VCO feedback.

The new strategy is to first iterate over requested outputs to see if any of them can be used as a feedback source.  If one can, it is selected, and if no output is suitable, it attempts to instantiate one.  Once the feedback path is selected, the VCO frequency is known and it attempts to calculate the remaining outputs' settings.

In addition, this implementation now respects datasheet limits in two new ways:

- It respects the post-input-divider minimum frequency of 10MHz
- It respects the max output frequency of 400MHz for instantiated feedback outputs

I am slightly unhappy with the seemingly-repetitive for loops. However each one has slightly different semantics and I don't see a way to combine them that doesn't hinder readability.

I've also rolled in a very small unrelated change that exposes the PLL's STANDBY signal.

Comments welcome, thanks for the useful framework!