### PR TITLE
Misc changes for a wider SoC

### DIFF
--- a/litex/soc/integration/common.py
+++ b/litex/soc/integration/common.py
@@ -40,7 +40,7 @@ def get_mem_regions(filename_or_regions, offset):
     return regions
 
 def get_mem_data(filename_or_regions, data_width=32, endianness="big", mem_size=None, offset=0):
-    assert data_width in [32, 64]
+    assert data_width % 32 == 0
     assert endianness in ["big", "little"]
 
     # Return empty list if no filename or regions.
@@ -80,11 +80,11 @@ def get_mem_data(filename_or_regions, data_width=32, endianness="big", mem_size=
                     "little": "<I",
                     "big":    ">I"
                 }[endianness]
-                if data_width == 32:
-                    data[(base - offset)//bytes_per_data + i] = struct.unpack(unpack_order, w)[0]
-                if data_width == 64:
-                    data[(base - offset)//bytes_per_data + i]  = (struct.unpack(unpack_order, w[0:4])[0] <<  0)
-                    data[(base - offset)//bytes_per_data + i] |= (struct.unpack(unpack_order, w[4:8])[0] << 32)
+                data[(base - offset)//bytes_per_data + i] = 0
+                for filled_data_width in range(0, data_width, 32):
+                    cur_byte = filled_data_width//8
+                    data[(base - offset)//bytes_per_data + i] |= (struct.unpack(unpack_order, w[cur_byte:cur_byte+4])[0] << filled_data_width)
+                    filled_data_width += 32
                 i += 1
     return data
 

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1581,7 +1581,7 @@ class LiteXSoC(SoC):
             port.data_width = 2**int(log2(port.data_width)) # Round to nearest power of 2.
 
             # Create Wishbone Slave.
-            wb_sdram = wishbone.Interface()
+            wb_sdram = wishbone.Interface(data_width=self.bus.data_width)
             self.bus.add_slave("main_ram", wb_sdram)
 
             # L2 Cache


### PR DESCRIPTION
OpenC906 core has a 128-bit data width bus, which could benefit from a wider SoC bus.

This PR includes two commits, one adding support for ROM initialization of a wider bus, the other attaching LiteDRAM to the SoC bus with a wider data port, allowing to utilize the full SoC bus width.

This increases sequential DRAM read speed of openC906 in LiteX from 110MB/s to 190MB/s when using a 128-bit SoC bus.