### PR TITLE
efinix: add a list of values to fix in xml

### DIFF
--- a/litex/build/efinix/efinity.py
+++ b/litex/build/efinix/efinity.py
@@ -313,6 +313,10 @@ class EfinityToolchain:
         if self.ifacewriter.xml_blocks or platform.iobank_info:
             self.ifacewriter.generate_xml_blocks()
 
+        # Because the Python API is sometimes bugged, we need to tweak the generated xml
+        if self.ifacewriter.fix_xml:
+            self.ifacewriter.fix_xml_values()
+
         # Run
         if run:
             # Synthesis/Mapping.


### PR DESCRIPTION
Sometimes the Python API of the interface designer produce a wrong XML
file. Values can be changed in the XML file with this new list.
For example:

fix_pll = [
	#      Tag              name                    properties / values
	("comp_output_clock", "mipi_clk",             [("out_divider", "20")]),
        ("comp_output_clock", "mipi_tx_clk_fastclk",  [("out_divider", "4"), ("phase_setting", "3")]),
        ("comp_output_clock", "mipi_tx_data_fastclk", [("out_divider", "4"), ("phase_setting", "1")]),
        ("comp_output_clock", "mipi_tx_slowclk",      [("out_divider", "16")])
]

platform.toolchain.ifacewriter.fix_xml += fix_pll