### PR TITLE
build: add DDRTristate

### DIFF
--- a/litex/build/io.py
+++ b/litex/build/io.py
@@ -145,6 +145,34 @@ class DDROutput(Special):
     def lower(dr):
         raise NotImplementedError("Attempted to use a DDR output, but platform does not support them")
 
+# DDR Tristate -------------------------------------------------------------------------------------
+
+class DDRTristate(Special):
+    def __init__(self, i1, i2, o1, o2, oe1, oe2, io, clk=ClockSignal()):
+        Special.__init__(self)
+        self.i1  = i1
+        self.i2  = i2
+        self.o1  = o1
+        self.o2  = o2
+        self.oe1 = oe1
+        self.oe2 = oe2
+        self.io  = io
+        self.clk = clk
+
+    def iter_expressions(self):
+        yield self, "io", SPECIAL_INOUT
+        yield self, "i1", SPECIAL_INPUT
+        yield self, "i2", SPECIAL_INPUT
+        yield self, "o1", SPECIAL_OUTPUT
+        yield self, "o2", SPECIAL_OUTPUT
+        yield self, "oe1", SPECIAL_INPUT
+        yield self, "oe2", SPECIAL_INPUT
+        yield self, "clk", SPECIAL_INPUT
+
+    @staticmethod
+    def lower(dr):
+        raise NotImplementedError("Attempted to use a DDR tristate, but platform does not support them")
+
 # Clock Reset Generator ----------------------------------------------------------------------------
 
 class CRG(Module):

--- a/litex/build/xilinx/common.py
+++ b/litex/build/xilinx/common.py
@@ -152,6 +152,28 @@ class XilinxSDRTristate:
     def lower(dr):
         return XilinxSDRTristateImpl(dr.io, dr.o, dr.oe, dr.i, dr.clk)
 
+# Common DDRTristate -------------------------------------------------------------------------------
+
+class XilinxDDRTristateImpl(Module):
+    def __init__(self, io, o1, o2, oe1, oe2, i1, i2, clk):
+        _o    = Signal()
+        _oe_n = Signal()
+        _i    = Signal()
+        self.specials += DDROutput(i1, i2, _o)
+        self.specials += DDROutput(~oe1, ~oe2, _oe_n)
+        self.specials += DDRInput(_i, o1, o2)
+        self.specials += Instance("IOBUF",
+            io_IO = io,
+            o_O   = _i,
+            i_I   = _o,
+            i_T   = _oe_n,
+        )
+
+class XilinxDDRTristate:
+    @staticmethod
+    def lower(dr):
+        return XilinxDDRTristateImpl(dr.io, dr.o1, dr.o2, dr.oe1, dr.oe2, dr.i1, dr.i2, dr.clk)
+
 # Common Special Overrides -------------------------------------------------------------------------
 
 xilinx_special_overrides = {
@@ -160,6 +182,7 @@ xilinx_special_overrides = {
     DifferentialInput:      XilinxDifferentialInput,
     DifferentialOutput:     XilinxDifferentialOutput,
     SDRTristate:            XilinxSDRTristate,
+    DDRTristate:            XilinxDDRTristate,
 }
 
 # Spartan6 DDROutput -------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds `DDRTristate` module that can be used to create bidirectional DDR IOs.
This should work with all supported Xilinx parts since `SDRTristate` already uses DDR primitives underneath.
I've tested this on Arty board and it instantiates `ODDR`/`IDDR` primitives correctly.