### PR TITLE
soc/software/liblitedram: fix max error count computation

### DIFF
--- a/litex/soc/software/liblitedram/sdram.c
+++ b/litex/soc/software/liblitedram/sdram.c
@@ -300,7 +300,7 @@ static void print_scan_errors(unsigned int errors) {
 #endif
 }
 
-#define READ_CHECK_TEST_PATTERN_MAX_ERRORS (8*SDRAM_PHY_PHASES*SDRAM_PHY_XDR)
+#define READ_CHECK_TEST_PATTERN_MAX_ERRORS (8*SDRAM_PHY_PHASES*DFII_PIX_DATA_BYTES/SDRAM_PHY_MODULES)
 
 static unsigned int sdram_write_read_check_test_pattern(int module, unsigned int seed) {
 	int p, i;


### PR DESCRIPTION
There is an error in READ_CHECK_TEST_PATTERN_MAX_ERRORS computation. It is being computed based on nphases and data rate (x1/x2), but this gives incorrect result when using DFIRateConverter which increases number of data bytes per phase. This may results in integer underflow when subtracting `(max_errors - errors)` and selecting wrong bitslip during read leveling.

With this change we make use of DFII_PIX_DATA_BYTES directly, which should be more reliable as sdram_write_read_check_test_pattern should always scan 1/SDRAM_PHY_MODULES of all data bytes on DFI. So max errors is nphases (outer for loop) times dfi data bytes (inner loop) divided by nmodules (scanning 1 module) times 8 bits in a byte ([relevant code](https://github.com/antmicro/litex/blob/f943092bb5a3aae1bfda08e2ffbe927d048e32be/litex/soc/software/liblitedram/sdram.c#L345-L356)).

I tested it with the script from https://github.com/enjoy-digital/litex/pull/986 and it doesn't modify the results for these cases. I also successfully tested on hardware (Arty and ZCU104).