### PR TITLE
bios/main: Wrap CONFIG_NO_BOOT around boot_sequence()

### DIFF
--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -49,6 +49,7 @@
 #include <liblitesdcard/sdcard.h>
 #include <liblitesata/sata.h>
 
+#ifndef CONFIG_BIOS_NO_BOOT
 static void boot_sequence(void)
 {
 #ifdef CSR_UART_BASE
@@ -75,6 +76,7 @@ static void boot_sequence(void)
 #endif
 	printf("No boot medium found\n");
 }
+#endif
 
 __attribute__((__used__)) int main(int i, char **c)
 {


### PR DESCRIPTION
This eliminates a "defined but unused" warning on the
`boot_sequence()` function if `main.c` is compiled with
`#define CONFIG_BIOS_NO_BOOT`