### PR TITLE
Set TX UART pin high on reset

### DIFF
--- a/litex/soc/cores/uart.py
+++ b/litex/soc/cores/uart.py
@@ -57,6 +57,8 @@ class RS232PHYTX(Module):
 
         # # #
 
+        pads.tx.reset = 1
+
         data  = Signal(8, reset_less=True)
         count = Signal(4, reset_less=True)
 


### PR DESCRIPTION
Without this we get corrupted data on the output after SoC reset. It was present there, but got removed in 908e72e65ba42114ac398a0a0710a08d9c6d03d0 refactor.

Fixes #991