### PR TITLE
soc/cores/video: fix framebuffer color output

### DIFF
--- a/litex/soc/cores/video.py
+++ b/litex/soc/cores/video.py
@@ -611,7 +611,7 @@ class VideoTerminal(Module):
             If(bit,
                 Case(term_rdport.dat_r[font_width:], {
                     0: [Cat(source.r, source.g, source.b).eq(0xffffff)],
-                    1: [Cat(source.r, source.g, source.b).eq(0x34e289)],
+                    1: [Cat(source.r, source.g, source.b).eq(0x89e234)],
                 })
             ).Else(
                 Cat(source.r, source.g, source.b).eq(0x000000),
@@ -680,15 +680,15 @@ class VideoFrameBuffer(Module, AutoCSR):
         ]
         if (depth == 32):
             self.comb += [
-               source.r.eq(video_pipe_source.data[16:24]),
+               source.r.eq(video_pipe_source.data[ 0: 8]),
                source.g.eq(video_pipe_source.data[ 8:16]),
-               source.b.eq(video_pipe_source.data[ 0: 8]),
+               source.b.eq(video_pipe_source.data[16:24]),
             ]
         else: # depth == 16
             self.comb += [
-                source.r.eq(Cat(Signal(3, reset = 0), video_pipe_source.data[ 0: 5])),
+                source.r.eq(Cat(Signal(3, reset = 0), video_pipe_source.data[11:16])),
                 source.g.eq(Cat(Signal(2, reset = 0), video_pipe_source.data[ 5:11])),
-                source.b.eq(Cat(Signal(3, reset = 0), video_pipe_source.data[11:16])),
+                source.b.eq(Cat(Signal(3, reset = 0), video_pipe_source.data[ 0: 5])),
             ]
 
         # Underflow.


### PR DESCRIPTION
An earlier patch fixed the swapped red and blue channels on the HDMI PHYs. This exposed the fact that the framebuffer readout was swapped too.

The framebuffer readout is fixed by this patch to match the r5g6b5 and a8b8g8r8 color format definitions documented in the Linux kernel's simplefb driver and used by LiteX:
https://www.kernel.org/doc/Documentation/devicetree/bindings/display/simple-framebuffer.txt

This has been tested using 16 bit SDRAM in both supported color formats.

Additionally the green color used by the video terminal is swapped. It now matches the color used by LiteX on Ubuntu's terminal, from which it was probably originally sourced.