### PR TITLE
Add bios test mode for CI

### DIFF
--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -25,7 +25,6 @@
 #include "readline.h"
 #include "helpers.h"
 #include "command.h"
-#include "sim_debug.h"
 
 #include <generated/csr.h>
 #include <generated/soc.h>
@@ -175,15 +174,6 @@ printf("\n");
 	video_framebuffer_dma_enable_write(0);
 	video_framebuffer_vtg_enable_write(1);
 	video_framebuffer_dma_enable_write(1);
-#endif
-
-#ifdef BIOS_TEST_MODE
-	printf("Bios successfully booted.\n");
-#ifdef CSR_SIM_FINISH_BASE
-	printf("Exiting simulation.\n");
-  	sim_finish();
-#endif
-	return 0;
 #endif
 
 	init_dispatcher();

--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -143,7 +143,6 @@ class SimSoC(SoCCore):
         with_gpio             = False,
         sim_debug             = False,
         trace_reset_on        = False,
-        bios_test_mode        = None,
         **kwargs):
         platform     = Platform()
         sys_clk_freq = int(1e6)
@@ -304,10 +303,6 @@ class SimSoC(SoCCore):
         else:
             self.comb += platform.trace.eq(1)
 
-        # Test mode for CI -------------------------------------------------------------------------
-        if bios_test_mode:
-            self.add_constant("BIOS_TEST_MODE")
-
 # Build --------------------------------------------------------------------------------------------
 
 def generate_gtkw_savefile(builder, vns, trace_fst):
@@ -378,7 +373,6 @@ def sim_args(parser):
     parser.add_argument("--sim-debug",            action="store_true",     help="Add simulation debugging modules")
     parser.add_argument("--gtkwave-savefile",     action="store_true",     help="Generate GTKWave savefile")
     parser.add_argument("--non-interactive",      action="store_true",     help="Run simulation without user input")
-    parser.add_argument("--bios-test-mode",       action="store_true",     help="Enables the test mode (no interactive console)")
 
 def main():
     parser = argparse.ArgumentParser(description="Generic LiteX SoC Simulation")
@@ -448,7 +442,6 @@ def main():
         with_spi_flash     = args.with_spi_flash,
         with_gpio          = args.with_gpio,
         sim_debug          = args.sim_debug,
-        bios_test_mode     = args.bios_test_mode,
         trace_reset_on     = trace_start > 0 or trace_end > 0,
         sdram_init         = [] if args.sdram_init is None else get_mem_data(args.sdram_init, cpu.endianness),
         spi_flash_init     = None if args.spi_flash_init is None else get_mem_data(args.spi_flash_init, "big"),


### PR DESCRIPTION
This enables to test the booting of each CPU configurations with the bios in Verilator simulation. This should partially help in #763. I am not sure about the compilers required for the non-riscv CPUs so I have not added those. This can be considered a WIP and I plan to add all the CPUs in litex into this once the toolchain requirements  are figrured out. 
@enjoy-digital Please review and let me know your thoughts on this.