### PR TITLE
build/trelis: Compress bitstream by default

### DIFF
--- a/litex/build/lattice/trellis.py
+++ b/litex/build/lattice/trellis.py
@@ -198,7 +198,7 @@ class LatticeTrellisToolchain:
         bootaddr       = 0,
         seed           = 1,
         spimode        = None,
-        compress       = False,
+        compress       = True,
         **kwargs):
 
         # Create build directory


### PR DESCRIPTION
Can we turn on bitstream compression as a default option?

Are there any reasons people can think of as to why this should default to disabled?