### PR TITLE
Fix IRQS handling for cv32e41p

### DIFF
--- a/litex/soc/cores/cpu/cv32e41p/csr-defs.h
+++ b/litex/soc/cores/cpu/cv32e41p/csr-defs.h
@@ -1,11 +1,19 @@
 #ifndef CSR_DEFS__H
 #define CSR_DEFS__H
 
+
 #define CSR_MSTATUS_MIE 0x8
 
-#define CSR_IRQ_MASK 0xBC0
-#define CSR_IRQ_PENDING 0xFC0
-
+#define CSR_IRQ_MASK    0x344
+#define CSR_IRQ_PENDING 0x304
+#define FIRQ_OFFSET     16
 #define CSR_DCACHE_INFO 0xCC0
 
 #endif	/* CSR_DEFS__H */
+
+
+/*
+For CV32E41P from https://docs.openhwgroup.org/projects/openhw-group-cv32e41p/control_status_registers.html
+Machine Interrupt Pending Register (mip): CSR_IRQ_MASK: 0x344
+Machine Interrupt Enable Register (mie): CSR_IRQ_PENDING: 0x304
+*/

--- a/litex/soc/cores/cpu/cv32e41p/irq.h
+++ b/litex/soc/cores/cpu/cv32e41p/irq.h
@@ -20,17 +20,21 @@ static inline void irq_setie(unsigned int ie)
 
 static inline unsigned int irq_getmask(void)
 {
-    return 0; // FIXME
+        unsigned int mask;
+	asm volatile ("csrr %0, %1" : "=r"(mask) : "i"(CSR_IRQ_MASK));
+	return (mask >> FIRQ_OFFSET);
 }
 
 static inline void irq_setmask(unsigned int mask)
 {
-    // FIXME
+    	asm volatile ("csrw %0, %1" :: "i"(CSR_IRQ_MASK), "r"(mask << FIRQ_OFFSET));
 }
 
 static inline unsigned int irq_pending(void)
 {
-    return 0;// FIXME
+        unsigned int pending;
+	asm volatile ("csrr %0, %1" : "=r"(pending) : "i"(CSR_IRQ_PENDING));
+	return (pending >> FIRQ_OFFSET);
 }
 
 #ifdef __cplusplus

--- a/litex/soc/software/libbase/isr.c
+++ b/litex/soc/software/libbase/isr.c
@@ -107,40 +107,7 @@ void isr(void)
 #endif
     }
 }
-#elif defined(__cv32e41p__)
 
-#define FIRQ_OFFSET 16
-#define IRQ_MASK 0x7FFFFFFF
-#define INVINST 2
-#define ECALL 11
-#define RISCV_TEST
-
-void isr(void)
-{
-    unsigned int cause = csrr(mcause) & IRQ_MASK;
-
-    if (csrr(mcause) & 0x80000000) {
-#ifndef UART_POLLING
-        if (cause == (UART_INTERRUPT+FIRQ_OFFSET)){
-            uart_isr();
-        }
-#endif
-    } else {
-#ifdef RISCV_TEST
-        int gp;
-        asm volatile ("mv %0, gp" : "=r"(gp));
-        printf("E %d\n", cause);
-        if (cause == INVINST) {
-            printf("Inv Instr\n");
-            for(;;);
-        }
-        if (cause == ECALL) {
-            printf("Ecall (gp: %d)\n", gp);
-            csrw(mepc, csrr(mepc)+4);
-        }
-#endif
-    }
-}
 #elif defined(__microwatt__)
 
 void isr(uint64_t vec)


### PR DESCRIPTION
I have added the right values of  CSR_IRQ_PENDING and CSR_IRQ_MASK (based on cv32e41p documentation). and fixed irqs handling functions(irq_setmask, irq_pending and irq_getmask) in irq.h (inspired from ibex interrupts support PR:#1070).

- Machine Interrupt Pending Register (mip): CSR_IRQ_MASK: 0x344
- Machine Interrupt Enable Register (mie): CSR_IRQ_PENDING: 0x304

Tested on Digilent arty a7 100T.
```
        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
   Build your hardware, easily!

 (c) Copyright 2012-2022 Enjoy-Digital
 (c) Copyright 2007-2015 M-Labs

 BIOS built on Oct 19 2022 14:26:40
 BIOS CRC passed (59910ade)

 Migen git sha1: 639e66f
 LiteX git sha1: a0853d15

--=============== SoC ==================--
CPU:		CV32E41P @ 100MHz
BUS:		WISHBONE 32-bit @ 4GiB
CSR:		32-bit data
ROM:		128KiB
SRAM:		8KiB
L2:		8KiB
SDRAM:		262144KiB 16-bit @ 800MT/s (CL-7 CWL-5)

--========== Initialization ============--
Initializing SDRAM @0x40000000...
Switching SDRAM to software control.
Read leveling:
  m0, b00: |00000000000000000000000000000000| delays: -
  m0, b01: |00000000000000000000000000000000| delays: -
  m0, b02: |11111111111100000000000000000000| delays: 06+-06
  m0, b03: |00000000000000111111111111110000| delays: 21+-07
  m0, b04: |00000000000000000000000000000011| delays: 00+-02
  m0, b05: |00000000000000000000000000000000| delays: -
  m0, b06: |00000000000000000000000000000000| delays: -
  m0, b07: |00000000000000000000000000000000| delays: -
  best: m0, b03 delays: 21+-07
  m1, b00: |00000000000000000000000000000000| delays: -
  m1, b01: |00000000000000000000000000000000| delays: -
  m1, b02: |11111111111100000000000000000000| delays: 06+-06
  m1, b03: |00000000000000111111111111110000| delays: 21+-07
  m1, b04: |00000000000000000000000000000011| delays: 00+-02
  m1, b05: |00000000000000000000000000000000| delays: -
  m1, b06: |00000000000000000000000000000000| delays: -
  m1, b07: |00000000000000000000000000000000| delays: -
  best: m1, b03 delays: 21+-07
Switching SDRAM to hardware control.
Memtest at 0x40000000 (2.0MiB)...
  Write: 0x40000000-0x40200000 2.0MiB     
   Read: 0x40000000-0x40200000 2.0MiB     
Memtest OK
Memspeed at 0x40000000 (Sequential, 2.0MiB)...
  Write speed: 27.2MiB/s
   Read speed: 44.8MiB/s

--============== Boot ==================--
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
[LITEX-TERM] Received firmware download request from the device.
[LITEX-TERM] Uploading demo.bin to 0x40000000 (8556 bytes)...
[LITEX-TERM] Upload calibration... (inter-frame: 10.00us, length: 64)
[LITEX-TERM] Upload complete (9.8KB/s).
[LITEX-TERM] Booting the device.
[LITEX-TERM] Done.
Executing booted program at 0x40000000

--============= Liftoff! ===============--

LiteX minimal demo app built Oct 19 2022 17:04:46

Available commands:
help               - Show this command
reboot             - Reboot CPU
led                - Led demo
testspi            - Test du spi
iotest             - Programme de test des gpios I/O
donut              - Spinning Donut demo
helloc             - Hello C
litex-demo-app> interruption rst detecté
interruption rst detecté
interruption rst detecté
interruption rst detecté
```