### PR TITLE
customize main ram size from command line argument

### DIFF
--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -325,7 +325,8 @@ def main():
     if args.rom_init:
         soc_kwargs["integrated_rom_init"] = get_mem_data(args.rom_init, cpu.endianness)
     if not args.with_sdram:
-        soc_kwargs["integrated_main_ram_size"] = 0x10000000 # 256 MB
+#configure main ram size from command line argument
+        soc_kwargs["integrated_main_ram_size"] = args.integrated_main_ram_size 
         if args.ram_init is not None:
             soc_kwargs["integrated_main_ram_init"] = get_mem_data(args.ram_init, cpu.endianness)
     else:


### PR DESCRIPTION
litex_sim.py is edited to customize main ram size from command line arguments, if main_ram_size is set to zero then it won't show in generated SoC logs.