### PR TITLE
Review eoss3 core

### DIFF
--- a/litex/soc/cores/cpu/eos_s3/core.py
+++ b/litex/soc/cores/cpu/eos_s3/core.py
@@ -78,17 +78,17 @@ class EOS_S3(CPU):
 
             # SDMA.
             # -----
-            #SDMA_Req(4'b0000),
-            #SDMA_Sreq(4'b0000),
-            #SDMA_Done(),
-            #SDMA_Active(),
+            i_SDMA_Req    = Signal(4),
+            i_SDMA_Sreq   = Signal(4),
+            o_SDMA_Done   = Open(),
+            o_SDMA_Active = Open(),
 
             # Interrupts.
             # -----------
-            i_FB_msg_out     = self.interrupt,
-            #FB_Int_Clr(8'h0),
-            #FB_Start(),
-            #FB_Busy= 0,
+            i_FB_msg_out = self.interrupt,
+            i_FB_Int_Clr = Signal(8),
+            o_FB_Start   = Open(),
+            i_FB_Busy    = 0,
 
             # Clocking.
             # ---------
@@ -99,42 +99,42 @@ class EOS_S3(CPU):
 
             # Packet FIFO.
             # ------------
-            #Sys_PKfb_Clk = 0,
-            #Sys_PKfb_Rst(),
-            #FB_PKfbData(32'h0),
-            #FB_PKfbPush(4'h0),
-            #FB_PKfbSOF = 0,
-            #FB_PKfbEOF = 0,
-            #FB_PKfbOverflow(),
+            i_Sys_PKfb_Clk    = 0,
+            o_Sys_PKfb_Rst    = Open(),
+            i_FB_PKfbData     = Signal(32),
+            i_FB_PKfbPush     = Signal(4),
+            i_FB_PKfbSOF      = 0,
+            i_FB_PKfbEOF      = 0,
+            o_FB_PKfbOverflow = Open(),
 
             # Sensor.
             # -------
-            #Sensor_Int(),
-            #TimeStamp(),
+            o_Sensor_Int = Open(),
+            o_TimeStamp  = Open(),
 
             # SPI Master (APB).
             # -----------------
-            #Sys_Pclk(),
-            #Sys_Pclk_Rst(),
-            #Sys_PSel = 0,
-            #SPIm_Paddr(16'h0),
-            #SPIm_PEnable = 0,
-            #SPIm_PWrite = 0,
-            #SPIm_PWdata(32'h0),
-            #SPIm_Prdata(),
-            #SPIm_PReady(),
-            #SPIm_PSlvErr(),
+            o_Sys_Pclk     = Open(),
+            o_Sys_Pclk_Rst = Open(),
+            i_Sys_PSel     = 0,
+            i_SPIm_Paddr   = Signal(16),
+            i_SPIm_PEnable = 0,
+            i_SPIm_PWrite  = 0,
+            i_SPIm_PWdata  = Signal(32),
+            o_SPIm_Prdata  = Open(),
+            o_SPIm_PReady  = Open(),
+            o_SPIm_PSlvErr = Open(),
 
             # Misc.
             # -----
             i_Device_ID = 0xCAFE,
             # FBIO Signals
-            #FBIO_In(),
-            #FBIO_In_En(),
-            #FBIO_Out(),
-            #FBIO_Out_En(),
+            o_FBIO_In         = Open(),
+            o_FBIO_In_En      = Open(),
+            o_FBIO_Out        = Open(),
+            o_FBIO_Out_En     = Open(),
             # ???
-            #SFBIO           =  ,
+            io_SFBIO          = Signal(14),
             i_Device_ID_6S    = 0,
             i_Device_ID_4S    = 0,
             i_SPIm_PWdata_26S = 0,

--- a/litex/soc/cores/cpu/eos_s3/core.py
+++ b/litex/soc/cores/cpu/eos_s3/core.py
@@ -47,13 +47,23 @@ class EOS_S3(CPU):
 
         # EOS-S3 Clocking --------------------------------------------------------------------------
         pbus_rst     = Signal()
+        eos_s3_0_clk = Signal()
         eos_s3_0_rst = Signal()
+        eos_s3_1_clk = Signal()
         eos_s3_1_rst = Signal()
         self.clock_domains.cd_eos_s3_0 = ClockDomain()
         self.clock_domains.cd_eos_s3_1 = ClockDomain()
         self.specials += Instance("gclkbuff",
+            i_A = eos_s3_0_clk,
+            o_Z = ClockSignal("eos_s3_0")
+        )
+        self.specials += Instance("gclkbuff",
             i_A = eos_s3_0_rst | pbus_rst,
             o_Z = ResetSignal("eos_s3_0")
+        )
+        self.specials += Instance("gclkbuff",
+            i_A = eos_s3_1_clk,
+            o_Z = ClockSignal("eos_s3_1")
         )
         self.specials += Instance("gclkbuff",
             i_A = eos_s3_1_rst | pbus_rst,
@@ -92,9 +102,9 @@ class EOS_S3(CPU):
 
             # Clocking.
             # ---------
-            o_Sys_Clk0     = ClockSignal("eos_s3_0"),
+            o_Sys_Clk0     = eos_s3_0_clk,
             o_Sys_Clk0_Rst = eos_s3_0_rst,
-            o_Sys_Clk1     = ClockSignal("eos_s3_1"),
+            o_Sys_Clk1     = eos_s3_1_clk,
             o_Sys_Clk1_Rst = eos_s3_1_rst,
 
             # Packet FIFO.


### PR DESCRIPTION
This PR updates eos_s3 core with:
- for all unused **qlal4s3b_cell_macro** a default 0 value or Open
- clocks signals are passed into a **gclkbuff**