### PR TITLE
liblitedram: Write latency calibration failure fix

### DIFF
--- a/litex/soc/software/liblitedram/sdram.c
+++ b/litex/soc/software/liblitedram/sdram.c
@@ -1045,10 +1045,14 @@ static void sdram_write_latency_calibration(void) {
 			}
 		}
 
+		#ifdef SDRAM_PHY_WRITE_LEVELING_CAPABLE
 		if (_sdram_write_leveling_bitslips[module] < 0)
 			bitslip = best_bitslip;
 		else
 			bitslip = _sdram_write_leveling_bitslips[module];
+		#else
+			bitslip = best_bitslip;
+		#endif
 		if (bitslip == -1)
 			printf("m%d:- ", module);
 		else


### PR DESCRIPTION
For targets that do not feature `SDRAM_PHY_WRITE_LEVELING_CAPABLE`  write latency procedure does not work properly. Use of `best_bitslip` was conditioned with value of `_sdram_write_leveling_bitslips[module]`. However, when `SDRAM_PHY_WRITE_LEVELING_CAPABLE` is not defined, this array is not filled with meaningful data. It makes the procedure ignore found `best_bitslip` value and in turn DDR calibration passes only when 0 is a valid bitslip. This PR ignores `_sdram_write_leveling_bitslips` value for targets not capable of write leveling.