### PR TITLE
Make "generated/soc.h" able to be included in assembly files.

### DIFF
--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -147,7 +147,7 @@ def get_mem_header(regions):
 def get_soc_header(constants, with_access_functions=True):
     r = generated_banner("//")
     r += "#ifndef __GENERATED_SOC_H\n#define __GENERATED_SOC_H\n"
-
+    funcs = ""
 
     for name, value in constants.items():
         if value is None:
@@ -161,8 +161,13 @@ def get_soc_header(constants, with_access_functions=True):
             ctype = "int"
         r += "#define "+name+" "+value+"\n"
         if with_access_functions:
-            r += "static inline "+ctype+" "+name.lower()+"_read(void) {\n"
-            r += "\treturn "+value+";\n}\n"
+            funcs += "static inline "+ctype+" "+name.lower()+"_read(void) {\n"
+            funcs += "\treturn "+value+";\n}\n"
+
+    if with_access_functions:
+        r += "\n#ifndef __ASSEMBLER__\n"
+        r += funcs
+        r += "#endif // !__ASSEMBLER__\n"
 
     r += "\n#endif\n"
     return r


### PR DESCRIPTION
Related Issue:  #966

This PR implements the proposed change from the related issue, this allows the `generated/soc.h` file to be safely included in any assembly files.

It does change the layout of `soc.h` from the following:
```C
//--------------------------------------------------------------------------------
// Auto-generated by Migen (3ffd64c) & LiteX (8276857c) on 2021-07-09 10:46:33
//--------------------------------------------------------------------------------
#ifndef __GENERATED_SOC_H
#define __GENERATED_SOC_H
#define CONFIG_CLOCK_FREQUENCY 24000000
static inline int config_clock_frequency_read(void) {
	return 24000000;
}
#define CONFIG_CPU_HAS_INTERRUPT
#define CONFIG_CPU_RESET_ADDR 2147680256
static inline int config_cpu_reset_addr_read(void) {
	return 2147680256;
}
...
#endif
```

to:

```C
//--------------------------------------------------------------------------------
// Auto-generated by Migen (3ffd64c) & LiteX (8276857c) on 2021-07-09 10:46:33
//--------------------------------------------------------------------------------
#ifndef __GENERATED_SOC_H
#define __GENERATED_SOC_H
#define CONFIG_CLOCK_FREQUENCY 24000000
#define CONFIG_CPU_HAS_INTERRUPT
#define CONFIG_CPU_RESET_ADDR 2147680256
...
#ifndef __ASSEMBLER__
static inline int config_clock_frequency_read(void) {
	return 24000000;
}
static inline int config_cpu_reset_addr_read(void) {
	return 2147680256;
}
...
#endif // !__ASSEMBLER__

#endif
```

I'm more than happy to update this PR with any suggestions or changes.