### PR TITLE
Revert litex_setup_url change

### DIFF
--- a/litex_setup.py
+++ b/litex_setup.py
@@ -104,7 +104,7 @@ if len(sys.argv) < 2:
 
 # Check/Update litex_setup.py
 
-litex_setup_url = "https://raw.githubusercontent.com/antmicro/litex/libbase-replacement/litex_setup.py"
+litex_setup_url = "https://raw.githubusercontent.com/enjoy-digital/litex/master/litex_setup.py"
 current_sha1 = hashlib.sha1(open(os.path.realpath(__file__)).read().encode("utf-8")).hexdigest()
 print("[checking litex_setup.py]...")
 try:


### PR DESCRIPTION
This change was mistakenly merged in with picolibc changes. Its sole purpose was making testing PR easier as I didn't know about `litex_setup.py dev` option.