### PR TITLE
build/altera: fix rbf generation on windows

### DIFF
--- a/litex/build/altera/quartus.py
+++ b/litex/build/altera/quartus.py
@@ -149,7 +149,14 @@ quartus_fit --read_settings_files=off --write_settings_files=off {build_name} -c
 quartus_asm --read_settings_files=off --write_settings_files=off {build_name} -c {build_name}
 quartus_sta {build_name} -c {build_name}"""
     if create_rbf:
-        script_contents += """
+        if sys.platform in ["win32", "cygwin"]:
+          script_contents += """
+if exist "{build_name}.sof" (
+    quartus_cpf -c {build_name}.sof {build_name}.rbf
+)
+"""
+        else:
+          script_contents += """
 if [ -f "{build_name}.sof" ]
 then
     quartus_cpf -c {build_name}.sof {build_name}.rbf


### PR DESCRIPTION
Testing for a file existing is slightly different
between bash and .bat files which caused the batch
file to error out.