### PR TITLE
Add docs static files to package_data in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,9 @@ setup(
     ],
     packages=find_packages(exclude=("test*", "sim*", "doc*")),
     include_package_data=True,
+    package_data={
+        'litex.soc.doc': ['static/*']
+    },
     platforms=["Any"],
     keywords="HDL ASIC FPGA hardware design",
     classifiers=[


### PR DESCRIPTION
This patch adds the static files needed for the documentation to the
`package_data` field in `setup.py`.

I ran into failures when generating documentation after installing litex
using pipenv which didn't copy these files which in turn caused the
documentation generation to fail.

This change causes all files in the `static` subfolder of the
litex.soc.doc module to be installed as well.