### PR TITLE
software/bios: Fix build error for targets with sdcard but without main_ram_base

### DIFF
--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -800,6 +800,7 @@ static void sdcardboot_from_json(const char * filename)
 		boot(boot_r1, boot_r2, boot_r3, boot_addr);
 }
 
+#ifdef MAIN_RAM_BASE
 static void sdcardboot_from_bin(const char * filename)
 {
 	uint32_t result;
@@ -808,6 +809,7 @@ static void sdcardboot_from_bin(const char * filename)
 		return;
 	boot(0, 0, 0, MAIN_RAM_BASE);
 }
+#endif
 
 void sdcardboot(void)
 {
@@ -824,9 +826,11 @@ void sdcardboot(void)
 	printf("Booting from boot.json...\n");
 	sdcardboot_from_json("boot.json");
 
+#ifdef MAIN_RAM_BASE
 	/* Boot from boot.bin */
 	printf("Booting from boot.bin...\n");
 	sdcardboot_from_bin("boot.bin");
+#endif
 
 	/* Boot failed if we are here... */
 	printf("SDCard boot failed.\n");


### PR DESCRIPTION
sdcardboot_from_bin assumes that the MAIN_RAM_BASE is set which is not always
the case. This commit deactivates the sdcardboot_from_bin support for targets
without main-ram. In those cases, the boot_from_json method can still be used.