### PR TITLE
Set LatticeiCE40SDROutputImpl to `PIN_INPUT` mode.

### DIFF
--- a/litex/build/lattice/common.py
+++ b/litex/build/lattice/common.py
@@ -446,7 +446,10 @@ class LatticeiCE40DDRInput:
 class LatticeiCE40SDROutputImpl(Module):
     def __init__(self, i, o, clk):
         self.specials += Instance("SB_IO",
-            p_PIN_TYPE      = C(0b010100, 6), # PIN_OUTPUT_REGISTERED
+            # i_INPUT_CLK must match between two SB_IOs in the same tile.
+            # In PIN_INPUT mode, this restriction is relaxed; an unconnected
+            # i_INPUT_CLK also works.
+            p_PIN_TYPE      = C(0b010101, 6), # PIN_OUTPUT_REGISTERED + PIN_INPUT
             p_IO_STANDARD   = "SB_LVCMOS",
             io_PACKAGE_PIN  = o,
             i_CLOCK_ENABLE  = 1,


### PR DESCRIPTION
I wanted to test 1x SPI Flash mode on the iCEBreaker as a workaround for some issues I'm having with 4x mode.

```diff
diff --git a/litex_boards/targets/1bitsquared_icebreaker.py b/litex_boards/targets/1bitsquared_icebreaker.py
index 0ab0434..f7b730e 100755
--- a/litex_boards/targets/1bitsquared_icebreaker.py
+++ b/litex_boards/targets/1bitsquared_icebreaker.py
@@ -108,7 +108,7 @@ class BaseSoC(SoCCore):
         # SPI Flash --------------------------------------------------------------------------------
         from litespi.modules import W25Q128JV
         from litespi.opcodes import SpiNorFlashOpCodes as Codes
-        self.add_spi_flash(mode="4x", module=W25Q128JV(Codes.READ_1_1_4), with_master=False)
+        self.add_spi_flash(mode="1x", module=W25Q128JV(Codes.READ_1_1_1_FAST), with_master=False)
 
         # Add ROM linker region --------------------------------------------------------------------
         self.bus.add_region("rom", SoCRegion(
```

Before this patch, this results in an error like the following during PNR: `ERROR: Bel 'X23/Y0/io0' of type 'SB_IO' is not valid for cell 'SB_IO' of type 'SB_IO'`.

What is happening here is that as of [d436b025](https://github.com/litex-hub/litespi/commit/d436b025e129fb81437bd3db93f85b7c6b534c77) commit of litespi, `SDRTristate`s are being replaced with `SDROutput`s and `SDRInput`s. MOSI and MISO on the iCEBreaker share an I/O tile, which typically has the following restrictions on the underlying `SB_IO`s:

* `OUTPUT_CLK` must be shared.
* `INPUT_CLK` must be shared.
* `CLOCK_ENABLE` must be shared.

A LiteX `SDROutput` doesn't actually use `INPUT_CLK` when generating the `SB_IO` for MOSI and leaves it unconnected. On the other hand, MISO by necessity uses `INPUT_CLK`. This causes an error in `nextpnr` when MOSI and MISO are in the same I/O tile, like on iCEBreaker, because their `INPUT_CLK`s will _not_ match.

Changing the `PIN_MODE` of the generated `SB_IO` from `20` to `21` on the `SDROutput` `SB_IO` tells nextpnr to ignore the mismatch between clocks when `INPUT_CLK` is disconnected. A `PIN_MODE` of `0bxxxx01` means "simple/unregistered" input; the `INPUT_CLK` will come from the other `SB_IO` in the tile, and ignored.

Thank you to @smunaut for explaining this to me in detail.