### PR TITLE
fix overflow in BIST

### DIFF
--- a/litex/soc/software/liblitedram/bist.c
+++ b/litex/soc/software/liblitedram/bist.c
@@ -131,7 +131,7 @@ void sdram_bist_loop(uint32_t loop, uint32_t burst_length, uint32_t random) {
 static uint32_t compute_speed_mibs(uint32_t length, uint32_t ticks) {
 	uint32_t speed;
 	//printf("(%u, %u)", length, ticks);
-	speed = length*(CONFIG_CLOCK_FREQUENCY/(1024*1024))/ticks;
+	speed = (uint64_t)length*(CONFIG_CLOCK_FREQUENCY/(1024*1024))/ticks;
 	return speed;
 }
 


### PR DESCRIPTION
With decent burst length, fast RAM and fast clock rate,
the intermediate result can easily overflow 32 bits.

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>