### PR TITLE
AXICrossbar: absorb data width setting when building crossbar

### DIFF
--- a/litex/soc/interconnect/axi/axi_full.py
+++ b/litex/soc/interconnect/axi/axi_full.py
@@ -574,7 +574,7 @@ class AXICrossbar(Module):
     """
     def __init__(self, masters, slaves, register=False, timeout_cycles=1e6):
         matches, busses = zip(*slaves)
-        access_m_s = [[AXIInterface() for j in slaves] for i in masters]  # a[master][slave]
+        access_m_s = [[AXIInterface(data_width = interface.data_width) for (f, interface) in slaves] for i in masters]  # a[master][slave]
         access_s_m = list(zip(*access_m_s))  # a[slave][master]
         # Decode each master into its access row.
         for slaves, master in zip(access_m_s, masters):


### PR DESCRIPTION
This patch allows the AXICrossbar to absorb non-default datawidths when the crossbar is built.

e.g. in the case of a 64-bit AXICrossbar, without this patch the crossbar was only connecting the bottom 32 bits.