### PR TITLE
openfpgaloader: add cable and freq options

### DIFF
--- a/litex/build/openfpgaloader.py
+++ b/litex/build/openfpgaloader.py
@@ -12,16 +12,22 @@ from litex.build.generic_programmer import GenericProgrammer
 class OpenFPGALoader(GenericProgrammer):
     needs_bitreverse = False
 
-    def __init__(self, board):
-        self.board = board
+    def __init__(self, board="", cable="", freq=0):
+        self.cmd = ["openFPGALoader"]
+        if board:
+            self.cmd += ["--board", board]
+        if cable:
+            self.cmd += ["--cable", cable]
+        if freq:
+            self.cmd += ["--freq", int(freq)]
 
     def load_bitstream(self, bitstream_file):
-        cmd = ["openFPGALoader", "--board", self.board, "--bitstream", bitstream_file]
-        self.call(cmd)
+        self.cmd += ["--bitstream", bitstream_file]
+        self.call(self.cmd)
 
     def flash(self, address, data_file):
-        cmd = ["openFPGALoader", "--board", self.board, "--write-flash", "--bitstream", data_file]
+        self.cmd += ["--write-flash", "--bitstream", data_file]
         if address:
-            cmd.append("--offset")
-            cmd.append(address)
-        self.call(cmd)
+            self.cmd.append("--offset")
+            self.cmd.append(address)
+        self.call(self.cmd)

--- a/litex/build/openfpgaloader.py
+++ b/litex/build/openfpgaloader.py
@@ -19,7 +19,7 @@ class OpenFPGALoader(GenericProgrammer):
         if cable:
             self.cmd += ["--cable", cable]
         if freq:
-            self.cmd += ["--freq", int(freq)]
+            self.cmd += ["--freq", str(int(freq))]
 
     def load_bitstream(self, bitstream_file):
         self.cmd += ["--bitstream", bitstream_file]


### PR DESCRIPTION
Not all boards have an onboard cable (FTDI, DFU, CMSIS-DAP, ...) it's the case for instance for acorn CLE 215+ or colorlight 5A-75B.
In this situation `--cable` is required or default `ft2232` cable is used.
Without `--freq` the cable is configured with a 6MHz clock frequency. It's a good compromise between speed and stability but with current master branch we have demonstrate *openFPGALoader* is able with arty to work at 30MHz (max FT2232 clock frequency).

This PR add two optional constructor params to pass cable name and frequency and build cmd line accordingly. 