### PR TITLE
bios: mark .note.gnu.build-id as non-loadable but don't disable it

### DIFF
--- a/litex/soc/software/bios/linker.ld
+++ b/litex/soc/software/bios/linker.ld
@@ -78,6 +78,8 @@ SECTIONS
 		_end = .;
 	} > sram
 
+	.note.gnu.build-id (NOLOAD) : { *(.note.gnu.build-id) }
+
 	/DISCARD/ :
 	{
 		*(.eh_frame)

--- a/litex/soc/software/common.mak
+++ b/litex/soc/software/common.mak
@@ -56,7 +56,7 @@ INCLUDES = -I$(PICOLIBC_DIRECTORY)/newlib/libc/tinystdio \
 COMMONFLAGS = $(DEPFLAGS) -Os $(CPUFLAGS) -g3 -fomit-frame-pointer -Wall -fno-builtin -fno-stack-protector -flto $(INCLUDES)
 CFLAGS = $(COMMONFLAGS) -fexceptions -Wstrict-prototypes -Wold-style-definition -Wmissing-prototypes
 CXXFLAGS = $(COMMONFLAGS) -std=c++11 -I$(SOC_DIRECTORY)/software/include/basec++ -fexceptions -fno-rtti -ffreestanding
-LDFLAGS = -nostdlib -nodefaultlibs -Wl,--no-dynamic-linker -Wl,--build-id=none $(CFLAGS) -L$(BUILDINC_DIRECTORY)
+LDFLAGS = -nostdlib -nodefaultlibs -Wl,--no-dynamic-linker $(CFLAGS) -L$(BUILDINC_DIRECTORY)
 
 define compilexx
 $(CX) -c $(CXXFLAGS) $(1) $< -o $@


### PR DESCRIPTION
If the linker is told to inject a .note.gnu.build-id section using
--build-id, it will be included in bios.elf but will be marked
non-loadable similar to the other kinds of metadata that already exists.

Marking it non-loadable ensures that it won't be placed anywhere in the
address space, so it will be excluded from the bios.bin image and won't
cause any issues due to the section overlapping with .text:

    ld: section .note.gnu.build-id LMA [0000000000000000,0000000000000023] overlaps section .text LMA [0000000000000000,000000000000519b]

or in later binutils versions:

    ld: error: no memory region specified for loadable section `.note.gnu.build-id'

Relates to #1020, #1042.