### PR TITLE
liblitespi: perform frequency initialization after entering quad/qpi mode

### DIFF
--- a/litex/soc/software/liblitespi/spiflash.c
+++ b/litex/soc/software/liblitespi/spiflash.c
@@ -84,14 +84,7 @@ static void spiflash_master_write(uint32_t val, size_t len, size_t width, uint32
 
 void spiflash_init(void)
 {
-	int ret;
-
 	printf("Initializing %s SPI Flash...\n", SPIFLASH_MODULE_NAME);
-
-	/* Clk frequency auto-calibration. */
-	ret = spiflash_freq_init();
-	if (ret < 0)
-		return;
 
 	/* Dummy bits setup. */
 #ifdef SPIFLASH_MODULE_DUMMY_BITS
@@ -115,6 +108,8 @@ void spiflash_init(void)
 
 #endif
 
+	/* Clk frequency auto-calibration. */
+	spiflash_freq_init();
 }
 
 #endif


### PR DESCRIPTION
It's been found that the frequency initialization routine that is currently present in liblitespi can affect negatively the flashboot process when using `READ_4_4_4` commands.

Currently when the `spiflash_freq_init` function reads CRC data from SPI flash, it does so using the default read command, in our case `READ_4_4_4`. Because we didn't enter QPI mode before (which we need to do after each power up), we get bogus data back (only `0xcc` byte) and this makes the system to _cache_ these bytes in the beginning of the `spiflash` region. This causes flashboot to fail:
```
Booting from flash...
Error: Invalid image length 0xcccccccc
No boot medium found
```

Moving the invocation of `spiflash_freq_init` to the end of `spiflash_init` solves this issue.