### PR TITLE
Improve WS2812 timings and add different hardware revision support

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -124,6 +124,7 @@ Copyright (c) 2019      vytautasb <v.buitvydas@limemicro.com>
 Copyright (c) 2013      Werner Almesberger <werner@almesberger.net>
 Copyright (c) 2015-2016 whitequark <whitequark@whitequark.org>
 Copyright (c) 2015-2021 William D. Jones <thor0505@comcast.net>
+Copyright (c) 2022      Wolfgang Nagele <mail@wnagele.com>
 Copyright (c) 2013-2014 Yann Sionneau <yann.sionneau@gmail.com>
 Copyright (c) 2015 Yves Delley <hack@delley.net>
 Copyright (c) 2020      Xiretza <xiretza@xiretza.xyz>

--- a/test/test_led.py
+++ b/test/test_led.py
@@ -1,0 +1,83 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2022 Wolfgang Nagele <mail@wnagele.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import *
+
+from litex.soc.cores.led import WS2812
+
+
+TEST_CLK_FREQS = (20e6, 16e6, 15e6, 10e6)
+
+
+class TestWS2812(unittest.TestCase):
+    def generator(self, dut, led_signal, led_data, sys_clk_freq, iterations):
+        error_margin = 0.15e-6 # defined in datasheet
+
+        # cap on how long a sequence will be evaluated
+        max_cycles_per_seq = int(dut.trst * sys_clk_freq * 2)
+
+        # initial reset
+        rst_cycles = 0
+        for _ in range(max_cycles_per_seq):
+            if (yield led_signal) != 0:
+                break
+            rst_cycles += 1
+            yield
+        rst_time = rst_cycles / sys_clk_freq
+        assert rst_time >= dut.trst
+
+        length = len(led_data)
+        for _ in range(iterations):
+            for i_num, num in enumerate(led_data, start = 1):
+                for idx_bit, bit in enumerate(TestWS2812.to_bits(num), start = 1):
+                    exp_high, exp_low = (dut.t0h, dut.t0l) if bit == 0 else (dut.t1h, dut.t1l)
+
+                    # end of chain reset
+                    if i_num == length and idx_bit == 24:
+                        exp_low += dut.trst
+
+                    high_cycles = 0
+                    for _ in range(max_cycles_per_seq):
+                        if (yield led_signal) != 1:
+                            break
+                        high_cycles += 1
+                        yield
+                    high_time = high_cycles / sys_clk_freq
+                    assert high_time >= exp_high - error_margin
+                    assert high_time <= exp_high + error_margin
+
+                    low_cycles = 0
+                    for _ in range(max_cycles_per_seq):
+                        if (yield led_signal) != 0:
+                            break
+                        low_cycles += 1
+                        yield
+                    low_time = low_cycles / sys_clk_freq
+                    assert low_time >= exp_low - error_margin
+                    assert low_time <= exp_low + error_margin
+
+
+    def to_bits(num, length = 24):
+        return ( int(x) for x in bin(num)[2:].zfill(length) )
+
+
+    def run_test(self, hardware_revision, sys_clk_freq):
+        led_signal = Signal()
+        led_data = [ 0x100000, 0x200000, 0x300000, 0x400000, 0x500000, 0x600000, 0x700000, 0x800000, 0x900000 ]
+        iterations = 3
+        dut = WS2812(led_signal, len(led_data), sys_clk_freq, hardware_revision = hardware_revision, test_data = led_data)
+        run_simulation(dut, self.generator(dut, led_signal, led_data, sys_clk_freq, iterations))
+
+
+    def test_WS2812_old(self):
+        for sys_clk_freq in TEST_CLK_FREQS:
+            self.run_test("old", sys_clk_freq)
+
+    def test_WS2812_new(self):
+        for sys_clk_freq in TEST_CLK_FREQS:
+            self.run_test("new", sys_clk_freq)


### PR DESCRIPTION
Started this when I had some newer model WS2812 LEDs for which the current timing didn't work.

So I added a test bench that validates everything according to the WS2812 datasheets for the old and new hardware revision.

As I was digging down into that rabbit hole I found a bunch of issues with the current FSM implementation causing timings to be off due to extra cycles spent in the low states. This doesn't matter much at higher clock speeds - but at lower clock speeds it can break the timing constraints.

Happy for feedback - this is my first PR towards LiteX so I did my best to try to make everything fit into the structure.