### PR TITLE
[WIP] soc/cores/cpu: add initial OpenC906 support

### DIFF
--- a/litex/build/altera/quartus.py
+++ b/litex/build/altera/quartus.py
@@ -88,6 +88,9 @@ def _build_sdc(clocks, false_paths, vns, named_sc, build_name, additional_sdc_co
             tpl = "create_clock -name {clk} -period {period} [get_nets {{{clk}}}]"
             sdc.append(tpl.format(clk=vns.get_name(clk), period=str(period)))
 
+    # Enable automatical constraint generation for PLLs
+    sdc.append("derive_pll_clocks")
+
     # False path constraints
     for from_, to in sorted(false_paths, key=lambda x: (x[0].duid, x[1].duid)):
         tpl = "set_false_path -from [get_clocks {{{from_}}}] -to [get_clocks {{{to}}}]"

--- a/litex/soc/cores/clock/intel_common.py
+++ b/litex/soc/cores/clock/intel_common.py
@@ -79,7 +79,7 @@ class IntelClocking(Module, AutoCSR):
                             diff = abs(clk_freq - f)
                             if diff <= f*_m and diff < best_diff:
                                 config[f"clk{_n}_freq"]   = clk_freq
-                                config[f"clk{_n}_divide"] = c
+                                config[f"clk{_n}_divide"] = c * n
                                 config[f"clk{_n}_phase"]  = p
                                 clk_valid[_n] = True
                                 diff_ratios[_n] = diff / f

--- a/litex/soc/cores/cpu/openc906/__init__.py
+++ b/litex/soc/cores/cpu/openc906/__init__.py
@@ -1,0 +1,1 @@
+from litex.soc.cores.cpu.openc906.core import OpenC906

--- a/litex/soc/cores/cpu/openc906/boot-helper.S
+++ b/litex/soc/cores/cpu/openc906/boot-helper.S
@@ -1,0 +1,4 @@
+.section    .text, "ax", @progbits
+.global     boot_helper
+boot_helper:
+	jr x13

--- a/litex/soc/cores/cpu/openc906/core.py
+++ b/litex/soc/cores/cpu/openc906/core.py
@@ -1,0 +1,162 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2022 Icenowy Zheng <uwu@icenowy.me>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import re
+
+from migen import *
+
+from litex import get_data_mod
+from litex.soc.interconnect import axi
+from litex.soc.interconnect import wishbone
+from litex.soc.cores.cpu import CPU, CPU_GCC_TRIPLE_RISCV64
+
+# Helpers ------------------------------------------------------------------------------------------
+
+def add_manifest_sources(platform, manifest):
+    basedir = os.path.join(os.environ["OPENC906_DIR"], "C906_RTL_FACTORY")
+    with open(os.path.join(basedir, manifest), 'r') as f:
+        for l in f:
+            res = re.search('\$\{CODE_BASE_PATH\}/(.+)', l)
+            if res and not re.match('//', l):
+                if re.match('\+incdir\+', l):
+                    platform.add_verilog_include_path(os.path.join(basedir, res.group(1)))
+                else:
+                    platform.add_source(os.path.join(basedir, res.group(1)))
+
+# OpenC906 -----------------------------------------------------------------------------------------
+
+class OpenC906(CPU):
+    category             = "softcore"
+    family               = "riscv"
+    name                 = "openc906"
+    human_name           = "OpenC906"
+    variants             = ["standard"]
+    data_width           = 64
+    endianness           = "little"
+    gcc_triple           = CPU_GCC_TRIPLE_RISCV64
+    linker_output_format = "elf64-littleriscv"
+    nop                  = "nop"
+    io_regions           = {0xa000_0000: 0x2000_0000} # Origin, Length.
+
+    # GCC Flags.
+    @property
+    def gcc_flags(self):
+        flags =  "-mno-save-restore "
+        flags += "-march=rv64gc -mabi=lp64d "
+        flags += "-D__openc906__ "
+        flags += "-mcmodel=medany"
+        return flags
+
+    # Memory Mapping.
+    @property
+    def mem_map(self):
+        # Based on vanilla sysmap.h
+        return {
+            "main_ram":       0x0000_0000, # Region 0, Cacheable, Bufferable
+            "rom":            0x8000_0000, # Region 0 too
+            "sram":           0x8800_0000, # Region 0 too
+            # "internal_apb":   0x9000_0000, Region 1, Strong Order, Non-cacheable, Non-bufferable
+            "csr":            0xa000_0000, # Region 1 too
+        }
+
+    def __init__(self, platform, variant="standard"):
+        self.platform     = platform
+        self.variant      = variant
+        self.reset        = Signal()
+        self.interrupt    = Signal(240)
+        self.wishbone_if  = wishbone.Interface(data_width=128, adr_width=36)
+        self.periph_buses = [self.wishbone_if] # Peripheral buses (Connected to main SoC's bus).
+        self.memory_buses = []                 # Memory buses (Connected directly to LiteDRAM).
+
+        # # #
+
+        # Cycle count
+        cycle_count = Signal(64)
+        self.sync += cycle_count.eq(cycle_count + 1)
+
+        # AXI <-> Wishbone conversion.
+        axi_if = axi.AXIInterface(data_width=128, address_width=40, id_width=8)
+        self.submodules += axi.AXI2Wishbone(axi_if, self.wishbone_if, base_address=0)
+
+        # CPU Instance.
+        self.cpu_params = dict(
+            # Clk / Rst.
+            i_pll_core_cpuclk     = ClockSignal("sys"),
+            i_pad_cpu_rst_b       = ~ResetSignal("sys") | self.reset,
+            i_axim_clk_en         = 1,
+
+            # Debug (ignored).
+            i_sys_apb_clk         = 0,
+            i_sys_apb_rst_b       = 0,
+
+            # Interrupts
+            i_pad_cpu_apb_base    = Signal(40, reset=0x9000_0000),
+            i_pad_plic_int_cfg    = 0,
+            i_pad_plic_int_vld    = self.interrupt,
+
+            # Integrated timer
+            i_pad_cpu_sys_cnt     = cycle_count,
+
+            # AXI
+            o_biu_pad_awvalid     = axi_if.aw.valid,
+            i_pad_biu_awready     = axi_if.aw.ready,
+            o_biu_pad_awid        = axi_if.aw.id,
+            o_biu_pad_awaddr      = axi_if.aw.addr,
+            o_biu_pad_awlen       = axi_if.aw.len,
+            o_biu_pad_awsize      = axi_if.aw.size,
+            o_biu_pad_awburst     = axi_if.aw.burst,
+            o_biu_pad_awlock      = axi_if.aw.lock,
+            o_biu_pad_awcache     = axi_if.aw.cache,
+            o_biu_pad_awprot      = axi_if.aw.prot,
+
+            o_biu_pad_wvalid      = axi_if.w.valid,
+            i_pad_biu_wready      = axi_if.w.ready,
+            o_biu_pad_wdata       = axi_if.w.data,
+            o_biu_pad_wstrb       = axi_if.w.strb,
+            o_biu_pad_wlast       = axi_if.w.last,
+
+            i_pad_biu_bvalid      = axi_if.b.valid,
+            o_biu_pad_bready      = axi_if.b.ready,
+            i_pad_biu_bid         = axi_if.b.id,
+            i_pad_biu_bresp       = axi_if.b.resp,
+
+            o_biu_pad_arvalid     = axi_if.ar.valid,
+            i_pad_biu_arready     = axi_if.ar.ready,
+            o_biu_pad_arid        = axi_if.ar.id,
+            o_biu_pad_araddr      = axi_if.ar.addr,
+            o_biu_pad_arlen       = axi_if.ar.len,
+            o_biu_pad_arsize      = axi_if.ar.size,
+            o_biu_pad_arburst     = axi_if.ar.burst,
+            o_biu_pad_arlock      = axi_if.ar.lock,
+            o_biu_pad_arcache     = axi_if.ar.cache,
+            o_biu_pad_arprot      = axi_if.ar.prot,
+
+            i_pad_biu_rvalid      = axi_if.r.valid,
+            o_biu_pad_rready      = axi_if.r.ready,
+            i_pad_biu_rid         = axi_if.r.id,
+            i_pad_biu_rdata       = axi_if.r.data,
+            i_pad_biu_rresp       = axi_if.r.resp,
+            i_pad_biu_rlast       = axi_if.r.last,
+        )
+
+        # Add Verilog sources.
+        add_manifest_sources(platform, "gen_rtl/filelists/C906_asic_rtl.fl")
+        from litex.build.xilinx import XilinxPlatform
+        if isinstance(platform, XilinxPlatform):
+            # Import a filelist for Xilinx FPGAs
+            add_manifest_sources(platform, "gen_rtl/filelists/xilinx_fpga.fl")
+        else:
+            # Import a filelist for generic platforms
+            add_manifest_sources(platform, "gen_rtl/filelists/generic_fpga.fl")
+
+    def set_reset_address(self, reset_address):
+        self.reset_address = reset_address
+        self.cpu_params.update(i_pad_cpu_rvba=Signal(40, reset=reset_address))
+
+    def do_finalize(self):
+        assert hasattr(self, "reset_address")
+        self.specials += Instance("openC906", **self.cpu_params)

--- a/litex/soc/cores/cpu/openc906/crt0.S
+++ b/litex/soc/cores/cpu/openc906/crt0.S
@@ -1,0 +1,92 @@
+.global main
+.global isr
+.global _start
+
+_start:
+  j crt_init
+  nop
+  nop
+  nop
+  nop
+  nop
+  nop
+  nop
+
+trap_entry:
+  sd x1,  - 1*8(sp)
+  sd x5,  - 2*8(sp)
+  sd x6,  - 3*8(sp)
+  sd x7,  - 4*8(sp)
+  sd x10, - 5*8(sp)
+  sd x11, - 6*8(sp)
+  sd x12, - 7*8(sp)
+  sd x13, - 8*8(sp)
+  sd x14, - 9*8(sp)
+  sd x15, -10*8(sp)
+  sd x16, -11*8(sp)
+  sd x17, -12*8(sp)
+  sd x28, -13*8(sp)
+  sd x29, -14*8(sp)
+  sd x30, -15*8(sp)
+  sd x31, -16*8(sp)
+  addi sp,sp,-16*8
+  call isr
+  ld x1 , 15*8(sp)
+  ld x5,  14*8(sp)
+  ld x6,  13*8(sp)
+  ld x7,  12*8(sp)
+  ld x10, 11*8(sp)
+  ld x11, 10*8(sp)
+  ld x12,  9*8(sp)
+  ld x13,  8*8(sp)
+  ld x14,  7*8(sp)
+  ld x15,  6*8(sp)
+  ld x16,  5*8(sp)
+  ld x17,  4*8(sp)
+  ld x28,  3*8(sp)
+  ld x29,  2*8(sp)
+  ld x30,  1*8(sp)
+  ld x31,  0*8(sp)
+  addi sp,sp,16*8
+  mret
+  .text
+
+
+crt_init:
+  la sp, _fstack
+  la t0, trap_entry
+  csrw mtvec, t0
+  li t0, 0x3
+  csrs 0x7c1, t0 // enable L1I+L1D
+
+data_init:
+  la t0, _fdata
+  la t1, _edata
+  la t2, _fdata_rom
+data_loop:
+  beq t0,t1,data_done
+  ld t3,0(t2)
+  sd t3,0(t0)
+  add t0,t0,8
+  add t2,t2,8
+  j data_loop
+data_done:
+
+bss_init:
+  la t0, _fbss
+  la t1, _ebss
+bss_loop:
+  beq t0,t1,bss_done
+  sd zero,0(t0)
+  add t0,t0,8
+  j bss_loop
+bss_done:
+
+  call plic_init // initialize external interrupt controller
+  li t0, 0x800   // external interrupt sources only (using LiteX timer);
+                 // NOTE: must still enable mstatus.MIE!
+  csrw mie,t0
+
+  call main
+inf_loop:
+  j inf_loop

--- a/litex/soc/cores/cpu/openc906/csr-defs.h
+++ b/litex/soc/cores/cpu/openc906/csr-defs.h
@@ -1,0 +1,21 @@
+#ifndef CSR_DEFS__H
+#define CSR_DEFS__H
+
+#define CSR_MSTATUS_MIE 	0x8
+
+#define CSR_MXSTATUS	0x7C0
+#define CSR_MXSTATUS_THEADISAEE	(1 << 22)
+#define CSR_MHCR	0x7C1
+#define CSR_MHCR_IE		(1 << 0)
+#define CSR_MHCR_DE		(1 << 1)
+#define CSR_MHCR_BPE		(1 << 5)
+#define CSR_MHCR_BTB		(1 << 6)
+#define CSR_MCOR	0x7C2
+#define CSR_MCOR_CACHE_SEL_I	(1 << 0)
+#define CSR_MCOR_CACHE_SEL_D	(1 << 1)
+#define CSR_MCOR_INV		(1 << 4)
+#define CSR_MCOR_CLR		(1 << 5)
+#define CSR_MCOR_BHT_INV	(1 << 16)
+#define CSR_MCOR_BTB_INV	(1 << 17)
+
+#endif	/* CSR_DEFS__H */

--- a/litex/soc/cores/cpu/openc906/irq.h
+++ b/litex/soc/cores/cpu/openc906/irq.h
@@ -1,0 +1,50 @@
+#ifndef __IRQ_H
+#define __IRQ_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <system.h>
+#include <generated/csr.h>
+#include <generated/soc.h>
+
+// The C906 core uses a Platform-Level Interrupt Controller (PLIC) which
+// is programmed and queried via a set of MMIO registers.
+
+#define PLIC_BASE    0x90000000L // Base address and per-pin priority array
+#define PLIC_PENDING 0x90001000L // Bit field matching currently pending pins
+#define PLIC_ENABLED 0x90002000L // Bit field corresponding to the current mask
+#define PLIC_THRSHLD 0x90200000L // Per-pin priority must be >= this to trigger
+#define PLIC_CLAIM   0x90200004L // Claim & completion register address
+
+static inline unsigned int irq_getie(void)
+{
+	return (csrr(mstatus) & CSR_MSTATUS_MIE) != 0;
+}
+
+static inline void irq_setie(unsigned int ie)
+{
+	if(ie) csrs(mstatus,CSR_MSTATUS_MIE); else csrc(mstatus,CSR_MSTATUS_MIE);
+}
+
+static inline unsigned int irq_getmask(void)
+{
+	return *((unsigned int *)PLIC_ENABLED) >> 16;
+}
+
+static inline void irq_setmask(unsigned int mask)
+{
+	*((unsigned int *)PLIC_ENABLED) = mask << 16;
+}
+
+static inline unsigned int irq_pending(void)
+{
+	return *((unsigned int *)PLIC_PENDING) >> 16;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __IRQ_H */

--- a/litex/soc/cores/cpu/openc906/system.h
+++ b/litex/soc/cores/cpu/openc906/system.h
@@ -1,0 +1,51 @@
+#ifndef __SYSTEM_H
+#define __SYSTEM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void flush_l2_cache(void);
+
+void busy_wait(unsigned int ms);
+void busy_wait_us(unsigned int us);
+
+#include <csr-defs.h>
+
+#define csrr(reg) ({ unsigned long __tmp; \
+  asm volatile ("csrr %0, " #reg : "=r"(__tmp)); \
+  __tmp; })
+
+#define csrw(reg, val) ({ \
+  if (__builtin_constant_p(val) && (unsigned long)(val) < 32) \
+	asm volatile ("csrw " #reg ", %0" :: "i"(val)); \
+  else \
+	asm volatile ("csrw " #reg ", %0" :: "r"(val)); })
+
+#define csrs(reg, bit) ({ \
+  if (__builtin_constant_p(bit) && (unsigned long)(bit) < 32) \
+	asm volatile ("csrrs x0, " #reg ", %0" :: "i"(bit)); \
+  else \
+	asm volatile ("csrrs x0, " #reg ", %0" :: "r"(bit)); })
+
+#define csrc(reg, bit) ({ \
+  if (__builtin_constant_p(bit) && (unsigned long)(bit) < 32) \
+	asm volatile ("csrrc x0, " #reg ", %0" :: "i"(bit)); \
+  else \
+	asm volatile ("csrrc x0, " #reg ", %0" :: "r"(bit)); })
+
+__attribute__((unused)) static void flush_cpu_icache(void) {
+    csrc(0x7c2, 0x33);
+    csrs(0x7c2, 0x11);
+};
+
+__attribute__((unused)) static void flush_cpu_dcache(void) {
+    csrc(0x7c2, 0x33);
+    csrs(0x7c2, 0x12);
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __SYSTEM_H */

--- a/litex/soc/software/libbase/isr.c
+++ b/litex/soc/software/libbase/isr.c
@@ -29,17 +29,22 @@ void isr(void)
     onetime++;
   }
 }
-#elif defined(__rocket__)
+#elif defined(__rocket__) || defined(__openc906__)
+#if defined(__openc906__)
+#define PLIC_EXT_IRQ_BASE 16
+#else
+#define PLIC_EXT_IRQ_BASE 1
+#endif
 void plic_init(void);
 void plic_init(void)
 {
 	int i;
 
-	// priorities for interrupt pins 1..8
-	for (i = 1; i <= 8; i++)
-		*((unsigned int *)PLIC_BASE + i) = 1;
-	// enable interrupt pins 1..8
-	*((unsigned int *)PLIC_ENABLED) = 0xff << 1;
+	// priorities for first 8 external interrupts
+	for (i = 0; i < 8; i++)
+		*((unsigned int *)PLIC_BASE + PLIC_EXT_IRQ_BASE + i) = 1;
+	// enable first 8 external interrupts
+	*((unsigned int *)PLIC_ENABLED) = 0xff << PLIC_EXT_IRQ_BASE;
 	// set priority threshold to 0 (any priority > 0 triggers interrupt)
 	*((unsigned int *)PLIC_THRSHLD) = 0;
 }
@@ -49,7 +54,7 @@ void isr(void)
 	unsigned int claim;
 
 	while ((claim = *((unsigned int *)PLIC_CLAIM))) {
-		switch (claim - 1) {
+		switch (claim - PLIC_EXT_IRQ_BASE) {
 		case UART_INTERRUPT:
 			uart_isr();
 			break;


### PR DESCRIPTION
It's only boot tested in sim and build tested in Vivado now, and it
requires a FPGA > 100k LUT4 (XC7A100T currently does not fit).

The ISR code is based on Rocket one.

These Python code depends on a forked version of OpenC906 at [1].

[1] https://github.com/Icenowy/openc906/tree/fpga-optimization

Signed-off-by: Icenowy Zheng <uwu@icenowy.me>