### PR TITLE
64-bit follow-up for picolibc warning fixes

### DIFF
--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -668,7 +668,7 @@ static int copy_file_from_sdcard_to_ram(const char * filename, unsigned long ram
 	FIL file;
 	uint32_t br;
 	uint32_t offset;
-	uint32_t length;
+	unsigned long length;
 
 	fr = f_mount(&fs, "", 1);
 	if (fr != FR_OK)

--- a/litex/soc/software/liblitesdcard/sdcard.c
+++ b/litex/soc/software/liblitesdcard/sdcard.c
@@ -104,7 +104,7 @@ static inline uint32_t pow2_round_up(uint32_t r) {
 	return r;
 }
 
-void sdcard_set_clk_freq(uint32_t clk_freq, int show) {
+void sdcard_set_clk_freq(unsigned long clk_freq, int show) {
 	uint32_t divider;
 	divider = clk_freq ? CONFIG_CLOCK_FREQUENCY/clk_freq : 256;
 	divider = pow2_round_up(divider);

--- a/litex/soc/software/liblitesdcard/sdcard.h
+++ b/litex/soc/software/liblitesdcard/sdcard.h
@@ -65,7 +65,7 @@ int sdcard_wait_response(void);
 /* SDCard clocker functions                                              */
 /*-----------------------------------------------------------------------*/
 
-void sdcard_set_clk_freq(uint32_t clk_freq, int show);
+void sdcard_set_clk_freq(unsigned long clk_freq, int show);
 
 /*-----------------------------------------------------------------------*/
 /* SDCard commands functions                                             */


### PR DESCRIPTION
Providing "uint32_t" to printf's "%ld" results in warnings on 64-bit
builds: use "unsigned long" instead.

This is a fixup on top of 77283d3d.