### PR TITLE
Do not build software as PIE

### DIFF
--- a/litex/soc/software/common.mak
+++ b/litex/soc/software/common.mak
@@ -54,7 +54,7 @@ INCLUDES = -I$(PICOLIBC_DIRECTORY)/newlib/libc/tinystdio \
            -I$(BUILDINC_DIRECTORY) \
            -I$(BUILDINC_DIRECTORY)/../libc \
            -I$(CPU_DIRECTORY)
-COMMONFLAGS = $(DEPFLAGS) -Os $(CPUFLAGS) -g3 -fomit-frame-pointer -Wall -fno-builtin -fno-stack-protector $(INCLUDES)
+COMMONFLAGS = $(DEPFLAGS) -Os $(CPUFLAGS) -g3 -no-pie -fomit-frame-pointer -Wall -fno-builtin -fno-stack-protector $(INCLUDES)
 ifeq ($(LTO), 1)
 COMMONFLAGS += -flto
 endif


### PR DESCRIPTION
Some builds may default to creating position independent executables with a .dynamic section containing symbols that must be relocated at runtime. This section appears after .data section and is included in the output .bin, causing it to be included in the build time CRC calculation. The runtime CRC calculation stops after .data, so there was always a mismatch.

The litex bios has no support for relocating the dynamic symbols, so disable pie on all platforms. This will improve compatibility with distro toolchains.

Tested with:

 marocchino / or1k-elf-gcc (GCC 12.1.0-2 Debian 1.0.3) 12.1.0

 vexriscv / riscv64-linux-gnu-gcc (Debian 12.2.0-3) 12.2.0

 microwatt / powerpc64le-linux-gnu-gcc (Debian 12.2.0-3) 12.2.0

Signed-off-by: Joel Stanley <joel@jms.id.au>