### PR TITLE
Version control with JSON file

### DIFF
--- a/litex/tools/litex_freeze.py
+++ b/litex/tools/litex_freeze.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2022 Mikołaj Sowiński <msowinski@technosystem.com.pl>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Small tool generate repo definitions overlay for litex_setup.
+
+import os
+import subprocess
+import argparse
+import json
+
+# Freeze -------------------------------------------------------------------------------------------
+
+def freeze(install_path, output=None, allow_dirty=False):
+    dirs = [d for d in os.listdir(install_path) if os.path.isdir(d)]
+    repos = {}
+    for d in dirs:
+        dir_path = os.path.join(install_path, d)
+        # Check if directory is Git repo
+        gitcmd = subprocess.run(['git', 'diff', '--stat'],
+                                cwd=dir_path, capture_output=True)
+        if gitcmd.returncode != 0:
+            continue
+
+        # Check if repo is clean
+        if gitcmd.stdout and not allow_dirty:
+            raise RuntimeError(f"Repository {d} is dirty!")
+
+        # Get origin url
+        gitcmd = subprocess.run(['git', 'remote', 'get-url', "origin"],
+                                cwd=dir_path, capture_output=True)
+        if gitcmd.returncode != 0:
+            raise RuntimeError(f"Repository {d} has no remotes!")
+        origin_url = gitcmd.stdout.decode().strip()
+
+        # Get SHA1 of the current commit
+        gitcmd = subprocess.run(['git', 'rev-parse', "--short=11", "HEAD"],
+                                cwd=dir_path, capture_output=True)
+        if gitcmd.returncode != 0:
+            raise RuntimeError(f"Failed to get commit SHA1 for {d}")
+        sha1 = gitcmd.stdout.decode().strip()
+
+        # Store repo data
+        repos[d] = {
+            "url": origin_url,
+            "sha1": sha1
+        }
+
+    # Output
+    if output is None:
+        print(json.dumps(repos, indent=4, sort_keys=True))
+    else:
+        with open(output, 'w+') as fp:
+            json.dump(repos, fp, indent=4, sort_keys=True)
+
+# Run ----------------------------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="Small tool generate repo definitions overlay for litex_setup.")
+    parser.add_argument("--install-path", default="./", help="Path to the directory where repositories were installed.")
+    parser.add_argument("--output", default=None, help="Output JSON path, defaults to stdout.")
+    parser.add_argument("--allow-dirty", action="store_true", help="Allow freezing dirty repository.")
+    args = parser.parse_args()
+
+    freeze(install_path=args.install_path, output=args.output, allow_dirty=args.allow_dirty)
+
+if __name__ == "__main__":
+    main()

--- a/litex_setup.py
+++ b/litex_setup.py
@@ -7,6 +7,7 @@ import subprocess
 import shutil
 import hashlib
 import argparse
+import json
 
 import urllib.request
 
@@ -67,48 +68,61 @@ class GitRepo:
 
 git_repos = {
     # HDL.
-    "migen":    GitRepo(url="https://github.com/m-labs/", clone="recursive"),
-    "amaranth": GitRepo(url="https://github.com/amaranth-lang/", branch="main"),
+    "migen":    GitRepo(url="https://github.com/m-labs/migen.git", clone="recursive"),
+    "amaranth": GitRepo(url="https://github.com/amaranth-lang/amaranth.git", branch="main"),
 
     # LiteX SoC builder
-    "pythondata-software-picolibc":    GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
-    "pythondata-software-compiler_rt": GitRepo(url="https://github.com/litex-hub/"),
-    "litex":                           GitRepo(url="https://github.com/enjoy-digital/"),
+    "pythondata-software-picolibc":    GitRepo(url="https://github.com/litex-hub/pythondata-software-picolibc.git", clone="recursive"),
+    "pythondata-software-compiler_rt": GitRepo(url="https://github.com/litex-hub/pythondata-software-compiler_rt.git"),
+    "litex":                           GitRepo(url="https://github.com/enjoy-digital/litex.git"),
 
     # LiteX Cores Ecosystem.
-    "liteeth":      GitRepo(url="https://github.com/enjoy-digital/"),
-    "litedram":     GitRepo(url="https://github.com/enjoy-digital/"),
-    "litepcie":     GitRepo(url="https://github.com/enjoy-digital/"),
-    "litesata":     GitRepo(url="https://github.com/enjoy-digital/"),
-    "litesdcard":   GitRepo(url="https://github.com/enjoy-digital/"),
-    "liteiclink":   GitRepo(url="https://github.com/enjoy-digital/"),
-    "litescope":    GitRepo(url="https://github.com/enjoy-digital/"),
-    "litejesd204b": GitRepo(url="https://github.com/enjoy-digital/"),
-    "litespi":      GitRepo(url="https://github.com/litex-hub/"),
-    "litehyperbus": GitRepo(url="https://github.com/litex-hub/"),
+    "liteeth":      GitRepo(url="https://github.com/enjoy-digital/liteeth.git"),
+    "litedram":     GitRepo(url="https://github.com/enjoy-digital/litedram.git"),
+    "litepcie":     GitRepo(url="https://github.com/enjoy-digital/litepcie.git"),
+    "litesata":     GitRepo(url="https://github.com/enjoy-digital/litesata.git"),
+    "litesdcard":   GitRepo(url="https://github.com/enjoy-digital/litesdcard.git"),
+    "liteiclink":   GitRepo(url="https://github.com/enjoy-digital/liteiclink.git"),
+    "litescope":    GitRepo(url="https://github.com/enjoy-digital/litescope.git"),
+    "litejesd204b": GitRepo(url="https://github.com/enjoy-digital/litejesd204b.git"),
+    "litespi":      GitRepo(url="https://github.com/litex-hub/litespi.git"),
+    "litehyperbus": GitRepo(url="https://github.com/litex-hub/litehyperbus.git"),
 
     # LiteX Boards.
-    "litex-boards": GitRepo(url="https://github.com/litex-hub/", clone="regular"),
+    "litex-boards": GitRepo(url="https://github.com/litex-hub/litex-boards.git", clone="regular"),
 
     # LiteX pythondata.
-    "pythondata-misc-tapcfg":      GitRepo(url="https://github.com/litex-hub/"),
-    "pythondata-misc-usb_ohci":    GitRepo(url="https://github.com/litex-hub/"),
-    "pythondata-cpu-lm32":         GitRepo(url="https://github.com/litex-hub/"),
-    "pythondata-cpu-mor1kx":       GitRepo(url="https://github.com/litex-hub/"),
-    "pythondata-cpu-picorv32":     GitRepo(url="https://github.com/litex-hub/"),
-    "pythondata-cpu-serv":         GitRepo(url="https://github.com/litex-hub/"),
-    "pythondata-cpu-vexriscv":     GitRepo(url="https://github.com/litex-hub/"),
-    "pythondata-cpu-vexriscv-smp": GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
-    "pythondata-cpu-naxriscv":     GitRepo(url="https://github.com/litex-hub/"),
-    "pythondata-cpu-rocket":       GitRepo(url="https://github.com/litex-hub/"),
-    "pythondata-cpu-minerva":      GitRepo(url="https://github.com/litex-hub/"),
-    "pythondata-cpu-microwatt":    GitRepo(url="https://github.com/litex-hub/", sha1=0xb940b55acff),
-    "pythondata-cpu-blackparrot":  GitRepo(url="https://github.com/litex-hub/"),
-    "pythondata-cpu-cv32e40p":     GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
-    "pythondata-cpu-cv32e41p":     GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
-    "pythondata-cpu-ibex":         GitRepo(url="https://github.com/litex-hub/", clone="recursive", sha1=0xd3d53df),
-    "pythondata-cpu-marocchino":   GitRepo(url="https://github.com/litex-hub/"),
+    "pythondata-misc-tapcfg":      GitRepo(url="https://github.com/litex-hub/pythondata-misc-tapcfg.git"),
+    "pythondata-misc-usb_ohci":    GitRepo(url="https://github.com/litex-hub/pythondata-misc-usb_ohci.git"),
+    "pythondata-cpu-lm32":         GitRepo(url="https://github.com/litex-hub/pythondata-cpu-lm32.git"),
+    "pythondata-cpu-mor1kx":       GitRepo(url="https://github.com/litex-hub/pythondata-cpu-mor1kx.git"),
+    "pythondata-cpu-picorv32":     GitRepo(url="https://github.com/litex-hub/pythondata-cpu-picorv32.git"),
+    "pythondata-cpu-serv":         GitRepo(url="https://github.com/litex-hub/pythondata-cpu-serv.git"),
+    "pythondata-cpu-vexriscv":     GitRepo(url="https://github.com/litex-hub/pythondata-cpu-vexriscv.git"),
+    "pythondata-cpu-vexriscv-smp": GitRepo(url="https://github.com/litex-hub/pythondata-cpu-vexriscv-smp.git", clone="recursive"),
+    "pythondata-cpu-naxriscv":     GitRepo(url="https://github.com/litex-hub/pythondata-cpu-naxriscv.git"),
+    "pythondata-cpu-rocket":       GitRepo(url="https://github.com/litex-hub/pythondata-cpu-rocket.git"),
+    "pythondata-cpu-minerva":      GitRepo(url="https://github.com/litex-hub/pythondata-cpu-minerva.git"),
+    "pythondata-cpu-microwatt":    GitRepo(url="https://github.com/litex-hub/pythondata-cpu-microwatt.git", sha1=0xb940b55acff),
+    "pythondata-cpu-blackparrot":  GitRepo(url="https://github.com/litex-hub/pythondata-cpu-blackparrot.git"),
+    "pythondata-cpu-cv32e40p":     GitRepo(url="https://github.com/litex-hub/pythondata-cpu-cv32e40p.git", clone="recursive"),
+    "pythondata-cpu-cv32e41p":     GitRepo(url="https://github.com/litex-hub/pythondata-cpu-cv32e41p.git", clone="recursive"),
+    "pythondata-cpu-ibex":         GitRepo(url="https://github.com/litex-hub/pythondata-cpu-ibex.git", clone="recursive", sha1=0xd3d53df),
+    "pythondata-cpu-marocchino":   GitRepo(url="https://github.com/litex-hub/pythondata-cpu-marocchino.git"),
 }
+
+def apply_overlay(json_path):
+    with open(json_path, 'r') as fp:
+        overlay = json.load(fp)
+    for k, v in overlay.items():
+        if "sha1" in v:
+            v["sha1"] = int(v["sha1"], 16)
+        if k in git_repos:
+            git_repos[k].__dict__.update(**v)
+        elif "url" in v:
+            git_repos[k] = GitRepo(**v)
+        else:
+            raise RuntimeError(f"Invalid repository configuration {k}!")
 
 # Installs -----------------------------------------------------------------------------------------
 
@@ -179,9 +193,10 @@ def litex_setup_init_repos(config="standard", dev_mode=False):
             repo_url = repo.url
             if dev_mode:
                 repo_url = repo_url.replace("https://github.com/", "git@github.com:")
-            subprocess.check_call("git clone {url} {options}".format(
-                url     = repo_url + name + ".git",
-                options = "--recursive" if repo.clone == "recursive" else ""
+            subprocess.check_call("git clone {url} {options} {dir}".format(
+                url     = repo_url,
+                options = "--recursive" if repo.clone == "recursive" else "",
+                dir     = name
                 ), shell=True)
             # Use specific SHA1 (Optional).
             if repo.sha1 is not None:
@@ -327,6 +342,7 @@ def main():
     parser.add_argument("--user",      action="store_true", help="Install in User-Mode.")
     parser.add_argument("--config",    default="standard",  help="Install config (minimal, standard, full).")
     parser.add_argument("--status",    action="store_true", help="Display Git status of repositories.")
+    parser.add_argument("--json",      default=None,        help="Apply overlay to repo definitions from given JSON file.")
 
     # GCC toolchains.
     parser.add_argument("--gcc", default=None, help="Download/Extract GCC Toolchain (riscv, powerpc, openrisc or lm32).")
@@ -350,6 +366,10 @@ def main():
     litex_setup_location_check()
     if not args.dev:
         litex_setup_auto_update()
+
+    # Apply overlay.
+    if args.json:
+        apply_overlay(args.json)
 
     # Init.
     if args.init:

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
             "litex_json2renode=litex.tools.litex_json2renode:main",
             "litex_bare_metal_demo=litex.soc.software.demo.demo:main",
             "litex_contributors=litex.tools.litex_contributors:main",
+            "litex_freeze=litex.tools.litex_freeze:main"
         ],
     },
 )


### PR DESCRIPTION
When debugging https://github.com/enjoy-digital/litedram/issues/293 I found it difficult to reproduce a complete LiteX environment with all dependencies in a specified repository revision. LiteX setup script by default pulls latest master, so installation leads to a different result at different times.

This PR attempts to address this issue by introducing a new option for `litex_setup.py`: `--json JSON`. It enables an overlay for defined source repositories. Such overlay can overwrite any `GitRepo` parameter (or create a new repository entry) what can be used to define a specific SHA1 for repository.

It also introduces a new tool - `litex_freeze` that can create JSON overlay out of existing LiteX installation directory.

To make overlays more consistent and straightforward while keeping implementation minimal, I've decided to change way repo URL is expressed in `git_repos`. Now key is name of target directory (where sources are cloned to) and `GitRepo` constructor is given a full repo URL.