### PR TITLE
Etherbone testing

### DIFF
--- a/litex/compat/__init__.py
+++ b/litex/compat/__init__.py
@@ -23,7 +23,7 @@ def compat_notice(name, date, info=""):
         date       = colorer(date),
         update     = colorer("update", color="red"),
         info       = info,
-    ), end="")
+    ))
     # Annoy user to force update :)
     for i in range(10):
         time.sleep(0.2)

--- a/litex/compat/stream_sim.py
+++ b/litex/compat/stream_sim.py
@@ -114,16 +114,20 @@ class PacketStreamer(Module):
         # # #
 
         self.packets = []
+        self.packet_bytes = []
+
+        self.n_bytes = 0
         self.packet = packet_cls()
         self.packet.done = True
 
-    def send(self, packet):
+    def send(self, packet, n_bytes):
         packet = deepcopy(packet)
         self.packets.append(packet)
+        self.packet_bytes.append(n_bytes)
         return packet
 
-    def send_blocking(self, packet):
-        packet = self.send(packet)
+    def send_blocking(self, packet, n_bytes):
+        packet = self.send(packet, n_bytes)
         while not packet.done:
             yield
 
@@ -132,6 +136,7 @@ class PacketStreamer(Module):
         while True:
             if len(self.packets) and self.packet.done:
                 self.packet = self.packets.pop(0)
+                self.n_bytes = self.packet_bytes.pop(0)
             if not self.packet.ongoing and not self.packet.done:
                 yield self.source.valid.eq(1)
                 yield self.source.data.eq(self.packet.pop(0))

--- a/litex/compat/stream_sim.py
+++ b/litex/compat/stream_sim.py
@@ -133,7 +133,6 @@ class PacketStreamer(Module):
 
     @passive
     def generator(self):
-        state = "idle"
         chunk_size = self.dw // 8
         while True:
             while len(self.packets) <= 0:
@@ -141,9 +140,9 @@ class PacketStreamer(Module):
             self.packet = self.packets.pop(0)
             n_chunks = len(self.packet) // chunk_size
             n_remainder = len(self.packet) % chunk_size
-            # print(n_chunks, n_remainder)
 
-            yield self.source.valid.eq(1)
+            if n_remainder > 0 or n_chunks > 0:
+                yield self.source.valid.eq(1)
 
             # Output complete chunks
             for i in range(n_chunks):

--- a/litex/compat/stream_sim.py
+++ b/litex/compat/stream_sim.py
@@ -204,7 +204,7 @@ class PacketLogger(Module):
                     else:
                         n = (yield self.sink.last_be).bit_length()
                     self.packet += bs[:n]
-                    print('last part', bs, bs[:n])
+                    # print('last part', bs, bs[:n])
                     self.packet.done = True
                     self.first = True
                 else:

--- a/litex/tools/remote/etherbone.py
+++ b/litex/tools/remote/etherbone.py
@@ -120,7 +120,7 @@ class EtherboneWrites(Packet):
     def decode(self):
         if not self.encoded:
             raise ValueError
-        ba = self.bytes
+        ba = bytes(self.bytes)
         self.base_addr = unpack_uint32_from(ba[:4])[0]
         writes = []
         offset = 4
@@ -174,7 +174,7 @@ class EtherboneReads(Packet):
     def decode(self):
         if not self.encoded:
             raise ValueError
-        ba = self.bytes
+        ba = bytes(self.bytes)
         base_ret_addr = unpack_uint32_from(ba[:4])[0]
         reads  = []
         offset = 4
@@ -300,7 +300,7 @@ class EtherbonePacket(Packet):
         if not self.encoded:
             raise ValueError
 
-        ba = self.bytes
+        ba = bytes(self.bytes)
 
         # Decode header
         header = list(ba[:etherbone_packet_header.length])
@@ -324,7 +324,8 @@ class EtherbonePacket(Packet):
 
     def encode(self):
         if self.encoded:
-            raise ValueError
+            return
+            # raise ValueError
 
         ba = bytearray()
 
@@ -346,14 +347,14 @@ class EtherbonePacket(Packet):
     def __repr__(self):
         r = "Packet\n"
         r += "--------\n"
+        for k in sorted(etherbone_packet_header.fields.keys()):
+            r += k + " : 0x{:0x}\n".format(getattr(self, k))
+        for i, record in enumerate(self.records):
+            r += record.__repr__(i)
         if self.encoded:
+            r += '\nencoded:\n'
             for d in self.bytes:
                 r += "{:02x}".format(d)
-        else:
-            for k in sorted(etherbone_packet_header.fields.keys()):
-                r += k + " : 0x{:0x}\n".format(getattr(self, k))
-            for i, record in enumerate(self.records):
-                r += record.__repr__(i)
         return r
 
 # Etherbone IPC ------------------------------------------------------------------------------------


### PR DESCRIPTION
Changes to stream_sim.py and stream.py to make liteeth testbenches and etherbone work with a 64 bit datapath.
Corresponding [liteeth pull request](https://github.com/enjoy-digital/liteeth/pull/106).

  * PacketStreamer / PacketLogger: make them take care of `last_be` and the conversion from bytes to words and vice versa. The interface towards the user is always in bytes
  * Also, make PacketStreamer / PacketLogger recognize stalls, which some PHYs don't like
  * StrideConverter: add last_be support when down-converting