### PR TITLE
yosys_nextpnr_toolchain: add flow3 option to abc9 mode

### DIFF
--- a/litex/build/lattice/oxide.py
+++ b/litex/build/lattice/oxide.py
@@ -65,6 +65,7 @@ def oxide_args(parser):
     toolchain_group = parser.add_argument_group(title="Toolchain options")
     toolchain_group.add_argument("--yosys-nowidelut",      action="store_true", help="Use Yosys's nowidelut mode.")
     toolchain_group.add_argument("--yosys-abc9",           action="store_true", help="Use Yosys's abc9 mode.")
+    toolchain_group.add_argument("--yosys-flow3",          action="store_true", help="Use Yosys's abc9 mode with the flow3 script.")
     toolchain_group.add_argument("--nextpnr-timingstrict", action="store_true", help="Use strict Timing mode (Build will fail when Timings are not met).")
     toolchain_group.add_argument("--nextpnr-ignoreloops",  action="store_true", help="Ignore combinatorial loops in Timing Analysis.")
     toolchain_group.add_argument("--nextpnr-seed",         default=1, type=int, help="Set Nextpnr's seed.")
@@ -74,6 +75,7 @@ def oxide_argdict(args):
     return {
         "nowidelut":    args.yosys_nowidelut,
         "abc9":         args.yosys_abc9,
+        "flow3":        args.yosys_flow3,
         "timingstrict": args.nextpnr_timingstrict,
         "ignoreloops":  args.nextpnr_ignoreloops,
         "seed":         args.nextpnr_seed,

--- a/litex/build/lattice/trellis.py
+++ b/litex/build/lattice/trellis.py
@@ -153,6 +153,7 @@ def trellis_args(parser):
     toolchain_group = parser.add_argument_group(title="Toolchain options")
     toolchain_group.add_argument("--yosys-nowidelut",      action="store_true", help="Use Yosys's nowidelut mode.")
     toolchain_group.add_argument("--yosys-abc9",           action="store_true", help="Use Yosys's abc9 mode.")
+    toolchain_group.add_argument("--yosys-flow3",          action="store_true", help="Use Yosys's abc9 mode with the flow3 script.")
     toolchain_group.add_argument("--nextpnr-timingstrict", action="store_true", help="Use strict Timing mode (Build will fail when Timings are not met).")
     toolchain_group.add_argument("--nextpnr-ignoreloops",  action="store_true", help="Ignore combinatorial loops in Timing Analysis.")
     toolchain_group.add_argument("--nextpnr-seed",         default=1, type=int, help="Set Nextpnr's seed.")
@@ -165,6 +166,7 @@ def trellis_argdict(args):
     return {
         "nowidelut":    args.yosys_nowidelut,
         "abc9":         args.yosys_abc9,
+        "flow3":        args.yosys_flow3,
         "timingstrict": args.nextpnr_timingstrict,
         "ignoreloops":  args.nextpnr_ignoreloops,
         "bootaddr":     args.ecppack_bootaddr,

--- a/litex/build/yosys_nextpnr_toolchain.py
+++ b/litex/build/yosys_nextpnr_toolchain.py
@@ -86,6 +86,7 @@ class YosysNextPNRToolchain(GenericToolchain):
     def build(self, platform, fragment,
         nowidelut    = False,
         abc9         = False,
+        flow3        = False,
         timingstrict = False,
         ignoreloops  = False,
         seed         = 1,
@@ -100,6 +101,8 @@ class YosysNextPNRToolchain(GenericToolchain):
             than native for the target (Yosys)
         abc9 : str
             use new ABC9 flow (Yosys)
+        flow3 : str
+            use ABC9 with flow3 (Yosys)
         timingstrict : list
             check timing failures (nextpnr)
         ignoreloops : str
@@ -110,6 +113,9 @@ class YosysNextPNRToolchain(GenericToolchain):
 
         self._nowidelut   = nowidelut
         self._abc9        = abc9 
+        if flow3:
+            self._abc9 = True
+            self._yosys_cmds.append("scratchpad -copy abc9.script.flow3 abc9.script")
         self.timingstrict = timingstrict
         self.ignoreloops  = ignoreloops
         self.seed         = seed


### PR DESCRIPTION
Add "flow3" option to abc9 mode. This runs FPGA mapping several times, producing a generally better mapping at the cost of increased runtime (see https://github.com/Ravenslofty/yosys-cookbook/blob/master/ecp5.md).

Also, add a "--yosys-flow3" build option to both "trellis" and "oxide".

Signed-off-by: Gabriel Somlo <gsomlo@gmail.com>