### PR TITLE
ClockFrequency() to get/set the frequency of a domain or signal

### DIFF
--- a/litex/soc/cores/clock/common.py
+++ b/litex/soc/cores/clock/common.py
@@ -8,6 +8,7 @@ import logging
 import math
 
 from migen import Record
+from migen.fhdl.structure import ClockDomain
 
 from litex.soc.integration.soc import colorer
 
@@ -56,3 +57,17 @@ def clkdiv_range(start, stop, step=1):
     while current < stop:
         yield int(current) if math.floor(current) == current else current
         current += step
+
+def ClockFrequency(cd_or_signal="sys", set_freq=None):
+    CF = ClockFrequency
+    CF.freqs = getattr(CF, 'freqs', {})
+    if set_freq is not None:
+        if isinstance(cd_or_signal, ClockDomain):
+            CF.freqs[cd_or_signal.name] = set_freq
+        else:
+            CF.freqs[cd_or_signal] = set_freq
+    else:
+        try:
+            return CF.freqs[cd_or_signal]
+        except KeyError:
+            raise KeyError(f"ClockFrequency has not yet been set for domain/signal '{cd_or_signal}'")

--- a/litex/soc/cores/clock/intel_common.py
+++ b/litex/soc/cores/clock/intel_common.py
@@ -36,6 +36,7 @@ class IntelClocking(Module, AutoCSR):
         else:
             raise ValueError
         self.clkin_freq = freq
+        ClockFrequency(clkin, set_freq=freq)
         register_clkin_log(self.logger, clkin, freq)
 
     def create_clkout(self, cd, freq, phase=0, margin=1e-2, with_reset=True):
@@ -45,6 +46,8 @@ class IntelClocking(Module, AutoCSR):
         if with_reset:
             self.specials += AsyncResetSynchronizer(cd, ~self.locked)
         self.comb += cd.clk.eq(clkout)
+        ClockFrequency(cd, set_freq=freq)
+        ClockFrequency(clkout, set_freq=freq)
         create_clkout_log(self.logger, cd.name, freq, margin, self.nclkouts)
         self.nclkouts += 1
 


### PR DESCRIPTION
`ClockFrequency(cd_or_signal="sys", set_freq=None)`

Can be used to verify correctness parameters like with the Intel chip ID functionality that specifies the clock should be <= 100 MHz.

```
if ClockFrequency() > 100e6:
    logging.warn(f"Altera Chip ID block should be clocked {colorer('<= 100 MHz')}, not " +
        colorer(f"{ClockFrequency()/1e6:.0f} MHz")
    )
```

Right now it is only integrated into Intel clocking, but if you like the idea I'll put it in all the clockers.