### PR TITLE
i2c: automatic device init by the BIOS

### DIFF
--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -203,6 +203,10 @@ class Builder:
             csr_base  = self.soc.mem_regions['csr'].origin)
         write_to_file(os.path.join(self.generated_dir, "csr.h"), csr_contents)
 
+        # Generate I2C command/value table
+        i2c_contents = export.get_i2c_header(self.soc.i2c_init)
+        write_to_file(os.path.join(self.generated_dir, "i2c.h"), i2c_contents)
+
         # Generate Git SHA1 of tools to git.h
         git_contents = export.get_git_header()
         write_to_file(os.path.join(self.generated_dir, "git.h"), git_contents)

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -174,6 +174,9 @@ class SoCCore(LiteXSoC):
         # Wishbone Slaves.
         self.wb_slaves = {}
 
+        # I2C initialisation tables
+        self.i2c_init = []
+
         # Modules instances ------------------------------------------------------------------------
 
         # Add SoCController
@@ -268,6 +271,9 @@ class SoCCore(LiteXSoC):
 
     def add_csr_region(self, name, origin, busword, obj):
         self.csr_regions[name] = SoCCSRRegion(origin, busword, obj)
+
+    def add_i2c_init_table(self, dev, i2c_addr, table, addr_len=1):
+        self.i2c_init.append((dev, i2c_addr, table, addr_len))
 
     # Finalization ---------------------------------------------------------------------------------
 

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -36,6 +36,7 @@
 
 #include <libbase/spiflash.h>
 #include <libbase/uart.h>
+#include <libbase/i2c.h>
 
 #include <liblitedram/sdram.h>
 
@@ -89,6 +90,10 @@ __attribute__((__used__)) int main(int i, char **c)
 #endif
 #ifdef CSR_UART_BASE
 	uart_init();
+#endif
+
+#ifdef CSR_I2C_BASE
+	i2c_send_init_cmds();
 #endif
 
 #ifndef CONFIG_SIM_DISABLE_BIOS_PROMPT

--- a/litex/soc/software/libbase/i2c.h
+++ b/litex/soc/software/libbase/i2c.h
@@ -6,6 +6,15 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#include <stdint.h>
+
+typedef void (*i2c_write_t)(uint32_t v);
+typedef uint32_t (*i2c_read_t)(void);
+
+struct i2c_ops {
+	i2c_write_t write;
+	i2c_read_t read;
+};
 
 /* I2C frequency defaults to a safe value in range 10-100 kHz to be compatible with SMBus */
 #ifndef I2C_FREQ_HZ
@@ -19,6 +28,7 @@ void i2c_reset(void);
 bool i2c_write(unsigned char slave_addr, unsigned char addr, const unsigned char *data, unsigned int len);
 bool i2c_read(unsigned char slave_addr, unsigned char addr, unsigned char *data, unsigned int len, bool send_stop);
 bool i2c_poll(unsigned char slave_addr);
+int i2c_send_init_cmds(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The BIOS can now initialize I2C peripherals during the boot.
The add_i2c_init_table method of the soc speficy parameters:

self.submodules.i2c = I2CMaster(pads)
self.add_i2c_init_table("i2c", i2c_addr=0x4c, table=it6263_i2c_hdmi_tx)

it6263_i2c_hdmi_tx = [
  (0x05, 0x40),
  (0x04, 0x3D),
  (0x04, 0x1D)
  ...

The table is a list of tupple as (address, value).