### PR TITLE
Improve connectors

### DIFF
--- a/litex/build/generic_platform.py
+++ b/litex/build/generic_platform.py
@@ -132,6 +132,12 @@ def _resource_type(resource):
 class ConnectorManager:
     def __init__(self, connectors):
         self.connector_table = dict()
+        self.add_connector(connectors)
+
+    def add_connector(self, connectors):
+        if isinstance(connectors, tuple):
+            connectors = [connectors]
+
         for connector in connectors:
             cit       = iter(connector)
             conn_name = next(cit)
@@ -192,6 +198,9 @@ class ConstraintManager:
 
     def add_extension(self, io):
         self.available.extend(io)
+
+    def add_connector(self, connectors):
+        self.connector_manager.add_connector(connectors)
 
     def request(self, name, number=None, loose=False):
         resource = _lookup(self.available, name, number, loose)
@@ -355,6 +364,9 @@ class GenericPlatform:
 
     def add_extension(self, *args, **kwargs):
         return self.constraint_manager.add_extension(*args, **kwargs)
+
+    def add_connector(self, *args, **kwargs):
+        self.constraint_manager.add_connector(*args, **kwargs)
 
     def finalize(self, fragment, *args, **kwargs):
         if self.finalized:

--- a/litex/build/generic_platform.py
+++ b/litex/build/generic_platform.py
@@ -168,7 +168,10 @@ class ConnectorManager:
                 if pn.isdigit():
                     pn = int(pn)
 
-                r.append(self.connector_table[conn][pn])
+                conn_pn = self.connector_table[conn][pn]
+                if ":" in conn_pn:
+                    conn_pn = self.resolve_identifiers([conn_pn])[0]
+                r.append(conn_pn)
             else:
                 r.append(identifier)
 


### PR DESCRIPTION
This PR try to provides a solution to comments in [PR](https://github.com/litex-hub/litex-boards/pull/418).
- the first commit add a serie of method, similar to `add_extension`, to allows extending connectors dictionary dinamicaly
- second commit add, when a connector reference another connector, a recursive way to retrieve pin name.