### PR TITLE
support custom toolchain

### DIFF
--- a/litex/soc/cores/cpu/__init__.py
+++ b/litex/soc/cores/cpu/__init__.py
@@ -50,6 +50,7 @@ class CPUNone(CPU):
     }
 
 CPU_GCC_TRIPLE_RISCV64 = (
+    "riscv64-pc-linux-musl",
     "riscv64-unknown-elf",
     "riscv64-unknown-linux-gnu",
     "riscv64-elf",

--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -89,9 +89,15 @@ def get_cpu_mak(cpu, compile_software):
             raise OSError(msg)
         return r
 
+    selected_triple = select_triple(triple)
+    if not clang:
+      binutils_version = re.match("GNU ar \(GNU Binutils\) (.+)\.(.+)", os.popen(selected_triple + "-ar -V").read())
+      if int(binutils_version.group(1)) >= 2 and int(binutils_version.group(2)) >= 37 and (not re.search("zicsr", flags)):
+        flags = re.compile("-march=([^ ]+)").sub("-march=\\1_zicsr", flags)
+
     # Return informations.
     return [
-        ("TRIPLE",        select_triple(triple)),
+        ("TRIPLE",        selected_triple),
         ("CPU",           cpu.name),
         ("CPUFAMILY",     cpu.family),
         ("CPUFLAGS",      flags),

--- a/litex/soc/software/common.mak
+++ b/litex/soc/software/common.mak
@@ -14,6 +14,7 @@ CX_normal      := $(CCACHE) clang++ -target $(TRIPLE) -integrated-as
 else
 CC_normal      := $(CCACHE) $(TARGET_PREFIX)gcc -std=gnu99
 CX_normal      := $(CCACHE) $(TARGET_PREFIX)g++
+GCC_INSTALLATION_PATH := $(patsubst %/libgcc.a,%,$(shell $(CC) -print-libgcc-file-name))
 endif
 AR_normal      := $(TARGET_PREFIX)gcc-ar
 LD_normal      := $(TARGET_PREFIX)ld
@@ -54,7 +55,13 @@ INCLUDES = -I$(PICOLIBC_DIRECTORY)/newlib/libc/tinystdio \
            -I$(BUILDINC_DIRECTORY) \
            -I$(BUILDINC_DIRECTORY)/../libc \
            -I$(CPU_DIRECTORY)
-COMMONFLAGS = $(DEPFLAGS) -Os $(CPUFLAGS) -g3 -fomit-frame-pointer -Wall -fno-builtin -fno-stack-protector -flto $(INCLUDES)
+COMMONFLAGS = $(DEPFLAGS) -Os $(CPUFLAGS) -g3 -fomit-frame-pointer -Wall -fno-builtin -fno-stack-protector $(INCLUDES)
+ifneq (,$(GCC_INSTALLATION_PATH))
+COMMONFLAGS += -nostdinc -I$(GCC_INSTALLATION_PATH)/include -I$(GCC_INSTALLATION_PATH)/include-fixed
+endif
+ifeq (,$(findstring musl,$(TRIPLE)))
+COMMONFLAGS += -flto
+endif
 ifneq ($(CPUFAMILY), arm)
 COMMONFLAGS += -fexceptions
 endif


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

close #1272 

Changes:

1. add "riscv64-pc-linux-musl" to support riscv64 musl
2. if `$(triple)-ar -V` reports it is binutils later than 2.37(refer https://github.com/bminor/binutils-gdb/commit/7671eff8f08de314d8c9837225eba95ed5ea053b), a post-processing on flags are executed, which will append `_zicsr` to `march` if `zicsr` is not present.
3. only append `-flto` if it is not musl
4. append `-nostdinc` and include paths explicitly if it is gcc, refer https://github.com/picolibc/picolibc/issues/277#issuecomment-1102069513 . For bios software, we should not rely on system libraries and headers.