### PR TITLE
Use the 'main' branch for Marocchino.

### DIFF
--- a/litex_setup.py
+++ b/litex_setup.py
@@ -102,7 +102,7 @@ git_repos = {
     "pythondata-cpu-blackparrot":  GitRepo(url="https://github.com/litex-hub/"),
     "pythondata-cpu-cv32e40p":     GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
     "pythondata-cpu-ibex":         GitRepo(url="https://github.com/litex-hub/", clone="recursive", sha1=0xd3d53df),
-    "pythondata-cpu-marocchino":   GitRepo(url="https://github.com/litex-hub/"),
+    "pythondata-cpu-marocchino":   GitRepo(url="https://github.com/litex-hub/", branch="main"),
 }
 
 # Installs -----------------------------------------------------------------------------------------


### PR DESCRIPTION
Avoids an exception in "litex_setup.py --config=full --update" as pythondata-cpu-marocchino has 'main' not 'master' branch.