### PR TITLE
sim/verilator: add an option to limit the number of compiler jobs

### DIFF
--- a/litex/build/sim/core/Makefile
+++ b/litex/build/sim/core/Makefile
@@ -52,7 +52,7 @@ sim: $(OBJS_SIM) | mkdir
 		$(INC_DIR) \
 		-Wno-BLKANDNBLK \
 		-Wno-WIDTH
-	make -j -C $(OBJ_DIR) -f Vsim.mk Vsim
+	make -j$(JOBS) -C $(OBJ_DIR) -f Vsim.mk Vsim
 
 .PHONY: modules
 modules:


### PR DESCRIPTION
Heavy simulations (CVA6 is one example) can spawn hundreds of compiler jobs, eat tens of GB of RAM and hang a usual computer. With the new flag forwarded to `make` one can limit the number of jobs and avoid the problem.
