### PR TITLE
Do not call spisdcard_select for CMD0.

### DIFF
--- a/litex/soc/software/liblitesdcard/spisdcard.c
+++ b/litex/soc/software/liblitesdcard/spisdcard.c
@@ -173,7 +173,7 @@ static uint8_t spisdcardsend_cmd(uint8_t cmd, uint32_t arg)
     }
 
     /* Select the card and wait for it, except for CMD12: STOP_TRANSMISSION */
-    if (cmd != CMD12) {
+    if (cmd != CMD12 && cmd != CMD0) {
         spisdcard_deselect();
         if (spisdcard_select() == 0)
             return 0xff;


### PR DESCRIPTION
### Issue

The initialization of my 64GB SDXC card was failing/timing out at:

[if (spi_xfer(0xff) == 0xff)](https://github.com/enjoy-digital/litex/blob/87bd29fec2de3a2a825b242e7cbc69160c9bf5a6/litex/soc/software/liblitesdcard/spisdcard.c#L95)
```
  at spisdcard.c-->spisdcard_select()
  at spisdcard.c-->spisdcardsend_cmd(CMD0, 0)
  at spisdcard.c-->spisdcard_init()
  at spisdcard.c-->spisd_disk_initialize()
  at ff.c-->mount_volume()
  at ff.c-->f_mount()
  at boot.c-->sdcardboot_from_json()
```
The return value of spi_xfer(0xff) was always 0 instead of 0xff.

Reading this [SPISD introduction](http://elm-chan.org/docs/mmc/mmc_e.html) it seems that after setting CS High for >74 cycles a CMD0 needs to be submitted immediately after that. It is not mentioned that the card needs to be deselected and selected before doing so.

Therefore, I was able to fix the issue by skipping these functions for CMD0.

### Workaround
The BIOS failed to initialize the sdcard. However, I found out, that once I booted to linux-on-litex-vexriscv once via serialboot, I was able to boot from the sdcard from the bios. 
Therefore, I assumed that something is odd with the initialization procedure.

I am not sure whether this proposed fix has any unwanted sideeffects, since I am not a SPI nor MMC expert.

More background information on my spisdcardboot issues can be found here:
https://github.com/litex-hub/linux-on-litex-vexriscv/issues/287
