### PR TITLE
demo: fix minor build issues

### DIFF
--- a/litex/soc/software/demo/demo.py
+++ b/litex/soc/software/demo/demo.py
@@ -7,6 +7,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import os
+import sys
 import argparse
 
 from litex.build.tools import replace_in_file
@@ -23,6 +24,7 @@ def main():
 
     # Copy contents to demo directory
     os.system(f"cp {os.path.abspath(os.path.dirname(__file__))}/* demo")
+    os.system("chmod -R u+w demo")
 
     # Update memory region.
     replace_in_file("demo/linker.ld", "main_ram", args.mem)
@@ -35,7 +37,7 @@ def main():
     os.system("cp demo/demo.bin ./")
 
     # Prepare flash boot image.
-    os.system("python3 -m litex.soc.software.crcfbigen demo.bin -o demo.fbi --fbi --little") # FIXME: Endianness.
+    os.system(f"{sys.executable or 'python3'} -m litex.soc.software.crcfbigen demo.bin -o demo.fbi --fbi --little") # FIXME: Endianness.
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Fixes a couple minor issues with the bare metal software demo encountered under Nix.

1. Programs are stored without write permissions. The demo data copied to the build directory is made writable after the copy so the linker script can be modified and it can be built.

2. The Python executable is a wrapper which also sets up library paths and so forth. The current Python executable is reused to generate the final output binary instead of whichever Python `python3` is to ensure the version of LiteX used is consistent.