### PR TITLE
Gowin: Fix `copyfile` paths

### DIFF
--- a/litex/build/gowin/gowin.py
+++ b/litex/build/gowin/gowin.py
@@ -182,8 +182,8 @@ class GowinToolchain:
 
             # Copy Bitstream to from impl to gateware directory.
             copyfile(
-                os.path.join(build_dir, "impl", "pnr", "project.fs"),
-                os.path.join(build_dir, build_name + ".fs")
+                os.path.join("impl", "pnr", "project.fs"),
+                os.path.join(build_name + ".fs")
             )
 
         os.chdir(cwd)


### PR DESCRIPTION
When copying from `impl/pnr/project.fs`, we are _already_ in the `build` directory.

So including those path components in the `copyfile` function will point to nonexistent files. This PR fixes this.

I'm probably gonna keep this branch around locally and add a few quality of life fixes in addition to this PR.