### PR TITLE
software: libc: fix Makefile dependecies

### DIFF
--- a/litex/soc/software/libc/Makefile
+++ b/litex/soc/software/libc/Makefile
@@ -64,11 +64,11 @@ libc.a: cross.txt
 	meson compile
 	cp newlib/libc.a libc.a
 
-stdio.c.o: $(LIBC_DIRECTORY)/stdio.c
+stdio.c.o: $(LIBC_DIRECTORY)/stdio.c libc.a
 	$(compile)
 	$(AR) csr libc.a $@
 
-missing.c.o: $(LIBC_DIRECTORY)/missing.c
+missing.c.o: $(LIBC_DIRECTORY)/missing.c libc.a
 	$(compile)
 	$(AR) csr libc.a $@
 


### PR DESCRIPTION
This PR fixes libc Makefile deps  - libc.a is required before we start building `stdio` and `missing`. Building `libc.a` also generates required headers.