### PR TITLE
Fix Zynq software support

### DIFF
--- a/litex/soc/cores/cpu/zynq7000/boot-helper.S
+++ b/litex/soc/cores/cpu/zynq7000/boot-helper.S
@@ -1,3 +1,0 @@
-.global     boot_helper
-boot_helper:
-    nop  // FIXME

--- a/litex/soc/cores/cpu/zynq7000/boot-helper.c
+++ b/litex/soc/cores/cpu/zynq7000/boot-helper.c
@@ -1,0 +1,5 @@
+void boot_helper(unsigned long r1, unsigned long r2, unsigned long r3, unsigned long addr);
+
+void boot_helper(unsigned long r1, unsigned long r2, unsigned long r3, unsigned long addr) {
+    goto *addr;
+}

--- a/litex/soc/cores/cpu/zynq7000/core.py
+++ b/litex/soc/cores/cpu/zynq7000/core.py
@@ -23,17 +23,20 @@ class Zynq7000(CPU):
     human_name           = "Zynq7000"
     data_width           = 32
     endianness           = "little"
-    reset_address        = 0x00000000
+    reset_address        = 0xfc00_0000
     gcc_triple           = "arm-none-eabi"
     gcc_flags            = "-mcpu=cortex-a9 -mfpu=vfpv3 -mfloat-abi=hard"
     linker_output_format = "elf32-littlearm"
     nop                  = "nop"
-    io_regions           = {0x00000000: 0x100000000} # Origin, Length.
+    io_regions           = {0x4000_0000: 0xbc00_0000} # Origin, Length.
 
     # Memory Mapping.
     @property
     def mem_map(self):
-        return {"csr": 0x00000000}
+        return {
+            "sram": 0x10_0000,  # DDR in fact
+            "rom":  0xfc00_0000,
+        }
 
     def __init__(self, platform, variant, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -935,7 +935,7 @@ class SoC(Module):
             self.mem_map.update(self.cpu.mem_map)
 
         # Add Bus Masters/CSR/IRQs.
-        if not isinstance(self.cpu, (cpu.CPUNone, cpu.Zynq7000)):
+        if not isinstance(self.cpu, cpu.CPUNone):
             if hasattr(self.cpu, "set_reset_address"):
                 if reset_address is None:
                     reset_address = self.mem_map["rom"]


### PR DESCRIPTION
This makes the memory map valid from the CPU point of view, enables software compilation for Zynq and adds a boot helper (this one not tested yet, but something like this should work).