### PR TITLE
litex_setup: change to installing with pip

### DIFF
--- a/litex_setup.py
+++ b/litex_setup.py
@@ -223,7 +223,7 @@ def litex_setup_install_repos(config="standard", user_mode=False):
         if repo.develop:
             print_status(f"Installing {name} Git repository...")
             os.chdir(os.path.join(current_path, name))
-            subprocess.check_call("{python3} setup.py develop {options}".format(
+            subprocess.check_call("{python3} -m pip install --editable . {options}".format(
                 python3 = sys.executable,
                 options = "--user" if user_mode else "",
                 ), shell=True)


### PR DESCRIPTION
fixes: EasyInstallDeprecationWarning: easy_install command is deprecated. Use build and pip and other standards-based tools.