### PR TITLE
litex/soc: update API to avoid unfortunate terms

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -416,6 +416,9 @@ class SoCBusHandler(LiteXModule):
             colorer(name,    color="underline"),
             colorer("added", color="green")))
 
+    def add_controller(self, name=None, controller=None):
+        self.add_master(self, name=name, master=controller)
+
     def add_slave(self, name=None, slave=None, region=None):
         no_name   = name is None
         no_region = region is None
@@ -447,6 +450,9 @@ class SoCBusHandler(LiteXModule):
         self.logger.info("{} {} as Bus Slave.".format(
             colorer(name, color="underline"),
             colorer("added", color="green")))
+
+    def add_peripheral(self, name=None, peripheral=None, region=None):
+        self.add_slave(self, name=name, slave=peripheral, region=region)
 
     def get_address_width(self, standard):
         standard_from = self.standard

--- a/litex/soc/interconnect/wishbone.py
+++ b/litex/soc/interconnect/wishbone.py
@@ -149,7 +149,12 @@ class InterconnectPointToPoint(Module):
 
 
 class Arbiter(Module):
-    def __init__(self, masters, target):
+    def __init__(self, masters=None, target=None, controllers=None):
+        assert target is not None
+        assert (masters is not None) or (controllers is not None)
+        if controllers is not None:
+            masters = controllers
+
         self.submodules.rr = roundrobin.RoundRobin(len(masters))
 
         # mux master->slave signals


### PR DESCRIPTION
Provides an alternate API to some functions of the SoCBusHandler and bus Arbiter classes to allow users of the API to avoid the terms 'master' and 'slave' in certain situations.

See discussion at #1025