### PR TITLE
software.fatfs: Align fatfs sector buffers

### DIFF
--- a/litex/soc/software/libfatfs/ff.h
+++ b/litex/soc/software/libfatfs/ff.h
@@ -172,7 +172,7 @@ typedef struct {
 	LBA_t	bitbase;		/* Allocation bitmap base sector */
 #endif
 	LBA_t	winsect;		/* Current sector appearing in the win[] */
-	BYTE	win[FF_MAX_SS];	/* Disk access window for Directory, FAT (and file data at tiny cfg) */
+	BYTE	win[FF_MAX_SS]  __attribute__ ((aligned (4))); /* Disk access window for Directory, FAT (and file data at tiny cfg) */
 } FATFS;
 
 
@@ -217,7 +217,7 @@ typedef struct {
 	DWORD*	cltbl;			/* Pointer to the cluster link map table (nulled on open, set by application) */
 #endif
 #if !FF_FS_TINY
-	BYTE	buf[FF_MAX_SS];	/* File private data read/write window */
+	BYTE	buf[FF_MAX_SS] __attribute__ ((aligned (4)));	/* File private data read/write window */
 #endif
 } FIL;
 


### PR DESCRIPTION
When working with the litesdcard I noticed that if the FatFs sector buffers were not aligned FatFs would fail, I suspect this is due to the DMA in litesdcard that's copying data into the buffer only performing 32bit writes.

In the FatFs header we can tell GCC to ensure that these buffers always fall on a word boundary.