### PR TITLE
cpu/vexriscv: Redo csr instruction fix

### DIFF
--- a/litex/soc/cores/cpu/vexriscv/core.py
+++ b/litex/soc/cores/cpu/vexriscv/core.py
@@ -46,30 +46,30 @@ CPU_VARIANTS = {
 # GCC Flags ----------------------------------------------------------------------------------------
 
 GCC_FLAGS = {
-    #                               /-------- Base ISA
-    #                               |/------- Hardware Multiply + Divide
-    #                               ||/----- Atomics
-    #                               |||/---- Compressed ISA
-    #                               ||||/--- Single-Precision Floating-Point
-    #                               |||||/-- Double-Precision Floating-Point
-    #                               imacfd
-    "minimal":          "-march=rv32i      -mabi=ilp32",
-    "minimal+debug":    "-march=rv32i      -mabi=ilp32",
-    "lite":             "-march=rv32im     -mabi=ilp32",
-    "lite+debug":       "-march=rv32im     -mabi=ilp32",
-    "standard":         "-march=rv32im     -mabi=ilp32",
-    "standard+debug":   "-march=rv32im     -mabi=ilp32",
-    "imac":             "-march=rv32imac   -mabi=ilp32",
-    "imac+debug":       "-march=rv32imac   -mabi=ilp32",
-    "full":             "-march=rv32im     -mabi=ilp32",
-    "full+cfu":         "-march=rv32im     -mabi=ilp32",
-    "full+debug":       "-march=rv32im     -mabi=ilp32",
-    "full+cfu+debug":   "-march=rv32im     -mabi=ilp32",
-    "linux":            "-march=rv32ima    -mabi=ilp32",
-    "linux+debug":      "-march=rv32ima    -mabi=ilp32",
-    "linux+no-dsp":     "-march=rv32ima    -mabi=ilp32",
-    "secure":           "-march=rv32ima    -mabi=ilp32",
-    "secure+debug":     "-march=rv32ima    -mabi=ilp32",
+    #                               /---------- Base ISA
+    #                               |    /----- Hardware Multiply + Divide
+    #                               |    |/---- Atomics
+    #                               |    ||/--- Compressed ISA
+    #                               |    |||/-- Single-Precision Floating-Point
+    #                               |    ||||/- Double-Precision Floating-Point
+    #                               i    macfd
+    "minimal":          "-march=rv32i2p0       -mabi=ilp32",
+    "minimal+debug":    "-march=rv32i2p0       -mabi=ilp32",
+    "lite":             "-march=rv32i2p0_m     -mabi=ilp32",
+    "lite+debug":       "-march=rv32i2p0_m     -mabi=ilp32",
+    "standard":         "-march=rv32i2p0_m     -mabi=ilp32",
+    "standard+debug":   "-march=rv32i2p0_m     -mabi=ilp32",
+    "imac":             "-march=rv32i2p0_mac   -mabi=ilp32",
+    "imac+debug":       "-march=rv32i2p0_mac   -mabi=ilp32",
+    "full":             "-march=rv32i2p0_m     -mabi=ilp32",
+    "full+cfu":         "-march=rv32i2p0_m     -mabi=ilp32",
+    "full+debug":       "-march=rv32i2p0_m     -mabi=ilp32",
+    "full+cfu+debug":   "-march=rv32i2p0_m     -mabi=ilp32",
+    "linux":            "-march=rv32i2p0_ma    -mabi=ilp32",
+    "linux+debug":      "-march=rv32i2p0_ma    -mabi=ilp32",
+    "linux+no-dsp":     "-march=rv32i2p0_ma    -mabi=ilp32",
+    "secure":           "-march=rv32i2p0_ma    -mabi=ilp32",
+    "secure+debug":     "-march=rv32i2p0_ma    -mabi=ilp32",
 }
 
 # VexRiscv Timer -----------------------------------------------------------------------------------

--- a/litex/soc/cores/cpu/vexriscv/crt0.S
+++ b/litex/soc/cores/cpu/vexriscv/crt0.S
@@ -2,8 +2,6 @@
 .global isr
 .global _start
 
-.option arch,+zicsr
-
 _start:
   j crt_init
   nop

--- a/litex/soc/cores/cpu/vexriscv_smp/core.py
+++ b/litex/soc/cores/cpu/vexriscv_smp/core.py
@@ -120,7 +120,7 @@ class VexRiscvSMP(CPU):
     # Arch.
     @staticmethod
     def get_arch():
-        arch = "rv32ima"
+        arch = "rv32i2p0_ma"
         if VexRiscvSMP.with_fpu:
             arch += "fd"
         if VexRiscvSMP.with_rvc:

--- a/litex/soc/cores/cpu/vexriscv_smp/crt0.S
+++ b/litex/soc/cores/cpu/vexriscv_smp/crt0.S
@@ -7,8 +7,6 @@
 .global smp_lottery_args
 .global smp_slave
 
-.option arch,+zicsr
-
 _start:
   j crt_init
   nop


### PR DESCRIPTION
Instead of enabling the zicsr extension in crt0.S, change -march to
specify that VexRISCV implements version 2.0 of I, rather than the
latest (2.1).  In 2.0 the csr instructions were still part of I.
This approach has two advantages:

* It is compatible with older versions of binutils, since they do not
  need to know about the new zicsr extension

* By modifying the -march in CFLAGS, csr instructions can be used in any
  code (for example by the inline functions in irq.h), not just in crt0.S.