### PR TITLE
riscv: Fix compilation with new binutils

### DIFF
--- a/litex/soc/cores/cpu/cv32e40p/core.py
+++ b/litex/soc/cores/cpu/cv32e40p/core.py
@@ -22,15 +22,15 @@ CPU_VARIANTS = ["standard", "full"]
 # GCC Flags ----------------------------------------------------------------------------------------
 
 GCC_FLAGS = {
-    #                       /-------- Base ISA
-    #                       |/------- Hardware Multiply + Divide
-    #                       ||/----- Atomics
-    #                       |||/---- Compressed ISA
-    #                       ||||/--- Single-Precision Floating-Point
-    #                       |||||/-- Double-Precision Floating-Point
-    #                       imacfd
-    "standard": "-march=rv32imc    -mabi=ilp32 ",
-    "full":     "-march=rv32imfc   -mabi=ilp32 ",
+    #                       /------------ Base ISA
+    #                       |    /------- Hardware Multiply + Divide
+    #                       |    |/----- Atomics
+    #                       |    ||/---- Compressed ISA
+    #                       |    |||/--- Single-Precision Floating-Point
+    #                       |    ||||/-- Double-Precision Floating-Point
+    #                       i    macfd
+    "standard": "-march=rv32i2p0_mc    -mabi=ilp32 ",
+    "full":     "-march=rv32i2p0_mfc   -mabi=ilp32 ",
 }
 
 # OBI / APB / Trace Layouts ------------------------------------------------------------------------

--- a/litex/soc/cores/cpu/cv32e41p/core.py
+++ b/litex/soc/cores/cpu/cv32e41p/core.py
@@ -22,14 +22,14 @@ CPU_VARIANTS = ["standard"]
 # GCC Flags ----------------------------------------------------------------------------------------
 
 GCC_FLAGS = {
-    #                       /-------- Base ISA
-    #                       |/------- Hardware Multiply + Divide
-    #                       ||/----- Atomics
-    #                       |||/---- Compressed ISA
-    #                       ||||/--- Single-Precision Floating-Point
-    #                       |||||/-- Double-Precision Floating-Point
-    #                       imacfd
-    "standard": "-march=rv32imc    -mabi=ilp32 ",
+    #                       /------------ Base ISA
+    #                       |    /------- Hardware Multiply + Divide
+    #                       |    |/----- Atomics
+    #                       |    ||/---- Compressed ISA
+    #                       |    |||/--- Single-Precision Floating-Point
+    #                       |    ||||/-- Double-Precision Floating-Point
+    #                       i    macfd
+    "standard": "-march=rv32i2p0_mc    -mabi=ilp32 ",
 }
 
 # OBI / APB / Trace Layouts ------------------------------------------------------------------------

--- a/litex/soc/cores/cpu/cva5/core.py
+++ b/litex/soc/cores/cpu/cva5/core.py
@@ -20,15 +20,15 @@ CPU_VARIANTS = ["minimal", "standard"]
 # GCC Flags ----------------------------------------------------------------------------------------
 
 GCC_FLAGS = {
-    #                        /-------- Base ISA
-    #                        |/------- Hardware Multiply + Divide
-    #                        ||/----- Atomics
-    #                        |||/---- Compressed ISA
-    #                        ||||/--- Single-Precision Floating-Point
-    #                        |||||/-- Double-Precision Floating-Point
-    #                        imacfd
-    "minimal"  : "-march=rv32i  -mabi=ilp32 ",
-    "standard" : "-march=rv32im -mabi=ilp32 ",
+    #                        /------------ Base ISA
+    #                        |    /------- Hardware Multiply + Divide
+    #                        |    |/----- Atomics
+    #                        |    ||/---- Compressed ISA
+    #                        |    |||/--- Single-Precision Floating-Point
+    #                        |    ||||/-- Double-Precision Floating-Point
+    #                        i    macfd
+    "minimal"  : "-march=rv32i2p0   -mabi=ilp32 ",
+    "standard" : "-march=rv32i2p0_m -mabi=ilp32 ",
 }
 
 # CVA5 ----------------------------------------------------------------------------------------------

--- a/litex/soc/cores/cpu/femtorv/core.py
+++ b/litex/soc/cores/cpu/femtorv/core.py
@@ -26,20 +26,20 @@ CPU_VARIANTS = {
 # GCC Flags ----------------------------------------------------------------------------------------
 
 GCC_FLAGS = {
-    #                               /-------- Base ISA
-    #                               |/------- Hardware Multiply + Divide
-    #                               ||/----- Atomics
-    #                               |||/---- Compressed ISA
-    #                               ||||/--- Single-Precision Floating-Point
-    #                               |||||/-- Double-Precision Floating-Point
-    #                               imacfd
-    "standard":         "-march=rv32i     -mabi=ilp32",
-    "quark":            "-march=rv32i     -mabi=ilp32",
-    "tachyon":          "-march=rv32i     -mabi=ilp32",
-    "electron":         "-march=rv32im    -mabi=ilp32",
-    "intermissum":      "-march=rv32im    -mabi=ilp32",
-    "gracilis":         "-march=rv32imc   -mabi=ilp32",
-    "petitbateau":      "-march=rv32imfc  -mabi=ilp32f",
+    #                               /------------ Base ISA
+    #                               |    /------- Hardware Multiply + Divide
+    #                               |    |/----- Atomics
+    #                               |    ||/---- Compressed ISA
+    #                               |    |||/--- Single-Precision Floating-Point
+    #                               |    ||||/-- Double-Precision Floating-Point
+    #                               i    macfd
+    "standard":         "-march=rv32i2p0      -mabi=ilp32",
+    "quark":            "-march=rv32i2p0      -mabi=ilp32",
+    "tachyon":          "-march=rv32i2p0      -mabi=ilp32",
+    "electron":         "-march=rv32i2p0_m    -mabi=ilp32",
+    "intermissum":      "-march=rv32i2p0_m    -mabi=ilp32",
+    "gracilis":         "-march=rv32i2p0_mc   -mabi=ilp32",
+    "petitbateau":      "-march=rv32i2p0_mfc  -mabi=ilp32f",
 }
 
 # FemtoRV ------------------------------------------------------------------------------------------

--- a/litex/soc/cores/cpu/firev/core.py
+++ b/litex/soc/cores/cpu/firev/core.py
@@ -20,14 +20,14 @@ CPU_VARIANTS = {
 # GCC Flags ----------------------------------------------------------------------------------------
 
 GCC_FLAGS = {
-    #                       /-------- Base ISA
-    #                       |/------- Hardware Multiply + Divide
-    #                       ||/----- Atomics
-    #                       |||/---- Compressed ISA
-    #                       ||||/--- Single-Precision Floating-Point
-    #                       |||||/-- Double-Precision Floating-Point
-    #                       imacfd
-    "standard": "-march=rv32i     -mabi=ilp32",
+    #                       /------------ Base ISA
+    #                       |    /------- Hardware Multiply + Divide
+    #                       |    |/----- Atomics
+    #                       |    ||/---- Compressed ISA
+    #                       |    |||/--- Single-Precision Floating-Point
+    #                       |    ||||/-- Double-Precision Floating-Point
+    #                       i    macfd
+    "standard": "-march=rv32i2p0      -mabi=ilp32",
 }
 
 # FireV ------------------------------------------------------------------------------------------

--- a/litex/soc/cores/cpu/ibex/core.py
+++ b/litex/soc/cores/cpu/ibex/core.py
@@ -22,14 +22,14 @@ CPU_VARIANTS = ["standard"]
 # GCC Flags ----------------------------------------------------------------------------------------
 
 GCC_FLAGS = {
-    #                       /-------- Base ISA
-    #                       |/------- Hardware Multiply + Divide
-    #                       ||/----- Atomics
-    #                       |||/---- Compressed ISA
-    #                       ||||/--- Single-Precision Floating-Point
-    #                       |||||/-- Double-Precision Floating-Point
-    #                       imacfd
-    "standard": "-march=rv32imc    -mabi=ilp32 ",
+    #                       /------------ Base ISA
+    #                       |    /------- Hardware Multiply + Divide
+    #                       |    |/----- Atomics
+    #                       |    ||/---- Compressed ISA
+    #                       |    |||/--- Single-Precision Floating-Point
+    #                       |    ||||/-- Double-Precision Floating-Point
+    #                       i    macfd
+    "standard": "-march=rv32i2p0_mc    -mabi=ilp32 ",
 }
 
 # OBI <> Wishbone ----------------------------------------------------------------------------------

--- a/litex/soc/cores/cpu/neorv32/core.py
+++ b/litex/soc/cores/cpu/neorv32/core.py
@@ -20,17 +20,17 @@ CPU_VARIANTS = ["minimal", "lite", "standard", "full"]
 # GCC Flags ----------------------------------------------------------------------------------------
 
 GCC_FLAGS = {
-    #                               /-------- Base ISA
-    #                               |/------- Hardware Multiply + Divide
-    #                               ||/----- Atomics
-    #                               |||/---- Compressed ISA
-    #                               ||||/--- Single-Precision Floating-Point
-    #                               |||||/-- Double-Precision Floating-Point
-    #                               imacfd
-    "minimal":          "-march=rv32i     -mabi=ilp32",
-    "lite":             "-march=rv32imc   -mabi=ilp32",
-    "standard":         "-march=rv32imc   -mabi=ilp32",
-    "full":             "-march=rv32imc   -mabi=ilp32",
+    #                               /------------ Base ISA
+    #                               |    /------- Hardware Multiply + Divide
+    #                               |    |/----- Atomics
+    #                               |    ||/---- Compressed ISA
+    #                               |    |||/--- Single-Precision Floating-Point
+    #                               |    ||||/-- Double-Precision Floating-Point
+    #                               i    macfd
+    "minimal":          "-march=rv32i2p0      -mabi=ilp32",
+    "lite":             "-march=rv32i2p0_mc   -mabi=ilp32",
+    "standard":         "-march=rv32i2p0_mc   -mabi=ilp32",
+    "full":             "-march=rv32i2p0_mc   -mabi=ilp32",
 }
 
 # NEORV32 ------------------------------------------------------------------------------------------

--- a/litex/soc/cores/cpu/picorv32/core.py
+++ b/litex/soc/cores/cpu/picorv32/core.py
@@ -23,15 +23,15 @@ CPU_VARIANTS = ["minimal", "standard"]
 # GCC Flags ----------------------------------------------------------------------------------------
 
 GCC_FLAGS = {
-    #                               /-------- Base ISA
-    #                               |/------- Hardware Multiply + Divide
-    #                               ||/----- Atomics
-    #                               |||/---- Compressed ISA
-    #                               ||||/--- Single-Precision Floating-Point
-    #                               |||||/-- Double-Precision Floating-Point
-    #                               imacfd
-    "minimal":          "-march=rv32i      -mabi=ilp32 ",
-    "standard":         "-march=rv32im     -mabi=ilp32 ",
+    #                               /------------ Base ISA
+    #                               |    /------- Hardware Multiply + Divide
+    #                               |    |/----- Atomics
+    #                               |    ||/---- Compressed ISA
+    #                               |    |||/--- Single-Precision Floating-Point
+    #                               |    ||||/-- Double-Precision Floating-Point
+    #                               i    macfd
+    "minimal":          "-march=rv32i2p0       -mabi=ilp32 ",
+    "standard":         "-march=rv32i2p0_m     -mabi=ilp32 ",
 }
 
 # PicoRV32 -----------------------------------------------------------------------------------------

--- a/litex/soc/cores/cpu/serv/core.py
+++ b/litex/soc/cores/cpu/serv/core.py
@@ -20,15 +20,15 @@ CPU_VARIANTS = ["standard", "mdu"]
 # GCC Flags ----------------------------------------------------------------------------------------
 
 GCC_FLAGS = {
-    #                               /-------- Base ISA
-    #                               |/------- Hardware Multiply + Divide
-    #                               ||/----- Atomics
-    #                               |||/---- Compressed ISA
-    #                               ||||/--- Single-Precision Floating-Point
-    #                               |||||/-- Double-Precision Floating-Point
-    #                               imacfd
-    "standard":         "-march=rv32i     -mabi=ilp32",
-    "mdu":              "-march=rv32im    -mabi=ilp32",
+    #                               /------------ Base ISA
+    #                               |    /------- Hardware Multiply + Divide
+    #                               |    |/----- Atomics
+    #                               |    ||/---- Compressed ISA
+    #                               |    |||/--- Single-Precision Floating-Point
+    #                               |    ||||/-- Double-Precision Floating-Point
+    #                               i    macfd
+    "standard":         "-march=rv32i2p0      -mabi=ilp32",
+    "mdu":              "-march=rv32i2p0_m    -mabi=ilp32",
 }
 
 # SERV ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
The csr opcodes are no longer part of the i instruction set, and must be enabled separately. This can be done by adding _zicsr to the march string, eg. -march=rv32i_zicsr. However this is not recognised by older toolchains, so we can't change over until everyone is using binutils 2.28 or later.

An alternate fix was merged for Vexriscv by patching .S files in https://github.com/enjoy-digital/litex/pull/1292. This only fixes the problem for .S files, so the usage of csr instructions in c files was still broken.

Later it was fixed for all source files for Vexriscv in https://github.com/enjoy-digital/litex/pull/1321 by telling the compiler to target the 2.0 ISA, where the csr instructions were still present.

Make the same change to all riscv cpus that specify -march=rv32. This should allow both old and new toolchains to build software.

Signed-off-by: Joel Stanley <joel@jms.id.au>