### PR TITLE
sim: allow custom modules to be in custom path

### DIFF
--- a/litex/build/sim/core/modules/Makefile
+++ b/litex/build/sim/core/modules/Makefile
@@ -1,12 +1,17 @@
 include ../variables.mak
 MODULES = xgmii_ethernet ethernet serial2console serial2tcp clocker spdeeprom gmii_ethernet
 
-.PHONY: $(MODULES)
-all: $(MODULES)
+.PHONY: $(MODULES) $(EXTRA_MOD_LIST)
+all: $(MODULES) $(EXTRA_MOD_LIST)
 
 $(MODULES): %:
 	mkdir -p $@
 	$(MAKE) MOD=$@ -C $@ -f $(SRC_DIR)/modules/$@/Makefile
+	cp $@/$@.so $@.so
+
+$(EXTRA_MOD_LIST): %:
+	mkdir -p $@
+	$(MAKE) MOD=$@ -C $@ -f $(EXTRA_MOD_BASE_DIR)/$@/Makefile
 	cp $@/$@.so $@.so
 
 .PHONY: clean

--- a/litex/build/sim/core/modules/rules.mak
+++ b/litex/build/sim/core/modules/rules.mak
@@ -11,11 +11,15 @@ endif
 LDFLAGS += -levent -shared -fPIC
 
 MOD_SRC_DIR=$(SRC_DIR)/modules/$(MOD)
+EXTRA_MOD_SRC_DIR=$(EXTRA_MOD_BASE_DIR)/$(MOD)
 
 all: $(MOD).so
 
 %.o: $(MOD_SRC_DIR)/%.c
 	$(CC) -c $(CFLAGS) -I$(MOD_SRC_DIR)/../.. -o $@ $<
+
+%.o: $(EXTRA_MOD_SRC_DIR)/%.c
+	$(CC) -c $(CFLAGS) -I$(SRC_DIR) -o $@ $<
 
 %.so: %.o
 ifeq ($(UNAME_S),Darwin)

--- a/litex/build/sim/verilator.py
+++ b/litex/build/sim/verilator.py
@@ -105,7 +105,7 @@ extern "C" void litex_sim_init(void **out)
     tools.write_to_file("sim_init.cpp", content)
 
 
-def _generate_sim_variables(include_paths):
+def _generate_sim_variables(include_paths, extra_mods, extra_mods_path):
     tapcfg_dir = get_data_mod("misc", "tapcfg").data_location
     include = ""
     for path in include_paths:
@@ -115,6 +115,13 @@ SRC_DIR = {}
 INC_DIR = {}
 TAPCFG_DIRECTORY = {}
 """.format(core_directory, include, tapcfg_dir)
+
+    if extra_mods:
+        modlist = " ".join(extra_mods)
+        content += "EXTRA_MOD_LIST = " + modlist + "\n"
+        content += "EXTRA_MOD_BASE_DIR = " + extra_mods_path + "\n"
+        tools.write_to_file(extra_mods_path + "/variables.mak", content)
+
     tools.write_to_file("variables.mak", content)
 
 
@@ -191,7 +198,9 @@ class SimVerilatorToolchain:
             trace_end        = -1,
             regular_comb     = False,
             interactive      = True,
-            pre_run_callback = None):
+            pre_run_callback = None,
+            extra_mods       = None,
+            extra_mods_path  = ""):
 
         # Create build directory
         os.makedirs(build_dir, exist_ok=True)
@@ -217,7 +226,10 @@ class SimVerilatorToolchain:
             # Generate cpp header/main/variables
             _generate_sim_h(platform)
             _generate_sim_cpp(platform, trace, trace_start, trace_end)
-            _generate_sim_variables(platform.verilog_include_paths)
+
+            _generate_sim_variables(platform.verilog_include_paths,
+                                    extra_mods,
+                                    extra_mods_path)
 
             # Generate sim config
             if sim_config:


### PR DESCRIPTION
If a project needs a custom verilator module, it can now
specifies the path where the module's directory is.

SimPlatform can now look for extra modules:

    builder.build(
        extra_mods = ["mymodule1", "mymodule2"],
        extra_mods_path = os.path.abspath(os.getcwd()) + "/modules",
        sim_config=sim_config
    )

Modules must be subdirectories of extra_mods_path:

.
├── modules
│   ├── mymodule1
│   ├── mymodule2
│   ├── ...