### PR TITLE
Fix premature selection of full PLL config with no feedback

### DIFF
--- a/litex/soc/cores/clock/lattice_ecp5.py
+++ b/litex/soc/cores/clock/lattice_ecp5.py
@@ -162,4 +162,6 @@ class ECP5PLL(Module):
             self.params[f"p_CLKO{n_to_l[n]}_FPHASE"] = 0
             self.params[f"p_CLKO{n_to_l[n]}_CPHASE"] = cphase
             self.params[f"o_CLKO{n_to_l[n]}"]        = clk
+            if f > 0:  # i.e. not a feedback-only clock
+                self.params["attr"].append((f"FREQUENCY_PIN_CLKO{n_to_l[n]}", str(f/1e6)))
         self.specials += Instance("EHXPLLL", **self.params)

--- a/litex/soc/cores/clock/lattice_ecp5.py
+++ b/litex/soc/cores/clock/lattice_ecp5.py
@@ -97,6 +97,9 @@ class ECP5PLL(Module):
                                     break
                             if not valid:
                                 all_valid = False
+                        if self.nclkouts == self.nclkouts_max and not config["clkfb"]:
+                            # If there is no output suitable for feedback and no spare, not valid
+                            all_valid = False
                     else:
                         all_valid = False
                     if all_valid:

--- a/test/test_clock.py
+++ b/test/test_clock.py
@@ -121,6 +121,15 @@ class TestClock(unittest.TestCase):
         pll.expose_dpa()
         pll.compute_config()
 
+        # Test corner cases that have historically had trouble:
+        pll = ECP5PLL()
+        pll.register_clkin(Signal(), 100e6)
+        pll.create_clkout(ClockDomain("clkout1"), 350e6)
+        pll.create_clkout(ClockDomain("clkout2"), 350e6)
+        pll.create_clkout(ClockDomain("clkout3"), 175e6)
+        pll.create_clkout(ClockDomain("clkout4"), 175e6)
+        pll.compute_config()
+
     # Lattice / NX
     def test_nxpll(self):
         pll = NXPLL()


### PR DESCRIPTION
Two changes here:

- clock/lattice_ecp5/ECP5PLL: ensure feedback path selected before exiting search

The test case I added is the one I originally hit. The loop would initially select clkfb=1, see that all 4 outputs were correct, and exit the search. Then it would try to generate a feedback clock and fail because all were already allocated.

Fix this by adding the feedback path to the search success criteria.

- clock/lattice_ecp5/ECP5PLL: emit frequency annotations to help Diamond

Unlike nextpnr, Diamond appears not to infer the frequency of PLL outputs.  Emit the same attributes that Diamond's PLL tool does.
