### PR TITLE
soc.jtag.ecp5: Support all ECP5 devices

### DIFF
--- a/litex/soc/cores/jtag.py
+++ b/litex/soc/cores/jtag.py
@@ -176,9 +176,10 @@ class JTAGPHY(Module):
                 jtag = S7JTAG(chain=chain)
             elif device[:4] in ["xcku", "xcvu"]:
                 jtag = USJTAG(chain=chain)
-            elif device[:6] == "LFE5UM":
+            elif device[:5] == "LFE5U":
                 jtag = ECP5JTAG()
             else:
+                print(device)
                 raise NotImplementedError
             self.submodules.jtag = jtag
 


### PR DESCRIPTION
The device check for "LFE5UM" excludes ECP5 without serdes. 
Because I've been testing on these devices I didn't catch it.