### PR TITLE
Add option in Makefile for (s)ccache support.

### DIFF
--- a/litex/soc/software/common.mak
+++ b/litex/soc/software/common.mak
@@ -6,13 +6,14 @@ endif
 
 RM ?= rm -f
 PYTHON ?= python3
+CCACHE ?=
 
 ifeq ($(CLANG),1)
-CC_normal      := clang -target $(TRIPLE) -integrated-as
-CX_normal      := clang++ -target $(TRIPLE) -integrated-as
+CC_normal      := $(CCACHE) clang -target $(TRIPLE) -integrated-as
+CX_normal      := $(CCACHE) clang++ -target $(TRIPLE) -integrated-as
 else
-CC_normal      := $(TARGET_PREFIX)gcc -std=gnu99
-CX_normal      := $(TARGET_PREFIX)g++
+CC_normal      := $(CCACHE) $(TARGET_PREFIX)gcc -std=gnu99
+CX_normal      := $(CCACHE) $(TARGET_PREFIX)g++
 endif
 AR_normal      := $(TARGET_PREFIX)gcc-ar
 LD_normal      := $(TARGET_PREFIX)ld

--- a/litex/soc/software/libc/Makefile
+++ b/litex/soc/software/libc/Makefile
@@ -9,9 +9,15 @@ ifeq ($(CPU), microwatt)
 	CFLAGS += -DLONG_LONG_MIN=LLONG_MIN -DLONG_LONG_MAX=LLONG_MAX -DLONG_LONG_MIN=LLONG_MIN -DULONG_LONG_MAX=ULLONG_MAX
 endif
 
+ifeq ($(CCACHE), )
+	MESON_CROSS_CC = '$(TRIPLE)-gcc'
+else
+	MESON_CROSS_CC = ['$(CCACHE)', '$(TRIPLE)-gcc']
+endif
+
 define CROSSFILE
 [binaries]
-c     = '$(TRIPLE)-gcc'
+c     = $(MESON_CROSS_CC)
 ar    = '$(TRIPLE)-gcc-ar'
 as    = '$(TRIPLE)-as'
 nm    = '$(TRIPLE)-gcc-nm'
@@ -60,4 +66,3 @@ libc.a: $(LIBC_DIRECTORY)/missing.c _libc.a
 	$(compile)
 	$(AR) csr _libc.a $@
 	cp _libc.a libc.a
-


### PR DESCRIPTION
This also prevents meson from autodetecting `ccache` support automatically, which may be desirable if, for instance, `ccache` is actually slower (it happens!) or you use `sccache`. Otherwise, this is an opt-in feature for users.

On a Linux machine, I saw a clean build time go down by 50% after the first build. On Windows, there is no significant difference, possibly because the file I/O time dominates the compile times.