### PR TITLE
Add sigma-delta DAC LiteX core.

### DIFF
--- a/litex/soc/cores/dac.py
+++ b/litex/soc/cores/dac.py
@@ -1,0 +1,24 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2022 Tim Callahan <tcal@google.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+
+from litex.soc.interconnect.csr import *
+
+# DAC  ---------------------------------------------------------------------------------------
+
+class DAC(Module, AutoCSR):
+
+    def __init__(self, out, data_width):
+        self.out    = out
+
+        self._value = CSRStorage(data_width, reset_less=True, description="Digital value to convert to analog.")
+        value       = Signal(data_width)
+        accum       = Signal(data_width+1)
+
+        self.comb   += value.eq(self._value.storage)
+        self.sync   += accum.eq(accum[0:data_width] + value)
+        self.comb   += out.eq(accum[data_width])

--- a/litex/soc/cores/dac.py
+++ b/litex/soc/cores/dac.py
@@ -8,17 +8,55 @@ from migen import *
 
 from litex.soc.interconnect.csr import *
 
-# DAC  ---------------------------------------------------------------------------------------
+# DAC -----------------------------------------------------------------------------------------------
 
 class DAC(Module, AutoCSR):
+    """First-order Sigma-Delta DAC.
 
-    def __init__(self, out, data_width):
-        self.out    = out
+    Provides a small one-bit Sigma-Delta DAC output. When
+    ``with_constant_transition`` is set, the raw Sigma-Delta bitstream is
+    encoded as a 3-cycle symbol:
 
-        self._value = CSRStorage(data_width, reset_less=True, description="Digital value to convert to analog.")
-        value       = Signal(data_width)
-        accum       = Signal(data_width+1)
+    - ``1`` -> ``1, 1, 0``
+    - ``0`` -> ``1, 0, 0``
 
-        self.comb   += value.eq(self._value.storage)
-        self.sync   += accum.eq(accum[0:data_width] + value)
-        self.comb   += out.eq(accum[data_width])
+    This keeps the output transition activity constant, at the cost of output rate/range.
+    """
+    def __init__(self, out, data_width=12, with_csr=True, with_constant_transition=False):
+        self.out   = out
+        self.value = Signal(data_width)
+
+        if with_csr:
+            self._value = CSRStorage(data_width, reset_less=True,
+                description="Digital value to convert to analog.")
+            self.comb += self.value.eq(self._value.storage)
+
+        # # #
+
+        accum      = Signal(data_width + 1, reset_less=True)
+        accum_next = Signal(data_width + 1)
+        sd_bit     = Signal()
+
+        self.comb += [
+            accum_next.eq(accum[:data_width] + self.value),
+            sd_bit.eq(accum[data_width]),
+        ]
+
+        if with_constant_transition:
+            phase = Signal(max=3)
+            self.sync += [
+                If(phase == 2,
+                    phase.eq(0),
+                    accum.eq(accum_next)
+                ).Else(
+                    phase.eq(phase + 1)
+                )
+            ]
+            self.comb += Case(phase, {
+                0 : out.eq(1),
+                1 : out.eq(sd_bit),
+                2 : out.eq(0),
+            })
+        else:
+            self.sync += accum.eq(accum_next)
+            self.comb += out.eq(sd_bit)

--- a/litex/soc/cores/dac.py
+++ b/litex/soc/cores/dac.py
@@ -22,14 +22,12 @@ class DAC(Module, AutoCSR):
 
     This keeps the output transition activity constant, at the cost of output rate/range.
     """
-    def __init__(self, out, data_width=12, with_csr=True, with_constant_transition=False):
-        self.out   = out
+    def __init__(self, out=None, data_width=12, with_csr=True, with_constant_transition=False):
+        if out is None:
+            self.out = out = Signal()
+        else:
+            self.out = out
         self.value = Signal(data_width)
-
-        if with_csr:
-            self._value = CSRStorage(data_width, reset_less=True,
-                description="Digital value to convert to analog.")
-            self.comb += self.value.eq(self._value.storage)
 
         # # #
 
@@ -60,3 +58,11 @@ class DAC(Module, AutoCSR):
         else:
             self.sync += accum.eq(accum_next)
             self.comb += out.eq(sd_bit)
+
+        if with_csr:
+            self.add_csr(data_width)
+
+    def add_csr(self, data_width):
+        self._value = CSRStorage(data_width, reset_less=True,
+            description="Digital value to convert to analog.")
+        self.comb += self.value.eq(self._value.storage)

--- a/test/test_dac.py
+++ b/test/test_dac.py
@@ -1,0 +1,80 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import *
+
+from litex.soc.cores.dac import DAC
+
+
+def sigma_delta_model(value, data_width, cycles):
+    accum = 0
+    mask  = 2**data_width - 1
+    out   = []
+    for i in range(cycles):
+        out.append((accum >> data_width) & 0x1)
+        accum = (accum & mask) + value
+    return out
+
+
+def constant_transition_model(value, data_width, cycles):
+    accum = 0
+    phase = 0
+    mask  = 2**data_width - 1
+    out   = []
+    for i in range(cycles):
+        sd_bit = (accum >> data_width) & 0x1
+        out.append({
+            0 : 1,
+            1 : sd_bit,
+            2 : 0,
+        }[phase])
+        if phase == 2:
+            phase = 0
+            accum = (accum & mask) + value
+        else:
+            phase += 1
+    return out
+
+
+class TestDAC(unittest.TestCase):
+    def run_dac(self, value, data_width=4, cycles=32, with_constant_transition=False):
+        out = Signal()
+        dut = DAC(
+            out                      = out,
+            data_width               = data_width,
+            with_csr                 = False,
+            with_constant_transition = with_constant_transition,
+        )
+        dut.value.reset = value
+        samples = []
+
+        def generator(dut):
+            for i in range(cycles):
+                samples.append((yield out))
+                yield
+
+        run_simulation(dut, generator(dut))
+        return samples
+
+    def test_sigma_delta(self):
+        self.assertEqual(
+            self.run_dac(value=9, data_width=4, cycles=32),
+            sigma_delta_model(value=9, data_width=4, cycles=32),
+        )
+
+    def test_constant_transition(self):
+        self.assertEqual(
+            self.run_dac(value=9, data_width=4, cycles=32, with_constant_transition=True),
+            constant_transition_model(value=9, data_width=4, cycles=32),
+        )
+
+    def test_constant_transition_zero_pattern(self):
+        self.assertEqual(
+            self.run_dac(value=0, data_width=4, cycles=9, with_constant_transition=True),
+            [1, 0, 0] * 3,
+        )


### PR DESCRIPTION
Tested on Arty and Icebreaker.

Sample usage from the BaseSoC for Arty, to output the analog signal on the first pin of PMOD B:
```
    def add_dac(self):
        self.platform.add_extension(arty.raw_pmod_io("pmodb"))
        outsig = self.platform.request("pmodb")[0]
        self.submodules.dac = DAC(outsig, 12)
```

The value to convert is written from software using:
```
#include <generated/csr.h>

    uint32_t v = .....;
    dac_value_write(v);
```




Signed-off-by: Tim Callahan <tcal@google.com>