### PR TITLE
Add get_signals function (w/ optional recursion) for litescope usage

### DIFF
--- a/litex/gen/fhdl/module.py
+++ b/litex/gen/fhdl/module.py
@@ -105,3 +105,13 @@ class LiteXModule(Module, AutoCSR, AutoDoc):
         if module is not None:
             assert isinstance(module, Module)
         return module
+
+    def get_signals(self, recurse=False):
+        """
+        Return public Signals/Record fields from the current module.
+
+        Args:
+            recurse (bool): Also collect Signals/Record fields from submodules.
+        """
+        from litex.gen.fhdl.utils import get_signals
+        return get_signals(self, recurse=recurse)

--- a/litex/gen/fhdl/utils.py
+++ b/litex/gen/fhdl/utils.py
@@ -1,8 +1,15 @@
 #
 # This file is part of LiteX.
 #
-# This file is Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2022 Jevin Sweval <jevinsweval@gmail.com>
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
+
+from collections.abc import Mapping
+
+from migen.fhdl.module import Module
+from migen.fhdl.structure import Signal
+from migen.genlib.record import Record
 
 def allocate_generated_name(obj, used_names):
     """Return a deterministic synthetic instance name for unnamed objects."""
@@ -13,3 +20,57 @@ def allocate_generated_name(obj, used_names):
         idx += 1
         name = f"{base}_{idx}"
     return name
+
+
+def get_signals(obj, recurse=False):
+    """Return public Signals/Record fields found on obj.
+
+    When recurse is set, registered Migen/LiteX submodules are traversed too.
+    The returned list preserves discovery order and removes duplicate Signals.
+    """
+    signals      = []
+    seen_signals = set()
+    seen_objects = set()
+
+    def add_signal(signal):
+        if signal not in seen_signals:
+            signals.append(signal)
+            seen_signals.add(signal)
+
+    def collect(value, root=False):
+        if isinstance(value, Signal):
+            add_signal(value)
+            return
+
+        value_id = id(value)
+        if value_id in seen_objects:
+            return
+
+        if isinstance(value, Record):
+            seen_objects.add(value_id)
+            for signal in value.flatten():
+                collect(signal)
+        elif isinstance(value, Mapping):
+            seen_objects.add(value_id)
+            for item in value.values():
+                collect(item)
+        elif isinstance(value, (list, tuple)):
+            seen_objects.add(value_id)
+            for item in value:
+                collect(item)
+        elif isinstance(value, set):
+            seen_objects.add(value_id)
+            for item in sorted(value, key=lambda item: getattr(item, "duid", id(item))):
+                collect(item)
+        elif (root or (recurse and isinstance(value, Module))) and hasattr(value, "__dict__"):
+            seen_objects.add(value_id)
+            for name, attr in vars(value).items():
+                if name.startswith("_"):
+                    continue
+                collect(attr)
+            if recurse and isinstance(value, Module):
+                for _, submodule in value._submodules:
+                    collect(submodule)
+
+    collect(obj, root=True)
+    return signals

--- a/test/test_fhdl_utils.py
+++ b/test/test_fhdl_utils.py
@@ -1,0 +1,98 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import *
+
+from litex.gen import LiteXModule
+from litex.gen.fhdl.utils import get_signals
+
+
+class TestFHDLUtils(unittest.TestCase):
+    def test_get_signals_from_object(self):
+        class DUT:
+            def __init__(self):
+                self.a        = Signal(name="a")
+                self.b        = Signal(name="b")
+                self.record   = Record([("c", 1), ("d", 2)])
+                self.group    = [self.a, {"b": self.b}, (self.record,)]
+                self._private = Signal(name="private")
+
+        dut = DUT()
+
+        self.assertEqual(get_signals(dut), [
+            dut.a,
+            dut.b,
+            dut.record.c,
+            dut.record.d,
+        ])
+
+    def test_get_signals_from_signal_record_and_containers(self):
+        signal = Signal(name="signal")
+        record = Record([("a", 1), ("b", 2)])
+
+        self.assertEqual(get_signals(object()), [])
+        self.assertEqual(get_signals(signal), [signal])
+        self.assertEqual(get_signals(record), [record.a, record.b])
+        self.assertEqual(get_signals([signal, record, {"again": signal}]), [
+            signal,
+            record.a,
+            record.b,
+        ])
+
+    def test_get_signals_recurse(self):
+        class Child(LiteXModule):
+            def __init__(self, name):
+                self.signal = Signal(name=name)
+
+        class DUT(LiteXModule):
+            def __init__(self):
+                self.top_signal = Signal(name="top")
+                self.child      = Child("child")
+                self.submodules += Child("unnamed")
+
+        dut = DUT()
+
+        self.assertEqual(get_signals(dut), [
+            dut.top_signal,
+        ])
+        self.assertEqual(get_signals(dut, recurse=True), [
+            dut.top_signal,
+            dut.child.signal,
+            dut._submodules[1][1].signal,
+        ])
+
+    def test_get_signals_cycle(self):
+        class Child(LiteXModule):
+            def __init__(self):
+                self.signal = Signal(name="child")
+
+        class DUT(LiteXModule):
+            def __init__(self):
+                self.signal = Signal(name="top")
+                self.child  = Child()
+                self.child.parent = self
+
+        dut = DUT()
+
+        self.assertEqual(get_signals(dut, recurse=True), [
+            dut.signal,
+            dut.child.signal,
+        ])
+
+    def test_litex_module_get_signals(self):
+        class DUT(LiteXModule):
+            def __init__(self):
+                self.signal = Signal(name="signal")
+
+        dut = DUT()
+
+        self.assertEqual(dut.get_signals(), [dut.signal])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Useful for collecting signals for litescope: e.g. `analyzer_signals = [*get_signals(self.usb, recurse=True)]`