### PR TITLE
bios/memtest: fix cast warning

### DIFF
--- a/litex/soc/software/libbase/memtest.c
+++ b/litex/soc/software/libbase/memtest.c
@@ -267,7 +267,7 @@ void memspeed(unsigned int *addr, unsigned long size, bool read_only, bool rando
 	__attribute__((unused)) unsigned long data;
 	const unsigned int sz = sizeof(unsigned long);
 	int burst_size = 4;
-	volatile unsigned long *ptr, *ptr_max = (volatile unsigned long )(((char *)array) + size - sz*burst_size);
+	volatile unsigned long *ptr, *ptr_max = (volatile unsigned long *)(((char *)array) + size - sz*burst_size);
 
 
 	printf("Memspeed at %p (", addr);


### PR DESCRIPTION
I get a warning when building the bios (for rocket, 64-bit) -- so I believe that cast is missing a `*` to make it a pointer. @dolu, LMK what you think -- thanks!