### PR TITLE
RFC: software/fatfs: allow sata, [spi]sdcard disk ops to co-exist

### DIFF
--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -812,9 +812,11 @@ void sdcardboot(void)
 {
 #ifdef CSR_SPISDCARD_BASE
 	printf("Booting from SDCard in SPI-Mode...\n");
+	fatfs_set_ops_spisdcard();	/* use spisdcard disk access ops */
 #endif
 #ifdef CSR_SDCORE_BASE
 	printf("Booting from SDCard in SD-Mode...\n");
+	fatfs_set_ops_sdcard();		/* use sdcard disk access ops */
 #endif
 
 	/* Boot from boot.json */
@@ -986,6 +988,7 @@ static void sataboot_from_bin(const char * filename)
 void sataboot(void)
 {
 	printf("Booting from SATA...\n");
+	fatfs_set_ops_sata();		/* use sata disk access ops */
 
 	/* Boot from boot.json */
 	printf("Booting from boot.json...\n");

--- a/litex/soc/software/libfatfs/diskio.h
+++ b/litex/soc/software/libfatfs/diskio.h
@@ -26,13 +26,16 @@ typedef enum {
 /*---------------------------------------*/
 /* Prototypes for disk control functions */
 
+typedef struct {
+	DSTATUS (*disk_initialize) (BYTE pdrv);
+	DSTATUS (*disk_status) (BYTE pdrv);
+	DRESULT (*disk_read) (BYTE pdrv, BYTE* buff, LBA_t sector, UINT count);
+	DRESULT (*disk_write) (BYTE pdrv, const BYTE* buff, LBA_t sector, UINT count);
+	DRESULT (*disk_ioctl) (BYTE pdrv, BYTE cmd, void* buff);
+} DISKOPS;
 
-DSTATUS disk_initialize (BYTE pdrv);
-DSTATUS disk_status (BYTE pdrv);
-DRESULT disk_read (BYTE pdrv, BYTE* buff, LBA_t sector, UINT count);
-DRESULT disk_write (BYTE pdrv, const BYTE* buff, LBA_t sector, UINT count);
-DRESULT disk_ioctl (BYTE pdrv, BYTE cmd, void* buff);
-
+/* Global disk control ops pointer */
+extern DISKOPS *FfDiskOps;
 
 /* Disk Status Bits (DSTATUS) */
 #define STA_NOINIT		0x01	/* Drive not initialized */

--- a/litex/soc/software/liblitesata/sata.c
+++ b/litex/soc/software/liblitesata/sata.c
@@ -101,21 +101,31 @@ void sata_write(uint32_t sector, uint32_t count, uint8_t* buf)
 
 static DSTATUS satastatus = STA_NOINIT;
 
-DSTATUS disk_status(BYTE drv) {
+static DSTATUS sata_disk_status(BYTE drv) {
 	if (drv) return STA_NOINIT;
 	return satastatus;
 }
 
-DSTATUS disk_initialize(BYTE drv) {
+static DSTATUS sata_disk_initialize(BYTE drv) {
 	if (drv) return STA_NOINIT;
 	if (satastatus)
 		satastatus = sata_init() ? 0 : STA_NOINIT;
 	return satastatus;
 }
 
-DRESULT disk_read(BYTE drv, BYTE *buf, LBA_t sector, UINT count) {
+static DRESULT sata_disk_read(BYTE drv, BYTE *buf, LBA_t sector, UINT count) {
 	sata_read(sector, count, buf);
 	return RES_OK;
+}
+
+static DISKOPS SataDiskOps = {
+	.disk_initialize = sata_disk_initialize,
+	.disk_status = sata_disk_status,
+	.disk_read = sata_disk_read,
+};
+
+void fatfs_set_ops_sata(void) {
+	FfDiskOps = &SataDiskOps;
 }
 
 #endif /* CSR_SATA_SECTOR2MEM_BASE */

--- a/litex/soc/software/liblitesata/sata.h
+++ b/litex/soc/software/liblitesata/sata.h
@@ -13,6 +13,7 @@
 #ifdef CSR_SATA_PHY_BASE
 
 int sata_init(void);
+void fatfs_set_ops_sata(void);
 
 #endif
 

--- a/litex/soc/software/liblitesdcard/sdcard.c
+++ b/litex/soc/software/liblitesdcard/sdcard.c
@@ -565,21 +565,31 @@ void sdcard_write(uint32_t block, uint32_t count, uint8_t* buf)
 
 static DSTATUS sdcardstatus = STA_NOINIT;
 
-DSTATUS disk_status(BYTE drv) {
+static DSTATUS sd_disk_status(BYTE drv) {
 	if (drv) return STA_NOINIT;
 	return sdcardstatus;
 }
 
-DSTATUS disk_initialize(BYTE drv) {
+static DSTATUS sd_disk_initialize(BYTE drv) {
 	if (drv) return STA_NOINIT;
 	if (sdcardstatus)
 		sdcardstatus = sdcard_init() ? 0 : STA_NOINIT;
 	return sdcardstatus;
 }
 
-DRESULT disk_read(BYTE drv, BYTE *buf, LBA_t block, UINT count) {
+static DRESULT sd_disk_read(BYTE drv, BYTE *buf, LBA_t block, UINT count) {
 	sdcard_read(block, count, buf);
 	return RES_OK;
+}
+
+static DISKOPS SdCardDiskOps = {
+	.disk_initialize = sd_disk_initialize,
+	.disk_status = sd_disk_status,
+	.disk_read = sd_disk_read,
+};
+
+void fatfs_set_ops_sdcard(void) {
+	FfDiskOps = &SdCardDiskOps;
 }
 
 #endif /* CSR_SDCORE_BASE */

--- a/litex/soc/software/liblitesdcard/sdcard.h
+++ b/litex/soc/software/liblitesdcard/sdcard.h
@@ -103,6 +103,7 @@ void sdcard_decode_csd(void);
 int sdcard_init(void);
 void sdcard_read(uint32_t sector, uint32_t count, uint8_t* buf);
 void sdcard_write(uint32_t sector, uint32_t count, uint8_t* buf);
+void fatfs_set_ops_sdcard(void);
 
 #endif /* CSR_SDCORE_BASE */
 

--- a/litex/soc/software/liblitesdcard/spisdcard.c
+++ b/litex/soc/software/liblitesdcard/spisdcard.c
@@ -264,12 +264,12 @@ uint8_t spisdcard_init(void) {
 
 static DSTATUS spisdcardstatus = STA_NOINIT;
 
-DSTATUS disk_status(BYTE drv) {
+static DSTATUS spisd_disk_status(BYTE drv) {
     if (drv) return STA_NOINIT;
     return spisdcardstatus;
 }
 
-DSTATUS disk_initialize(BYTE drv) {
+static DSTATUS spisd_disk_initialize(BYTE drv) {
     if (drv) return STA_NOINIT;
     if (spisdcardstatus) {
         spisdcardstatus = spisdcard_init() ? 0 : STA_NOINIT;
@@ -278,7 +278,7 @@ DSTATUS disk_initialize(BYTE drv) {
     return spisdcardstatus;
 }
 
-DRESULT disk_read(BYTE drv, BYTE *buf, LBA_t block, UINT count) {
+static DRESULT spisd_disk_read(BYTE drv, BYTE *buf, LBA_t block, UINT count) {
     uint8_t cmd;
     if (count > 1)
         cmd = CMD18; /* READ_MULTIPLE_BLOCK */
@@ -300,6 +300,16 @@ DRESULT disk_read(BYTE drv, BYTE *buf, LBA_t block, UINT count) {
         return RES_ERROR;
 
     return RES_OK;
+}
+
+static DISKOPS SpiSdDiskOps = {
+	.disk_initialize = spisd_disk_initialize,
+	.disk_status = spisd_disk_status,
+	.disk_read = spisd_disk_read,
+};
+
+void fatfs_set_ops_spisdcard(void) {
+	FfDiskOps = &SpiSdDiskOps;
 }
 
 #endif

--- a/litex/soc/software/liblitesdcard/spisdcard.h
+++ b/litex/soc/software/liblitesdcard/spisdcard.h
@@ -50,6 +50,7 @@
 /*-----------------------------------------------------------------------*/
 
 uint8_t spisdcard_init(void);
+void fatfs_set_ops_spisdcard(void);
 
 #endif /* CSR_SPISDCARD_BASE */
 


### PR DESCRIPTION
At the moment, sata and [spi]sdcard fatfs disk access methods
are mutually exclusive, as their names collide with each other.

Implement a DISKOPS structure with media-specific disk access
methods, and a way for the boot code to specifiy which media
type's methods to use when loading files into RAM at boot time.

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>

This (together with https://github.com/litex-hub/litex-boards/pull/325) allows me to build both sdcard and sata support for rocket on nexys_video like so:

```
litex-boards/litex_boards/targets/digilent_nexys_video.py --build \
    --cpu-type rocket --cpu-variant full4d --sys-clk-freq 50e6 \
    --with-ethernet \
    --with-sdcard \
    --with-sata --sata-gen 1
```

NOTE 1: I haven't actually ***run*** it yet, but so far this allows the build process to complete without crashing :)
NOTE 2: There might be more elegant ways to do this, happy to do revisions if needed (hence the "RFC" in the title)!