### PR TITLE
add $PATH note in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ $ ./litex_setup.py --init --install --user (--user to install to user directory)
 ```sh
 $ ./litex_setup.py --update
 ```
+> **Note:** The cli is installed by pip, make sure that pip folder (tipically `~/.local/`, or `%APPDATA%Python` on Windows) are in the `PATH`.
 
 > **Note:** On MacOS, make sure you have [HomeBrew](https://brew.sh) installed. Then do, ``brew install wget``.
 


### PR DESCRIPTION
I have trubles installing installing on linux,
I don't find the `litex_sim` after run the install script.

I'm not a python user and my `~/.local/bin` are not in the `$PATH`, maybe is nice add a note in docs.

I only can in Read.me, I don't now how update the docs
