### PR TITLE
F4pga edalize

### DIFF
--- a/litex/build/generic_toolchain.py
+++ b/litex/build/generic_toolchain.py
@@ -144,7 +144,7 @@ class GenericToolchain:
             edam = {
                 'name'         : self._build_name,
                 'files'        : files,
-                'tool_options' : {tool: tool_options},
+                **tool_options,
                 'toplevel'     : self._build_name,
             }
 

--- a/litex/build/generic_toolchain.py
+++ b/litex/build/generic_toolchain.py
@@ -122,7 +122,7 @@ class GenericToolchain:
             from edalize import get_edatool
 
             # Get tool name and options
-            (tool, tool_options)= self.get_tool_options()
+            (tool, tool_options) = self.get_tool_options()
 
             # Files list
             files = []

--- a/litex/build/lattice/icestorm.py
+++ b/litex/build/lattice/icestorm.py
@@ -102,7 +102,7 @@ class LatticeIceStormToolchain(YosysNextPNRToolchain):
             "yosys_synth_options": self._synth_opts.split(' '),
             "nextpnr_options": self._pnr_opts.split(' '),
         }
-        return ("icestorm", tool_options)
+        return ("icestorm", {"tool_options": {"icestorm": tool_options}})
 
 
 def icestorm_args(parser):

--- a/litex/build/lattice/icestorm.py
+++ b/litex/build/lattice/icestorm.py
@@ -100,7 +100,7 @@ class LatticeIceStormToolchain(YosysNextPNRToolchain):
         tool_options = {
             "icepack_options": ["-s"],
             "yosys_synth_options": self._synth_opts.split(' '),
-            "nextpnr_options": self._pnr_opts.split(' '),
+            "nextpnr_options": self.pnr_opts.split(' '),
         }
         return ("icestorm", {"tool_options": {"icestorm": tool_options}})
 

--- a/litex/build/nextpnr_wrapper.py
+++ b/litex/build/nextpnr_wrapper.py
@@ -62,6 +62,15 @@ class NextPNRWrapper():
                 if value != "":
                     self._pnr_opts += f"--{key} {value} "
 
+    @property
+    def pnr_opts(self):
+        """return PNR configuration options
+        Returns
+        =======
+        str containing configuration options passed to nextpnr-xxx
+        """
+        return self._pnr_opts
+
     def get_call(self, target="script"):
         """built a script command or a Makefile rule + command
 

--- a/litex/build/xilinx/f4pga.py
+++ b/litex/build/xilinx/f4pga.py
@@ -40,6 +40,7 @@ class F4PGAToolchain(GenericToolchain):
         "ars_ff2":         ("ars_ff2",    "true"), # user-defined attribute
         "no_shreg_extract": None
     }
+    supported_build_backend = ["litex", "edalize"]
 
     def __init__(self):
         super().__init__()
@@ -130,3 +131,20 @@ class F4PGAToolchain(GenericToolchain):
     def add_false_path_constraint(self, platform, from_, to):
         # FIXME: false path constraints are currently not supported by the F4PGA toolchain
         return
+
+    # Edalize tool name and tool options -----------------------------------------------------------
+    def get_tool_options(self):
+        device_name = {
+            "xc7a10": "xc7a100t_test",
+            "xc7a20": "xc7a200t_test",
+            "xc7z01": "xc7z010_test",
+            "xc7z02": "xc7z020_test",
+        }.get(self.platform.device[0:6], "xc7a50t_test")
+
+        tool_options = {
+                "arch"   : "xilinx",
+                "chip"   : device_name,
+                "device" : "artix7" if self.platform.device.startswith("xc7a") else "zynq",
+                "part"   : self._partname,
+        }
+        return ("f4pga", {"flow_options": tool_options})

--- a/litex/build/xilinx/f4pga.py
+++ b/litex/build/xilinx/f4pga.py
@@ -64,7 +64,7 @@ class F4PGAToolchain(GenericToolchain):
     def build_io_constraints(self):
         # Generate design constraints
         tools.write_to_file(self._build_name + ".xdc", _build_xdc(self.named_sc, self.named_pc))
-        return (self._build_name + ".xdc", "XDC")
+        return (self._build_name + ".xdc", "xdc")
 
     def build_timing_constraints(self, vns):
         self.platform.add_platform_command(_xdc_separator("Clock constraints"))

--- a/litex/build/yosys_nextpnr_toolchain.py
+++ b/litex/build/yosys_nextpnr_toolchain.py
@@ -157,6 +157,19 @@ class YosysNextPNRToolchain(GenericToolchain):
             seed              = self.seed
         )
 
+    @property
+    def pnr_opts(self):
+        """return PNR configuration options
+        Returns
+        =======
+        str containing configuration options passed to nextpnr-xxx or None if
+            _nextpnr is not already instanciated
+        """
+        if self._nextpnr is None:
+            return None
+        else:
+            return self._nextpnr.pnr_opts
+
     def build_project(self):
         """ create project files (mainly Yosys ys file)
         """


### PR DESCRIPTION
- Second commit adapts `edam` dictionnary according to backend used: With the recent integration of **edaflow** (used for **f4pga**) `edam` is currently a bit different between `f4pga` and `icestorm` This why toolchain return a dict with key == `flow_options` for backend using `eda_flow` or `tool_options` for classic backend
- third commit fix a second typo: **edalize** search for a constraints with `file_type` equal to `xdc` (lower case)
- fourth commit add **edalize** support for **f4pga** toolchain.
- last 2 commits adds getter for PNR options to nextpnr to have access to the complete PNR configuration

Tested with **icebreaker** and **arty_a35t** (after disabling `DNA` and `XADC`).