### PR TITLE
soc/software: Support non 8bit i2c memory addresses

### DIFF
--- a/litex/soc/software/bios/cmds/cmd_litedram.c
+++ b/litex/soc/software/bios/cmds/cmd_litedram.c
@@ -388,7 +388,7 @@ static void sdram_spd_handler(int nb_params, char **params)
 		}
 	}
 
-	if (!i2c_read(SPD_RW_ADDR(spdaddr), 0, buf, len, send_stop)) {
+	if (!i2c_read(SPD_RW_ADDR(spdaddr), 0, buf, len, send_stop, 1)) {
 		printf("Error when reading SPD EEPROM");
 		return;
 	}

--- a/litex/soc/software/libbase/i2c.h
+++ b/litex/soc/software/libbase/i2c.h
@@ -33,8 +33,8 @@ struct i2c_dev {
 #define I2C_ADDR_RD(addr) (((addr) << 1) | 1u)
 
 void i2c_reset(void);
-bool i2c_write(unsigned char slave_addr, unsigned char addr, const unsigned char *data, unsigned int len);
-bool i2c_read(unsigned char slave_addr, unsigned char addr, unsigned char *data, unsigned int len, bool send_stop);
+bool i2c_write(unsigned char slave_addr, unsigned int addr, const unsigned char *data, unsigned int len, unsigned int addr_size);
+bool i2c_read(unsigned char slave_addr, unsigned int addr, unsigned char *data, unsigned int len, bool send_stop, unsigned int addr_size);
 bool i2c_poll(unsigned char slave_addr);
 int i2c_send_init_cmds(void);
 struct i2c_dev *get_i2c_devs(void);


### PR DESCRIPTION
Add another parameter to i2c_read/write to specify the size (in bytes) of the addresses.

i2c_read/writes with 2-byte addresses were tested with a OV5647 camera.