### PR TITLE
quartus warnings pll instantiation.

### DIFF
--- a/litex/soc/cores/clock/intel_common.py
+++ b/litex/soc/cores/clock/intel_common.py
@@ -28,7 +28,7 @@ def geometric_mean(vals):
 class IntelClocking(Module, AutoCSR):
     def __init__(self, vco_margin=0):
         self.vco_margin = vco_margin
-        self.pll_reset  = Signal()
+        self.reset  = Signal()
         self.locked     = Signal()
         self.clkin_freq = None
         self.vcxo_freq  = None
@@ -108,7 +108,7 @@ class IntelClocking(Module, AutoCSR):
             p_OPERATION_MODE         = "NORMAL",
             i_INCLK                  = Cat(self.clkin, 0),
             o_CLK                    = clks,
-            i_ARESET                 = self.pll_reset,
+            i_ARESET                 = self.reset,
             i_CLKENA                 = 2**self.nclkouts_max - 1,
             i_EXTCLKENA              = 0xf,
             i_FBIN                   = 1,

--- a/litex/soc/cores/clock/intel_cyclone4.py
+++ b/litex/soc/cores/clock/intel_cyclone4.py
@@ -12,7 +12,7 @@ from litex.soc.cores.clock.intel_common import *
 # Intel / CycloneIV -------------------------------------------------------------------------------
 
 class CycloneIVPLL(IntelClocking):
-    nclkouts_max   = 5
+    nclkouts_max   = 6
     n_div_range    = (1, 512+1)
     m_div_range    = (1, 512+1)
     c_div_range    = (1, 512+1)

--- a/litex/soc/cores/cpu/vexriscv/core.py
+++ b/litex/soc/cores/cpu/vexriscv/core.py
@@ -125,7 +125,7 @@ class VexRiscv(CPU, AutoCSR):
         flags += " -D__vexriscv__"
         return flags
 
-    def __init__(self, platform, variant="standard", with_timer=False):
+    def __init__(self, platform, variant="standard", with_timer=False, **kwargs):
         self.platform         = platform
         self.variant          = variant
         self.human_name       = CPU_VARIANTS.get(variant, "VexRiscv")
@@ -136,6 +136,9 @@ class VexRiscv(CPU, AutoCSR):
         self.dbus             = dbus = wishbone.Interface()
         self.periph_buses     = [ibus, dbus] # Peripheral buses (Connected to main SoC's bus).
         self.memory_buses     = []           # Memory buses (Connected directly to LiteDRAM).
+
+        ### naming scheme
+        self.postfix = kwargs.pop("postfix", "")
 
         # # #
 
@@ -362,6 +365,6 @@ class VexRiscv(CPU, AutoCSR):
         assert hasattr(self, "reset_address")
         if not self.external_variant:
             self.add_sources(self.platform, self.variant)
-        self.specials += Instance("VexRiscv", **self.cpu_params)
+        self.specials += Instance("VexRiscv"+self.postfix, **self.cpu_params)
         if hasattr(self, "cfu_params"):
             self.specials += Instance("Cfu", **self.cfu_params)

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1290,7 +1290,7 @@ class LiteXSoC(SoC):
         setattr(self.submodules, name, Identifier(identifier))
 
     # Add UART -------------------------------------------------------------------------------------
-    def add_uart(self, name="uart", uart_name="serial", baudrate=115200, fifo_depth=16):
+    def add_uart(self, name="uart", uart_name="serial", baudrate=115200, fifo_depth=16, uart_pads_name="serial"):
         # Imports.
         from litex.soc.cores.uart import UART, UARTCrossover
 
@@ -1307,7 +1307,7 @@ class LiteXSoC(SoC):
             "usb_acm",
             "serial(x)",
         ]
-        uart_pads_name = "serial" if uart_name == "sim" else uart_name
+        uart_pads_name = "serial" if uart_name == "sim" else uart_pads_name
         uart_pads      = self.platform.request(uart_pads_name, loose=True)
         uart_phy       = None
         uart           = None

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -954,7 +954,7 @@ class SoC(Module):
         self.add_config("CSR_DATA_WIDTH", self.csr.data_width)
         self.add_config("CSR_ALIGNMENT",  self.csr.alignment)
 
-    def add_cpu(self, name="vexriscv", variant="standard", reset_address=None, cfu=None):
+    def add_cpu(self, name="vexriscv", variant="standard", reset_address=None, cfu=None, postfix=""):
         # Check that CPU is supported.
         if name not in cpu.CPUS.keys():
             supported_cpus = []
@@ -978,7 +978,7 @@ class SoC(Module):
                 colorer("\n - ".join(sorted(cpu_cls.variants)))))
             raise SoCError()
         self.check_if_exists("cpu")
-        self.submodules.cpu = cpu_cls(self.platform, variant)
+        self.submodules.cpu = cpu_cls(self.platform, variant, postfix)
         self.logger.info("CPU {} {}.".format(
             colorer(name, color="underline"),
             colorer("added", color="green")))

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -192,7 +192,8 @@ class SoCCore(LiteXSoC):
             name          = str(cpu_type),
             variant       = "standard" if cpu_variant is None else cpu_variant,
             reset_address = None if integrated_rom_size else cpu_reset_address,
-            cfu           = cpu_cfu)
+            cfu           = cpu_cfu,
+            postfix       = postfix)
 
         # Add User's interrupts
         if self.irq.enabled:

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -144,6 +144,9 @@ class SoCCore(LiteXSoC):
         self.mem_map     = self.mem_map
         self.config      = {}
 
+        # naming scheme
+        postfix = kwargs.get("postfix", "")
+
         # Parameters management --------------------------------------------------------------------
 
         # CPU.
@@ -226,7 +229,10 @@ class SoCCore(LiteXSoC):
 
         # Add UART
         if with_uart:
-            self.add_uart(name="uart", uart_name=uart_name, baudrate=uart_baudrate, fifo_depth=uart_fifo_depth)
+            self.add_uart(name="uart", uart_name=uart_name, 
+                          baudrate=uart_baudrate, fifo_depth=uart_fifo_depth,
+                          uart_pads_name = uart_name + postfix)
+
 
         # Add Timer
         if with_timer:


### PR DESCRIPTION
fixed quartus warnings using cyclone4 pll, 
and using reset signal pll_reset for clarity, the reset seemed not to be connected anyway in the original code. 

Rather using a dedicated name for the reset looks to create less confusion according to me. 