### PR TITLE
core/naxriscv: Don't use os.system to execute sbt

### DIFF
--- a/litex/soc/cores/cpu/naxriscv/core.py
+++ b/litex/soc/cores/cpu/naxriscv/core.py
@@ -260,8 +260,7 @@ class NaxRiscv(CPU):
         cmd = f"""cd {ndir} && sbt "runMain naxriscv.platform.LitexGen {" ".join(gen_args)}\""""
         print("NaxRiscv generation command :")
         print(cmd)
-        if os.system(cmd) != 0:
-            raise OSError('Failed to run sbt')
+        subprocess.check_call(cmd, shell=True)
 
 
     def add_sources(self, platform):


### PR DESCRIPTION
The use of os.system together with cd is a problem because it changes the CWD for the whole python process. This breaks for example --csr-csv.
--> The csr.csv will be written to the wrong directory