### PR TITLE
Fixes to allow crossover uart over PCIe with lxterm and litex_server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# VS Code settings
+.vscode

--- a/litex/tools/litex_client.py
+++ b/litex/tools/litex_client.py
@@ -31,8 +31,11 @@ class RemoteClient(EtherboneIPC, CSRBuilder):
             csr_data_width = 32
         self.host         = host
         self.port         = port
-        self.base_address = base_address
         self.debug        = debug
+        if base_address is not None:
+            self.base_address = base_address
+        else:
+            self.base_address = 0
 
     def open(self):
         if hasattr(self, "socket"):

--- a/litex/tools/litex_term.py
+++ b/litex/tools/litex_term.py
@@ -87,8 +87,8 @@ else:
 from litex import RemoteClient
 
 class BridgeUART:
-    def __init__(self, name="uart_xover", host="localhost", base_address=0): # FIXME: add command line arguments
-        self.bus = RemoteClient(host=host, base_address=base_address)
+    def __init__(self, name="uart_xover", host="localhost", base_address=None, csr_csv=None): # FIXME: add command line arguments
+        self.bus = RemoteClient(host=host, base_address=base_address, csr_csv=csr_csv)
         present = False
         for k, v in self.bus.regs.d.items():
             if f"{name}_" in k:
@@ -96,6 +96,10 @@ class BridgeUART:
                 present = True
         if not present:
             raise ValueError(f"CrossoverUART {name} not present in design.")
+
+        # On PCIe designs, CSR is remapped to 0 to limit BAR0 size.
+        if base_address is None and hasattr(self.bus.bases, "pcie_phy"):
+            self.bus.base_address = -self.bus.mems.csr.base
 
     def open(self):
         self.bus.open()
@@ -534,17 +538,19 @@ class LiteXTerm:
 def _get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("port",                                              help="Serial port (eg /dev/tty*, bridge, jtag)")
-    parser.add_argument("--speed",       default=115200,                     help="Serial baudrate")
-    parser.add_argument("--serial-boot", default=False, action='store_true', help="Automatically initiate serial boot")
-    parser.add_argument("--kernel",      default=None,                       help="Kernel image")
-    parser.add_argument("--kernel-adr",  default="0x40000000",               help="Kernel address")
-    parser.add_argument("--images",      default=None,                       help="JSON description of the images to load to memory")
+    parser.add_argument("--speed",        default=115200,                     help="Serial baudrate")
+    parser.add_argument("--serial-boot",  default=False, action='store_true', help="Automatically initiate serial boot")
+    parser.add_argument("--kernel",       default=None,                       help="Kernel image")
+    parser.add_argument("--kernel-adr",   default="0x40000000",               help="Kernel address")
+    parser.add_argument("--images",       default=None,                       help="JSON description of the images to load to memory")
 
-    parser.add_argument("--bridge-name", default="uart_xover",               help="Bridge UART name to use (present in design/csr.csv)")
+    parser.add_argument("--csr-csv",      default=None,                       help="SoC mapping file")
+    parser.add_argument("--base-address", default=None,                       help="CSR base address")
+    parser.add_argument("--bridge-name",  default="uart_xover",               help="Bridge UART name to use (present in design/csr.csv)")
 
-    parser.add_argument("--jtag-name",   default="jtag_uart",                help="JTAG UART type: jtag_uart (default), jtag_atlantic")
-    parser.add_argument("--jtag-config", default="openocd_xc7_ft2232.cfg",   help="OpenOCD JTAG configuration file for jtag_uart")
-    parser.add_argument("--jtag-chain",  default=1,                          help="JTAG chain.")
+    parser.add_argument("--jtag-name",    default="jtag_uart",                help="JTAG UART type: jtag_uart (default), jtag_atlantic")
+    parser.add_argument("--jtag-config",  default="openocd_xc7_ft2232.cfg",   help="OpenOCD JTAG configuration file for jtag_uart")
+    parser.add_argument("--jtag-chain",   default=1,                          help="JTAG chain.")
     return parser.parse_args()
 
 def main():
@@ -555,7 +561,11 @@ def main():
         if args.port in ["bridge", "jtag"]:
             raise NotImplementedError
     if args.port in ["bridge", "crossover"]: # FIXME: 2021-02-18, crossover for retro-compatibility remove and update targets?
-        bridge = BridgeUART(name=args.bridge_name)
+        if args.base_address is not None:
+            base_address = int(args.base_address)
+        else:
+            base_address = None
+        bridge = BridgeUART(base_address=base_address,csr_csv=args.csr_csv,name=args.bridge_name)
         bridge.open()
         port = os.ttyname(bridge.name)
     elif args.port in ["jtag"]:


### PR DESCRIPTION
Add a command line option for lxterm to allow specification of the path to the CSR register CSV file, rather than just requiring csr.csv to be in the directory lxterm is executed from

Add a command line option to specify the base address of whatever addresses lxterm is sending to lxserver. In the case of PCIe, these are negative values (e.g. -0xF000_0000)

If the base address was not specified and the design uses PCIe, automatically remap the base address to the CSR start

```
# Generate bitstream for SQRL Acorn
./sqrl_acorn.py --with-pcie --build --driver --uart-name=crossover --csr-csv=build/sqrl_acorn/csr.csv

# flash the board using your programmer

# connect to crossover UART
litex_server --pcie --pcie-bar 48:00.0 &
lxterm --csr-csv=build/sqrl_acorn/csr.csv bridge
```