### PR TITLE
Remove -flto flag from demo.bin

### DIFF
--- a/litex/soc/software/demo/Makefile
+++ b/litex/soc/software/demo/Makefile
@@ -8,6 +8,9 @@ ifdef WITH_CXX
 	OBJECTS += hellocpp.o
 endif
 
+CXXFLAGS:=$(filter-out -flto,$(CXXFLAGS))
+CFLAGS:=$(filter-out -flto,$(CFLAGS))
+
 all: demo.bin
 
 # pull in dependency info for *existing* .o files


### PR DESCRIPTION
Fixes the failing lift-off on the Rocket chip.