### PR TITLE
litex_json2dts_linux: add config_earlycon constant

### DIFF
--- a/litex/tools/litex_json2dts_linux.py
+++ b/litex/tools/litex_json2dts_linux.py
@@ -57,8 +57,8 @@ def generate_dts(d, initrd_start=None, initrd_size=None, initrd=None, root_devic
 
     dts += """
         chosen {{
-            bootargs = "{console} {rootfs}";""".format(
-    console = "console=liteuart earlycon=liteuart,0x{:x}".format(d["csr_bases"]["uart"]),
+            bootargs = "console=liteuart {earlycon} {rootfs}";""".format(
+    earlycon = "earlycon={}".format(d["constants"].get("config_earlycon", "liteuart,0x{:x}".format(d["csr_bases"]["uart"]))),
     rootfs  = "rootwait root=/dev/{}".format(root_device))
 
     if initrd_enabled is True:


### PR DESCRIPTION
This patch checks for a configuration constant named "config_earlycon"
and if present uses it for the "earlycon=" value in the dts
"bootargs".

If the constant is not present, default to the uart defined in the
"csr_bases".

This is useful for the sim.py case, where that configuration wants to
use "earlycon=sbi", while true hardware platforms want the uart from
"csr_bases".

See litex-hub/linux-on-litex-vexriscv#258