### PR TITLE
Fix clang support detection

### DIFF
--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -46,9 +46,9 @@ def get_cpu_mak(cpu, compile_software):
         clang = bool(int(clang))
     else:
         clang = None
-    if not hasattr(cpu, "clang_triple"):
+    if cpu.clang_triple is None:
         if clang:
-            raise ValueError(cpu.name + "not supported with clang.")
+            raise ValueError(cpu.name + " is not supported with clang.")
         else:
             clang = False
     else:


### PR DESCRIPTION
## Why

Analyzing code, I found that it should be possible to use clang for compilation ([Makefile](https://github.com/enjoy-digital/litex/blob/9bec0ce7a28afb498c7b7eb79943c270225c061a/litex/soc/software/common.mak#L10)).

Turns out that after defining `CLANG=1` environmental variable, export.py script crashes trying to [concatenate `None` and `str`](https://github.com/enjoy-digital/litex/blob/master/litex/soc/integration/export.py#L81).

That's because `t` gets value of `triple`, which in turn is [`equal to cpu.clang_triple`](https://github.com/enjoy-digital/litex/blob/master/litex/soc/integration/export.py#L60).

And that should be ok, but only if `clang` python variable was `True`, which in this case is.

But why didn't [exception informing about not supporting clang](https://github.com/enjoy-digital/litex/blob/master/litex/soc/integration/export.py#L51) fire earlier?

That's because `clang_triple` field is [by default defined to be `None`](https://github.com/enjoy-digital/litex/blob/ce5864983d9432fa8a3ce57516a89ee4156be0e5/litex/soc/cores/cpu/__init__.py#L18), which in turn makes [support check](https://github.com/enjoy-digital/litex/blob/master/litex/soc/integration/export.py#L49) always pass.

## What
So this PR changes [that check](https://github.com/enjoy-digital/litex/blob/master/litex/soc/integration/export.py#L49), to comparing with `None` value instead.
Also it improves error message a little bit.