### PR TITLE
test_cpu: Add NeoRV32 to tested CPUs

### DIFF
--- a/test/test_cpu.py
+++ b/test/test_cpu.py
@@ -42,6 +42,7 @@ class TestCPU(unittest.TestCase):
             "firev",        # (riscv   / softcore)
             "marocchino",   # (or1k    / softcore)
             "naxriscv",     # (riscv   / softcore)
+            "neorv32",      # (riscv   / softcore)
             "serv",         # (riscv   / softcore)
             "vexriscv",     # (riscv   / softcore)
             "vexriscv_smp", # (riscv   / softcore)
@@ -60,7 +61,6 @@ class TestCPU(unittest.TestCase):
             "lm32",         # (lm32    / softcore) -> Requires LM32 toolchain.
             "minerva",      # (riscv   / softcore) -> Broken install? (Amaranth?)
             "mor1kx",       # (or1k    / softcore) -> Verilator compilation issue.
-            "neorv32",      # (riscv   / softcore) -> Requires VHDL->Verilog (GHDL + Yosys).
             "picorv32",     # (riscv   / softcore) -> Verilator compilation issue.
             "rocket",       # (riscv   / softcore) -> Not enough RAM in CI.
             "zynq7000",     # (arm     / hardcore) -> Hardcore.


### PR DESCRIPTION
With CI supporting GHDL to convert VHDL to Verilog the neorv32 simulation can be tested.

Fixes https://github.com/enjoy-digital/litex/issues/1320

Signed-off-by: Joel Stanley <joel@jms.id.au>