### PR TITLE
Add request_remaining("name") that returns unallocated pins.

### DIFF
--- a/litex/build/generic_platform.py
+++ b/litex/build/generic_platform.py
@@ -230,7 +230,18 @@ class ConstraintManager:
             except ConstraintError:
                 break
         if not len(r):
-            raise ValueError
+            raise ValueError(f"Could not request some pin(s) named '{name}'")
+        return Cat(r)
+
+    def request_remaining(self, name):
+        r = []
+        while True:
+            try:
+                r.append(self.request(name))
+            except ConstraintError:
+                break
+        if not len(r):
+            raise ValueError(f"Could not request any pins named '{name}'")
         return Cat(r)
 
     def lookup_request(self, name, number=None, loose=False):
@@ -320,6 +331,9 @@ class GenericPlatform:
 
     def request_all(self, *args, **kwargs):
         return self.constraint_manager.request_all(*args, **kwargs)
+
+    def request_remaining(self, *args, **kwargs):
+        return self.constraint_manager.request_remaining(*args, **kwargs)
 
     def lookup_request(self, *args, **kwargs):
         return self.constraint_manager.lookup_request(*args, **kwargs)


### PR DESCRIPTION
 Improve error reporting on `request_all()`.

This allows me to grab a few LEDs for debugging purposes with `platform.request()` and pass the rest to `LedChaser` with `platform.request_remaining()` instead of `request_all` (which fails) so I still get the handy "proof of life" indicator for the overall design.