### PR TITLE
sim: enable relative include paths for verilator

### DIFF
--- a/litex/build/sim/core/Makefile
+++ b/litex/build/sim/core/Makefile
@@ -51,7 +51,8 @@ sim: $(OBJS_SIM) | mkdir
 		--output-split-ctrace 500 \
 		$(INC_DIR) \
 		-Wno-BLKANDNBLK \
-		-Wno-WIDTH
+		-Wno-WIDTH \
+		--relative-includes
 	make -j$(JOBS) -C $(OBJ_DIR) -f Vsim.mk Vsim
 
 .PHONY: modules


### PR DESCRIPTION
This is required for example to simulate openc906 which uses verilog includes at relative paths with litex_sim.