### PR TITLE
litex_setup.py on Windows: Change install "python3" to current interpreter

### DIFF
--- a/litex_setup.py
+++ b/litex_setup.py
@@ -222,7 +222,8 @@ def litex_setup_install_repos(config="standard", user_mode=False):
         if repo.develop:
             print_status(f"Installing {name} Git repository...")
             os.chdir(os.path.join(current_path, name))
-            subprocess.check_call("python3 setup.py develop {options}".format(
+            subprocess.check_call("{python_executable} setup.py develop {options}".format(
+                python_executable = sys.executable,
                 options="--user" if user_mode else "",
                 ), shell=True)
     if user_mode:


### PR DESCRIPTION
On Windows, default Python 3.x installation uses just `python` command. Therefore, `litex_setup.py` fails:
```
$ python .\litex_setup.py --init --install
```
...
```
[  65.500] Installing Git repositories...
[  65.500] ------------------------------
[  65.500] Installing migen Git repository...
Python was not found; run without arguments to install from the Microsoft Store, or disable this shortcut from Settings > Manage App Execution Aliases.
Traceback (most recent call last):
  File "C:\Users\ben\litex\litex_setup.py", line 363, in <module>
    main()
  File "C:\Users\ben\litex\litex_setup.py", line 349, in main
    litex_setup_install_repos(config=args.config, user_mode=args.user)
  File "C:\Users\ben\litex\litex_setup.py", line 225, in litex_setup_install_repos
    subprocess.check_call("python3 setup.py develop {options}".format(
  File "C:\Users\ben\AppData\Local\Programs\Python\Python310\lib\subprocess.py", line 369, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command 'python3 setup.py develop ' returned non-zero exit status 9009.
```

This can be avoided by getting the full path to the current interpreter through `sys.executable`