### PR TITLE
Increase JTAG UART upload speed

### DIFF
--- a/litex/build/openocd.py
+++ b/litex/build/openocd.py
@@ -139,12 +139,8 @@ proc jtagstream_drain {tap tx chunk_rx max_rx} {
 
 proc jtagstream_rxtx {tap client is_poll} {
     if {![$client eof]} {
-        if {!$is_poll} {
-            set tx [$client read 1]
-        } else {
-            set tx ""
-        }
-        set rx [jtagstream_drain $tap $tx 64 4096]
+        set tx [$client read 512]
+        set rx [jtagstream_drain $tap $tx 512 4096]
         if {[string length $rx]} {
             #echo [string length $rx]
             $client puts -nonewline $rx
@@ -162,6 +158,7 @@ proc jtagstream_rxtx {tap client is_poll} {
 proc jtagstream_client {tap sock} {
     set client [$sock accept]
     fconfigure $client -buffering none
+    fconfigure $client -blocking 0
     $client readable [list jtagstream_rxtx $tap $client 0]
     $client onexception [list $client close]
     after 1 [list jtagstream_rxtx $tap $client 1]


### PR DESCRIPTION
This patch increases the JTAG UART upload speed by switching to nonblocking read mode in the OpenOCD Tcl script, then reading and writing up to 512 byte blocks instead of 1 byte at a time.

On my setup, this increases the LiteX terminal upload speed from 74 bytes per second (assuming I patch out the BIOS's command timeout so uploads are even possible) to about 18.3KB/s. As a quick measure of download speed, the FPS of the donut demo has increased by ~50% as well.

It's not clear to me why blocking mode was used before. I would suggest testing other setups to make sure there aren't any regressions in other scenarios.

My setup:
* Ubuntu 18.04
* OpenOCD 0.11.0
* Altera USB Blaster (not the II)
* Cyclone V
* 75MHz VexRiscv SoC