### PR TITLE
adding JTAG support for the xcau, Xilinx Artix UltraScale+

### DIFF
--- a/litex/soc/cores/jtag.py
+++ b/litex/soc/cores/jtag.py
@@ -307,7 +307,7 @@ class XilinxJTAG(Module):
         prim_dict = {
             # Primitive Name   Ðevice (startswith)
             "BSCAN_SPARTAN6" : ["xc6"],
-            "BSCANE2"        : ["xc7a", "xc7k", "xc7v", "xc7z"] +  ["xcku", "xcvu", "xczu"],
+            "BSCANE2"        : ["xc7a", "xc7k", "xc7v", "xc7z"] +  ["xcau", "xcku", "xcvu", "xczu"],
         }
         for prim, prim_devs in prim_dict.items():
             for prim_dev in prim_devs:


### PR DESCRIPTION
This is for supporting the JTAG-UART for the XEM8320 AU25P litex-board (to be PR later).