### PR TITLE
Get the default IP prefix from LITEX_DEFAULT_IP_PREFIX env-var if set.

### DIFF
--- a/litex/config.py
+++ b/litex/config.py
@@ -1,0 +1,3 @@
+import os
+
+DEFAULT_IP_PREFIX = os.getenv("LITEX_DEFAULT_IP_PREFIX", "192.168.1") + "."

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -23,6 +23,8 @@ from litex.soc.interconnect import stream
 from litex.soc.interconnect import wishbone
 from litex.soc.interconnect import axi
 
+from litex.config import DEFAULT_IP_PREFIX
+
 logging.basicConfig(level=logging.INFO)
 
 # Helpers ------------------------------------------------------------------------------------------
@@ -1498,7 +1500,7 @@ class LiteXSoC(SoC):
     # Add Etherbone --------------------------------------------------------------------------------
     def add_etherbone(self, name="etherbone", phy=None, phy_cd="eth",
         mac_address             = 0x10e2d5000000,
-        ip_address              = "192.168.1.50",
+        ip_address              = DEFAULT_IP_PREFIX + "50",
         udp_port                = 1234,
         buffer_depth            = 4,
         with_timing_constraints = True):

--- a/litex/tools/litex_server.py
+++ b/litex/tools/litex_server.py
@@ -19,6 +19,8 @@ import threading
 from litex.tools.remote.etherbone import EtherbonePacket, EtherboneRecord, EtherboneWrites
 from litex.tools.remote.etherbone import EtherboneIPC
 
+from litex.config import DEFAULT_IP_PREFIX
+
 # Read Merger --------------------------------------------------------------------------------------
 
 def _read_merger(addrs, max_length=256, bursts=["incr", "fixed"]):
@@ -182,7 +184,7 @@ def main():
 
     # UDP arguments
     parser.add_argument("--udp",             action="store_true",    help="Select UDP interface.")
-    parser.add_argument("--udp-ip",          default="192.168.1.50", help="Set UDP remote IP address.")
+    parser.add_argument("--udp-ip",          default=DEFAULT_IP_PREFIX + "50", help="Set UDP remote IP address.")
     parser.add_argument("--udp-port",        default=1234,           help="Set UDP remote port.")
     parser.add_argument("--udp-scan",        action="store_true",    help="Scan network for available UDP devices.")
 

--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -26,6 +26,8 @@ from litex.soc.cores.bitbang import *
 from litex.soc.cores.gpio import GPIOTristate
 from litex.soc.cores.cpu import CPUS
 
+from litex.config import DEFAULT_IP_PREFIX
+
 from litedram import modules as litedram_modules
 from litedram.modules import parse_spd_hexdump
 from litedram.phy.model import sdram_module_nphases, get_sdram_phy_settings
@@ -143,7 +145,7 @@ class SimSoC(SoCCore):
         ethernet_phy_model    = "sim",
         with_etherbone        = False,
         etherbone_mac_address = 0x10e2d5000001,
-        etherbone_ip_address  = "192.168.1.51",
+        etherbone_ip_address  = DEFAULT_IP_PREFIX + "51",
         with_analyzer         = False,
         sdram_module          = "MT48LC16M16",
         sdram_init            = [],
@@ -371,8 +373,8 @@ def sim_args(parser):
     parser.add_argument("--with-ethernet",        action="store_true",     help="Enable Ethernet support.")
     parser.add_argument("--ethernet-phy-model",   default="sim",           help="Ethernet PHY to simulate (sim, xgmii or gmii).")
     parser.add_argument("--with-etherbone",       action="store_true",     help="Enable Etherbone support.")
-    parser.add_argument("--local-ip",             default="192.168.1.50",  help="Local IP address of SoC.")
-    parser.add_argument("--remote-ip",            default="192.168.1.100", help="Remote IP address of TFTP server.")
+    parser.add_argument("--local-ip",             default=DEFAULT_IP_PREFIX + "50",  help="Local IP address of SoC.")
+    parser.add_argument("--remote-ip",            default=DEFAULT_IP_PREFIX + "100", help="Remote IP address of TFTP server.")
     parser.add_argument("--with-analyzer",        action="store_true",     help="Enable Analyzer support.")
     parser.add_argument("--with-i2c",             action="store_true",     help="Enable I2C support.")
     parser.add_argument("--with-sdcard",          action="store_true",     help="Enable SDCard support.")

--- a/litex/tools/remote/comm_udp.py
+++ b/litex/tools/remote/comm_udp.py
@@ -12,10 +12,12 @@ from litex.tools.remote.etherbone import EtherboneReads, EtherboneWrites
 
 from litex.tools.remote.csr_builder import CSRBuilder
 
+from litex.config import DEFAULT_IP_PREFIX
+
 # CommUDP ------------------------------------------------------------------------------------------
 
 class CommUDP(CSRBuilder):
-    def __init__(self, server="192.168.1.50", port=1234, csr_csv=None, debug=False):
+    def __init__(self, server=DEFAULT_IP_PREFIX + "50", port=1234, csr_csv=None, debug=False):
         CSRBuilder.__init__(self, comm=self, csr_csv=csr_csv)
         self.server = server
         self.port   = port
@@ -57,7 +59,7 @@ class CommUDP(CSRBuilder):
                 raise Exception(f"Unable to probe Etherbone server at {self.server}.")
         return 0
 
-    def scan(self, ip="192.168.1.x"):
+    def scan(self, ip=DEFAULT_IP_PREFIX + "x"):
         print(f"Etherbone scan on {ip} network:")
         ip = ip.replace("x", "{}")
         self.socket.settimeout(0.01)


### PR DESCRIPTION
My home network is on 192.168.1.x and I like to keep my misbehaving FPGA designs off of it so I use a different IP range. This is designed to make that easy.