### PR TITLE
efinix: don't hardcode timing model

### DIFF
--- a/litex/build/efinix/efinity.py
+++ b/litex/build/efinix/efinity.py
@@ -160,7 +160,7 @@ def _build_peri(efinity_path, build_name, partnumber, named_sc, named_pc, fragme
 
 # Project configuration ------------------------------------------------------------------------
 
-def _build_xml(partnumber, build_name, sources, additional_xml_commands):
+def _build_xml(partnumber, timing_model, build_name, sources, additional_xml_commands):
 
     root = et.Element('efx:project')
 
@@ -187,7 +187,7 @@ def _build_xml(partnumber, build_name, sources, additional_xml_commands):
     device_info = et.SubElement(root, 'efx:device_info')
     et.SubElement(device_info, 'efx:family', name = 'Trion')
     et.SubElement(device_info, 'efx:device', name = partnumber)
-    et.SubElement(device_info, 'efx:timing_model', name = 'C4')
+    et.SubElement(device_info, 'efx:timing_model', name = timing_model)
 
     design_info = et.SubElement(root, 'efx:design_info')
     et.SubElement(design_info, "efx:top_module", name = build_name)
@@ -292,6 +292,7 @@ class EfinityToolchain():
         # Generate project file (.xml)
         _build_xml(
             partnumber              = platform.device,
+            timing_model            = platform.timing_model,
             build_name              = build_name,
             sources                 = platform.sources,
             additional_xml_commands = self.additional_xml_commands)

--- a/litex/build/efinix/platform.py
+++ b/litex/build/efinix/platform.py
@@ -19,6 +19,9 @@ class EfinixPlatform(GenericPlatform):
     def __init__(self, *args, toolchain="efinity", **kwargs):
         GenericPlatform.__init__(self, *args, **kwargs)
 
+        self.timing_model = self.device[-2:]
+        self.device       = self.device[:-2]
+
         self.pll_available = ['PLL_TL0', 'PLL_TR0', 'PLL_TR1', 'PLL_TR2', 'PLL_TR3', 'PLL_BR0', 'PLL_BR1', 'PLL_BR2', 'PLL_BL0']
         self.pll_used = []
 


### PR DESCRIPTION
Current efinix support have an hardcoded 'C4' timing model. But this one is not available for all trion devices.
This PR add extraction of device and timing model from information provided by platform in litex-boards (*T120F324I4* instead of *T120F214* for instance)