### PR TITLE
Add CPUs to litex_json2renode script

### DIFF
--- a/litex/tools/litex_json2renode.py
+++ b/litex/tools/litex_json2renode.py
@@ -253,6 +253,24 @@ cpu: CPU.RiscV32 @ sysbus
     timeProvider: empty
     interruptMode: InterruptMode.Vectored
 """
+    elif kind == 'cv32e40p':
+        result = """
+cpu: CPU.CV32E40P @ sysbus
+"""
+        if variant == 'standard':
+            result += """
+    cpuType: "rv32imc"
+"""
+        else:
+            result += """
+    cpuType: "rv32imc"
+"""
+        if time_provider:
+            result += """
+    timeProvider: {}
+""".format(time_provider)
+
+        return result
     else:
         raise Exception('Unsupported cpu type: {}'.format(kind))
 

--- a/litex/tools/litex_json2renode.py
+++ b/litex/tools/litex_json2renode.py
@@ -246,6 +246,10 @@ cpu: CPU.VexRiscv @ sysbus
 cpu: CPU.PicoRV32 @ sysbus
     cpuType: "rv32imc"
 """
+    elif kind == 'minerva':
+        return """
+cpu: CPU.Minerva @ sysbus
+"""
     elif kind == 'ibex':
         return """
 cpu: CPU.IbexRiscV32 @ sysbus

--- a/litex/tools/litex_json2renode.py
+++ b/litex/tools/litex_json2renode.py
@@ -248,10 +248,7 @@ cpu: CPU.PicoRV32 @ sysbus
 """
     elif kind == 'ibex':
         return """
-cpu: CPU.RiscV32 @ sysbus
-    cpuType: "rv32imc"
-    timeProvider: empty
-    interruptMode: InterruptMode.Vectored
+cpu: CPU.IbexRiscV32 @ sysbus
 """
     elif kind == 'cv32e40p':
         result = """


### PR DESCRIPTION
Adds cv32e40p and Minerva to the script. No longer uses generic rv32 for Ibex.