### PR TITLE
soc/software/liblitedram: fix pattern checking for low DFI databits

### DIFF
--- a/litex/soc/software/liblitedram/sdram.c
+++ b/litex/soc/software/liblitedram/sdram.c
@@ -6,6 +6,7 @@
 // This file is Copyright (c) 2018 Jean-François Nguyen <jf@lambdaconcept.fr>
 // This file is Copyright (c) 2018 Sergiusz Bazanski <q3k@q3k.org>
 // This file is Copyright (c) 2018 Tim 'mithro' Ansell <me@mith.ro>
+// This file is Copyright (c) 2021 Antmicro <www.antmicro.com>
 // License: BSD
 
 #include <generated/csr.h>
@@ -57,7 +58,7 @@ __attribute__((unused)) void cdelay(int i)
 #define MEMTEST_DATA_SIZE (2*1024*1024)
 #endif
 
-#define DFII_PIX_DATA_BYTES SDRAM_PHY_DATABITS*SDRAM_PHY_XDR/8
+#define DFII_PIX_DATA_BYTES SDRAM_PHY_DFI_DATABITS/8
 
 int sdram_get_databits(void) {
 	return SDRAM_PHY_DATABITS;
@@ -299,7 +300,7 @@ static void print_scan_errors(unsigned int errors) {
 #endif
 }
 
-#define READ_CHECK_TEST_PATTERN_MAX_ERRORS (SDRAM_PHY_PHASES*2*32)
+#define READ_CHECK_TEST_PATTERN_MAX_ERRORS (8*SDRAM_PHY_PHASES*SDRAM_PHY_XDR)
 
 static unsigned int sdram_write_read_check_test_pattern(int module, unsigned int seed) {
 	int p, i;
@@ -346,8 +347,12 @@ static unsigned int sdram_write_read_check_test_pattern(int module, unsigned int
 		/* Read back test pattern */
 		csr_rd_buf_uint8(sdram_dfii_pix_rddata_addr(p), tst, DFII_PIX_DATA_BYTES);
 		/* Verify bytes matching current 'module' */
-		errors += popcount(prs[p][	SDRAM_PHY_MODULES-1-module] ^ tst[	SDRAM_PHY_MODULES-1-module]);
-		errors += popcount(prs[p][2*SDRAM_PHY_MODULES-1-module] ^ tst[2*SDRAM_PHY_MODULES-1-module]);
+		for (int i = 0; i < DFII_PIX_DATA_BYTES; ++i) {
+			int j = p * DFII_PIX_DATA_BYTES + i;
+			if (j % SDRAM_PHY_MODULES == SDRAM_PHY_MODULES-1-module) {
+				errors += popcount(prs[p][i] ^ tst[i]);
+			}
+		}
 	}
 
 #ifdef SDRAM_PHY_ECP5DDRPHY


### PR DESCRIPTION
This a fix described at the end of https://github.com/enjoy-digital/litedram/pull/258#issuecomment-882435501.

To my understanding this should be correct, but please check if you think it is. I've tested this on xilinx_zcu104, digilent_arty and antmicro_lpddr4_test_board and it worked correctly on these.

I also used the following script to verify the error counts:
```python
#!/usr/bin/env python

VERBOSE = False

def check_test_pattern_popcounts(module, *, nphases, dfii_pix_data_bytes, nmodules):
    per_phase = []
    for p in range(nphases):
        this_phase = []
        for i in range(dfii_pix_data_bytes):
            j = p * dfii_pix_data_bytes + i
            if j % nmodules == (nmodules - 1 - module):
                this_phase.append(i)
        per_phase.append(this_phase)
    # max 8 per popcount as we always compare unsigned char
    max_errors = sum(8*len(popcounts) for popcounts in per_phase)
    # calculated analytically
    xdr = 2
    max_errors_calculated = 8 * nphases * xdr
    return per_phase, max_errors, max_errors_calculated

for nphases in [1, 2, 4, 8]:
    for nmodules in [1, 2, 4, 8]:
        xdr = 2
        pix_databits = nmodules*8 * xdr
        pix_databytes = pix_databits//8
        for module in range(nmodules):
            per_phase, max_errors, max_errors_calculated = check_test_pattern_popcounts(
                module, nphases=nphases, dfii_pix_data_bytes=pix_databytes, nmodules=nmodules)

            variables = f'{nphases=} {pix_databytes=:2} {nmodules=} {module=} {max_errors=:4} {max_errors_calculated=:4}'
            if max_errors != max_errors_calculated:
                print(f'!MISMATCH! {variables}')
            else:
                print(f' ok        {variables}')
            if VERBOSE:
                # lines = [f'    prs[{p}][{i}] ^ tst[{i}]' for (p, i) in enumerate(per_phase)]
                lines = []
                for p, phase in enumerate(per_phase):
                    for i in phase:
                        lines.append(f'    prs[{p}][{i}] ^ tst[{i}]')
                print('\n'.join(lines))
```
which yields:
```
 ok        nphases=1 pix_databytes= 2 nmodules=1 module=0 max_errors=  16 max_errors_calculated=  16
 ok        nphases=1 pix_databytes= 4 nmodules=2 module=0 max_errors=  16 max_errors_calculated=  16
 ok        nphases=1 pix_databytes= 4 nmodules=2 module=1 max_errors=  16 max_errors_calculated=  16
 ok        nphases=1 pix_databytes= 8 nmodules=4 module=0 max_errors=  16 max_errors_calculated=  16
 ok        nphases=1 pix_databytes= 8 nmodules=4 module=1 max_errors=  16 max_errors_calculated=  16
 ok        nphases=1 pix_databytes= 8 nmodules=4 module=2 max_errors=  16 max_errors_calculated=  16
 ok        nphases=1 pix_databytes= 8 nmodules=4 module=3 max_errors=  16 max_errors_calculated=  16
 ok        nphases=1 pix_databytes=16 nmodules=8 module=0 max_errors=  16 max_errors_calculated=  16
 ok        nphases=1 pix_databytes=16 nmodules=8 module=1 max_errors=  16 max_errors_calculated=  16
 ok        nphases=1 pix_databytes=16 nmodules=8 module=2 max_errors=  16 max_errors_calculated=  16
 ok        nphases=1 pix_databytes=16 nmodules=8 module=3 max_errors=  16 max_errors_calculated=  16
 ok        nphases=1 pix_databytes=16 nmodules=8 module=4 max_errors=  16 max_errors_calculated=  16
 ok        nphases=1 pix_databytes=16 nmodules=8 module=5 max_errors=  16 max_errors_calculated=  16
 ok        nphases=1 pix_databytes=16 nmodules=8 module=6 max_errors=  16 max_errors_calculated=  16
 ok        nphases=1 pix_databytes=16 nmodules=8 module=7 max_errors=  16 max_errors_calculated=  16
 ok        nphases=2 pix_databytes= 2 nmodules=1 module=0 max_errors=  32 max_errors_calculated=  32
 ok        nphases=2 pix_databytes= 4 nmodules=2 module=0 max_errors=  32 max_errors_calculated=  32
 ok        nphases=2 pix_databytes= 4 nmodules=2 module=1 max_errors=  32 max_errors_calculated=  32
 ok        nphases=2 pix_databytes= 8 nmodules=4 module=0 max_errors=  32 max_errors_calculated=  32
 ok        nphases=2 pix_databytes= 8 nmodules=4 module=1 max_errors=  32 max_errors_calculated=  32
 ok        nphases=2 pix_databytes= 8 nmodules=4 module=2 max_errors=  32 max_errors_calculated=  32
 ok        nphases=2 pix_databytes= 8 nmodules=4 module=3 max_errors=  32 max_errors_calculated=  32
 ok        nphases=2 pix_databytes=16 nmodules=8 module=0 max_errors=  32 max_errors_calculated=  32
 ok        nphases=2 pix_databytes=16 nmodules=8 module=1 max_errors=  32 max_errors_calculated=  32
 ok        nphases=2 pix_databytes=16 nmodules=8 module=2 max_errors=  32 max_errors_calculated=  32
 ok        nphases=2 pix_databytes=16 nmodules=8 module=3 max_errors=  32 max_errors_calculated=  32
 ok        nphases=2 pix_databytes=16 nmodules=8 module=4 max_errors=  32 max_errors_calculated=  32
 ok        nphases=2 pix_databytes=16 nmodules=8 module=5 max_errors=  32 max_errors_calculated=  32
 ok        nphases=2 pix_databytes=16 nmodules=8 module=6 max_errors=  32 max_errors_calculated=  32
 ok        nphases=2 pix_databytes=16 nmodules=8 module=7 max_errors=  32 max_errors_calculated=  32
 ok        nphases=4 pix_databytes= 2 nmodules=1 module=0 max_errors=  64 max_errors_calculated=  64
 ok        nphases=4 pix_databytes= 4 nmodules=2 module=0 max_errors=  64 max_errors_calculated=  64
 ok        nphases=4 pix_databytes= 4 nmodules=2 module=1 max_errors=  64 max_errors_calculated=  64
 ok        nphases=4 pix_databytes= 8 nmodules=4 module=0 max_errors=  64 max_errors_calculated=  64
 ok        nphases=4 pix_databytes= 8 nmodules=4 module=1 max_errors=  64 max_errors_calculated=  64
 ok        nphases=4 pix_databytes= 8 nmodules=4 module=2 max_errors=  64 max_errors_calculated=  64
 ok        nphases=4 pix_databytes= 8 nmodules=4 module=3 max_errors=  64 max_errors_calculated=  64
 ok        nphases=4 pix_databytes=16 nmodules=8 module=0 max_errors=  64 max_errors_calculated=  64
 ok        nphases=4 pix_databytes=16 nmodules=8 module=1 max_errors=  64 max_errors_calculated=  64
 ok        nphases=4 pix_databytes=16 nmodules=8 module=2 max_errors=  64 max_errors_calculated=  64
 ok        nphases=4 pix_databytes=16 nmodules=8 module=3 max_errors=  64 max_errors_calculated=  64
 ok        nphases=4 pix_databytes=16 nmodules=8 module=4 max_errors=  64 max_errors_calculated=  64
 ok        nphases=4 pix_databytes=16 nmodules=8 module=5 max_errors=  64 max_errors_calculated=  64
 ok        nphases=4 pix_databytes=16 nmodules=8 module=6 max_errors=  64 max_errors_calculated=  64
 ok        nphases=4 pix_databytes=16 nmodules=8 module=7 max_errors=  64 max_errors_calculated=  64
 ok        nphases=8 pix_databytes= 2 nmodules=1 module=0 max_errors= 128 max_errors_calculated= 128
 ok        nphases=8 pix_databytes= 4 nmodules=2 module=0 max_errors= 128 max_errors_calculated= 128
 ok        nphases=8 pix_databytes= 4 nmodules=2 module=1 max_errors= 128 max_errors_calculated= 128
 ok        nphases=8 pix_databytes= 8 nmodules=4 module=0 max_errors= 128 max_errors_calculated= 128
 ok        nphases=8 pix_databytes= 8 nmodules=4 module=1 max_errors= 128 max_errors_calculated= 128
 ok        nphases=8 pix_databytes= 8 nmodules=4 module=2 max_errors= 128 max_errors_calculated= 128
 ok        nphases=8 pix_databytes= 8 nmodules=4 module=3 max_errors= 128 max_errors_calculated= 128
 ok        nphases=8 pix_databytes=16 nmodules=8 module=0 max_errors= 128 max_errors_calculated= 128
 ok        nphases=8 pix_databytes=16 nmodules=8 module=1 max_errors= 128 max_errors_calculated= 128
 ok        nphases=8 pix_databytes=16 nmodules=8 module=2 max_errors= 128 max_errors_calculated= 128
 ok        nphases=8 pix_databytes=16 nmodules=8 module=3 max_errors= 128 max_errors_calculated= 128
 ok        nphases=8 pix_databytes=16 nmodules=8 module=4 max_errors= 128 max_errors_calculated= 128
 ok        nphases=8 pix_databytes=16 nmodules=8 module=5 max_errors= 128 max_errors_calculated= 128
 ok        nphases=8 pix_databytes=16 nmodules=8 module=6 max_errors= 128 max_errors_calculated= 128
 ok        nphases=8 pix_databytes=16 nmodules=8 module=7 max_errors= 128 max_errors_calculated= 128
```