### PR TITLE
FIX: fix wishbone arbiter

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -184,6 +184,7 @@ class SoCBusHandler(LiteXModule):
     supported_address_width = [32, 64]
     supported_addressing    = ["word", "byte"]
     supported_interconnect  = ["shared", "crossbar"]
+    supported_arbiter       = ["default", "transaction"]
 
     # Creation -------------------------------------------------------------------------------------
     def __init__(self, name="SoCBusHandler",
@@ -194,6 +195,7 @@ class SoCBusHandler(LiteXModule):
         timeout          = int(1e6),
         bursting         = False,
         interconnect     = "shared", interconnect_register=True,
+        arbiter          = "default",
         reserved_regions = None,
     ):
         self.logger = logging.getLogger(name)
@@ -253,6 +255,17 @@ class SoCBusHandler(LiteXModule):
             raise SoCError()
         if timeout is not None:
             timeout = int(timeout)
+        if arbiter not in self.supported_arbiter:
+            self.logger.error("Unsupported {} {}, supported are: {:s}".format(
+                colorer("Bus Arbiter", color="red"),
+                colorer(arbiter),
+                colorer(", ".join(self.supported_arbiter))))
+            raise SoCError()
+        if standard != "wishbone" and arbiter != "default":
+            self.logger.error("{} can only be used with {} Bus.".format(
+                colorer("Bus Arbiter", color="red"),
+                colorer("Wishbone")))
+            raise SoCError()
 
         # Create Bus
         self.standard              = standard
@@ -262,6 +275,7 @@ class SoCBusHandler(LiteXModule):
         self.bursting              = bursting
         self.interconnect          = interconnect
         self.interconnect_register = interconnect_register
+        self.arbiter               = arbiter
         self.masters               = {}
         self.slaves                = {}
         self.regions               = {}
@@ -902,12 +916,18 @@ class SoCBusHandler(LiteXModule):
                     "shared"  : interconnect_shared_cls,
                     "crossbar": interconnect_crossbar_cls,
                 }[self.interconnect]
-                self._interconnect = interconnect_cls(
+                interconnect_kwargs = dict(
                     masters        = list(self.masters.values()),
                     slaves         = [(self.regions[n].decoder(self), s) for n, s in self.slaves.items()],
                     register       = self.interconnect_register,
-                    timeout_cycles = self.timeout
+                    timeout_cycles = self.timeout,
                 )
+                if self.standard == "wishbone":
+                    interconnect_kwargs["arbiter"] = {
+                        "default"     : "cycle",
+                        "transaction" : "transaction",
+                    }[self.arbiter]
+                self._interconnect = interconnect_cls(**interconnect_kwargs)
             self.logger.info("Interconnect: {} ({} <-> {}).".format(
                 colorer(self._interconnect.__class__.__name__),
                 colorer(len(self.masters)),
@@ -1260,6 +1280,7 @@ class SoC(LiteXModule):
         bus_timeout          = int(1e6),
         bus_bursting         = False,
         bus_interconnect     = "shared",
+        bus_arbiter          = "default",
         bus_reserved_regions = None,
 
         csr_data_width       = 32,
@@ -1310,6 +1331,7 @@ class SoC(LiteXModule):
             timeout          = bus_timeout,
             bursting         = bus_bursting,
             interconnect     = bus_interconnect,
+            arbiter          = bus_arbiter,
             reserved_regions = bus_reserved_regions,
            )
 
@@ -3441,6 +3463,7 @@ class SoCCore(LiteXSoC):
         bus_timeout                = int(1e6),
         bus_bursting               = False,
         bus_interconnect           = "shared",
+        bus_arbiter                = "default",
 
         # CPU parameters.
         cpu_type                   = "vexriscv",
@@ -3521,6 +3544,7 @@ class SoCCore(LiteXSoC):
             bus_timeout          = bus_timeout,
             bus_bursting         = bus_bursting,
             bus_interconnect     = bus_interconnect,
+            bus_arbiter          = bus_arbiter,
             bus_reserved_regions = {},
 
             csr_data_width       = csr_data_width,
@@ -3715,6 +3739,7 @@ def soc_core_args(parser, cpu_type="vexriscv", cpu_variant=None):
     soc_group.add_argument("--bus-timeout",       default=int(1e6),    type=auto_int,                                                help="Bus timeout in cycles.")
     soc_group.add_argument("--bus-bursting",      action="store_true",                                                               help="Enable burst cycles on the bus if supported.")
     soc_group.add_argument("--bus-interconnect",  default="shared",                   choices=SoCBusHandler.supported_interconnect,  help="Select bus interconnect.")
+    soc_group.add_argument("--bus-arbiter",       default="default",                  choices=SoCBusHandler.supported_arbiter,        help="Select bus arbiter.")
 
     # CPU parameters.
     soc_group.add_argument("--cpu-type",                 default="vexriscv",                 help="Select CPU: {}.".format(", ".join(map(str, cpu.CPUS.keys()))))

--- a/litex/soc/interconnect/wishbone.py
+++ b/litex/soc/interconnect/wishbone.py
@@ -374,13 +374,20 @@ class InterconnectPointToPoint(LiteXModule):
 
 
 class Arbiter(LiteXModule):
-    def __init__(self, masters=None, target=None, controllers=None):
+    def __init__(self, masters=None, target=None, controllers=None, mode="cycle"):
         assert target is not None
         assert (masters is not None) or (controllers is not None)
         if controllers is not None:
             masters = controllers
 
-        self.rr = roundrobin.RoundRobin(len(masters))
+        if mode == "cycle":
+            self.rr = roundrobin.RoundRobin(len(masters))
+        elif mode == "transaction":
+            self.rr = roundrobin.RoundRobin(len(masters), roundrobin.SP_CE)
+            cycs = Array(m.cyc for m in masters)
+            self.comb += self.rr.ce.eq(target.ack | target.err | ~cycs[self.rr.grant])
+        else:
+            raise ValueError(f"Unsupported Wishbone Arbiter mode: {mode}.")
 
         # mux master->slave signals
         for name, size, direction in _layout:
@@ -446,18 +453,18 @@ class Decoder(LiteXModule):
 
 
 class InterconnectShared(LiteXModule):
-    def __init__(self, masters, slaves, register=False, timeout_cycles=1e6):
+    def __init__(self, masters, slaves, register=False, timeout_cycles=1e6, arbiter="cycle"):
         data_width, addressing = get_check_parameters(ports=masters + [s for _, s in slaves])
         adr_width = max([m.adr_width for m in masters])
         shared = Interface(data_width=data_width, adr_width=adr_width, addressing=addressing)
-        self.arbiter = Arbiter(masters, shared)
+        self.arbiter = Arbiter(masters, shared, mode=arbiter)
         self.decoder = Decoder(shared, slaves, register)
         if timeout_cycles is not None:
             self.timeout = Timeout(shared, timeout_cycles)
 
 
 class Crossbar(LiteXModule):
-    def __init__(self, masters, slaves, register=False, timeout_cycles=1e6):
+    def __init__(self, masters, slaves, register=False, timeout_cycles=1e6, arbiter="cycle"):
         data_width, addressing = get_check_parameters(ports=masters + [s for _, s in slaves])
         matches, busses = zip(*slaves)
         adr_width = max([m.adr_width for m in masters])
@@ -468,7 +475,7 @@ class Crossbar(LiteXModule):
             self.submodules += Decoder(master, row, register)
         # arbitrate each access column onto its slave
         for column, bus in zip(zip(*access), busses):
-            self.submodules += Arbiter(column, bus)
+            self.submodules += Arbiter(column, bus, mode=arbiter)
 
 # Wishbone Data Width Converter --------------------------------------------------------------------
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -128,6 +128,16 @@ class TestLiteXArgumentParserCPUArguments(unittest.TestCase):
         self.assertEqual(args.cpu_variant, "full+cfu")
         self.assertEqual(args.cpu_cfu,  "cfu.v")
 
+    def test_bus_arbiter_is_forwarded_to_soc_argdict(self):
+        parser = self.make_parser()
+
+        parser.parse_args([
+            "--bus-arbiter=transaction",
+            "--no-build-log",
+        ])
+
+        self.assertEqual(parser.soc_argdict["bus_arbiter"], "transaction")
+
 
 class TestLiteXArgumentParserXilinxToolchainArguments(unittest.TestCase):
     def make_parser(self):

--- a/test/test_soc.py
+++ b/test/test_soc.py
@@ -308,6 +308,20 @@ class TestSoCBusHandler(unittest.TestCase):
         with _assert_raises_soc_error(self):
             SoCBusHandler(standard="axi", addressing="word")
 
+    def test_bus_arbiter_transaction_is_wishbone_only(self):
+        self.assertEqual(SoCBusHandler(standard="wishbone").arbiter, "default")
+        self.assertEqual(
+            SoCBusHandler(
+                standard = "wishbone",
+                arbiter  = "transaction",
+            ).arbiter,
+            "transaction",
+        )
+        with _assert_raises_soc_error(self):
+            SoCBusHandler(standard="axi-lite", arbiter="transaction")
+        with _assert_raises_soc_error(self):
+            SoCBusHandler(standard="axi", arbiter="transaction")
+
     def test_address_width_conversion_between_bus_standards(self):
         wishbone_bus = SoCBusHandler(standard="wishbone", data_width=32, address_width=32)
         axi_bus      = SoCBusHandler(standard="axi",      data_width=64, address_width=32)

--- a/test/test_wishbone.py
+++ b/test/test_wishbone.py
@@ -575,6 +575,53 @@ class TestWishbone(unittest.TestCase):
 # Arbiter ------------------------------------------------------------------------------------------
 
 class TestWishboneArbiter(unittest.TestCase):
+    def grant_after_termination_test(self, mode, termination, expected_grant):
+        class DUT(LiteXModule):
+            def __init__(self):
+                self.m0     = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+                self.m1     = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+                self.target = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+                self.arbiter = wishbone.Arbiter(
+                    masters = [self.m0, self.m1],
+                    target  = self.target,
+                    mode    = mode,
+                )
+
+        dut = DUT()
+
+        def gen():
+            yield dut.m0.cyc.eq(1)
+            yield dut.m1.cyc.eq(1)
+            yield
+            self.assertEqual((yield dut.arbiter.rr.grant), 0)
+            yield getattr(dut.target, termination).eq(1)
+            yield
+            yield
+            self.assertEqual((yield dut.arbiter.rr.grant), expected_grant)
+
+        run_simulation(dut, gen())
+
+    def test_cycle_mode_keeps_grant_until_current_master_withdraws(self):
+        self.grant_after_termination_test(
+            mode           = "cycle",
+            termination    = "ack",
+            expected_grant = 0,
+        )
+
+    def test_transaction_mode_can_switch_after_ack(self):
+        self.grant_after_termination_test(
+            mode           = "transaction",
+            termination    = "ack",
+            expected_grant = 1,
+        )
+
+    def test_transaction_mode_can_switch_after_err(self):
+        self.grant_after_termination_test(
+            mode           = "transaction",
+            termination    = "err",
+            expected_grant = 1,
+        )
+
     def test_two_masters_one_slave(self):
         # Two masters share a single SRAM slave via a round-robin Arbiter. Each master does a
         # write followed by a read at its own address and must see its own value.


### PR DESCRIPTION
Commit 07184d37df9921fa2bf729f131d276402bbb3605 breaks designs in my CI testbench. The intent of the commit was to change the wishbone arbiter policy for "everyone" to solve a corner case, but in fact, it breaks other corner cases.

This fix does the following:

- makes the legacy arbiter choice the default, so we don't break designs that currently work just fine

- expose an `arbiter_policy` flag available on `soc.bus` which can be set to override the default policy for designs that require a different arbiter policy to work around a particular use case.

Even if this PR isn't what one would go with syntatically, I would strongly suggest either making the change optional or figuring out why changing the wishbone arbiter policy breaks existing designs. Really chasing down all the implications of a bus policy change like this is a big project that could take a lot of time, especially on SoCs with a single CPU core that is expected to "own" the bus.

@mtdudek it's a big change to switch the default shared fabric arbiter policy for an entire design ecosystem!