### PR TITLE
cores/cpu/vexriscv_smp: add default cores used by linux with l2 cache

### DIFF
--- a/litex/soc/cores/cpu/vexriscv_smp/core.py
+++ b/litex/soc/cores/cpu/vexriscv_smp/core.py
@@ -176,8 +176,12 @@ class VexRiscvSMP(CPU):
     @staticmethod
     def generate_default_configs():
         # Single cores.
-        for data_width in [16, 32, 64, 128]:
-            VexRiscvSMP.litedram_width = data_width
+        for data_width in [None, 16, 32, 64, 128]:
+            if data_width is None:
+                VexRiscvSMP.wishbone_memory = True
+            else:
+                VexRiscvSMP.wishbone_memory = False
+                VexRiscvSMP.litedram_width = data_width
             VexRiscvSMP.icache_width   = 32
             VexRiscvSMP.dcache_width   = 32
             VexRiscvSMP.coherent_dma   = False
@@ -204,8 +208,10 @@ class VexRiscvSMP(CPU):
             VexRiscvSMP.icache_size    = 8192
             VexRiscvSMP.dcache_ways    = 2
             VexRiscvSMP.icache_ways    = 2
-            VexRiscvSMP.icache_width   = 32 if data_width < 64 else 64
-            VexRiscvSMP.dcache_width   = 32 if data_width < 64 else 64
+            VexRiscvSMP.icache_width   = 32 if data_width is None \
+                                              or data_width < 64 else 64
+            VexRiscvSMP.dcache_width   = 32 if data_width is None \
+                                              or data_width < 64 else 64
 
             # Without DMA.
             VexRiscvSMP.coherent_dma = False


### PR DESCRIPTION
This prevents needing to install `sbt` etc. for the demos in linux-on-litex-vexriscv which use the Wishbone interface and the L2 cache.