### PR TITLE
tools/litex_json2dts_linux.py fix double {{

### DIFF
--- a/litex/tools/litex_json2dts_linux.py
+++ b/litex/tools/litex_json2dts_linux.py
@@ -238,7 +238,7 @@ def generate_dts(d, initrd_start=None, initrd_size=None, initrd=None, root_devic
             compatible = "simple-bus";
             interrupt-parent = <&intc0>;
             ranges;
-"""
+""".format()
 
     # SoC Controller -------------------------------------------------------------------------------
 


### PR DESCRIPTION
A string with a {{ was missing the .format call, generating some broken dts