### PR TITLE
cores/cpu/vexriscv_smp: define SYNTHESIS in Quartus

### DIFF
--- a/litex/soc/cores/cpu/vexriscv_smp/core.py
+++ b/litex/soc/cores/cpu/vexriscv_smp/core.py
@@ -369,6 +369,10 @@ class VexRiscvSMP(CPU):
         from litex.build.altera import AlteraPlatform
         if isinstance(platform, AlteraPlatform):
             ram_filename = "Ram_1w_1rs_Intel.v"
+            # define SYNTHESIS verilog name to avoid issues with unsupported
+            # functions
+            platform.toolchain.additional_qsf_commands.append(
+                'set_global_assignment -name VERILOG_MACRO "SYNTHESIS=1"')
         # On Efinix platforms, use specific implementation.
         from litex.build.efinix import EfinixPlatform
         if isinstance(platform, EfinixPlatform):


### PR DESCRIPTION
This fixes issues along the lines of `Verilog HDL Unsupported Feature error at ***.v(14192): system function "$urandom" is not supported for synthesis`.

I tested that this issue is fixed on with Quartus 20.1.1 building the `de10nano` example of `linux_on_litex_vexriscv`. I also checked that Vivado 2020.1 building `arty_a7` and Yosys 0.16 building `butterstick` don't need a similar fix. I also tested that the regular `vexriscv` CPU doesn't seem to need a similar fix.

This partially addresses https://github.com/litex-hub/linux-on-litex-vexriscv/issues/295