### PR TITLE
Linker fix for initialized global variables

### DIFF
--- a/litex/soc/software/demo/linker.ld
+++ b/litex/soc/software/demo/linker.ld
@@ -40,7 +40,7 @@ SECTIONS
 		*(.sdata .sdata.* .gnu.linkonce.s.*)
 		. = ALIGN(8);
 		_edata = .;
-	} > main_ram
+	} > sram AT > main_ram
 
 	.bss :
 	{


### PR DESCRIPTION
I found that in some cases, initialized global variables don't work with user libraries, so a little change to the linker that I use, taken from the demo file, seems to solve the problem. I think it makes more sense to put the global variables in sram and their initial values in the main_ram, similar to the bios linker.