### PR TITLE
build/xilinx/ise: Fix yosys flow

### DIFF
--- a/litex/build/xilinx/ise.py
+++ b/litex/build/xilinx/ise.py
@@ -96,8 +96,8 @@ def _run_yosys(device, sources, vincpaths, build_name):
     else:
         raise OSError("Unsupported device")
 
-    ys_contents += """hierarchy -top top
-synth_xilinx -top top -family {family} -ise
+    ys_contents += """hierarchy -top {build_name}
+synth_xilinx -top {build_name} -family {family} -ise
 write_edif -pvector bra {build_name}.edif""".format(build_name=build_name, family=family)
 
     ys_name = build_name + ".ys"


### PR DESCRIPTION
The top name changed in 2016 but only XST was changed.