### PR TITLE
build/yosys,nextpnr, lattice: refactor args

### DIFF
--- a/litex/build/lattice/icestorm.py
+++ b/litex/build/lattice/icestorm.py
@@ -17,7 +17,7 @@ from migen.fhdl.structure import _Fragment
 from litex.build.generic_platform import *
 from litex.build import tools
 from litex.build.lattice import common
-from litex.build.yosys_nextpnr_toolchain import YosysNextPNRToolchain
+from litex.build.yosys_nextpnr_toolchain import YosysNextPNRToolchain, yosys_nextpnr_args, yosys_nextpnr_argdict
 
 # LatticeIceStormToolchain -------------------------------------------------------------------------
 
@@ -107,13 +107,9 @@ class LatticeIceStormToolchain(YosysNextPNRToolchain):
 
 def icestorm_args(parser):
     toolchain_group = parser.add_argument_group(title="Toolchain options")
-    toolchain_group.add_argument("--nextpnr-timingstrict", action="store_true", help="Make the build fail when Timing is not met.")
-    toolchain_group.add_argument("--nextpnr-ignoreloops",  action="store_true", help="Use strict Timing mode (Build will fail when Timings are not met).")
-    toolchain_group.add_argument("--nextpnr-seed",         default=1, type=int, help="Set Nextpnr's seed.")
+    yosys_nextpnr_args(toolchain_group)
 
 def icestorm_argdict(args):
     return {
-        "timingstrict": args.nextpnr_timingstrict,
-        "ignoreloops":  args.nextpnr_ignoreloops,
-        "seed":         args.nextpnr_seed,
+        **yosys_nextpnr_argdict(args),
     }

--- a/litex/build/lattice/oxide.py
+++ b/litex/build/lattice/oxide.py
@@ -17,7 +17,7 @@ from litex.build.generic_platform import *
 from litex.build import tools
 from litex.build.lattice import common
 from litex.build.lattice.radiant import _format_constraint, _format_ldc, _build_pdc
-from litex.build.yosys_nextpnr_toolchain import YosysNextPNRToolchain
+from litex.build.yosys_nextpnr_toolchain import YosysNextPNRToolchain, yosys_nextpnr_args, yosys_nextpnr_argdict
 
 import math
 
@@ -63,21 +63,11 @@ class LatticeOxideToolchain(YosysNextPNRToolchain):
 
 def oxide_args(parser):
     toolchain_group = parser.add_argument_group(title="Toolchain options")
-    toolchain_group.add_argument("--yosys-nowidelut",      action="store_true", help="Use Yosys's nowidelut mode.")
-    toolchain_group.add_argument("--yosys-abc9",           action="store_true", help="Use Yosys's abc9 mode.")
-    toolchain_group.add_argument("--yosys-flow3",          action="store_true", help="Use Yosys's abc9 mode with the flow3 script.")
-    toolchain_group.add_argument("--nextpnr-timingstrict", action="store_true", help="Use strict Timing mode (Build will fail when Timings are not met).")
-    toolchain_group.add_argument("--nextpnr-ignoreloops",  action="store_true", help="Ignore combinatorial loops in Timing Analysis.")
-    toolchain_group.add_argument("--nextpnr-seed",         default=1, type=int, help="Set Nextpnr's seed.")
-    toolchain_group.add_argument("--nexus-es-device",      action="store_true", help="Use Nexus-ES1 part.")
+    yosys_nextpnr_args(toolchain_group)
+    toolchain_group.add_argument("--nexus-es-device", action="store_true", help="Use Nexus-ES1 part.")
 
 def oxide_argdict(args):
     return {
-        "nowidelut":    args.yosys_nowidelut,
-        "abc9":         args.yosys_abc9,
-        "flow3":        args.yosys_flow3,
-        "timingstrict": args.nextpnr_timingstrict,
-        "ignoreloops":  args.nextpnr_ignoreloops,
-        "seed":         args.nextpnr_seed,
+        **yosys_nextpnr_argdict(args),
         "es_device":    args.nexus_es_device,
     }

--- a/litex/build/lattice/trellis.py
+++ b/litex/build/lattice/trellis.py
@@ -17,7 +17,7 @@ from migen.fhdl.structure import _Fragment
 from litex.build.generic_platform import *
 from litex.build import tools
 from litex.build.lattice import common
-from litex.build.yosys_nextpnr_toolchain import YosysNextPNRToolchain
+from litex.build.yosys_nextpnr_toolchain import YosysNextPNRToolchain, yosys_nextpnr_args, yosys_nextpnr_argdict
 
 # LatticeTrellisToolchain --------------------------------------------------------------------------
 
@@ -151,12 +151,7 @@ class LatticeTrellisToolchain(YosysNextPNRToolchain):
 
 def trellis_args(parser):
     toolchain_group = parser.add_argument_group(title="Toolchain options")
-    toolchain_group.add_argument("--yosys-nowidelut",      action="store_true", help="Use Yosys's nowidelut mode.")
-    toolchain_group.add_argument("--yosys-abc9",           action="store_true", help="Use Yosys's abc9 mode.")
-    toolchain_group.add_argument("--yosys-flow3",          action="store_true", help="Use Yosys's abc9 mode with the flow3 script.")
-    toolchain_group.add_argument("--nextpnr-timingstrict", action="store_true", help="Use strict Timing mode (Build will fail when Timings are not met).")
-    toolchain_group.add_argument("--nextpnr-ignoreloops",  action="store_true", help="Ignore combinatorial loops in Timing Analysis.")
-    toolchain_group.add_argument("--nextpnr-seed",         default=1, type=int, help="Set Nextpnr's seed.")
+    yosys_nextpnr_args(toolchain_group)
     toolchain_group.add_argument("--ecppack-bootaddr",     default=0,           help="Set boot address for next image.")
     toolchain_group.add_argument("--ecppack-spimode",      default=None,        help="Set slave SPI programming mode.")
     toolchain_group.add_argument("--ecppack-freq",         default=None,        help="Set SPI MCLK frequency.")
@@ -164,14 +159,9 @@ def trellis_args(parser):
 
 def trellis_argdict(args):
     return {
-        "nowidelut":    args.yosys_nowidelut,
-        "abc9":         args.yosys_abc9,
-        "flow3":        args.yosys_flow3,
-        "timingstrict": args.nextpnr_timingstrict,
-        "ignoreloops":  args.nextpnr_ignoreloops,
+        **yosys_nextpnr_argdict(args),
         "bootaddr":     args.ecppack_bootaddr,
         "spimode":      args.ecppack_spimode,
         "freq":         float(args.ecppack_freq) if args.ecppack_freq is not None else None,
         "compress":     args.ecppack_compress,
-        "seed":         args.nextpnr_seed,
     }

--- a/litex/build/nextpnr_wrapper.py
+++ b/litex/build/nextpnr_wrapper.py
@@ -92,3 +92,15 @@ class NextPNRWrapper():
             return base_cmd
         else:
             raise ValueError("Invalid target type")
+
+def nextpnr_args(parser):
+    parser.add_argument("--nextpnr-timingstrict", action="store_true", help="Use strict Timing mode (Build will fail when Timings are not met).")
+    parser.add_argument("--nextpnr-ignoreloops",  action="store_true", help="Ignore combinatorial loops in Timing Analysis.")
+    parser.add_argument("--nextpnr-seed",         default=1, type=int, help="Set Nextpnr's seed.")
+
+def nextpnr_argdict(args):
+    return {
+        "timingstrict": args.nextpnr_timingstrict,
+        "ignoreloops":  args.nextpnr_ignoreloops,
+        "seed":         args.nextpnr_seed,
+    }

--- a/litex/build/yosys_nextpnr_toolchain.py
+++ b/litex/build/yosys_nextpnr_toolchain.py
@@ -12,8 +12,8 @@ from shutil import which
 
 from litex.build import tools
 from litex.build.generic_toolchain import GenericToolchain
-from litex.build.nextpnr_wrapper import NextPNRWrapper
-from litex.build.yosys_wrapper import YosysWrapper
+from litex.build.nextpnr_wrapper import NextPNRWrapper, nextpnr_args, nextpnr_argdict
+from litex.build.yosys_wrapper import YosysWrapper, yosys_args, yosys_argdict
 
 # YosysNextPNRToolchain ----------------------------------------------------------------------------
 
@@ -216,3 +216,13 @@ class YosysNextPNRToolchain(GenericToolchain):
 
     def build_io_constraints(self):
         raise NotImplementedError("GenericToolchain.build_io_constraints must be overloaded.")
+
+def yosys_nextpnr_args(parser):
+    yosys_args(parser)
+    nextpnr_args(parser)
+
+def yosys_nextpnr_argdict(args):
+    return {
+        **yosys_argdict(args),
+        **nextpnr_argdict(args),
+    }

--- a/litex/build/yosys_wrapper.py
+++ b/litex/build/yosys_wrapper.py
@@ -137,3 +137,15 @@ class YosysWrapper():
             return base_cmd
         else:
             raise ValueError("Invalid script type")
+
+def yosys_args(parser):
+    parser.add_argument("--yosys-nowidelut", action="store_true", help="Use Yosys's nowidelut mode.")
+    parser.add_argument("--yosys-abc9",      action="store_true", help="Use Yosys's abc9 mode.")
+    parser.add_argument("--yosys-flow3",     action="store_true", help="Use Yosys's abc9 mode with the flow3 script.")
+
+def yosys_argdict(args):
+    return {
+        "nowidelut": args.yosys_nowidelut,
+        "abc9":      args.yosys_abc9,
+        "flow3":     args.yosys_flow3,
+    }


### PR DESCRIPTION
Toolchains based on *yosys+nextpnr+packer* have more or less same options: in this [PR](https://github.com/enjoy-digital/litex/pull/1435)  3 toolchains have to be updated to add the same option.
*packer* part is target dependant and it make sense to keep tihis at toolchain level, but only a subset of *yosys* and *nextpnr* are hardware dependants: consequently having those at the wrapper level is more logical.

This PR move *yosys* args to `YosysWrapper`, *nextpnr* args to `NextPNRWrapper` and keep only specifics options (primarely packer) at toolchain level. Since *icestorm*, *trellis* and *oxyde* toolchains uses `YosysNextPNRToolchain`, this one is updated too to add an abstraction layer.