### PR TITLE
cpu/rocket: naturally align data defined in crt0.S

### DIFF
--- a/litex/soc/cores/cpu/rocket/crt0.S
+++ b/litex/soc/cores/cpu/rocket/crt0.S
@@ -112,11 +112,14 @@ inf_loop:
   j inf_loop
 
 .bss
+  .align 8
 smp_ap_args:
   .dword 0
   .dword 0
   .dword 0
+  .align 8
 smp_ap_target:
   .dword 0
+  .align 8
 smp_ap_ready:
   .dword 0


### PR DESCRIPTION
This issue came up while investigating #1049. This PR does not completely fix the problem described there, but it's a step in the right direction.
The startup code accesses this data using `sd/ld` instructions, which require that the address being accessed is 8-byte aligned.
The `.dword` asm directive does NOT imply any alignment, so we need to force it using the `.align` directive.