### PR TITLE
 for Vivavo 2020/2021 - for all Kitex-7 420+ / Ultrascale

### DIFF
--- a/litex/build/xilinx/vivado.py
+++ b/litex/build/xilinx/vivado.py
@@ -287,7 +287,8 @@ class XilinxVivadoToolchain:
         for clk, period in sorted(self.clocks.items(), key=lambda x: x[0].duid):
             platform.add_platform_command(
                 "create_clock -name {clk} -period " + str(period) +
-                " [get_nets {clk}]", clk=clk)
+                " [get_ports {clk}]", clk=clk)
+#                " [get_nets {clk}]", clk=clk)
         for from_, to in sorted(self.false_paths,
                                 key=lambda x: (x[0].duid, x[1].duid)):
             platform.add_platform_command(


### PR DESCRIPTION
error: No clocks found. Please use 'create_clock' or 'create_generated_clock' command to create clocks

 solution in route
 _create_clock -name clk100 -period 10.0 [get_nets clk100]_
 suggestion to replace with get_ports
 _create_clock -name clk100 -period 10.0 [get_ports clk100]_
 /litex/litex/build/xilinx/vivado.py :  line 290
                " [get_ports {clk}]", clk=clk)
               # " [get_nets {clk}]", clk=clk)
 fixes problem of vivado 2020+ optimizations 