### PR TITLE
Fix microwatt synthesis

### DIFF
--- a/litex/soc/cores/cpu/microwatt/core.py
+++ b/litex/soc/cores/cpu/microwatt/core.py
@@ -86,7 +86,7 @@ class Microwatt(CPU):
             i_wishbone_insn_ack   = ibus.ack,
             i_wishbone_insn_stall = ibus.cyc & ~ibus.ack, # No burst support
 
-            o_wishbone_insn_adr   = Cat(Signal(3), ibus.adr),
+            o_wishbone_insn_adr   = ibus.adr,
             o_wishbone_insn_dat_w = ibus.dat_w,
             o_wishbone_insn_cyc   = ibus.cyc,
             o_wishbone_insn_stb   = ibus.stb,
@@ -98,7 +98,7 @@ class Microwatt(CPU):
             i_wishbone_data_ack   = dbus.ack,
             i_wishbone_data_stall = dbus.cyc & ~dbus.ack, # No burst support
 
-            o_wishbone_data_adr   = Cat(Signal(3), dbus.adr),
+            o_wishbone_data_adr   = dbus.adr,
             o_wishbone_data_dat_w = dbus.dat_w,
             o_wishbone_data_cyc   = dbus.cyc,
             o_wishbone_data_stb   = dbus.stb,
@@ -147,6 +147,7 @@ class Microwatt(CPU):
             "utils.vhdl",
             "common.vhdl",
             "helpers.vhdl",
+            "nonrandom.vhdl",
 
             # Fetch.
             "fetch1.vhdl",
@@ -160,8 +161,6 @@ class Microwatt(CPU):
             # Decode.
             "insn_helpers.vhdl",
             "decode1.vhdl",
-            "gpr_hazard.vhdl",
-            "cr_hazard.vhdl",
             "control.vhdl",
             "decode2.vhdl",
 
@@ -183,6 +182,12 @@ class Microwatt(CPU):
             # Multiply/Divide.
             "multiply.vhdl",
             "divider.vhdl",
+
+            # FPU.
+            "fpu.vhdl",
+
+            # PMU.
+            "pmu.vhdl",
 
             # Writeback.
             "writeback.vhdl",

--- a/litex/soc/cores/cpu/microwatt/microwatt_wrapper.vhdl
+++ b/litex/soc/cores/cpu/microwatt/microwatt_wrapper.vhdl
@@ -16,7 +16,8 @@ use work.wishbone_types.all;
 entity microwatt_wrapper is
     generic (
         SIM             : boolean := false;
-        DISABLE_FLATTEN : boolean := false
+        DISABLE_FLATTEN : boolean := false;
+        HAS_FPU         : boolean := false
     );
     port (
         clk          : in std_logic;
@@ -26,7 +27,7 @@ entity microwatt_wrapper is
         wishbone_insn_ack   : in std_ulogic;
         wishbone_insn_stall : in std_ulogic;
 
-        wishbone_insn_adr   : out std_ulogic_vector(31 downto 0);
+        wishbone_insn_adr   : out std_ulogic_vector(28 downto 0);
         wishbone_insn_dat_w : out std_ulogic_vector(63 downto 0);
         wishbone_insn_cyc   : out std_ulogic;
         wishbone_insn_stb   : out std_ulogic;
@@ -37,12 +38,14 @@ entity microwatt_wrapper is
         wishbone_data_ack   : in std_ulogic;
         wishbone_data_stall : in std_ulogic;
 
-        wishbone_data_adr   : out std_ulogic_vector(31 downto 0);
+        wishbone_data_adr   : out std_ulogic_vector(28 downto 0);
         wishbone_data_dat_w : out std_ulogic_vector(63 downto 0);
         wishbone_data_cyc   : out std_ulogic;
         wishbone_data_stb   : out std_ulogic;
         wishbone_data_sel   : out std_ulogic_vector(7 downto 0);
         wishbone_data_we    : out std_ulogic;
+
+        wb_snoop_in         : in wishbone_master_out;
 
         dmi_addr : in  std_ulogic_vector(3 downto 0);
         dmi_din  : in  std_ulogic_vector(63 downto 0);
@@ -94,7 +97,8 @@ begin
     microwatt_core : entity work.core
         generic map (
             SIM             => SIM,
-            DISABLE_FLATTEN => DISABLE_FLATTEN
+            DISABLE_FLATTEN => DISABLE_FLATTEN,
+            HAS_FPU         => HAS_FPU
         )
         port map (
             clk               => clk,
@@ -107,6 +111,8 @@ begin
 
             wishbone_data_in  => wishbone_data_in,
             wishbone_data_out => wishbone_data_out,
+
+            wb_snoop_in       => wb_snoop_in,
 
             dmi_addr          => dmi_addr,
             dmi_din           => dmi_din,


### PR DESCRIPTION
While testing microwatt for #1063 I found, that microwatt synthesis is broken due to update of pythondata-cpu-microwatt.
Now LiteX should be working with microwatt@master again.

Should close #1063 