### PR TITLE
efinix:dbparser: add get_pad_name_from_pin and use it

### DIFF
--- a/litex/build/efinix/dbparser.py
+++ b/litex/build/efinix/dbparser.py
@@ -124,13 +124,17 @@ class EfinixDbParser:
 
         return None
 
-    def get_pll_inst_from_pin(self, pin):
+    def get_gpio_instance_from_pin(self, pin):
         dmap = self.get_device_map(self.device)
         pad = self.get_pad_name_xml(dmap, pin)
-        inst = self.get_instance_name_xml(dmap, pad)
+        return self.get_instance_name_xml(dmap, pad)
+
+    def get_pll_inst_from_pin(self, pin):
+        dmap = self.get_device_map(self.device)
+        inst = self.get_gpio_instance_from_pin(pin)
 
         return self.get_pll_inst_from_gpio_inst(dmap, inst)
 
-    def get_gpio_instance_from_pin(self, pin):
+    def get_pad_name_from_pin(self, pin):
         dmap = self.get_device_map(self.device)
         return self.get_pad_name_xml(dmap, pin)

--- a/litex/build/efinix/ifacewriter.py
+++ b/litex/build/efinix/ifacewriter.py
@@ -288,7 +288,7 @@ design.save()"""
             dir  = "rx"
             mode = "in"
 
-        pad = self.platform.parser.get_gpio_instance_from_pin(params["location"][0])
+        pad = self.platform.parser.get_pad_name_from_pin(params["location"][0])
         pad = pad.replace("TXP", "TX")
         pad = pad.replace("TXN", "TX")
         pad = pad.replace("RXP", "RX")

--- a/litex/soc/cores/clock/efinix.py
+++ b/litex/soc/cores/clock/efinix.py
@@ -49,7 +49,7 @@ class TRIONPLL(Module):
         if self.platform.get_pin_location(clkin):
             pad_name = self.platform.get_pin_location(clkin)[0]
             # PLL v1 needs pin name
-            pin_name = self.platform.parser.get_gpio_instance_from_pin(pad_name)
+            pin_name = self.platform.parser.get_pad_name_from_pin(pad_name)
             if pin_name.count("_") == 2:
                 pin_name = pin_name.rsplit("_", 1)[0]
             self.platform.toolchain.excluded_ios.append(clkin)


### PR DESCRIPTION
get_gpio_instance_from_pin returned the pad name.
It now returns the gpio block name.

To get the pad name, there is now get_pad_name_from_pin.