### PR TITLE
microwatt: Fix family property

### DIFF
--- a/litex/soc/cores/cpu/microwatt/core.py
+++ b/litex/soc/cores/cpu/microwatt/core.py
@@ -25,7 +25,7 @@ CPU_VARIANTS = ["standard", "standard+ghdl", "standard+irq", "standard+ghdl+irq"
 # Microwatt ----------------------------------------------------------------------------------------
 
 class Microwatt(CPU):
-    family               = "powerpc"
+    family               = "ppc64"
     name                 = "microwatt"
     human_name           = "Microwatt"
     variants             = CPU_VARIANTS


### PR DESCRIPTION
In commit 061b89beffde ("cpu/picolibc: Add family property to CPUs and
directly use it for picolibc.") a family was added for meson cross
compilation, but this doesn't exist, leading to the following warning:

 WARNING: Unknown CPU family powerpc, please report this at https://github.com/mesonbuild/meson/issues/new

Instead use ppc64. While this seems wrong for a ppc64le machine, it
appears to be what meson expects.

Signed-off-by: Joel Stanley <joel@jms.id.au>