### PR TITLE
Restructure config flags for dcache/icache presence in Vex.

### DIFF
--- a/litex/soc/cores/cpu/vexriscv/core.py
+++ b/litex/soc/cores/cpu/vexriscv/core.py
@@ -336,6 +336,12 @@ class VexRiscv(CPU, AutoCSR):
             soc.bus.add_slave("vexriscv_debug", self.debug_bus, region=soc_region_cls(
                 origin=soc.mem_map.get("vexriscv_debug"), size=0x100, cached=False))
 
+        base_variant = str(self.variant.split('+')[0])
+        if base_variant == "lite" or base_variant == "minimal":
+            soc.add_config("CPU_NO_DCACHE")
+        if base_variant == "minimal":
+            soc.add_config("CPU_NO_ICACHE")
+
     def use_external_variant(self, variant_filename):
         self.external_variant = True
         self.platform.add_source(variant_filename)

--- a/litex/soc/cores/cpu/vexriscv/system.h
+++ b/litex/soc/cores/cpu/vexriscv/system.h
@@ -11,7 +11,7 @@ extern "C" {
 
 __attribute__((unused)) static void flush_cpu_icache(void)
 {
-#if defined(CONFIG_CPU_VARIANT_MINIMAL)
+#if defined(CONFIG_CPU_NO_ICACHE)
   /* No instruction cache */
 #else
   asm volatile(
@@ -27,7 +27,7 @@ __attribute__((unused)) static void flush_cpu_icache(void)
 
 __attribute__((unused)) static void flush_cpu_dcache(void)
 {
-#if defined(CONFIG_CPU_VARIANT_MINIMAL) || defined(CONFIG_CPU_VARIANT_LITE)
+#if defined(CONFIG_CPU_NO_DCACHE)
   /* No data cache */
 #else
   asm volatile(".word(0x500F)\n");


### PR DESCRIPTION
This change uses new explicit config flags CONFIG_CPU_NO_DCACHE and CONFIG_CPU_NO_ICACHE to control whether special instructions are emitted to flush these caches when present.

This makes it more convenient when adding new VexRiscv variants without one or both of the caches.   For example, currently we need to lie and set CONFIG_CPU_VARIANT_LITE to suppress the dcache flush instruction.

This change centralizes knowledge about the different variants into vexriscv/core.py.

Signed-off-by: Tim Callahan <tcal@google.com>