### PR TITLE
gowin: add hack for copackaged PSRAM

### DIFF
--- a/litex/build/gowin/gowin.py
+++ b/litex/build/gowin/gowin.py
@@ -109,6 +109,8 @@ class GowinToolchain:
         # Apply Synthesis directives.
         tools.replace_in_file(v_file, "wire [0:0] IO_hpram_rwds,", "wire [0:0] IO_hpram_rwds, /* synthesis syn_tristate = 1 */")
         tools.replace_in_file(v_file, "wire [7:0] IO_hpram_dq,",    "wire [7:0] IO_hpram_dq,  /* synthesis syn_tristate = 1 */")
+        tools.replace_in_file(v_file, "[1:0] IO_psram_rwds,", "[1:0] IO_psram_rwds, /* synthesis syn_tristate = 1 */")
+        tools.replace_in_file(v_file, "[15:0] IO_psram_dq,",    "[15:0] IO_psram_dq,  /* synthesis syn_tristate = 1 */")
 
     def build(self, platform, fragment,
         build_dir  = "build",


### PR DESCRIPTION
Some Gowin FPGAs has copackaged "PSRAM" instead of "HyperRAM". They're
in fact also HyperRAM, but named differently and because of this needs
slightly changed hack.

Add hack for PSRAM too. In case of two PSRAM chips are used, the bus is
wider so the needed definition is already in place, so the bus width
hack is not needed.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>