### PR TITLE
litex_sim: optionally add GPIOTristate core

### DIFF
--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -22,6 +22,7 @@ from litex.soc.integration.soc_core import *
 from litex.soc.integration.builder import *
 from litex.soc.integration.soc import *
 from litex.soc.cores.bitbang import *
+from litex.soc.cores.gpio import GPIOTristate
 from litex.soc.cores.cpu import CPUS
 
 
@@ -87,6 +88,13 @@ _io = [
         Subsignal("clk",  Pins(1)),
         Subsignal("dq",   Pins(4)),
     ),
+    # Simulated tristate IO (Verilator does not support top-level
+    # tristate signals)
+    ("gpio", 0,
+        Subsignal("oe",   Pins(32)),
+        Subsignal("o",    Pins(32)),
+        Subsignal("i",    Pins(32)),
+    )
 ]
 
 # Platform -----------------------------------------------------------------------------------------
@@ -117,6 +125,7 @@ class SimSoC(SoCCore):
         with_sdcard           = False,
         with_spi_flash        = False,
         spi_flash_init        = [],
+        with_gpio             = False,
         sim_debug             = False,
         trace_reset_on        = False,
         **kwargs):
@@ -262,6 +271,11 @@ class SimSoC(SoCCore):
             self.submodules.spiflash_phy = LiteSPIPHYModel(spiflash_module, init=spi_flash_init)
             self.add_spi_flash(phy=self.spiflash_phy, mode="4x", module=spiflash_module, with_master=True)
 
+        # GPIO --------------------------------------------------------------------------------------
+        if with_gpio:
+            self.submodules.gpio = GPIOTristate(platform.request("gpio"), with_irq=True)
+            self.irq.add("gpio", use_loc_if_exists=True)
+
         # Simulation debugging ----------------------------------------------------------------------
         if sim_debug:
             platform.add_debug(self, reset=1 if trace_reset_on else 0)
@@ -327,6 +341,7 @@ def sim_args(parser):
     parser.add_argument("--with-sdcard",          action="store_true",     help="Enable SDCard support")
     parser.add_argument("--with-spi-flash",       action="store_true",     help="Enable SPI Flash (MMAPed)")
     parser.add_argument("--spi_flash-init",       default=None,            help="SPI Flash init file")
+    parser.add_argument("--with-gpio",            action="store_true",     help="Enable Tristate GPIO (32 pins)")
     parser.add_argument("--trace",                action="store_true",     help="Enable Tracing")
     parser.add_argument("--trace-fst",            action="store_true",     help="Enable FST tracing (default=VCD)")
     parser.add_argument("--trace-start",          default="0",             help="Time to start tracing (ps)")
@@ -394,6 +409,7 @@ def main():
         with_i2c       = args.with_i2c,
         with_sdcard    = args.with_sdcard,
         with_spi_flash = args.with_spi_flash,
+        with_gpio      = args.with_gpio,
         sim_debug      = args.sim_debug,
         trace_reset_on = trace_start > 0 or trace_end > 0,
         sdram_init     = [] if args.sdram_init is None else get_mem_data(args.sdram_init, cpu.endianness),


### PR DESCRIPTION
This changeset encompasses two distinct commits:

- litex/soc/cores/gpio: support external tristate buffer

  Support exposing tristate GPIOs with tristate pads, by avoiding instantiation of tristate buffers directly in the module. This gives the developers more flexibility in how they want to implement their tristate IOs (for example with level shifters behind the IOs), and allows to use the GPIOTristate core in the Verilated simulation as Verilator does not support top-level inout signals.

- litex_sim: add optional GPIOTristate core

  Adds a switch `--with-gpio`, which will add a 32 pin GPIOTristate core, with the GPIOTristate signals exposed on the top-level module. This can be used to add a custom GPIO module in the Verilated simulation.

Both of these changes combined have allowed me to write a GPIO Verilator module, controlled via ZeroMQ, which external (CI) tools can use to interact with the simulation as if it were a typical development board. The plan is to use this for a CI workflow in Tock OS (tock/tock#2801). I will create a PR for the ZeroMQ/JSON-based simulation control module later.

The first changeset is also required by boards such as the NetFPGA-SUME, which have bidirectional level shifters attached to their PMOD GPIOs. By exposing the raw tristate signals, implementations can attach such chips and be transparent about the level shifters and other hardware details to software.