### PR TITLE
Fix stack alignment

### DIFF
--- a/litex/soc/cores/cpu/cv32e40p/crt0.S
+++ b/litex/soc/cores/cpu/cv32e40p/crt0.S
@@ -90,7 +90,7 @@ trap_entry:
 
 
 crt_init:
-  la sp, _fstack + 4
+  la sp, _fstack
   la a0, vector_table
   csrw mtvec, a0
 

--- a/litex/soc/cores/cpu/vexriscv/crt0.S
+++ b/litex/soc/cores/cpu/vexriscv/crt0.S
@@ -54,7 +54,7 @@ trap_entry:
 
 
 crt_init:
-  la sp, _fstack + 4
+  la sp, _fstack
   la a0, trap_entry
   csrw mtvec, a0
 

--- a/litex/soc/cores/cpu/vexriscv_smp/crt0.S
+++ b/litex/soc/cores/cpu/vexriscv_smp/crt0.S
@@ -58,7 +58,7 @@ trap_entry:
   .text
 
 crt_init:
-  la sp, _fstack + 4
+  la sp, _fstack
   la a0, trap_entry
   csrw mtvec, a0
   sw x0, smp_lottery_lock, a1

--- a/litex/soc/software/bios/linker.ld
+++ b/litex/soc/software/bios/linker.ld
@@ -85,7 +85,7 @@ SECTIONS
 	}
 }
 
-PROVIDE(_fstack = ORIGIN(sram) + LENGTH(sram) - 8);
+PROVIDE(_fstack = ORIGIN(sram) + LENGTH(sram));
 
 PROVIDE(_fdata_rom = LOADADDR(.data));
 PROVIDE(_edata_rom = LOADADDR(.data) + SIZEOF(.data));


### PR DESCRIPTION
RISC-V requires stack to be aligned to 16 bytes.
https://github.com/riscv/riscv-elf-psabi-doc/blob/1d5384e6690ea39b5395ddc6943882ed2830dbee/riscv-elf.md?plain=1#L183

Right now, in bios/linker.ld, `_fstack` is being set to 8 bytes before the end of sram region.
```
PROVIDE(_fstack = ORIGIN(sram) + LENGTH(sram) - 8);
```

Removing ` - 8` makes it aligned to 16.

Also there are changes in crt0.S for vexriscv, vexriscv_smp and cv32e40p.

Code that was setting up stack, was adding 4 to its address for some reason.

Removing it makes it aligned to 8 bytes, and with change in bios/linker.ld to 16 bytes.

It also fixes `printf` with long long integers on 32bit CPUs ([relevant issue](https://github.com/riscv/riscv-gcc/issues/63)).

Should close #322 and #910 