### PR TITLE
GW1NPLL: add GW2A

### DIFF
--- a/litex/soc/cores/clock/gowin_gw1n.py
+++ b/litex/soc/cores/clock/gowin_gw1n.py
@@ -77,6 +77,9 @@ class GW1NPLL(Module):
         elif device.startswith('GW1N-') or device.startswith('GW1NR-'):
             self.vco_freq_range = (400e6, 900e6)
             self.pfd_freq_range = (3e6, 400e6)  # not verified: not found in the datasheet
+        elif device.startswith('GW2A-'):
+            self.vco_freq_range = (500e6, 1250e6) # datasheet values
+            self.pfd_freq_range = (3e6, 500e6)  # datasheet values
 
         try:
             self.vco_freq_range


### PR DESCRIPTION
GW2A has the same PLL primitive with GW1N.

Add support for it to GW1NPLL.

Signed-off-by: Icenowy Zheng <uwu@icenowy.me>