### PR TITLE
tools/litex_json2renode: Add video_framebuffer support, vexriscv interrupt fixes

### DIFF
--- a/litex/tools/litex_json2renode.py
+++ b/litex/tools/litex_json2renode.py
@@ -667,6 +667,28 @@ def filter_memory_regions(raw_regions, alignment=None, autoalign=[]):
         yield r
 
 
+def find_memory_region(memory_regions, address):
+    """ Finds the memory region containing the specified address.
+
+        Args:
+            memory_regions (list): list of memory regions filtered
+                                   with filter_memory_regions
+            address (int): the address to find
+
+        Returns:
+            dict or None: the region from `memory_regions` that contains
+                          `address` or None if none of them do
+    """
+    for r in memory_regions:
+        base, size = r['base'], r['size']
+        end = base + size
+
+        if base <= address < end:
+            return r
+
+    return None
+
+
 def generate_resc(csr, args, flash_binaries={}, tftp_binaries={}):
     """ Generates platform definition.
 

--- a/litex/tools/litex_json2renode.py
+++ b/litex/tools/litex_json2renode.py
@@ -562,7 +562,10 @@ def generate_repl(csr, etherbone_peripherals, autoalign):
         x['name'] = m
         memories.append(x)
 
-    for mem_region in filter_memory_regions(memories, alignment=0x1000, autoalign=autoalign):
+    filtered_memories = list(filter_memory_regions(memories, alignment=0x1000, autoalign=autoalign))
+    csr['filtered_memories'] = filtered_memories # Save for use by peripheral generators
+
+    for mem_region in filtered_memories:
         result += generate_memory_region(mem_region)
 
     time_provider = None

--- a/litex/tools/litex_json2renode.py
+++ b/litex/tools/litex_json2renode.py
@@ -235,11 +235,6 @@ cpu: CPU.VexRiscv @ sysbus
     timeProvider: {}
 """.format(time_provider)
 
-        if kind == 'vexriscv_smp':
-            result += """
-    builtInIrqController: false
-"""
-
         return result
     elif kind == 'picorv32':
         return """

--- a/litex/tools/litex_json2renode.py
+++ b/litex/tools/litex_json2renode.py
@@ -166,7 +166,7 @@ was {} bytes.
 {}: Memory.MappedMemory @ {}
     size: {}
 """.format(region_descriptor['name'],
-           generate_sysbus_registration(region_descriptor, skip_size=True),
+           generate_sysbus_registration(region_descriptor, skip_size=True, skip_braces=True),
            hex(region_descriptor['size']))
 
     return result

--- a/litex/tools/litex_json2renode.py
+++ b/litex/tools/litex_json2renode.py
@@ -433,12 +433,12 @@ clint: IRQControllers.CoreLevelInterruptor @ {}
 
 
 def generate_plic(plic):
-    # TODO: this is configuration for VexRiscv - add support for other CPU types
+    # TODO: this is configuration for linux-on-litex-vexriscv - add support for other CPU types
     result = """
 plic: IRQControllers.PlatformLevelInterruptController @ {}
-    [0-3] -> cpu@[8-11]
+    [0, 1] -> cpu@[11, 9]
     numberOfSources: 31
-    numberOfTargets: 2
+    numberOfContexts: 2
     prioritiesEnabled: false
 """.format(generate_sysbus_registration(plic,
                                         skip_braces=True,

--- a/litex/tools/litex_json2renode.py
+++ b/litex/tools/litex_json2renode.py
@@ -186,7 +186,7 @@ def generate_silencer(csr, name, **kwargs):
     return """
 sysbus:
     init add:
-        SilenceRange <{} 0x200> # {}
+        SilenceRange <0x{:08x} 0x200> # {}
 """.format(csr['csr_bases'][name], name)
 
 


### PR DESCRIPTION
This PR adds support for generating the Renode `LiteX_Framebuffer_CSR32` peripheral based on the `video_framebuffer` node in csr.json. It also updates interrupt configuration to match changes in the `PlatformLevelInterruptController` peripheral and makes a few cosmetic improvements to the generated Renode platform file.