### PR TITLE
efinix: pll v1 (T4/T8) support

### DIFF
--- a/litex/build/efinix/dbparser.py
+++ b/litex/build/efinix/dbparser.py
@@ -102,14 +102,22 @@ class EfinixDbParser():
 
         peri = root.findall('efxpt:periphery_instance', namespaces)
         for p in peri:
+            # T20/T120 have instance attribute in single_conn
+            # not true for T4/T8 -> search in dependency subnode
             if p.get('block') == 'pll':
-                conn = p.findall('efxpt:single_conn', namespaces)
-                for c in conn:
-                    if c.get('instance') == inst:
-                        refclk_no = 0
-                        if c.get('index') == '3':
-                            refclk_no = 1
-                        return (p.get('name'), refclk_no)
+                if self.device[0:2] not in ['T4', 'T8']:
+                    conn = p.findall('efxpt:single_conn', namespaces)
+                    for c in conn:
+                        if c.get('instance') == inst:
+                            refclk_no = 0
+                            if c.get('index') == '3':
+                                refclk_no = 1
+                            return (p.get('name'), refclk_no)
+                else:
+                    deps = p.findall('efxpt:dependency', namespaces)[0]
+                    for c in deps.findall('efxpt:instance_dep', namespaces)
+                        if c.get('name') == inst:
+                            return (p.get('name'), 3) # always 3 ?
 
         return None
 

--- a/litex/build/efinix/efinity.py
+++ b/litex/build/efinix/efinity.py
@@ -148,7 +148,7 @@ def _build_peri(efinity_path, build_name, partnumber, named_sc, named_pc, fragme
     pythonpath = ""
 
     header    = platform.toolchain.ifacewriter.header(build_name, partnumber)
-    gen       = platform.toolchain.ifacewriter.generate()
+    gen       = platform.toolchain.ifacewriter.generate(partnumber)
     #TODO: move this to ifacewriter
     gpio      = _build_iface_gpio(named_sc, named_pc, fragment, platform, specials_gpios)
     add       = '\n'.join(additional_iface_commands)

--- a/litex/build/efinix/ifacewriter.py
+++ b/litex/build/efinix/ifacewriter.py
@@ -308,7 +308,7 @@ design.create('{2}', '{3}', './../gateware', overwrite=True)
         cmd = '# TODO: ' + str(block) +'\n'
         return cmd
 
-    def generate_pll(self, block, verbose=True):
+    def generate_pll(self, block, partnumber, verbose=True):
         name = block['name']
         cmd = '# ---------- PLL {} ---------\n'.format(name)
         cmd += 'design.create_block("{}", block_type="PLL")\n'.format(name)
@@ -316,8 +316,13 @@ design.create('{2}', '{3}', './../gateware', overwrite=True)
         cmd += 'design.set_property("{}", pll_config, block_type="PLL")\n\n'.format(name)
 
         if block['input_clock'] == 'EXTERNAL':
-            cmd += 'design.gen_pll_ref_clock("{}", pll_res="{}", refclk_src="{}", refclk_name="{}", ext_refclk_no="{}")\n\n' \
-                .format(name, block['resource'], block['input_clock'], block['input_clock_name'], block['clock_no'])
+            # PLL V1 has a different configuration
+            if partnumber[0:2] in ["T4", "T8"]:
+                cmd += 'design.gen_pll_ref_clock("{}", pll_res="{}", refclk_res="{}", refclk_name="{}", ext_refclk_no="{}")\n\n' \
+                    .format(name, block['resource'], block['input_clock_pad'], block['input_clock_name'], block['clock_no'])
+            else:
+                cmd += 'design.gen_pll_ref_clock("{}", pll_res="{}", refclk_src="{}", refclk_name="{}", ext_refclk_no="{}")\n\n' \
+                    .format(name, block['resource'], block['input_clock'], block['input_clock_name'], block['clock_no'])
         else:
             cmd += 'design.gen_pll_ref_clock("{}", pll_res="{}", refclk_name="{}", refclk_src="CORE")\n'.format(name, block['resource'], block['input_signal'])
             cmd += 'design.set_property("{}", "CORE_CLK_PIN", "{}", block_type="PLL")\n\n'.format(name, block['input_signal'])
@@ -361,11 +366,11 @@ design.create('{2}', '{3}', './../gateware', overwrite=True)
         cmd += '# ---------- END PLL {} ---------\n\n'.format(name)
         return cmd
 
-    def generate(self):
+    def generate(self, partnumber):
         output = ''
         for b in self.blocks:
             if b['type'] == 'PLL':
-                output += self.generate_pll(b)
+                output += self.generate_pll(b, partnumber)
             if b['type'] == 'GPIO':
                 output += self.generate_gpio(b)
 

--- a/litex/soc/cores/clock/efinix_trion.py
+++ b/litex/soc/cores/clock/efinix_trion.py
@@ -58,8 +58,12 @@ class TRIONPLL(Module):
 
         # If clkin has a pin number, PLL clock input is EXTERNAL
         if self.platform.get_pin_location(clkin):
-           
             pad_name = self.platform.get_pin_location(clkin)[0]
+            # PLL v1 needs pin name
+            pin_name = self.platform.parser.get_gpio_instance_from_pin(pad_name)
+            if pin_name.count('_') == 2:
+                pin_name = pin_name.rsplit('_', 1)[0]
+
             self.platform.delete(clkin)
 
             #tpl = "create_clock -name {clk} -period {period} [get_ports {{{clk}}}]"
@@ -73,6 +77,7 @@ class TRIONPLL(Module):
                 quit()
 
             block['input_clock'] = 'EXTERNAL'
+            block['input_clock_pad'] = pin_name
             block['resource'] = pll_res
             block['clock_no'] = clock_no
             self.logger.info("Clock source: {}, using EXT_CLK{}".format(block['input_clock'], clock_no))


### PR DESCRIPTION
As mentionned in *efinity/VERS/pt/bin/api_service/design.py* there is two PLL versions. Currently only Advance PLL is supported.

This PR add:
- in *dbparser.py*: search pll source in `single_conn` or `dependency` according to device
- `design.gen_pll_ref_clock` calls is adapted according to device/PLL version