### PR TITLE
Add random_access option to memspeed and perform mem_speed in liblitespi

### DIFF
--- a/litex/soc/software/bios/cmds/cmd_mem.c
+++ b/litex/soc/software/bios/cmds/cmd_mem.c
@@ -202,9 +202,10 @@ static void mem_speed_handler(int nb_params, char **params)
 	unsigned int *addr;
 	unsigned long size;
 	bool read_only = false;
+	bool random_access = false;
 
 	if (nb_params < 1) {
-		printf("mem_speed <addr> <size> [<readonly>]");
+		printf("mem_speed <addr> <size> [<readonly>] [<random_access>]");
 		return;
 	}
 
@@ -228,6 +229,14 @@ static void mem_speed_handler(int nb_params, char **params)
 		}
 	}
 
-	memspeed(addr, size, read_only);
+	if (nb_params >= 4) {
+		random_access = (bool) strtoul(params[3], &c, 0);
+		if (*c != 0) {
+			printf("Incorrect random_access value");
+			return;
+		}
+	}
+
+	memspeed(addr, size, read_only, random_access);
 }
 define_command(mem_speed, mem_speed_handler, "Test memory speed", MEM_CMDS);

--- a/litex/soc/software/include/base/memtest.h
+++ b/litex/soc/software/include/base/memtest.h
@@ -20,7 +20,7 @@ int memtest_bus(unsigned int *addr, unsigned long size);
 int memtest_addr(unsigned int *addr, unsigned long size, int random);
 int memtest_data(unsigned int *addr, unsigned long size, int random, struct memtest_config *config);
 
-void memspeed(unsigned int *addr, unsigned long size, bool read_only);
+void memspeed(unsigned int *addr, unsigned long size, bool read_only, bool random_access);
 int memtest(unsigned int *addr, unsigned long maxsize);
 
 #endif /* __MEMTEST_H */

--- a/litex/soc/software/liblitespi/spiflash.c
+++ b/litex/soc/software/liblitespi/spiflash.c
@@ -88,10 +88,14 @@ void spiflash_init(void)
 
 	printf("Initializing %s SPI Flash...\n", SPIFLASH_MODULE_NAME);
 
+#ifndef SPIFLASH_SKIP_FREQ_INIT
 	/* Clk frequency auto-calibration. */
 	ret = spiflash_freq_init();
 	if (ret < 0)
 		return;
+#else
+	printf("Warning: SPI Flash frequency auto-calibration skipped, using the default divisor of %d", spiflash_phy_clk_divisor_read());
+#endif
 
 	/* Dummy bits setup. */
 #ifdef SPIFLASH_MODULE_DUMMY_BITS
@@ -115,6 +119,11 @@ void spiflash_init(void)
 
 #endif
 
+	printf("SPI Flash bandwidth benchmarks\n");
+	printf("Sequential accesses:");
+	memspeed(SPIFLASH_BASE, SPIFLASH_SIZE, 1, 0);
+	printf("Random accesses:");
+	memspeed(SPIFLASH_BASE, SPIFLASH_SIZE, 1, 1);
 }
 
 #endif


### PR DESCRIPTION
This PR add the `random_access` option to the `memspeed` function so that it allows the user to choose between sequential and random accesses when testing the memory speed.

There are minor cleanups still to be done.