### PR TITLE
platform: fix add_sources

### DIFF
--- a/litex/build/altera/quartus.py
+++ b/litex/build/altera/quartus.py
@@ -108,7 +108,7 @@ def _build_qsf(device, ips, sources, vincpaths, named_sc, named_pc, build_name, 
     qsf.append("set_global_assignment -name DEVICE {}".format(device))
 
     # Add sources
-    for filename, language, library in sources:
+    for filename, language, library, *copy in sources:
         if language == "verilog": language = "systemverilog" # Enforce use of SystemVerilog
         tpl = "set_global_assignment -name {lang}_FILE {path} -library {lib}"
         # Do not add None type files

--- a/litex/build/efinix/efinity.py
+++ b/litex/build/efinix/efinity.py
@@ -202,7 +202,7 @@ def _build_xml(family, device, timing_model, build_name, sources):
     et.SubElement(design_info, "efx:top_module", name=build_name)
 
     # Add Design Sources.
-    for filename, language, library in sources:
+    for filename, language, library, *copy in sources:
         if language is None:
             continue
         et.SubElement(design_info, "efx:design_file", {

--- a/litex/build/lattice/diamond.py
+++ b/litex/build/lattice/diamond.py
@@ -89,7 +89,7 @@ def _build_tcl(device, sources, vincpaths, build_name):
     tcl.append("prj_impl option {include path} {\"" + vincpath + "\"}")
 
     # Add sources
-    for filename, language, library in sources:
+    for filename, language, library, *copy in sources:
         tcl.append("prj_src add \"{}\" -work {}".format(tcl_path(filename), library))
 
     # Set top level

--- a/litex/build/lattice/icestorm.py
+++ b/litex/build/lattice/icestorm.py
@@ -55,7 +55,7 @@ def _yosys_import_sources(platform):
     reads = []
     for path in platform.verilog_include_paths:
         includes += " -I" + path
-    for filename, language, library in platform.sources:
+    for filename, language, library, *copy in platform.sources:
         # yosys has no such function read_systemverilog
         if language == "systemverilog":
             language = "verilog -sv"

--- a/litex/build/lattice/oxide.py
+++ b/litex/build/lattice/oxide.py
@@ -36,7 +36,7 @@ def _yosys_import_sources(platform):
     reads = []
     for path in platform.verilog_include_paths:
         includes += " -I" + path
-    for filename, language, library in platform.sources:
+    for filename, language, library, *copy in platform.sources:
         # yosys has no such function read_systemverilog
         if language == "systemverilog":
             language = "verilog -sv"

--- a/litex/build/lattice/radiant.py
+++ b/litex/build/lattice/radiant.py
@@ -30,7 +30,7 @@ def _run_yosys(device, sources, vincpaths, build_name):
     incflags = ""
     for path in vincpaths:
         incflags += " -I" + path
-    for filename, language, library in sources:
+    for filename, language, library, *copy in sources:
         assert language != "vhdl"
         ys_contents += "read_{}{} {}\n".format(language, incflags, filename)
 
@@ -146,7 +146,7 @@ def _build_tcl(device, sources, vincpaths, build_name, pdc_file, synth_mode):
         tcl.append("prj_add_source \"{}_yosys.vm\" -work work".format(build_name))
         library = "work"
     else:
-        for filename, language, library in sources:
+        for filename, language, library, *copy in sources:
             tcl.append("prj_add_source \"{}\" -work {}".format(tcl_path(filename), library))
 
     tcl.append("prj_add_source \"{}\" -work {}".format(tcl_path(pdc_file), library))

--- a/litex/build/lattice/trellis.py
+++ b/litex/build/lattice/trellis.py
@@ -66,7 +66,7 @@ def _yosys_import_sources(platform):
     reads = []
     for path in platform.verilog_include_paths:
         includes += " -I" + path
-    for filename, language, library in platform.sources:
+    for filename, language, library, *copy in platform.sources:
         # yosys has no such function read_systemverilog
         if language == "systemverilog":
             language = "verilog -sv"

--- a/litex/build/microsemi/libero_soc.py
+++ b/litex/build/microsemi/libero_soc.py
@@ -111,7 +111,7 @@ def _build_tcl(platform, sources, build_dir, build_name):
     ]))
 
     # Add sources
-    for filename, language, library in sources:
+    for filename, language, library, *copy in sources:
         filename_tcl = "{" + filename + "}"
         tcl.append("import_files -hdl_source " + filename_tcl)
 

--- a/litex/build/sim/verilator.py
+++ b/litex/build/sim/verilator.py
@@ -126,7 +126,7 @@ def _generate_sim_config(config):
 def _build_sim(build_name, sources, threads, coverage, opt_level="O3", trace_fst=False):
     makefile = os.path.join(core_directory, 'Makefile')
     cc_srcs = []
-    for filename, language, library in sources:
+    for filename, language, library, *copy in sources:
         cc_srcs.append("--cc " + filename + " ")
     build_script_contents = """\
 rm -rf obj_dir/

--- a/litex/build/xilinx/common.py
+++ b/litex/build/xilinx/common.py
@@ -413,7 +413,7 @@ def _run_yosys(device, sources, vincpaths, build_name):
     incflags = ""
     for path in vincpaths:
         incflags += " -I" + path
-    for filename, language, library in sources:
+    for filename, language, library, *copy in sources:
         assert language != "vhdl"
         ys_contents += "read_{}{} {}\n".format(language, incflags, filename)
 

--- a/litex/build/xilinx/ise.py
+++ b/litex/build/xilinx/ise.py
@@ -60,7 +60,7 @@ def _build_ucf(named_sc, named_pc):
 
 def _build_xst(device, sources, vincpaths, build_name, xst_opt):
     prj_contents = ""
-    for filename, language, library in sources:
+    for filename, language, library, *copy in sources:
         prj_contents += language + " " + library + " " + tools.cygpath(filename) + "\n"
     tools.write_to_file(build_name + ".prj", prj_contents)
 
@@ -85,7 +85,7 @@ def _run_yosys(device, sources, vincpaths, build_name):
     incflags = ""
     for path in vincpaths:
         incflags += " -I" + path
-    for filename, language, library in sources:
+    for filename, language, library, *copy in sources:
         ys_contents += "read_{}{} {}\n".format(language, incflags, filename)
 
     family = ""

--- a/litex/build/xilinx/vivado.py
+++ b/litex/build/xilinx/vivado.py
@@ -163,7 +163,7 @@ class XilinxVivadoToolchain:
         if synth_mode == "vivado":
             tcl.append("\n# Add Sources\n")
             # "-include_dirs {}" crashes Vivado 2016.4
-            for filename, language, library in platform.sources:
+            for filename, language, library, *copy in platform.sources:
                 filename_tcl = "{" + filename + "}"
                 if (language == "systemverilog"):
                     tcl.append("read_verilog -v " + filename_tcl)


### PR DESCRIPTION
If the Builder class is not used to build the projet, platform sources
is still a list of tupples with 4 elements.

For now, we don't handle file copy when Builder is not used but at least
it won't crash.