### PR TITLE
cores/vexriscv_smp: Fix vexriscv_smp doesn't build without a memory bus

### DIFF
--- a/litex/soc/cores/cpu/vexriscv_smp/core.py
+++ b/litex/soc/cores/cpu/vexriscv_smp/core.py
@@ -419,8 +419,6 @@ class VexRiscvSMP(CPU):
     def add_memory_buses(self, address_width, data_width):
         VexRiscvSMP.litedram_width = data_width
 
-        VexRiscvSMP.generate_cluster_name()
-
         from litedram.common import LiteDRAMNativePort
         if(not VexRiscvSMP.wishbone_memory):
             ibus = LiteDRAMNativePort(mode="both", address_width=32, data_width=VexRiscvSMP.litedram_width)
@@ -457,6 +455,7 @@ class VexRiscvSMP(CPU):
 
     def do_finalize(self):
         assert hasattr(self, "reset_address")
+        VexRiscvSMP.generate_cluster_name()
         self.specials += Instance(self.cluster_name, **self.cpu_params)
 
         # Add Verilog sources


### PR DESCRIPTION
The current code only works with a memory bus because otherwise
"generate_cluster_name" doesn't get called.
Cluster_name is only needed in the finalize phase.
Therefore, the name will now be generated just before its usage.

Verifiable with: 
litex_sim --cpu-type vexriscv_smp (should be broken before this commit)