### PR TITLE
Fix alignments in demo/linker.ld

### DIFF
--- a/litex/soc/software/demo/linker.ld
+++ b/litex/soc/software/demo/linker.ld
@@ -16,27 +16,29 @@ SECTIONS
 
 	.rodata :
 	{
-		. = ALIGN(4);
+		. = ALIGN(8);
 		_frodata = .;
 		*(.rodata .rodata.* .gnu.linkonce.r.*)
 		*(.rodata1)
+		. = ALIGN(8);
 		_erodata = .;
 	} > main_ram
 
 	.data :
 	{
-		. = ALIGN(4);
+		. = ALIGN(8);
 		_fdata = .;
 		*(.data .data.* .gnu.linkonce.d.*)
 		*(.data1)
 		_gp = ALIGN(16);
 		*(.sdata .sdata.* .gnu.linkonce.s.*)
+		. = ALIGN(8);
 		_edata = .;
 	} > main_ram
 
 	.bss :
 	{
-		. = ALIGN(4);
+		. = ALIGN(8);
 		_fbss = .;
 		*(.dynsbss)
 		*(.sbss .sbss.* .gnu.linkonce.sb.*)
@@ -44,13 +46,13 @@ SECTIONS
 		*(.dynbss)
 		*(.bss .bss.* .gnu.linkonce.b.*)
 		*(COMMON)
-		. = ALIGN(4);
+		. = ALIGN(8);
 		_ebss = .;
 		_end = .;
 	} > sram
 }
 
-PROVIDE(_fstack = ORIGIN(sram) + LENGTH(sram) - 4);
+PROVIDE(_fstack = ORIGIN(sram) + LENGTH(sram));
 
 PROVIDE(_fdata_rom = LOADADDR(.data));
 PROVIDE(_edata_rom = LOADADDR(.data) + SIZEOF(.data));

--- a/litex/soc/software/demo/linker.ld
+++ b/litex/soc/software/demo/linker.ld
@@ -10,6 +10,12 @@ SECTIONS
 	.text :
 	{
 		_ftext = .;
+		/* Make sure crt0 files come first, and they, and the isr */
+		/* don't get disposed of by greedy optimisation */
+		*crt0*(.text)
+		KEEP(*crt0*(.text))
+		KEEP(*(.text.isr))
+
 		*(.text .stub .text.* .gnu.linkonce.t.*)
 		_etext = .;
 	} > main_ram


### PR DESCRIPTION
Without this change, when `.data` section size wasn't multiple of word size, `data_loop` in crt0 was jumping over `_edata` and continued looping. As it works on words and right now 64 bit CPUs are biggest ones supported - alignment is now 8 bytes.

Also removed `- 4` from stack address, as it needs to be aligned to 16 bytes on RISC-V.

Should fix #856 and at least explain why #876 wasn't working.