### PR TITLE
cpu/rocket/core: Remove ResetInserter on adapters.

### DIFF
--- a/litex/soc/cores/cpu/rocket/core.py
+++ b/litex/soc/cores/cpu/rocket/core.py
@@ -294,12 +294,10 @@ class RocketRV64(CPU):
         self.cpu_params.update({'i_resetctrl_hartIsInReset_%s'%i : Open() for i in range(num_cores)})
 
         # Adapt AXI interfaces to Wishbone.
-        mmio_a2w = ResetInserter()(axi.AXI2Wishbone(mmio_axi, mmio_wb, base_address=0))
-        self.comb += mmio_a2w.reset.eq(ResetSignal() | self.reset) # Note: Must be reset with the CPU.
+        mmio_a2w = axi.AXI2Wishbone(mmio_axi, mmio_wb, base_address=0)
         self.submodules += mmio_a2w
 
-        l2fb_a2w = ResetInserter()(axi.Wishbone2AXI(l2fb_wb, l2fb_axi, base_address=0))
-        self.comb += l2fb_a2w.reset.eq(ResetSignal() | self.reset) # Note: Must be reset with the CPU.
+        l2fb_a2w = axi.Wishbone2AXI(l2fb_wb, l2fb_axi, base_address=0)
         self.submodules += l2fb_a2w
 
         # Add Verilog sources.

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1333,12 +1333,10 @@ class LiteXSoC(SoC):
                         mem_wb  = wishbone.Interface(
                             data_width = self.cpu.mem_axi.data_width,
                             adr_width  = 32-log2_int(self.cpu.mem_axi.data_width//8))
-                        # FIXME: AXI2Wishbone FSMs must be reset with the CPU.
-                        mem_a2w = ResetInserter()(axi.AXI2Wishbone(
+                        mem_a2w = axi.AXI2Wishbone(
                             axi          = self.cpu.mem_axi,
                             wishbone     = mem_wb,
-                            base_address = 0))
-                        self.comb += mem_a2w.reset.eq(ResetSignal() | self.cpu.reset)
+                            base_address = 0)
                         self.submodules += mem_a2w
                         litedram_wb = wishbone.Interface(port.data_width)
                         self.submodules += LiteDRAMWishbone2Native(


### PR DESCRIPTION
Previously, the SoCController was only reseting the CPU, which required adding
these ResetInserters. Now that the SoCController resets both CPU and peripherals
these ResetInserters are redundant and no longer useful.