### PR TITLE
soc/interconnect/wishbone: Add incrementing address burst mode to SRAM

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -837,7 +837,7 @@ class SoC(Module):
             colorer("added", color="green")))
         setattr(self.submodules, name, SoCController(**kwargs))
 
-    def add_ram(self, name, origin, size, contents=[], mode="rw"):
+    def add_ram(self, name, origin, size, contents=[], mode="rw", burst=False):
         ram_cls = {
             "wishbone": wishbone.SRAM,
             "axi-lite": axi.AXILiteSRAM,
@@ -847,7 +847,7 @@ class SoC(Module):
             "axi-lite": axi.AXILiteInterface,
         }[self.bus.standard]
         ram_bus = interface_cls(data_width=self.bus.data_width)
-        ram     = ram_cls(size, bus=ram_bus, init=contents, read_only=(mode == "r"))
+        ram     = ram_cls(size, bus=ram_bus, init=contents, read_only=(mode == "r"), burst=burst)
         self.bus.add_slave(name, ram.bus, SoCRegion(origin=origin, size=size, mode=mode))
         self.check_if_exists(name)
         self.logger.info("RAM {} {} {}.".format(
@@ -858,8 +858,8 @@ class SoC(Module):
         if contents != []:
             self.add_config(f"{name}_INIT", 1)
 
-    def add_rom(self, name, origin, size, contents=[], mode="r"):
-        self.add_ram(name, origin, size, contents, mode=mode)
+    def add_rom(self, name, origin, size, contents=[], mode="r", burst=False):
+        self.add_ram(name, origin, size, contents, mode=mode, burst=burst)
 
     def init_rom(self, name, contents=[], auto_size=True):
         self.logger.info("Initializing ROM {} with contents (Size: {}).".format(

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -117,7 +117,7 @@ class SoCBusHandler(Module):
     supported_address_width = [32]
 
     # Creation -------------------------------------------------------------------------------------
-    def __init__(self, name="SoCBusHandler", standard="wishbone", data_width=32, address_width=32, timeout=1e6, reserved_regions={}):
+    def __init__(self, name="SoCBusHandler", standard="wishbone", data_width=32, address_width=32, timeout=1e6, bursting=False, reserved_regions={}):
         self.logger = logging.getLogger(name)
         self.logger.info("Creating Bus Handler...")
 
@@ -149,6 +149,7 @@ class SoCBusHandler(Module):
         self.standard         = standard
         self.data_width       = data_width
         self.address_width    = address_width
+        self.bursting         = bursting
         self.masters          = {}
         self.slaves           = {}
         self.regions          = {}
@@ -719,6 +720,7 @@ class SoC(Module):
         bus_data_width       = 32,
         bus_address_width    = 32,
         bus_timeout          = 1e6,
+        bus_bursting         = False,
         bus_reserved_regions = {},
 
         csr_data_width       = 32,
@@ -756,6 +758,7 @@ class SoC(Module):
             data_width       = bus_data_width,
             address_width    = bus_address_width,
             timeout          = bus_timeout,
+            bursting         = bus_bursting,
             reserved_regions = bus_reserved_regions,
            )
 
@@ -837,7 +840,7 @@ class SoC(Module):
             colorer("added", color="green")))
         setattr(self.submodules, name, SoCController(**kwargs))
 
-    def add_ram(self, name, origin, size, contents=[], mode="rw", burst=False):
+    def add_ram(self, name, origin, size, contents=[], mode="rw"):
         ram_cls = {
             "wishbone": wishbone.SRAM,
             "axi-lite": axi.AXILiteSRAM,
@@ -846,8 +849,8 @@ class SoC(Module):
             "wishbone": wishbone.Interface,
             "axi-lite": axi.AXILiteInterface,
         }[self.bus.standard]
-        ram_bus = interface_cls(data_width=self.bus.data_width)
-        ram     = ram_cls(size, bus=ram_bus, init=contents, read_only=(mode == "r"), burst=burst)
+        ram_bus = interface_cls(data_width=self.bus.data_width, bursting=self.bus.bursting)
+        ram     = ram_cls(size, bus=ram_bus, init=contents, read_only=(mode == "r"))
         self.bus.add_slave(name, ram.bus, SoCRegion(origin=origin, size=size, mode=mode))
         self.check_if_exists(name)
         self.logger.info("RAM {} {} {}.".format(
@@ -858,8 +861,8 @@ class SoC(Module):
         if contents != []:
             self.add_config(f"{name}_INIT", 1)
 
-    def add_rom(self, name, origin, size, contents=[], mode="r", burst=False):
-        self.add_ram(name, origin, size, contents, mode=mode, burst=burst)
+    def add_rom(self, name, origin, size, contents=[], mode="r"):
+        self.add_ram(name, origin, size, contents, mode=mode)
 
     def init_rom(self, name, contents=[], auto_size=True):
         self.logger.info("Initializing ROM {} with contents (Size: {}).".format(
@@ -991,6 +994,7 @@ class SoC(Module):
                     standard         = "wishbone",
                     data_width       = self.bus.data_width,
                     address_width    = self.bus.address_width,
+                    bursting         = self.bus.bursting
                 )
                 dma_bus = wishbone.Interface(data_width=self.bus.data_width)
                 self.dma_bus.add_slave("dma", slave=dma_bus, region=SoCRegion(origin=0x00000000, size=0x100000000)) # FIXME: covers lower 4GB only
@@ -1078,6 +1082,7 @@ class SoC(Module):
         self.add_constant("CONFIG_BUS_STANDARD",      self.bus.standard.upper())
         self.add_constant("CONFIG_BUS_DATA_WIDTH",    self.bus.data_width)
         self.add_constant("CONFIG_BUS_ADDRESS_WIDTH", self.bus.address_width)
+        self.add_constant("CONFIG_BUS_BURSTING",      int(self.bus.bursting))
 
         # SoC DMA Bus Interconnect (Cache Coherence) -----------------------------------------------
         if hasattr(self, "dma_bus"):

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -64,6 +64,7 @@ class SoCCore(LiteXSoC):
         bus_data_width           = 32,
         bus_address_width        = 32,
         bus_timeout              = 1e6,
+        bus_bursting             = False,
 
         # CPU parameters
         cpu_type                 = "vexriscv",
@@ -78,17 +79,14 @@ class SoCCore(LiteXSoC):
         integrated_rom_size      = 0,
         integrated_rom_mode      = "r",
         integrated_rom_init      = [],
-        integrated_rom_burst     = False,
 
         # SRAM parameters
         integrated_sram_size     = 0x2000,
         integrated_sram_init     = [],
-        integrated_sram_burst    = False,
 
         # MAIN_RAM parameters
-        integrated_main_ram_size  = 0,
-        integrated_main_ram_init  = [],
-        integrated_main_ram_burst = False,
+        integrated_main_ram_size = 0,
+        integrated_main_ram_init = [],
 
         # CSR parameters
         csr_data_width           = 32,
@@ -125,6 +123,7 @@ class SoCCore(LiteXSoC):
             bus_data_width       = bus_data_width,
             bus_address_width    = bus_address_width,
             bus_timeout          = bus_timeout,
+            bus_bursting         = bus_bursting,
             bus_reserved_regions = {},
 
             csr_data_width       = csr_data_width,
@@ -201,8 +200,7 @@ class SoCCore(LiteXSoC):
                 origin   = self.cpu.reset_address,
                 size     = integrated_rom_size,
                 contents = integrated_rom_init,
-                mode     = integrated_rom_mode,
-                burst    = integrated_rom_burst
+                mode     = integrated_rom_mode
             )
 
         # Add integrated SRAM
@@ -210,7 +208,6 @@ class SoCCore(LiteXSoC):
             self.add_ram("sram",
                 origin = self.mem_map["sram"],
                 size   = integrated_sram_size,
-                burst  = integrated_sram_burst
             )
 
         # Add integrated MAIN_RAM (only useful when no external SRAM/SDRAM is available)
@@ -219,7 +216,6 @@ class SoCCore(LiteXSoC):
                 origin   = self.mem_map["main_ram"],
                 size     = integrated_main_ram_size,
                 contents = integrated_main_ram_init,
-                burst    = integrated_main_ram_burst,
             )
 
         # Add Identifier
@@ -307,6 +303,7 @@ def soc_core_args(parser):
     soc_group.add_argument("--bus-data-width",    default=32,         type=auto_int, help="Bus data-width.")
     soc_group.add_argument("--bus-address-width", default=32,         type=auto_int, help="Bus address-width.")
     soc_group.add_argument("--bus-timeout",       default=int(1e6),   type=float,    help="Bus timeout in cycles.")
+    soc_group.add_argument("--bus-bursting",      action="store_true",               help="Enable burst cycles on the bus if supported.")
 
     # CPU parameters
     soc_group.add_argument("--cpu-type",          default="vexriscv",               help="Select CPU: {}.".format(", ".join(iter(cpu.CPUS.keys()))))
@@ -318,13 +315,11 @@ def soc_core_args(parser):
     soc_group.add_argument("--no-ctrl", action="store_true", help="Disable Controller.")
 
     # ROM parameters
-    soc_group.add_argument("--integrated-rom-size",  default=0x20000, type=auto_int,       help="Size/Enable the integrated (BIOS) ROM (Automatically resized to BIOS size when smaller).")
-    soc_group.add_argument("--integrated-rom-init",  default=None,    type=str,            help="Integrated ROM binary initialization file (override the BIOS when specified).")
-    soc_group.add_argument("--integrated-rom-burst", default=False,   action="store_true", help="Enable burst cycles support in integrated ROM (works only for Wishbone interconnect).")
+    soc_group.add_argument("--integrated-rom-size", default=0x20000, type=auto_int, help="Size/Enable the integrated (BIOS) ROM (Automatically resized to BIOS size when smaller).")
+    soc_group.add_argument("--integrated-rom-init", default=None,    type=str,      help="Integrated ROM binary initialization file (override the BIOS when specified).")
 
     # SRAM parameters
-    soc_group.add_argument("--integrated-sram-size",  default=0x2000, type=auto_int,       help="Size/Enable the integrated SRAM.")
-    soc_group.add_argument("--integrated-sram-burst", default=False,  action="store_true", help="Enable burst cycles support in integrated ROM (works only for Wishbone interconnect).")
+    soc_group.add_argument("--integrated-sram-size", default=0x2000, type=auto_int, help="Size/Enable the integrated SRAM.")
 
     # MAIN_RAM parameters
     soc_group.add_argument("--integrated-main-ram-size", default=None, type=auto_int, help="size/enable the integrated main RAM.")

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -78,14 +78,17 @@ class SoCCore(LiteXSoC):
         integrated_rom_size      = 0,
         integrated_rom_mode      = "r",
         integrated_rom_init      = [],
+        integrated_rom_burst     = False,
 
         # SRAM parameters
         integrated_sram_size     = 0x2000,
         integrated_sram_init     = [],
+        integrated_sram_burst    = False,
 
         # MAIN_RAM parameters
-        integrated_main_ram_size = 0,
-        integrated_main_ram_init = [],
+        integrated_main_ram_size  = 0,
+        integrated_main_ram_init  = [],
+        integrated_main_ram_burst = False,
 
         # CSR parameters
         csr_data_width           = 32,
@@ -198,7 +201,8 @@ class SoCCore(LiteXSoC):
                 origin   = self.cpu.reset_address,
                 size     = integrated_rom_size,
                 contents = integrated_rom_init,
-                mode     = integrated_rom_mode
+                mode     = integrated_rom_mode,
+                burst    = integrated_rom_burst
             )
 
         # Add integrated SRAM
@@ -206,6 +210,7 @@ class SoCCore(LiteXSoC):
             self.add_ram("sram",
                 origin = self.mem_map["sram"],
                 size   = integrated_sram_size,
+                burst  = integrated_sram_burst
             )
 
         # Add integrated MAIN_RAM (only useful when no external SRAM/SDRAM is available)
@@ -214,6 +219,7 @@ class SoCCore(LiteXSoC):
                 origin   = self.mem_map["main_ram"],
                 size     = integrated_main_ram_size,
                 contents = integrated_main_ram_init,
+                burst    = integrated_main_ram_burst,
             )
 
         # Add Identifier
@@ -312,11 +318,13 @@ def soc_core_args(parser):
     soc_group.add_argument("--no-ctrl", action="store_true", help="Disable Controller.")
 
     # ROM parameters
-    soc_group.add_argument("--integrated-rom-size", default=0x20000, type=auto_int, help="Size/Enable the integrated (BIOS) ROM (Automatically resized to BIOS size when smaller).")
-    soc_group.add_argument("--integrated-rom-init", default=None,    type=str,      help="Integrated ROM binary initialization file (override the BIOS when specified).")
+    soc_group.add_argument("--integrated-rom-size",  default=0x20000, type=auto_int,       help="Size/Enable the integrated (BIOS) ROM (Automatically resized to BIOS size when smaller).")
+    soc_group.add_argument("--integrated-rom-init",  default=None,    type=str,            help="Integrated ROM binary initialization file (override the BIOS when specified).")
+    soc_group.add_argument("--integrated-rom-burst", default=False,   action="store_true", help="Enable burst cycles support in integrated ROM (works only for Wishbone interconnect).")
 
     # SRAM parameters
-    soc_group.add_argument("--integrated-sram-size", default=0x2000, type=auto_int, help="Size/Enable the integrated SRAM.")
+    soc_group.add_argument("--integrated-sram-size",  default=0x2000, type=auto_int,       help="Size/Enable the integrated SRAM.")
+    soc_group.add_argument("--integrated-sram-burst", default=False,  action="store_true", help="Enable burst cycles support in integrated ROM (works only for Wishbone interconnect).")
 
     # MAIN_RAM parameters
     soc_group.add_argument("--integrated-main-ram-size", default=None, type=auto_int, help="size/enable the integrated main RAM.")

--- a/litex/soc/interconnect/axi.py
+++ b/litex/soc/interconnect/axi.py
@@ -793,7 +793,7 @@ class AXILite2CSR(Module):
 # AXILite SRAM -------------------------------------------------------------------------------------
 
 class AXILiteSRAM(Module):
-    def __init__(self, mem_or_size, read_only=None, init=None, bus=None):
+    def __init__(self, mem_or_size, read_only=None, init=None, bus=None, burst=False):
         if bus is None:
             bus = AXILiteInterface()
         self.bus = bus

--- a/litex/soc/interconnect/axi.py
+++ b/litex/soc/interconnect/axi.py
@@ -196,7 +196,8 @@ class AXILiteInterface:
         self.data_width    = data_width
         self.address_width = address_width
         self.clock_domain  = clock_domain
-        self.bursting      = False  # Not supported in AXI Lite
+        if bursting is not False:
+            raise NotImplementedError("AXI-Lite does not support bursting")
 
         self.aw = stream.Endpoint(ax_lite_description(address_width), name=name)
         self.w  = stream.Endpoint(w_lite_description(data_width), name=name)

--- a/litex/soc/interconnect/axi.py
+++ b/litex/soc/interconnect/axi.py
@@ -192,10 +192,11 @@ def r_lite_description(data_width):
     ]
 
 class AXILiteInterface:
-    def __init__(self, data_width=32, address_width=32, clock_domain="sys", name=None):
+    def __init__(self, data_width=32, address_width=32, clock_domain="sys", name=None, bursting=False):
         self.data_width    = data_width
         self.address_width = address_width
         self.clock_domain  = clock_domain
+        self.bursting      = False  # Not supported in AXI Lite
 
         self.aw = stream.Endpoint(ax_lite_description(address_width), name=name)
         self.w  = stream.Endpoint(w_lite_description(data_width), name=name)
@@ -793,7 +794,7 @@ class AXILite2CSR(Module):
 # AXILite SRAM -------------------------------------------------------------------------------------
 
 class AXILiteSRAM(Module):
-    def __init__(self, mem_or_size, read_only=None, init=None, bus=None, burst=False):
+    def __init__(self, mem_or_size, read_only=None, init=None, bus=None):
         if bus is None:
             bus = AXILiteInterface()
         self.bus = bus

--- a/litex/soc/interconnect/wishbone.py
+++ b/litex/soc/interconnect/wishbone.py
@@ -330,7 +330,7 @@ class Converter(Module):
 # Wishbone SRAM ------------------------------------------------------------------------------------
 
 class SRAM(Module):
-    def __init__(self, mem_or_size, read_only=None, init=None, bus=None, burst=True):
+    def __init__(self, mem_or_size, read_only=None, init=None, bus=None, burst=False):
         if bus is None:
             bus = Interface()
         self.bus = bus

--- a/test/test_wishbone.py
+++ b/test/test_wishbone.py
@@ -59,14 +59,14 @@ class TestWishbone(unittest.TestCase):
 
     def test_sram_burst(self):
         def generator(dut):
-            yield from dut.wb.write(0x0000, 0x01234567, cti=0b010)
-            yield from dut.wb.write(0x0001, 0x89abcdef, cti=0b010)
-            yield from dut.wb.write(0x0002, 0xdeadbeef, cti=0b010)
-            yield from dut.wb.write(0x0003, 0xc0ffee00, cti=0b111)
-            self.assertEqual((yield from dut.wb.read(0x0000, cti=0b010)), 0x01234567)
-            self.assertEqual((yield from dut.wb.read(0x0001, cti=0b010)), 0x89abcdef)
-            self.assertEqual((yield from dut.wb.read(0x0002, cti=0b010)), 0xdeadbeef)
-            self.assertEqual((yield from dut.wb.read(0x0003, cti=0b111)), 0xc0ffee00)
+            yield from dut.wb.write(0x0000, 0x01234567, cti=wishbone.CTI_BURST_INCREMENTING)
+            yield from dut.wb.write(0x0001, 0x89abcdef, cti=wishbone.CTI_BURST_INCREMENTING)
+            yield from dut.wb.write(0x0002, 0xdeadbeef, cti=wishbone.CTI_BURST_INCREMENTING)
+            yield from dut.wb.write(0x0003, 0xc0ffee00, cti=wishbone.CTI_BURST_END)
+            self.assertEqual((yield from dut.wb.read(0x0000, cti=wishbone.CTI_BURST_INCREMENTING)), 0x01234567)
+            self.assertEqual((yield from dut.wb.read(0x0001, cti=wishbone.CTI_BURST_INCREMENTING)), 0x89abcdef)
+            self.assertEqual((yield from dut.wb.read(0x0002, cti=wishbone.CTI_BURST_INCREMENTING)), 0xdeadbeef)
+            self.assertEqual((yield from dut.wb.read(0x0003, cti=wishbone.CTI_BURST_END)), 0xc0ffee00)
 
         class DUT(Module):
             def __init__(self):
@@ -80,14 +80,14 @@ class TestWishbone(unittest.TestCase):
     def test_sram_burst_wrap(self):
         def generator(dut):
             bte = 0b01
-            yield from dut.wb.write(0x0001, 0x01234567, cti=0b010, bte=bte)
-            yield from dut.wb.write(0x0002, 0x89abcdef, cti=0b010, bte=bte)
-            yield from dut.wb.write(0x0003, 0xdeadbeef, cti=0b010, bte=bte)
-            yield from dut.wb.write(0x0000, 0xc0ffee00, cti=0b111, bte=bte)
-            self.assertEqual((yield from dut.wb.read(0x0001, cti=0b010, bte=bte)), 0x01234567)
-            self.assertEqual((yield from dut.wb.read(0x0002, cti=0b010, bte=bte)), 0x89abcdef)
-            self.assertEqual((yield from dut.wb.read(0x0003, cti=0b010, bte=bte)), 0xdeadbeef)
-            self.assertEqual((yield from dut.wb.read(0x0000, cti=0b111, bte=bte)), 0xc0ffee00)
+            yield from dut.wb.write(0x0001, 0x01234567, cti=wishbone.CTI_BURST_INCREMENTING, bte=bte)
+            yield from dut.wb.write(0x0002, 0x89abcdef, cti=wishbone.CTI_BURST_INCREMENTING, bte=bte)
+            yield from dut.wb.write(0x0003, 0xdeadbeef, cti=wishbone.CTI_BURST_INCREMENTING, bte=bte)
+            yield from dut.wb.write(0x0000, 0xc0ffee00, cti=wishbone.CTI_BURST_END, bte=bte)
+            self.assertEqual((yield from dut.wb.read(0x0001, cti=wishbone.CTI_BURST_INCREMENTING, bte=bte)), 0x01234567)
+            self.assertEqual((yield from dut.wb.read(0x0002, cti=wishbone.CTI_BURST_INCREMENTING, bte=bte)), 0x89abcdef)
+            self.assertEqual((yield from dut.wb.read(0x0003, cti=wishbone.CTI_BURST_INCREMENTING, bte=bte)), 0xdeadbeef)
+            self.assertEqual((yield from dut.wb.read(0x0000, cti=wishbone.CTI_BURST_END, bte=bte)), 0xc0ffee00)
 
         class DUT(Module):
             def __init__(self):
@@ -100,14 +100,14 @@ class TestWishbone(unittest.TestCase):
 
     def test_sram_burst_constant(self):
         def generator(dut):
-            yield from dut.wb.write(0x0001, 0x01234567, cti=0b001)
-            yield from dut.wb.write(0x0002, 0x89abcdef, cti=0b001)
-            yield from dut.wb.write(0x0003, 0xdeadbeef, cti=0b001)
-            yield from dut.wb.write(0x0000, 0xc0ffee00, cti=0b111)
-            self.assertEqual((yield from dut.wb.read(0x0001, cti=0b001)), 0x01234567)
-            self.assertEqual((yield from dut.wb.read(0x0002, cti=0b001)), 0x89abcdef)
-            self.assertEqual((yield from dut.wb.read(0x0003, cti=0b001)), 0xdeadbeef)
-            self.assertEqual((yield from dut.wb.read(0x0000, cti=0b111)), 0xc0ffee00)
+            yield from dut.wb.write(0x0001, 0x01234567, cti=wishbone.CTI_BURST_CONSTANT)
+            yield from dut.wb.write(0x0002, 0x89abcdef, cti=wishbone.CTI_BURST_CONSTANT)
+            yield from dut.wb.write(0x0003, 0xdeadbeef, cti=wishbone.CTI_BURST_CONSTANT)
+            yield from dut.wb.write(0x0000, 0xc0ffee00, cti=wishbone.CTI_BURST_END)
+            self.assertEqual((yield from dut.wb.read(0x0001, cti=wishbone.CTI_BURST_CONSTANT)), 0x01234567)
+            self.assertEqual((yield from dut.wb.read(0x0002, cti=wishbone.CTI_BURST_CONSTANT)), 0x89abcdef)
+            self.assertEqual((yield from dut.wb.read(0x0003, cti=wishbone.CTI_BURST_CONSTANT)), 0xdeadbeef)
+            self.assertEqual((yield from dut.wb.read(0x0000, cti=wishbone.CTI_BURST_END)), 0xc0ffee00)
 
         class DUT(Module):
             def __init__(self):

--- a/test/test_wishbone.py
+++ b/test/test_wishbone.py
@@ -56,3 +56,44 @@ class TestWishbone(unittest.TestCase):
 
         dut = DUT()
         run_simulation(dut, generator(dut))
+
+    def test_sram_burst(self):
+        def generator(dut):
+            yield from dut.wb.write(0x0000, 0x01234567, cti=0b010)
+            yield from dut.wb.write(0x0001, 0x89abcdef, cti=0b010)
+            yield from dut.wb.write(0x0002, 0xdeadbeef, cti=0b010)
+            yield from dut.wb.write(0x0003, 0xc0ffee00, cti=0b111)
+            self.assertEqual((yield from dut.wb.read(0x0000, cti=0b010)), 0x01234567)
+            self.assertEqual((yield from dut.wb.read(0x0001, cti=0b010)), 0x89abcdef)
+            self.assertEqual((yield from dut.wb.read(0x0002, cti=0b010)), 0xdeadbeef)
+            self.assertEqual((yield from dut.wb.read(0x0003, cti=0b111)), 0xc0ffee00)
+
+        class DUT(Module):
+            def __init__(self):
+                self.wb = wishbone.Interface(bursting=True)
+                wishbone_mem = wishbone.SRAM(32, bus=self.wb)
+                self.submodules += wishbone_mem
+
+        dut = DUT()
+        run_simulation(dut, generator(dut))
+
+    def test_sram_burst_wrap(self):
+        def generator(dut):
+            bte = 0b01
+            yield from dut.wb.write(0x0001, 0x01234567, cti=0b010, bte=bte)
+            yield from dut.wb.write(0x0002, 0x89abcdef, cti=0b010, bte=bte)
+            yield from dut.wb.write(0x0003, 0xdeadbeef, cti=0b010, bte=bte)
+            yield from dut.wb.write(0x0000, 0xc0ffee00, cti=0b111, bte=bte)
+            self.assertEqual((yield from dut.wb.read(0x0001, cti=0b010, bte=bte)), 0x01234567)
+            self.assertEqual((yield from dut.wb.read(0x0002, cti=0b010, bte=bte)), 0x89abcdef)
+            self.assertEqual((yield from dut.wb.read(0x0003, cti=0b010, bte=bte)), 0xdeadbeef)
+            self.assertEqual((yield from dut.wb.read(0x0000, cti=0b111, bte=bte)), 0xc0ffee00)
+
+        class DUT(Module):
+            def __init__(self):
+                self.wb = wishbone.Interface(bursting=True)
+                wishbone_mem = wishbone.SRAM(32, bus=self.wb)
+                self.submodules += wishbone_mem
+
+        dut = DUT()
+        run_simulation(dut, generator(dut))


### PR DESCRIPTION
This pull request adds support for incrementing address burst cycles to SRAM module. Both linear and wrapped increments are supported.
Because for some designs burst might be unnecessary (e.g. no cache in CPU core), it is disabled by default. It can be turned on by passing parameter `burst=True` in `SoCCore.add_ram()` function, with shortcut available for integrated *RAM/ROM modules in the form of `integrated_{rom,sram,main_ram}_burst` parameters in `SoCCore` class.

Implementation was tested by writing a test suite and an example SoC for measuring speed difference: https://github.com/antmicro/wishbone-interconnect-burst-mode-benchmark (README contains results and instructions how to run tests).

Wishbone burst cycle documentation: https://wishbone-interconnect.readthedocs.io/en/latest/04_registered.html
