### PR TITLE
Cpu fix csr decoding

### DIFF
--- a/litex/soc/cores/cpu/eos_s3/core.py
+++ b/litex/soc/cores/cpu/eos_s3/core.py
@@ -48,6 +48,7 @@ class EOS_S3(CPU):
         self.pbus           = wishbone.Interface(data_width=32, adr_width=15)
         self.periph_buses   = [self.pbus]
         self.memory_buses   = []
+        self.csr_decode     = False # Wishbone address is decoded before fabric
 
         # # #
 

--- a/litex/soc/cores/cpu/zynq7000/core.py
+++ b/litex/soc/cores/cpu/zynq7000/core.py
@@ -43,12 +43,13 @@ class Zynq7000(CPU):
         super().__init__(*args, **kwargs)
         self.platform       = platform
         self.reset          = Signal()
-        self.periph_buses   = [] # Peripheral buses (Connected to main SoC's bus).
-        self.memory_buses   = [] # Memory buses (Connected directly to LiteDRAM).
+        self.periph_buses   = []    # Peripheral buses (Connected to main SoC's bus).
+        self.memory_buses   = []    # Memory buses (Connected directly to LiteDRAM).
 
-        self.axi_gp_masters = [] # General Purpose AXI Masters.
-        self.axi_gp_slaves  = [] # General Purpose AXI Slaves.
-        self.axi_hp_slaves  = [] # High Performance AXI Slaves.
+        self.axi_gp_masters = []    # General Purpose AXI Masters.
+        self.axi_gp_slaves  = []    # General Purpose AXI Slaves.
+        self.axi_hp_slaves  = []    # High Performance AXI Slaves.
+        self.csr_decode     = False # AXI address is decoded in AXI2Wishbone (target level).
 
         # # #
 

--- a/litex/soc/cores/cpu/zynqmp/core.py
+++ b/litex/soc/cores/cpu/zynqmp/core.py
@@ -41,6 +41,7 @@ class ZynqMP(CPU):
         self.periph_buses   = []          # Peripheral buses (Connected to main SoC's bus).
         self.memory_buses   = []          # Memory buses (Connected directly to LiteDRAM).
         self.axi_gp_masters = [None] * 3  # General Purpose AXI Masters.
+        self.csr_decode     = False       # AXI address is decoded in AXI2Wishbone (target level).
 
         self.clock_domains.cd_ps = ClockDomain()
 


### PR DESCRIPTION
As mentioned in issue #1154 some hard CPUs may have address translated before fabric or a second time when AXI is converted to wishbone:
- **eos s3** use absolute adress in CPU but relative address is exported to eFPGA side;
- **zynq7000** and **zynqMP** have, currently, two adress decoding (one in [SoCRegion](https://github.com/enjoy-digital/litex/blob/master/litex/soc/integration/soc.py#L87), a second in [AXILite2Wishbone](https://github.com/enjoy-digital/litex/blob/0d2183062d14d8babf444fe196c84a48d099586d/litex/soc/interconnect/axi.py#L542)

In all case, these decoding are not required and communication CPU<->FPGA fails due to mismatch addresses.

This PR (inspired by @sergachev [commit](https://github.com/sergachev/litex/commit/197a6353d597a4e06bab7d2af4e3e9dde31fabdd):
- adds `SoCRegion` CTOR parameter to allow/disallow decoding
- adds `SoC` attribute to store if a CSR address translation must be done (default True to keep default behaviour)
- adds for **eos**, **zynq7000** and **zynqmp** previous attribute to False to bypass translation at `SoCRegion` level.