### PR TITLE
Fix Wishbone arbiter

### DIFF
--- a/litex/soc/interconnect/wishbone.py
+++ b/litex/soc/interconnect/wishbone.py
@@ -166,7 +166,8 @@ class Arbiter(Module):
         if controllers is not None:
             masters = controllers
 
-        self.submodules.rr = roundrobin.RoundRobin(len(masters))
+        self.submodules.rr = roundrobin.RoundRobin(len(masters), roundrobin.SP_CE)
+        cycs = Array(m.cyc for m in masters)
 
         # mux master->slave signals
         for name, size, direction in _layout:
@@ -184,6 +185,8 @@ class Arbiter(Module):
                         self.comb += dest.eq(source & (self.rr.grant == i))
                     else:
                         self.comb += dest.eq(source)
+
+        self.comb += self.rr.ce.eq(target.ack | ~cycs[self.rr.grant])
 
         # connect bus requests to round-robin selector
         reqs = [m.cyc for m in masters]


### PR DESCRIPTION
Right now, when multiple masters want to access the bus, access is granted to one of them, and is not revoked until selected master has finished all of its transactions (cyc goes low).

This state causes master starvation if access is granted to high bandwidth master, like cpu in busy loop.

This commit makes it so access to bus is revoked when pending transaction is finished (ack and cyc are high) or when selected master is idle.