### PR TITLE
RFC: Fix sensitivity dependencies in FSM for AXI-lite/AXI

### DIFF
--- a/litex/soc/interconnect/axi/axi_full.py
+++ b/litex/soc/interconnect/axi/axi_full.py
@@ -343,7 +343,7 @@ class AXITimeout(Module):
                 timer.wait.eq(wait_cond),
                 # done is updated in `sync`, so we must make sure that `ready` has not been issued
                 # by slave during that single cycle, by checking `timer.wait`.
-                If(timer.done & timer.wait,
+                If(timer.done & wait_cond, # timer.wait.eq(wait_cond),
                     error.eq(1),
                     NextState("RESPOND")
                 )
@@ -360,7 +360,7 @@ class AXITimeout(Module):
                 master.w.ready.eq(master.w.valid),
                 master.b.valid.eq(~master.aw.valid & ~master.w.valid),
                 master.b.resp.eq(RESP_SLVERR),
-                If(master.b.valid & master.b.ready,
+                If((~master.aw.valid & ~master.w.valid) & master.b.ready, # timer.wait.eq(wait_cond),
                     NextState("WAIT")
                 )
             ])
@@ -375,7 +375,7 @@ class AXITimeout(Module):
                 master.r.last.eq(1),
                 master.r.resp.eq(RESP_SLVERR),
                 master.r.data.eq(2**len(master.r.data) - 1),
-                If(master.r.valid & master.r.ready,
+                If(~master.ar.valid & master.r.ready, # master.ar.ready.eq(master.ar.valid),
                     NextState("WAIT")
                 )
             ])

--- a/litex/soc/interconnect/axi/axi_full_to_axi_lite.py
+++ b/litex/soc/interconnect/axi/axi_full_to_axi_lite.py
@@ -81,7 +81,8 @@ class AXI2AXILite(Module):
             axi.r.data.eq(axi_lite.r.data),
             axi_lite.r.ready.eq(axi.r.ready),
             # Exit
-            If(axi.r.valid & axi.r.last & axi.r.ready,
+            # If(axi.r.valid & axi.r.last & axi.r.ready,   # Original semantic intent
+            If(axi_lite.r.valid & _cmd_done & axi.r.ready, # Revised so assignments not affecting always(@*) sensitivity list
                 ax_beat.ready.eq(1),
                 NextState("IDLE")
             )
@@ -105,7 +106,8 @@ class AXI2AXILite(Module):
             axi_lite.w.strb.eq(axi.w.strb),
             axi.w.ready.eq(axi_lite.w.ready),
             # Exit
-            If(axi.w.valid & axi.w.last & axi.w.ready,
+            # If(axi.w.valid & axi.w.last & axi.w.ready,    # Original semantic intent
+            If(axi.w.valid & axi.w.last & axi_lite.w.ready, # Revised so assignments not affecting always(@*) sensitivity list
                 NextState("WRITE-RESP")
             )
         )

--- a/litex/soc/interconnect/axi/axi_lite.py
+++ b/litex/soc/interconnect/axi/axi_lite.py
@@ -538,7 +538,7 @@ class AXILiteTimeout(Module):
                 timer.wait.eq(wait_cond),
                 # done is updated in `sync`, so we must make sure that `ready` has not been issued
                 # by slave during that single cycle, by checking `timer.wait`.
-                If(timer.done & timer.wait,
+                If(timer.done & wait_cond, # timer.wait.eq(wait_cond)
                     error.eq(1),
                     NextState("RESPOND")
                 )
@@ -555,7 +555,7 @@ class AXILiteTimeout(Module):
                 master.w.ready.eq(master.w.valid),
                 master.b.valid.eq(~master.aw.valid & ~master.w.valid),
                 master.b.resp.eq(RESP_SLVERR),
-                If(master.b.valid & master.b.ready,
+                If((~master.aw.valid & ~master.w.valid) & master.b.ready, # master.b.valid.eq(~master.aw.valid & ~master.w.valid)
                     NextState("WAIT")
                 )
             ])
@@ -569,7 +569,7 @@ class AXILiteTimeout(Module):
                 master.r.valid.eq(~master.ar.valid),
                 master.r.resp.eq(RESP_SLVERR),
                 master.r.data.eq(2**len(master.r.data) - 1),
-                If(master.r.valid & master.r.ready,
+                If(~master.ar.valid & master.r.ready, # master.ar.ready.eq(master.ar.valid),
                     NextState("WAIT")
                 )
             ])

--- a/litex/soc/interconnect/axi/axi_lite.py
+++ b/litex/soc/interconnect/axi/axi_lite.py
@@ -135,7 +135,6 @@ def axi_lite_to_simple(axi_lite, port_adr, port_dat_r, port_dat_w=None, port_we=
                 comb.append(port_we[i].eq(axi_lite.w.valid & axi_lite.w.ready & axi_lite.w.strb[i]))
         else:
             comb.append(port_we.eq(axi_lite.w.valid & axi_lite.w.ready & (axi_lite.w.strb != 0)))
-<<<<<<< HEAD
     # Compute do_write/do_read/axi_lite.r.valid as `comb`, so they do not affect the sensitivity list of the FSM
     nocomb_axl_r_valid = Signal()
     nocomb_axl_w_ready = Signal()
@@ -143,11 +142,6 @@ def axi_lite_to_simple(axi_lite, port_adr, port_dat_r, port_dat_w=None, port_we=
     nocomb_axl_ar_ready = Signal()
     nocomb_axl_b_valid = Signal()
     comb += [
-=======
-
-    fsm = FSM()
-    fsm.act("START-TRANSACTION",
->>>>>>> parent of a41d3014... ensure that the address is valid for only one cycle on reads
         # If the last access was a read, do a write, and vice versa.
         If(axi_lite.aw.valid & axi_lite.ar.valid,
             do_write.eq(last_was_read),
@@ -156,7 +150,6 @@ def axi_lite_to_simple(axi_lite, port_adr, port_dat_r, port_dat_w=None, port_we=
             do_write.eq(axi_lite.aw.valid),
             do_read.eq(axi_lite.ar.valid),
         ),
-<<<<<<< HEAD
         axi_lite.r.valid.eq(nocomb_axl_r_valid),
         axi_lite.aw.ready.eq(nocomb_axl_aw_ready),
         axi_lite.w.ready.eq(nocomb_axl_w_ready),
@@ -165,28 +158,19 @@ def axi_lite_to_simple(axi_lite, port_adr, port_dat_r, port_dat_w=None, port_we=
     ]
     fsm = FSM()
     fsm.act("START-TRANSACTION",
-=======
->>>>>>> parent of a41d3014... ensure that the address is valid for only one cycle on reads
         # Start reading/writing immediately not to waste a cycle.
         axi_lite.aw.ready.eq(last_was_read  | ~axi_lite.ar.valid),
         axi_lite.ar.ready.eq(~last_was_read | ~axi_lite.aw.valid),
         If(do_write,
             port_adr.eq(axi_lite.aw.addr[adr_shift:]),
             If(axi_lite.w.valid,
-<<<<<<< HEAD
                 nocomb_axl_aw_ready.eq(1),
                 nocomb_axl_w_ready.eq(1),
-=======
-                axi_lite.w.ready.eq(1),
->>>>>>> parent of a41d3014... ensure that the address is valid for only one cycle on reads
                 NextState("SEND-WRITE-RESPONSE")
             )
         ).Elif(do_read,
             port_adr.eq(axi_lite.ar.addr[adr_shift:]),
-<<<<<<< HEAD
             nocomb_axl_ar_ready.eq(1),
-=======
->>>>>>> parent of a41d3014... ensure that the address is valid for only one cycle on reads
             NextState("SEND-READ-RESPONSE"),
         )
     )

--- a/litex/soc/interconnect/axi/axi_lite.py
+++ b/litex/soc/interconnect/axi/axi_lite.py
@@ -550,7 +550,7 @@ class AXILiteTimeout(Module):
                 timer.wait.eq(wait_cond),
                 # done is updated in `sync`, so we must make sure that `ready` has not been issued
                 # by slave during that single cycle, by checking `timer.wait`.
-                If(timer.done & timer.wait,
+                If(timer.done & wait_cond,
                     error.eq(1),
                     NextState("RESPOND")
                 )
@@ -567,7 +567,7 @@ class AXILiteTimeout(Module):
                 master.w.ready.eq(master.w.valid),
                 master.b.valid.eq(~master.aw.valid & ~master.w.valid),
                 master.b.resp.eq(RESP_SLVERR),
-                If(master.b.valid & master.b.ready,
+                If((~master.aw.valid & ~master.w.valid) & master.b.ready, # master.b.valid.eq(~master.aw.valid & ~master.w.valid)
                     NextState("WAIT")
                 )
             ])
@@ -581,7 +581,7 @@ class AXILiteTimeout(Module):
                 master.r.valid.eq(~master.ar.valid),
                 master.r.resp.eq(RESP_SLVERR),
                 master.r.data.eq(2**len(master.r.data) - 1),
-                If(master.r.valid & master.r.ready,
+                If(~master.ar.valid & master.r.ready,
                     NextState("WAIT")
                 )
             ])


### PR DESCRIPTION
The re-use of a left hand side (LHS) assignment in a right hand
side (RHS) evaluation inside an `always (@*)` block with non-blocking
operators leads to an infinite loop in some verilog simulators.

In particular, a form such as
```python
fsm.act("A",
   sig.eq(new_value),
   If(sig,
      # ...
   )
)
```
Causes an infinite loop when `new_value` is not 0. This is because
this gets translated in verilog to
```verilog
always (@*) begin
   sig <= 1'd0;
   ...
   sig <= new_value;
   if (sig) begin
      ...
   end
end
```
So what happens is that `sig` gets 0, then, it gets assigned
`new_value`; it is then used by the `if` to decide what to do.

When `new_value` is 0, no change is detected, and there is no
inifnite loop.

However, if `new_value` is 1, the simulator detects the 0->1
transition, and schedules the `always(@*)` for re-evaluation,
because the sensitivity list, which includes `sig` had a transition.

In this case, the simulator (at least some of them) ends up
in an infinite loop, and the simulation is unable to proceed.

This PR is more of an RFC for how to fix the underlying problem.
The commits here as-writ allow the simulation to run and it seems
correct, however, please note that I was unable to fix the
AXITimeout/AXILiteTimeout blocks, for now I am just not using them.
