### PR TITLE
build/sim/verilator: fixed missing placeholder

### DIFF
--- a/litex/build/sim/verilator.py
+++ b/litex/build/sim/verilator.py
@@ -137,7 +137,7 @@ def _build_sim(build_name, sources, jobs, threads, coverage, opt_level="O3", tra
         cc_srcs.append("--cc " + filename + " ")
     build_script_contents = """\
 rm -rf obj_dir/
-make -C . -f {} {} {} {} {} {}
+make -C . -f {} {} {} {} {} {} {}
 """.format(makefile,
     "CC_SRCS=\"{}\"".format("".join(cc_srcs)),
     "JOBS={}".format(jobs) if jobs else "",


### PR DESCRIPTION
Fst tracing stopped working since: https://github.com/enjoy-digital/litex/pull/1381 
It added a new variable but missed to add an extra placeholder on the formatted string.