### PR TITLE
FIX: arg name is changed.

### DIFF
--- a/litex/soc/software/liblitesdcard/spisdcard.c
+++ b/litex/soc/software/liblitesdcard/spisdcard.c
@@ -284,7 +284,7 @@ DRESULT disk_read(BYTE drv, BYTE *buf, LBA_t block, UINT count) {
         cmd = CMD18; /* READ_MULTIPLE_BLOCK */
     else
         cmd = CMD17; /* READ_SINGLE_BLOCK */
-    if (spisdcardsend_cmd(cmd, sector) == 0) {
+    if (spisdcardsend_cmd(cmd, block) == 0) {
         while(count > 0) {
             if (spisdcardreceive_block(buf) == 0)
                 break;


### PR DESCRIPTION
**Problem**

In commit 01a906add7cddcb63bc93813f30e3fd39336eec6, argument name is changed from `sector` to `block`, but not changed the one used in the code.

**Solution**

Use `block` instead.