### PR TITLE
Misc fixes to Altera PLL support

### DIFF
--- a/litex/build/altera/quartus.py
+++ b/litex/build/altera/quartus.py
@@ -88,6 +88,9 @@ def _build_sdc(clocks, false_paths, vns, named_sc, build_name, additional_sdc_co
             tpl = "create_clock -name {clk} -period {period} [get_nets {{{clk}}}]"
             sdc.append(tpl.format(clk=vns.get_name(clk), period=str(period)))
 
+    # Enable automatical constraint generation for PLLs
+    sdc.append("derive_pll_clocks")
+
     # False path constraints
     for from_, to in sorted(false_paths, key=lambda x: (x[0].duid, x[1].duid)):
         tpl = "set_false_path -from [get_clocks {{{from_}}}] -to [get_clocks {{{to}}}]"

--- a/litex/soc/cores/clock/intel_common.py
+++ b/litex/soc/cores/clock/intel_common.py
@@ -79,7 +79,7 @@ class IntelClocking(Module, AutoCSR):
                             diff = abs(clk_freq - f)
                             if diff <= f*_m and diff < best_diff:
                                 config[f"clk{_n}_freq"]   = clk_freq
-                                config[f"clk{_n}_divide"] = c
+                                config[f"clk{_n}_divide"] = c * n
                                 config[f"clk{_n}_phase"]  = p
                                 clk_valid[_n] = True
                                 diff_ratios[_n] = diff / f


### PR DESCRIPTION
This PR contains two small fixes to Altera/Intel PLL support, one is fixing N multiplier is ignored when generating ALTPLL instance, another is adding `derive_pll_clocks` to SDC to allow PLLs to be analyzed by TimeQuest.