### PR TITLE
litex_sim: Allow regular_comb=False argument

### DIFF
--- a/litex/build/sim/verilator.py
+++ b/litex/build/sim/verilator.py
@@ -189,6 +189,7 @@ class SimVerilatorToolchain:
             trace_fst        = False,
             trace_start      = 0,
             trace_end        = -1,
+            regular_comb     = False,
             interactive      = True,
             pre_run_callback = None):
 
@@ -202,6 +203,9 @@ class SimVerilatorToolchain:
             if not isinstance(fragment, _Fragment):
                 fragment = fragment.get_fragment()
             platform.finalize(fragment)
+
+            if regular_comb:
+                raise ValueError("SimVerilatorToolchain disallows regular_comb=True")
 
             # Generate verilog
             v_output = platform.get_verilog(fragment, name=build_name)


### PR DESCRIPTION
This was removed in
3b78fd9 fhdl/verilog: Remove blocking_assign (not used with LiteX).
(I had the wrong rev here in the initial pull request)

However that breaks `litedram_gen --sim` which passes regular_comb=False
to all toolchain builders

```
  File "/home/matt/3rd/fpga/currvenv/bin/litedram_gen", line 11, in <module>
    load_entry_point('litedram==0.0.0', 'console_scripts', 'litedram_gen')()
  File "/home/matt/3rd/fpga/currvenv/lib/python3.9/site-packages/litedram-0.0.0-py3.9.egg/litedram/gen.py", line 834, in main
  File "/home/matt/3rd/fpga/currvenv/lib/python3.9/site-packages/litex-0.0.0-py3.9.egg/litex/soc/integration/builder.py", line 330, in build
    vns = self.soc.build(build_dir=self.gateware_dir, **kwargs)
  File "/home/matt/3rd/fpga/currvenv/lib/python3.9/site-packages/litex-0.0.0-py3.9.egg/litex/soc/integration/soc.py", line 1138, in build
    return self.platform.build(self, *args, **kwargs)
  File "/home/matt/3rd/fpga/currvenv/lib/python3.9/site-packages/litex-0.0.0-py3.9.egg/litex/build/sim/platform.py", line 54, in build
    return self.toolchain.build(self, *args, **kwargs)
TypeError: build() got an unexpected keyword argument 'regular_comb'
```