### PR TITLE
build/lattice/trellis: Add MCLK frequency option

### DIFF
--- a/litex/build/lattice/trellis.py
+++ b/litex/build/lattice/trellis.py
@@ -257,7 +257,7 @@ def trellis_argdict(args):
         "ignoreloops":  args.nextpnr_ignoreloops,
         "bootaddr":     args.ecppack_bootaddr,
         "spimode":      args.ecppack_spimode,
-        "freq":         float(args.ecppack_freq),
+        "freq":         float(args.ecppack_freq) if args.ecppack_freq is not None else None,
         "compress":     args.ecppack_compress,
         "seed":         args.nextpnr_seed,
     }


### PR DESCRIPTION
Add options for increasing the SPI config MCLK frequency for nextpnr_ecp5/trellis.

Because the frequencies are somewhat odd I've also added a basic assert that lists the valid options.