### PR TITLE
Eos s3 fix wb adr

### DIFF
--- a/litex/soc/cores/cpu/eos_s3/core.py
+++ b/litex/soc/cores/cpu/eos_s3/core.py
@@ -43,7 +43,7 @@ class EOS_S3(CPU):
         self.wishbone_master = [] # General Purpose Wishbone Masters.
 
         # # #
-        self.wb             = wishbone.Interface(data_width=32, adr_width=17)
+        self.wb             = wishbone.Interface(data_width=32, adr_width=15)
 
         # EOS-S3 Clocking.
         self.clock_domains.cd_Sys_Clk0 = ClockDomain()
@@ -58,7 +58,7 @@ class EOS_S3(CPU):
             # AHB-To-FPGA Bridge
             i_WB_CLK       = ClockSignal("Sys_Clk0"),
             o_WB_RST       = WB_RST,
-            o_WBs_ADR      = self.wb.adr,
+            o_WBs_ADR      = Cat(Signal(2), self.wb.adr),
             o_WBs_CYC      = self.wb.cyc,
             o_WBs_BYTE_STB = self.wb.sel,
             o_WBs_WE       = self.wb.we,

--- a/litex/soc/cores/cpu/eos_s3/core.py
+++ b/litex/soc/cores/cpu/eos_s3/core.py
@@ -36,6 +36,7 @@ class EOS_S3(CPU):
     def __init__(self, platform, variant):
         self.platform       = platform
         self.reset          = Signal()
+        self.interrupt      = Signal(4)
         self.periph_buses   = [] # Peripheral buses (Connected to main SoC's bus).
         self.memory_buses   = [] # Memory buses (Connected directly to LiteDRAM).
 
@@ -72,7 +73,7 @@ class EOS_S3(CPU):
             #SDMA_Done(),
             #SDMA_Active(),
             # FB Interrupts
-            #FB_msg_out(4'b0000),
+            i_FB_msg_out     = self.interrupt,
             #FB_Int_Clr(8'h0),
             #FB_Start(),
             #FB_Busy= 0,

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -926,6 +926,11 @@ class SoC(Module):
         # Add Bus Masters/CSR/IRQs.
         if isinstance(self.cpu, cpu.EOS_S3):
             self.bus.add_master(master=self.cpu.wb)
+            if hasattr(self.cpu, "interrupt"):
+                self.irq.enable()
+                for name, loc in self.cpu.interrupts.items():
+                    self.irq.add(name, loc)
+                self.add_config("CPU_HAS_INTERRUPT")
         if not isinstance(self.cpu, (cpu.CPUNone, cpu.Zynq7000, cpu.EOS_S3)):
             if reset_address is None:
                 reset_address = self.mem_map["rom"]


### PR DESCRIPTION
With EOS-S3 the Wishbone address bus is 8bits aligned, but all transaction are 32bits (or  WBs_BYTE_STB is used for 8 or 16 bits requests).
Anyway, in all cases the 2LSB are always 0.

In other hand, when data_width == 32, litex consider an address bus aligned (ie 2LSB are already discarded).
This patch fix alignment to fit litex requirement.