### PR TITLE
microwatt: Move to latest and add countzero module

### DIFF
--- a/litex/soc/cores/cpu/microwatt/core.py
+++ b/litex/soc/cores/cpu/microwatt/core.py
@@ -180,7 +180,7 @@ class Microwatt(CPU):
             "ppc_fx_insns.vhdl",
             "logical.vhdl",
             "rotator.vhdl",
-            "countzero.vhdl",
+            "countbits.vhdl",
             "execute1.vhdl",
 
             # Load/Store.

--- a/litex_setup.py
+++ b/litex_setup.py
@@ -101,7 +101,7 @@ git_repos = {
     "pythondata-cpu-vexriscv-smp": GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
     "pythondata-cpu-rocket":       GitRepo(url="https://github.com/litex-hub/"),
     "pythondata-cpu-minerva":      GitRepo(url="https://github.com/litex-hub/"),
-    "pythondata-cpu-microwatt":    GitRepo(url="https://github.com/litex-hub/", sha1=0xdad611c),
+    "pythondata-cpu-microwatt":    GitRepo(url="https://github.com/litex-hub/", sha1=0xb940b55acff),
     "pythondata-cpu-blackparrot":  GitRepo(url="https://github.com/litex-hub/"),
     "pythondata-cpu-cv32e40p":     GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
     "pythondata-cpu-ibex":         GitRepo(url="https://github.com/litex-hub/", clone="recursive", sha1=0xd3d53df),


### PR DESCRIPTION
The microwatt version has renamed countbits to countzero. Update to the
latest and update the file list.

Signed-off-by: Joel Stanley <joel@jms.id.au>