### PR TITLE
Improve DMA

### DIFF
--- a/litex/soc/cores/dma.py
+++ b/litex/soc/cores/dma.py
@@ -187,7 +187,7 @@ class WishboneDMAWriter(Module, AutoCSR):
         )
         fsm.act("RUN",
             self._sink.valid.eq(self.sink.valid),
-            self._sink.last.eq(offset == (length - 1)),
+            self._sink.last.eq(self.sink.last | (offset + 1 == length)),
             self._sink.address.eq(base + offset),
             self._sink.data.eq(self.sink.data),
             self.sink.ready.eq(self._sink.ready),

--- a/litex/soc/cores/dma.py
+++ b/litex/soc/cores/dma.py
@@ -182,7 +182,6 @@ class WishboneDMAWriter(Module, AutoCSR):
         self.submodules += fsm
         self.comb += fsm.reset.eq(~self._enable.storage)
         fsm.act("IDLE",
-            self.sink.ready.eq(1),
             NextValue(offset, 0),
             NextState("RUN"),
         )


### PR DESCRIPTION
I'd like to use the `WishboneDMAWriter` to receive packets from a stream, and this PR addresses two issues I were having:

The first is that originally `sink.ready` were set while idle, effectively blackholing data until the DMA is enabled. I think in general it's more reasonable to apply backpressure until DMA is enabled, so I changed this.

The second is that I've got a packetized stream and would like to preserve the packet boundaries, so I added the ability to stop early when the `last` flag is set. For applications where this behavior is not desired, the `last` flag can be stripped from the stream before passing it to `WishboneDMAWriter`.