### PR TITLE
litex_setup: fix path reference for python3 binary on non-Linux hosts

### DIFF
--- a/litex_setup.py
+++ b/litex_setup.py
@@ -253,7 +253,7 @@ def litex_setup_install_repos(config="standard", user_mode=False):
         if repo.develop:
             print_status(f"Installing {name} Git repository...")
             os.chdir(os.path.join(current_path, name))
-            subprocess.check_call("{python3} -m pip install --editable . {options}".format(
+            subprocess.check_call("\"{python3}\" -m pip install --editable . {options}".format(
                 python3 = sys.executable,
                 options = "--user" if user_mode else "",
                 ), shell=True)


### PR DESCRIPTION
the python binary is stored in the "Program Files" directory.  without
delimiting the path the calls to the binary will fail on Windows hosts.