### PR TITLE
cpu/vexriscv: Fix compilation of crt0.S with new binutils.

### DIFF
--- a/litex/soc/cores/cpu/vexriscv/crt0.S
+++ b/litex/soc/cores/cpu/vexriscv/crt0.S
@@ -2,6 +2,8 @@
 .global isr
 .global _start
 
+.option arch,+zicsr
+
 _start:
   j crt_init
   nop

--- a/litex/soc/cores/cpu/vexriscv_smp/crt0.S
+++ b/litex/soc/cores/cpu/vexriscv_smp/crt0.S
@@ -7,6 +7,8 @@
 .global smp_lottery_args
 .global smp_slave
 
+.option arch,+zicsr
+
 _start:
   j crt_init
   nop


### PR DESCRIPTION
The csrw opcode is no longer part of the "I" instruction set but has
been moved to a separate extension.  Enable that extension in crt0.S.