### PR TITLE
Json2dts sdcard booting

### DIFF
--- a/litex/tools/litex_json2dts_linux.py
+++ b/litex/tools/litex_json2dts_linux.py
@@ -57,7 +57,7 @@ def generate_dts(d, initrd_start=None, initrd_size=None, initrd=None, polling=Fa
             bootargs = "mem={main_ram_size_mb}M@0x{main_ram_base:x} {console} {rootfs} init=/sbin/init swiotlb=32";""".format(
     main_ram_base      = d["memories"]["main_ram"]["base"],
     main_ram_size_mb   = d["memories"]["main_ram"]["size"] // mB,
-    console            = "console=liteuart earlycon=sbi",
+    console            = "console=liteuart earlycon=liteuart,0x{:x}".format(d["csr_bases"]["uart"]),
     rootfs             = "rootwait root=/dev/ram0")
 
     if initrd_enabled is True:


### PR DESCRIPTION
This is a series of 3 patches to allow setting up the DTS for booting from an sdcard.
  1. We want to be able to disable the initrd loading from ram.  This also was pointed out by @shenki as being something that keeps him from using the dts generator as it means we cannot use kernels with built in rootfs. (option `--without-initrd`)
  2. We want to be able to set a different root device, for my SD card I use `mmcblk0p3` (option `--root-device mmcblk0p3`)
  3. I setup earlycon to use liteuart rather than the risc-v only `sbi`, no option, this is now the hard coded default.  This means we get console output right away rather than waiting for the console drive to be initialized (usually after loading initrd).