### PR TITLE
litex/soc/cores/clock/xilinx_common: fix yosys synth: replace FD by FDCE

### DIFF
--- a/litex/soc/cores/clock/xilinx_common.py
+++ b/litex/soc/cores/clock/xilinx_common.py
@@ -145,7 +145,7 @@ class XilinxClocking(Module, AutoCSR):
     def add_reset_delay(self, cycles):
         for i in range(cycles):
             reset = Signal()
-            self.specials += Instance("FD", i_C=self.clkin, i_D=self.reset, o_Q=reset)
+            self.specials += Instance("FDCE", i_C=self.clkin, i_CE=1, i_CLR=0, i_D=self.reset, o_Q=reset)
             self.reset = reset
 
     def do_finalize(self):


### PR DESCRIPTION
for Xilinx devices, when *yosys* is used for synthesis, as mentionned in this [issue](https://github.com/YosysHQ/yosys/issues/1583), FD primitive is not supported and this step fails with
```
ERROR: Module `\FD' referenced in module `\digilent_arty_z7' in cell `\FD_7' is not part of the design
```
This PR replace `FD` by `FDSE` with same behaviour.