### PR TITLE
integration/builder: Make bios console configurable + add no console option

### DIFF
--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -163,7 +163,7 @@ class Builder:
         # Define Compile/BIOS Options.
         define("LTO", f"{self.lto:d}")
         for bios_option in self.bios_options:
-            assert bios_option in ["TERM_NO_HIST", "TERM_MINI", "TERM_NO_COMPLETE"]
+            assert bios_option in ["TERM_NO_HIST", "TERM_MINI", "TERM_NO_COMPLETE", "NO_TERM"]
             define(bios_option, "1")
 
         return "\n".join(variables_contents)
@@ -397,7 +397,7 @@ def builder_args(parser):
     builder_group.add_argument("--no-compile-software", action="store_true", help="Disable Software compilation only.")
     builder_group.add_argument("--no-compile-gateware", action="store_true", help="Disable Gateware compilation only.")
     builder_group.add_argument("--lto",                 action="store_true", help="Enable LTO (Link Time Optimization) for Software compilation.")
-    builder_group.add_argument("--bios-console",        default=[],          help="Select bios options.", choices=["TERM_NO_HIST", "TERM_MINI", "TERM_NO_COMPLETE"], nargs=1)
+    builder_group.add_argument("--bios-console",        default=[],          help="Select bios options.", choices=["TERM_NO_HIST", "TERM_MINI", "TERM_NO_COMPLETE", "NO_TERM"], nargs=1)
     builder_group.add_argument("--csr-csv",             default=None,        help="Write SoC mapping to the specified CSV file.")
     builder_group.add_argument("--csr-json",            default=None,        help="Write SoC mapping to the specified JSON file.")
     builder_group.add_argument("--csr-svd",             default=None,        help="Write SoC mapping to the specified SVD file.")

--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -117,7 +117,6 @@ class Builder:
         # List software packages and libraries.
         self.software_packages  = []
         self.software_libraries = []
-
         for name in soc_software_packages:
             self.add_software_package(name)
             self.add_software_library(name)
@@ -398,6 +397,7 @@ def builder_args(parser):
     builder_group.add_argument("--no-compile-software", action="store_true", help="Disable Software compilation only.")
     builder_group.add_argument("--no-compile-gateware", action="store_true", help="Disable Gateware compilation only.")
     builder_group.add_argument("--lto",                 action="store_true", help="Enable LTO (Link Time Optimization) for Software compilation.")
+    builder_group.add_argument("--bios-console",        default=[],          help="Select bios options.", choices=["TERM_NO_HIST", "TERM_MINI", "TERM_NO_COMPLETE"], nargs=1)
     builder_group.add_argument("--csr-csv",             default=None,        help="Write SoC mapping to the specified CSV file.")
     builder_group.add_argument("--csr-json",            default=None,        help="Write SoC mapping to the specified JSON file.")
     builder_group.add_argument("--csr-svd",             default=None,        help="Write SoC mapping to the specified SVD file.")
@@ -415,6 +415,7 @@ def builder_argdict(args):
         "compile_software" : (not args.no_compile) and (not args.no_compile_software),
         "compile_gateware" : (not args.no_compile) and (not args.no_compile_gateware),
         "lto"              : args.lto,
+        "bios_options"     : args.bios_console,
         "csr_csv"          : args.csr_csv,
         "csr_json"         : args.csr_json,
         "csr_svd"          : args.csr_svd,

--- a/litex/soc/software/bios/Makefile
+++ b/litex/soc/software/bios/Makefile
@@ -31,6 +31,10 @@ ifdef TERM_NO_HIST
 CFLAGS += -DTERM_NO_HIST
 endif
 
+ifdef NO_TERM
+CFLAGS += -DNO_TERM
+endif
+
 ifdef TERM_MINI
 CFLAGS += -DTERM_MINI
 OBJECTS += readline_simple.o

--- a/litex/soc/software/bios/command.h
+++ b/litex/soc/software/bios/command.h
@@ -32,17 +32,20 @@ struct command_struct {
 extern struct command_struct *const __bios_cmd_start[];
 extern struct command_struct *const __bios_cmd_end[];
 
-#define define_command(cmd_name, handler, help_txt, group_id) \
-	struct command_struct s_##cmd_name = {					     \
-		.func = (cmd_handler)handler,					     \
-		.name = #cmd_name,						     \
-		.help = help_txt,						     \
-		.group = group_id,						     \
-	};									     \
-	const struct command_struct *__bios_cmd_##cmd_name __attribute__((__used__)) \
-	__attribute__((__section__(".bios_cmd"))) = &s_##cmd_name
+#ifdef NO_TERM
+	#define define_command(cmd_name, handler, help_txt, group_id)
+#else
+	#define define_command(cmd_name, handler, help_txt, group_id) \
+		struct command_struct s_##cmd_name = {					     \
+			.func = (cmd_handler)handler,					     \
+			.name = #cmd_name,						     \
+			.help = help_txt,						     \
+			.group = group_id,						     \
+		};									     \
+		const struct command_struct *__bios_cmd_##cmd_name __attribute__((__used__)) \
+		__attribute__((__section__(".bios_cmd"))) = &s_##cmd_name
 
+	struct command_struct *command_dispatcher(char *command, int nb_params, char **params);
 
-struct command_struct *command_dispatcher(char *command, int nb_params, char **params);
-
+	#endif
 #endif

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -80,11 +80,13 @@ static void boot_sequence(void)
 
 __attribute__((__used__)) int main(int i, char **c)
 {
+#ifndef NO_TERM
 	char buffer[CMD_LINE_BUFFER_SIZE];
 	char *params[MAX_PARAM];
 	char *command;
 	struct command_struct *cmd;
 	int nb_params;
+#endif
 	int sdr_ok;
 
 #ifdef CONFIG_CPU_HAS_INTERRUPT
@@ -206,6 +208,9 @@ __attribute__((__used__)) int main(int i, char **c)
 	}
 #endif
 
+#ifdef NO_TERM
+	printf("--============= \e[1mBuild without Console!\e[0m ================--\n");
+#else
 	/* Console */
 	printf("--============= \e[1mConsole\e[0m ================--\n");
 #if !defined(TERM_MINI) && !defined(TERM_NO_HIST)
@@ -223,5 +228,6 @@ __attribute__((__used__)) int main(int i, char **c)
 		}
 		printf("\n%s", PROMPT);
 	}
+#endif
 	return 0;
 }


### PR DESCRIPTION
The first commit adds the bios-console option to the argparser of the builder.
I decided to call it bios-console in the hope that more options can be added to the argparser in the future. Different bios options could get their own argument with a specific help text and finally be merged into the bios_options list (in the builder_argdict function).

The second commit adds the option to remove the cmd handlers together with the serial parsing code.
If this option is selected, the target system can still be booted using the boot_sequence methods, but the user cannot interact with the bios if this fails.

All options were tested with litex_sim:
**no option:**
ROM usage: 22.91KiB     (17.90%)
RAM usage: 1.61KiB      (20.12%)
**no option + lto:**
ROM usage: 20.45KiB     (15.97%)
RAM usage: 1.60KiB      (20.02%)
**TERM_NO_HIST:**
ROM usage: 22.35KiB     (17.46%)
RAM usage: 0.97KiB      (12.11%)
**TERM_NO_HIST + lto:**
ROM usage: 19.91KiB     (15.56%)
RAM usage: 0.96KiB      (12.01%)
**TERM_NO_COMPLETE:**
ROM usage: 21.61KiB     (16.88%)
RAM usage: 0.91KiB      (11.43%)
**TERM_NO_COMPLETE + lto:**
ROM usage: 19.29KiB     (15.07%)
RAM usage: 0.91KiB      (11.43%)
**TERM_MINI:**
ROM usage: 19.59KiB     (15.31%)
RAM usage: 0.27KiB      (3.42%)
**TERM_MINI + lto:**
ROM usage: 17.34KiB     (13.54%)
RAM usage: 0.27KiB      (3.42%)
**NO_TERM:**
ROM usage: 11.33KiB     (8.85%)
RAM usage: 0.27KiB      (3.32%)
**NO_TERM + lto**
ROM usage: 9.07KiB      (7.09%)
RAM usage: 0.27KiB      (3.32%)