### PR TITLE
soc/software/bios/cmds/cmd_mem.c: fix number of required params

### DIFF
--- a/litex/soc/interconnect/wishbone.py
+++ b/litex/soc/interconnect/wishbone.py
@@ -199,8 +199,8 @@ class Decoder(Module):
 
 
 class InterconnectShared(Module):
-    def __init__(self, masters, slaves, register=False, timeout_cycles=1e6):
-        shared = Interface()
+    def __init__(self, masters, slaves, register=False, timeout_cycles=1e6,data_width=32):
+        shared = Interface(data_width=data_width)
         self.submodules.arbiter = Arbiter(masters, shared)
         self.submodules.decoder = Decoder(shared, slaves, register)
         if timeout_cycles is not None:

--- a/litex/soc/software/bios/cmds/cmd_mem.c
+++ b/litex/soc/software/bios/cmds/cmd_mem.c
@@ -225,7 +225,7 @@ static void mem_speed_handler(int nb_params, char **params)
 	bool read_only = false;
 	bool random = false;
 
-	if (nb_params < 1) {
+	if (nb_params < 2) {
 		printf("mem_speed <addr> <size> [<readonly>] [<random>]");
 		return;
 	}


### PR DESCRIPTION
soc/software/bios/cmds/cmd_mem.c: 
The required number parameters is at least 2.

litex/soc/interconnect/wishbone.py: 
When using a 64-bit wishbone interface, the higher 4-byte of the data will not be transferred as the default width of the ['shared'](https://github.com/enjoy-digital/litex/blob/8ac3fbc0391b133775cbb6f12db89a27d7b18bd4/litex/soc/interconnect/wishbone.py#L203) interface is 32-bit. Add this parameter to make the 64bit wishbone bus work.