### PR TITLE
Add Microwatt CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
       - name: Setup CCache
         uses: hendrikmuhs/ccache-action@v1
 
+      - uses: ghdl/setup-ghdl-ci@nightly
+        with:
+          backend: llvm
+
       # Install Tools
       - name: Install Tools
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           python3 litex_setup.py --gcc=openrisc
           sudo mkdir /usr/local/openrisc
           sudo cp -r $PWD/../openrisc-*/* /usr/local/openrisc
+          sudo apt install gcc-powerpc64le-linux-gnu binutils-multiarch
 
       # Build / Install Verilator
       - name: Build Verilator

--- a/test/test_cpu.py
+++ b/test/test_cpu.py
@@ -45,6 +45,7 @@ class TestCPU(unittest.TestCase):
             "serv",         # (riscv   / softcore)
             "vexriscv",     # (riscv   / softcore)
             "vexriscv_smp", # (riscv   / softcore)
+            "microwatt",    # (ppc64   / softcore)
         ]
         untested_cpus = [
             "blackparrot",  # (riscv   / softcore) -> Broken install?
@@ -57,7 +58,6 @@ class TestCPU(unittest.TestCase):
             "gowin_emcu",   # (arm     / hardcore) -> Hardcore.
             "ibex",         # (riscv   / softcore) -> Broken since 2022.11.12.
             "lm32",         # (lm32    / softcore) -> Requires LM32 toolchain.
-            "microwatt",    # (ppc64   / softcore) -> Requires PPC toolchain + VHDL->Verilog (GHDL + Yosys).
             "minerva",      # (riscv   / softcore) -> Broken install? (Amaranth?)
             "mor1kx",       # (or1k    / softcore) -> Verilator compilation issue.
             "neorv32",      # (riscv   / softcore) -> Requires VHDL->Verilog (GHDL + Yosys).

--- a/test/test_cpu.py
+++ b/test/test_cpu.py
@@ -7,10 +7,11 @@
 import unittest
 import pexpect
 import sys
+import os
 
 class TestCPU(unittest.TestCase):
-    def boot_test(self, cpu_type, cpu_variant="standard"):
-        cmd = f'litex_sim --cpu-type={cpu_type} --cpu-variant={cpu_variant} --opt-level=O0'
+    def boot_test(self, cpu_type, jobs, cpu_variant="standard"):
+        cmd = f'litex_sim --cpu-type={cpu_type} --cpu-variant={cpu_variant} --opt-level=O0 --jobs {jobs}'
         litex_prompt = [b'\033\[[0-9;]+mlitex\033\[[0-9;]+m>']
         is_success = True
         with open("/tmp/test_boot_log", "wb") as result_file:
@@ -65,6 +66,7 @@ class TestCPU(unittest.TestCase):
             "zynq7000",     # (arm     / hardcore) -> Hardcore.
             "zynqmp",       # (aarch64 / hardcore) -> Hardcore.
         ]
+        jobs = os.cpu_count()
         for cpu in tested_cpus:
              with self.subTest(target=cpu):
-                self.assertTrue(self.boot_test(cpu))
+                self.assertTrue(self.boot_test(cpu, jobs))


### PR DESCRIPTION
Add GHDL to the build image to convert VHDL to Verilog, and use the distro compiler for ppc64le.

The Microwatt design caused verilator to be killed when compiling, which was probably due to the memory requirements of a large number of compiler jobs. Limit the number of jobs used by the test harness when running verilator.