### PR TITLE
software/liblitesata: address printf int size warning

### DIFF
--- a/litex/soc/software/liblitesata/sata.c
+++ b/litex/soc/software/liblitesata/sata.c
@@ -26,7 +26,7 @@ int sata_init(int show) {
 	uint16_t buf[128];
 	uint8_t  model[38];
 	uint64_t sectors;
-	uint32_t capacity;
+	unsigned capacity;
 
 	for (timeout=16; timeout>0; timeout--) {
 		/* Reset SATA PHY */
@@ -84,7 +84,7 @@ int sata_init(int show) {
 		sectors += (((uint64_t) buf[103]) << 48);
 		capacity = sectors/(1000*1000*500/256);
 		if (show)
-			printf("Capacity: %ldGB\n", capacity);
+			printf("Capacity: %dGB\n", capacity);
 
 		/* Init succeeded */
 		return 1;


### PR DESCRIPTION
uint32_t is treated as `unsigned int` by the 64-bit compiler, and
as `long unsigned int` by the 32-bit compiler. As such, we'll get
a warning on one or the other regardless of whether we use "%ld"
or "%d" with printf:

on 64-bit (rocket, using "%ld"):

./litex/litex/soc/software/liblitesata/sata.c: In function 'sata_init':
./litex/litex/soc/software/liblitesata/sata.c:87:45:
    warning: format '%ld' expects argument of type 'long int', but
    argument 2 has type 'uint32_t' {aka 'unsigned int'} [-Wformat=]
   87 |     printf("Capacity: %ldGB\n", capacity);
      |                       ~~^       ~~~~~~~~
      |                         |       |
      |                         |       uint32_t {aka unsigned int}
      |                         long int
      |                       %d

on 32-bit (vexriscv, using "%d"):

./litex/litex/soc/software/liblitesata/sata.c: In function 'sata_init':
./litex/litex/soc/software/liblitesata/sata.c:87:44:
    warning: format '%d' expects argument of type 'int', but
    argument 2 has type 'uint32_t' {aka 'long unsigned int'} [-Wformat=]
   87 |     printf("Capacity: %dGB\n", capacity);
      |                       ~^       ~~~~~~~~
      |                        |       |
      |                        int     uint32_t {aka long unsigned int}
      |                       %ld

This patch changes `capacity` to `unsigned`, which has the same size
as `uint32_t`, but has the advantage of being treated the same by
`printf` regardless of whether we use the 32- or 64-bit compiler.