### PR TITLE
i2c: handle multiple i2c controllers in the BIOS

### DIFF
--- a/litex/soc/cores/bitbang.py
+++ b/litex/soc/cores/bitbang.py
@@ -23,7 +23,7 @@ class I2CMaster(Module, AutoCSR):
     Software get back SDA value with the read CSRStatus (_r).
     """
     pads_layout = [("scl", 1), ("sda", 1)]
-    def __init__(self, pads=None):
+    def __init__(self, pads=None, default_dev=False):
         self.init = []
         if pads is None:
             pads = Record(self.pads_layout)
@@ -36,6 +36,8 @@ class I2CMaster(Module, AutoCSR):
         self._r = CSRStatus(fields=[
             CSRField("sda", size=1, offset=0)],
             name="r")
+
+        self.default_dev = default_dev
 
         self.connect(pads)
 
@@ -83,13 +85,16 @@ class I2CMasterSim(I2CMaster):
 
 # I2C Master Init Collection  ----------------------------------------------------------------------
 
-def collect_i2c_init(soc):
+def collect_i2c_info(soc):
     i2c_init = []
+    i2c_devs = []
     for name, obj in xdir(soc, True):
-        if isinstance(obj, I2CMaster) and hasattr(obj, "init"):
-            for addr, init, init_addr_len in obj.init:
-                i2c_init.append((name, addr, init, init_addr_len))
-    return i2c_init
+        if isinstance(obj, I2CMaster):
+            i2c_devs.append((name, getattr(obj, "default_dev")))
+            if hasattr(obj, "init"):
+                for addr, init, init_addr_len in obj.init:
+                    i2c_init.append((name, addr, init, init_addr_len))
+    return i2c_devs, i2c_init
 
 # SPI Master Bit-Banging ---------------------------------------------------------------------------
 

--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -203,10 +203,12 @@ class Builder:
             csr_base  = self.soc.mem_regions['csr'].origin)
         write_to_file(os.path.join(self.generated_dir, "csr.h"), csr_contents)
 
-        # Generate I2C command/value table
-        from litex.soc.cores.bitbang import collect_i2c_init
-        i2c_contents = export.get_i2c_header(collect_i2c_init(self.soc))
-        write_to_file(os.path.join(self.generated_dir, "i2c.h"), i2c_contents)
+        # Generate I2C configuration and command/value table
+        from litex.soc.cores.bitbang import collect_i2c_info
+        i2c_devs, i2c_init = collect_i2c_info(self.soc)
+        if i2c_devs:
+            i2c_info = export.get_i2c_header((i2c_devs, i2c_init))
+            write_to_file(os.path.join(self.generated_dir, "i2c.h"), i2c_info)
 
         # Generate Git SHA1 of tools to git.h
         git_contents = export.get_git_header()

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -791,21 +791,22 @@ class SoC(Module):
                 colorer("declared", color="red")))
             raise SoCError()
 
-    def add_constant(self, name, value=None):
+    def add_constant(self, name, value=None, check_duplicate=True):
         name = name.upper()
         if name in self.constants.keys():
-            self.logger.error("{} Constant already {}.".format(
-                colorer(name),
-                colorer("declared", color="red")))
-            raise SoCError()
+            if check_duplicate:
+                self.logger.error("{} Constant already {}.".format(
+                    colorer(name),
+                    colorer("declared", color="red")))
+                raise SoCError()
         self.constants[name] = SoCConstant(value)
 
-    def add_config(self, name, value=None):
+    def add_config(self, name, value=None, check_duplicate=True):
         name = "CONFIG_" + name
         if isinstance(value, str):
-            self.add_constant(name + "_" + value)
+            self.add_constant(name + "_" + value, check_duplicate=check_duplicate)
         else:
-            self.add_constant(name, value)
+            self.add_constant(name, value, check_duplicate=check_duplicate)
 
     def check_bios_requirements(self):
         # Check for required Peripherals.

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -20,6 +20,7 @@ import os
 import inspect
 
 from migen import *
+from migen.util.misc import xdir
 
 from litex.soc.cores import cpu
 from litex.soc.interconnect import wishbone
@@ -272,6 +273,11 @@ class SoCCore(LiteXSoC):
     # Finalization ---------------------------------------------------------------------------------
 
     def do_finalize(self):
+        for name, obj in xdir(self, True):
+            from litex.soc.cores.bitbang import I2CMaster
+            if isinstance(obj, I2CMaster):
+                self.add_config("HAS_I2C", check_duplicate=False)
+
         # Retro-compatibility
         for address, interface in self.wb_slaves.items():
             wb_name = None

--- a/litex/soc/software/bios/cmds/cmd_litedram.c
+++ b/litex/soc/software/bios/cmds/cmd_litedram.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <libbase/memtest.h>
 
+#include <generated/soc.h>
 #include <generated/csr.h>
 #include <generated/mem.h>
 #include <libbase/i2c.h>
@@ -352,7 +353,7 @@ define_command(sdram_mr_write, sdram_mr_write_handler, "Write SDRAM Mode Registe
  * SPD address is a 3-bit address defined by the pins A0, A1, A2.
  *
  */
-#ifdef CSR_I2C_BASE
+#ifdef CONFIG_HAS_I2C
 #define SPD_RW_PREAMBLE    0b1010
 #define SPD_RW_ADDR(a210)  ((SPD_RW_PREAMBLE << 3) | ((a210) & 0b111))
 

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -92,7 +92,7 @@ __attribute__((__used__)) int main(int i, char **c)
 	uart_init();
 #endif
 
-#ifdef CSR_I2C_BASE
+#ifdef CONFIG_HAS_I2C
 	i2c_send_init_cmds();
 #endif
 

--- a/litex/soc/software/libbase/i2c.h
+++ b/litex/soc/software/libbase/i2c.h
@@ -14,6 +14,14 @@ typedef uint32_t (*i2c_read_t)(void);
 struct i2c_ops {
 	i2c_write_t write;
 	i2c_read_t read;
+	int w_scl_offset;
+	int w_sda_offset;
+	int w_oe_offset;
+};
+
+struct i2c_dev {
+	char *name;
+	struct i2c_ops ops;
 };
 
 /* I2C frequency defaults to a safe value in range 10-100 kHz to be compatible with SMBus */
@@ -29,6 +37,10 @@ bool i2c_write(unsigned char slave_addr, unsigned char addr, const unsigned char
 bool i2c_read(unsigned char slave_addr, unsigned char addr, unsigned char *data, unsigned int len, bool send_stop);
 bool i2c_poll(unsigned char slave_addr);
 int i2c_send_init_cmds(void);
+struct i2c_dev *get_i2c_devs(void);
+int get_i2c_devs_count(void);
+void set_i2c_active_dev(int dev);
+int get_i2c_active_dev(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
A new command is introduced: "i2c_dev".
With this command you can list i2c devices and choose on to be active.