### PR TITLE
soc/software/demo/Makefile: define WITH_CXX

### DIFF
--- a/litex/soc/software/demo/Makefile
+++ b/litex/soc/software/demo/Makefile
@@ -6,6 +6,7 @@ include $(SOC_DIRECTORY)/software/common.mak
 OBJECTS   = donut.o helloc.o crt0.o main.o
 ifdef WITH_CXX
 	OBJECTS += hellocpp.o
+	CFLAGS += -DWITH_CXX
 endif
 
 


### PR DESCRIPTION
Defines WITH_CXX to the C compiler when including hello.cpp in the demo. This fixes a bug wahere the the menu did not include the hellocpp item even when --with-cpp was passed to demo.py

Signed-off-by: Alan Green <alan.green@gmail.com>