### PR TITLE
litex_sim/xgmii_ethernet: fix RX frame check sequence generation

### DIFF
--- a/litex/build/sim/core/modules/xgmii_ethernet/xgmii_ethernet.c
+++ b/litex/build/sim/core/modules/xgmii_ethernet/xgmii_ethernet.c
@@ -302,10 +302,10 @@ static xgmii_bus_snapshot_t xgmii_ethernet_rx_adv(xgmii_ethernet_state_t *s,
             // is going to be wrong and thus the packet being cut off
             // can be detected.
             uint32_t crc = crc32(0, popped_rx_pkt->data, popped_rx_pkt->len);
-            s->current_rx_pkt[copy_len + 0] = (crc >> 24) & 0xFF;
-            s->current_rx_pkt[copy_len + 1] = (crc >> 16) & 0xFF;
-            s->current_rx_pkt[copy_len + 2] = (crc >>  8) & 0xFF;
-            s->current_rx_pkt[copy_len + 3] = (crc >>  0) & 0xFF;
+            s->current_rx_pkt[copy_len + 3] = (crc >> 24) & 0xFF;
+            s->current_rx_pkt[copy_len + 2] = (crc >> 16) & 0xFF;
+            s->current_rx_pkt[copy_len + 1] = (crc >>  8) & 0xFF;
+            s->current_rx_pkt[copy_len + 0] = (crc >>  0) & 0xFF;
 
 #ifdef XGMII_RX_DEBUG
             fprintf(stderr, "\n----------------------------------\n"


### PR DESCRIPTION
The rewritten XGMII Ethernet module generates proper frame check sequences (FCS) on Ethernet frames received by the simulation, such that the unmodified MAC pipeline including CRC checking can be used. However, the byte order of the generated frame check sequence has been inverted. This becomes apparent when one specifies that the CRC should be calculated in the LiteX BIOS.

This fixes the byte order to be correct. The similar GMII Ethernet module did not contain this mistake.

Fixes: 7b533a032da824 ("litex_sim: rewrite XGMII verilator...")
Signed-off-by: Leon Schuermann <leon@is.currently.online>