### PR TITLE
soc.intergration.dram: Use nranks in capacity calc

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1301,7 +1301,7 @@ class LiteXSoC(SoC):
         # Compute/Check SDRAM size.
         sdram_size = 2**(module.geom_settings.bankbits +
                          module.geom_settings.rowbits +
-                         module.geom_settings.colbits)*phy.settings.databits//8
+                         module.geom_settings.colbits)*phy.settings.nranks*phy.settings.databits//8
         if size is not None:
             sdram_size = min(sdram_size, size)
 


### PR DESCRIPTION
This ensures that dual ranked memory appears with the correct capacity.

When testing butterstick configurations I noticed that the SoC always showed 1/2 the memory.
It looks like this calculation of sdram_size ignores dram ranks. Since the butterstick is dual rank this halves the memory reported/mapped to the SoC.