### PR TITLE
FHDL Namer integration and memory .init naming improvements.

### DIFF
--- a/litex/gen/fhdl/memory.py
+++ b/litex/gen/fhdl/memory.py
@@ -13,7 +13,7 @@ from migen.fhdl.verilog import _printexpr as verilog_printexpr
 from migen.fhdl.specials import *
 
 
-def memory_emit_verilog(memory, namespace, add_data_file):
+def memory_emit_verilog(name, memory, namespace, add_data_file):
     # Helpers.
     # --------
     def gn(e):
@@ -76,7 +76,7 @@ def memory_emit_verilog(memory, namespace, add_data_file):
         formatter = f"{{:0{int(memory.width/4)}x}}\n"
         for d in memory.init:
             content += formatter.format(d)
-        memory_filename = add_data_file(f"{gn(memory)}.init", content)
+        memory_filename = add_data_file(f"{name}_{gn(memory)}.init", content)
 
         r += "initial begin\n"
         r += f"\t$readmemh(\"{memory_filename}\", {gn(memory)});\n"

--- a/litex/gen/fhdl/namer.py
+++ b/litex/gen/fhdl/namer.py
@@ -237,21 +237,21 @@ class Namespace:
         self.clock_domains = dict()
 
     def get_name(self, sig):
-        # Clock Signal.
-        # -------------
+        # Get name of a Clock Signal.
+        # ---------------------------
         if isinstance(sig, ClockSignal):
             sig = self.clock_domains[sig.cd].clk
 
-        # Reset Signal.
-        # -------------
+        # Get name of a Reset Signal.
+        # ---------------------------
         if isinstance(sig, ResetSignal):
             sig = self.clock_domains[sig.cd].rst
             if sig is None:
                 msg = f"Clock Domain {sig.cd} is reset-less, can't obtain name"
                 raise ValueError(msg)
 
-        # Regular Signal.
-        # ---------------
+        # Get name of a Regular Signal.
+        # -----------------------------
         # Use Name's override when set...
         if sig.name_override is not None:
             sig_name = sig.name_override

--- a/litex/gen/fhdl/verilog.py
+++ b/litex/gen/fhdl/verilog.py
@@ -500,7 +500,7 @@ def _print_specials(name, overrides, specials, namespace, add_data_file, attr_tr
         # Replace Migen Memory's emit_verilog with LiteX's implementation.
         if isinstance(special, Memory):
             from litex.gen.fhdl.memory import memory_emit_verilog
-            pr = memory_emit_verilog(special, namespace, add_data_file)
+            pr = memory_emit_verilog(name, special, namespace, add_data_file)
         else:
             pr = call_special_classmethod(overrides, special, "emit_verilog", namespace, add_data_file)
         if pr is None:

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -851,7 +851,7 @@ class SoC(Module):
             "axi-lite": axi.AXILiteInterface,
         }[self.bus.standard]
         ram_bus = interface_cls(data_width=self.bus.data_width, bursting=self.bus.bursting)
-        ram     = ram_cls(size, bus=ram_bus, init=contents, read_only=(mode == "r"))
+        ram     = ram_cls(size, bus=ram_bus, init=contents, read_only=(mode == "r"), name=name)
         self.bus.add_slave(name, ram.bus, SoCRegion(origin=origin, size=size, mode=mode))
         self.check_if_exists(name)
         self.logger.info("RAM {} {} {}.".format(

--- a/litex/soc/interconnect/axi.py
+++ b/litex/soc/interconnect/axi.py
@@ -795,7 +795,7 @@ class AXILite2CSR(Module):
 # AXILite SRAM -------------------------------------------------------------------------------------
 
 class AXILiteSRAM(Module):
-    def __init__(self, mem_or_size, read_only=None, init=None, bus=None):
+    def __init__(self, mem_or_size, read_only=None, init=None, bus=None, name=None):
         if bus is None:
             bus = AXILiteInterface()
         self.bus = bus
@@ -805,7 +805,7 @@ class AXILiteSRAM(Module):
             assert(mem_or_size.width <= bus_data_width)
             self.mem = mem_or_size
         else:
-            self.mem = Memory(bus_data_width, mem_or_size//(bus_data_width//8), init=init)
+            self.mem = Memory(bus_data_width, mem_or_size//(bus_data_width//8), init=init, name=name)
 
         if read_only is None:
             if hasattr(self.mem, "bus_read_only"):

--- a/litex/soc/interconnect/wishbone.py
+++ b/litex/soc/interconnect/wishbone.py
@@ -344,7 +344,7 @@ class Converter(Module):
 # Wishbone SRAM ------------------------------------------------------------------------------------
 
 class SRAM(Module):
-    def __init__(self, mem_or_size, read_only=None, init=None, bus=None):
+    def __init__(self, mem_or_size, read_only=None, init=None, bus=None, name=None):
         if bus is None:
             bus = Interface()
         self.bus = bus
@@ -353,7 +353,7 @@ class SRAM(Module):
             assert(mem_or_size.width <= bus_data_width)
             self.mem = mem_or_size
         else:
-            self.mem = Memory(bus_data_width, mem_or_size//(bus_data_width//8), init=init)
+            self.mem = Memory(bus_data_width, mem_or_size//(bus_data_width//8), init=init, name=name)
 
         if read_only is None:
             if hasattr(self.mem, "bus_read_only"):


### PR DESCRIPTION
Memory` .init `files were using generic mem_x names, which made them difficult to re-integrate in Super SoCs and to figure out contents:

Previously generated gateware:
```
litex_soc.v
mem.init (ROM contents)
mem_1.init (SRAM contents) 
```

This PR adds `build_name` as prefix to the memory `.init` files and also use name parameter of Memory to pass information from SoC.

The generated gateware is now:
```
litex_soc.v
litex_soc_rom.init (ROM contents).
litex_soc_sram.init (SRAM contents).
```
Which should be easier to re-integrate and figure out contents.