### PR TITLE
Binutils fixes

### DIFF
--- a/litex/soc/cores/cpu/microwatt/core.py
+++ b/litex/soc/cores/cpu/microwatt/core.py
@@ -58,7 +58,6 @@ class Microwatt(CPU):
         flags += "-mlittle-endian "
         flags += "-mstrict-align "
         flags += "-fno-stack-protector "
-        flags += "-mcmodel=small "
         flags += "-D__microwatt__ "
         return flags
 

--- a/litex/soc/software/common.mak
+++ b/litex/soc/software/common.mak
@@ -53,7 +53,7 @@ INCLUDES = -I$(SOC_DIRECTORY)/software/include/base \
 COMMONFLAGS = $(DEPFLAGS) -Os $(CPUFLAGS) -g3 -fomit-frame-pointer -Wall -fno-builtin -nostdinc -fno-stack-protector $(INCLUDES)
 CFLAGS = $(COMMONFLAGS) -fexceptions -Wstrict-prototypes -Wold-style-definition -Wmissing-prototypes
 CXXFLAGS = $(COMMONFLAGS) -std=c++11 -I$(SOC_DIRECTORY)/software/include/basec++ -fexceptions -fno-rtti -ffreestanding
-LDFLAGS = -nostdlib -nodefaultlibs -Wl,--no-dynamic-linker -L$(BUILDINC_DIRECTORY)
+LDFLAGS = -nostdlib -nodefaultlibs -Wl,--no-dynamic-linker -Wl,--build-id=none -L$(BUILDINC_DIRECTORY)
 
 define compilexx
 $(CX) -c $(CXXFLAGS) $(1) $< -o $@

--- a/litex/soc/software/common.mak
+++ b/litex/soc/software/common.mak
@@ -53,7 +53,7 @@ INCLUDES = -I$(SOC_DIRECTORY)/software/include/base \
 COMMONFLAGS = $(DEPFLAGS) -Os $(CPUFLAGS) -g3 -fomit-frame-pointer -Wall -fno-builtin -nostdinc -fno-stack-protector $(INCLUDES)
 CFLAGS = $(COMMONFLAGS) -fexceptions -Wstrict-prototypes -Wold-style-definition -Wmissing-prototypes
 CXXFLAGS = $(COMMONFLAGS) -std=c++11 -I$(SOC_DIRECTORY)/software/include/basec++ -fexceptions -fno-rtti -ffreestanding
-LDFLAGS = -nostdlib -nodefaultlibs -L$(BUILDINC_DIRECTORY)
+LDFLAGS = -nostdlib -nodefaultlibs -Wl,--no-dynamic-linker -L$(BUILDINC_DIRECTORY)
 
 define compilexx
 $(CX) -c $(CXXFLAGS) $(1) $< -o $@


### PR DESCRIPTION
These fix building the BIOS for microwatt with the cross compilers in Debian unstable. The first two patches are required for any platform running a newer binutils.

$ powerpc64le-linux-gnu-ld --version
GNU ld (GNU Binutils for Debian) 2.37

$ powerpc64le-linux-gnu-gcc --version
powerpc64le-linux-gnu-gcc (Debian 11.2.0-2) 11.2.1 20210815
