### PR TITLE
openfpgaloader: improves freq conversion type

### DIFF
--- a/litex/build/openfpgaloader.py
+++ b/litex/build/openfpgaloader.py
@@ -19,7 +19,7 @@ class OpenFPGALoader(GenericProgrammer):
         if cable:
             self.cmd += ["--cable", cable]
         if freq:
-            self.cmd += ["--freq", str(int(freq))]
+            self.cmd += ["--freq", str(int(float(freq)))]
 
     def load_bitstream(self, bitstream_file):
         self.cmd += ["--bitstream", bitstream_file]


### PR DESCRIPTION
`freq` param may be a string, an int but in all cases it's usualy easier to use engineering notation to represent big number.
This PR add a conversion to float to avoid exception like:
`
ValueError: invalid literal for int() with base 10: '10e6'
`
