### PR TITLE
build/altera: fix clock constraints

### DIFF
--- a/litex/build/altera/quartus.py
+++ b/litex/build/altera/quartus.py
@@ -22,7 +22,9 @@ from litex.build import tools
 # AlteraQuartusToolchain ---------------------------------------------------------------------------
 
 class AlteraQuartusToolchain(GenericToolchain):
-    attr_translate = {}
+    attr_translate = {
+        "keep": ("keep", 1),
+    }
 
     def __init__(self):
         super().__init__()
@@ -100,7 +102,7 @@ class AlteraQuartusToolchain(GenericToolchain):
                 sdc.append(tpl.format(clk=vns.get_name(clk), period=str(period)))
 
         # Enable automatical constraint generation for PLLs
-        sdc.append("derive_pll_clocks")
+        sdc.append("derive_pll_clocks -use_net_name")
 
         # False path constraints
         for from_, to in sorted(self.false_paths, key=lambda x: (x[0].duid, x[1].duid)):


### PR DESCRIPTION
This fixes two issues that prevented clock constraints (e.g. "add_false_path_constraint") from working properly in Quartus.

The first fix passes the "keep" synthesis attribute through to the generated Verilog in a way Quartus can understand.

The second fix tells Quartus to name PLL clocks according to their net instead of the physical pin name by passing the "use_net_name" flag to "derive_pll_clocks" in the .sdc file. Combined with the above, PLL clocks will now be named according to the kept net.

This fix has been verified on Quartus Prime Lite 20.1.1.720.