### PR TITLE
[cores/neorv32] add CPU cache and interrupt management functions

### DIFF
--- a/litex/soc/cores/cpu/neorv32/irq.h
+++ b/litex/soc/cores/cpu/neorv32/irq.h
@@ -1,4 +1,54 @@
 #ifndef __IRQ_H
 #define __IRQ_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline unsigned int irq_getie(void) {
+
+	unsigned int tmp;
+	asm volatile ("csrr %0, mstatus" : "=r"(tmp) : );
+
+  if (tmp & (1<<3)) { /* check mstatus.mie */
+    return 1;
+  }
+  else {
+    return 0;
+  }
+}
+
+static inline void irq_setie(unsigned int ie) {
+
+	if (ie) {
+    asm volatile ("csrrs zero, mstatus, 1<<3"); /* atomic set mstatus.mie */
+  }
+  else {
+    asm volatile ("csrrc zero, mstatus, 1<<3"); /* atomic clear mstatus.mie */
+  }
+}
+
+static inline unsigned int irq_getmask(void) {
+
+	unsigned int mask;
+	asm volatile ("csrr %0, mie" : "=r"(mask) : );
+	return mask;
+}
+
+static inline void irq_setmask(unsigned int mask) {
+
+	asm volatile ("csrw mie, %0" : : "r"(mask));
+}
+
+static inline unsigned int irq_pending(void) {
+
+	unsigned int pending;
+	asm volatile ("csrr %0, mip" : "=r"(pending) : );
+	return pending;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __IRQ_H */

--- a/litex/soc/cores/cpu/neorv32/system.h
+++ b/litex/soc/cores/cpu/neorv32/system.h
@@ -5,8 +5,16 @@
 extern "C" {
 #endif
 
-__attribute__((unused)) static void flush_cpu_icache(void){}; /* No instruction cache */
-__attribute__((unused)) static void flush_cpu_dcache(void){}; /* No instruction cache */
+__attribute__((unused)) static void flush_cpu_icache(void)
+{
+    asm volatile ("fence.i");
+}
+
+__attribute__((unused)) static void flush_cpu_dcache(void)
+{
+    asm volatile ("fence"); /* No data cache yet */
+}
+
 void flush_l2_cache(void);
 
 void busy_wait(unsigned int ms);


### PR DESCRIPTION
This PR add cache flush functions to `system.h` and interrupt management functions to `irq.h` (using same function names as [`litex/soc/cores/cpu/ibex`](https://github.com/enjoy-digital/litex/blob/master/litex/soc/cores/cpu/ibex/irq.h)).