### PR TITLE
RFC: locate reset vector in custom memory bus

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1241,7 +1241,7 @@ class SoC(LiteXModule, SoCCoreCompat):
                     cpu_reset_address_valid = True
                     if name == "rom":
                         self.cpu.use_rom = True
-            if not cpu_reset_address_valid:
+            if not cpu_reset_address_valid and not self.cpu_custom_memory:
                 self.logger.error("CPU needs {} to be in a {} Region.".format(
                     colorer("reset address 0x{:08x}".format(self.cpu.reset_address)),
                     colorer("defined", color="red")))

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -65,6 +65,7 @@ class SoCCore(LiteXSoC):
         cpu_reset_address        = None,
         cpu_variant              = None,
         cpu_cfu                  = None,
+        cpu_custom_memory        = False,
 
         # CFU parameters
         cfu_filename             = None,
@@ -143,8 +144,9 @@ class SoCCore(LiteXSoC):
         cpu_type          = None if cpu_type == "None" else cpu_type
         cpu_reset_address = None if cpu_reset_address == "None" else cpu_reset_address
 
-        self.cpu_type     = cpu_type
-        self.cpu_variant  = cpu_variant
+        self.cpu_type          = cpu_type
+        self.cpu_variant       = cpu_variant
+        self.cpu_custom_memory = cpu_custom_memory
 
         # ROM.
         # Initialize ROM from binary file when provided.


### PR DESCRIPTION
This PR allows the reset vector to be located within a custom memory bus that is not enumerated by the SoC bus handler.

The use case is when generating a core that is:

1) to be integrated into a third party SoC, where all the memory bus wiring is handled by a different framework
2) none of the local/automatic busses are desired to be inferred with the framework.

An example of this usage would be here:

https://github.com/buncram/cram-soc/blob/cram/cram_core.py

I imagine I'm not quite doing this the way that @enjoy-digital would prefer it to be done, but at the high level, I wanted to be able to configure LiteX to not check that the CPU reset region is in a defined memory region in the case that the memory region is to be defined elsewhere for third-party integrations.
