### PR TITLE
interconnect/axi: map from one address space to another

### DIFF
--- a/litex/soc/interconnect/axi/axi_full.py
+++ b/litex/soc/interconnect/axi/axi_full.py
@@ -131,6 +131,13 @@ class AXIInterface:
     def connect(self, slave, **kwargs):
         return connect_axi(self, slave, **kwargs)
 
+    def connect_mapped(self, slave, map_fct):
+        comb = []
+        comb += self.connect(slave, omit={"addr"})
+        comb += [slave.ar.addr.eq(map_fct(self.ar.addr))]
+        comb += [slave.aw.addr.eq(map_fct(self.aw.addr))]
+        return comb
+
     def layout_flat(self):
         return list(axi_layout_flat(self))
 


### PR DESCRIPTION
When trying to connect to the PS axi gp slave to the main Bus of the LiteX SoC I came across the problem that the address space of the zybo PS and the address space/memory map of the Litex SoC are conflicting.
To solve this problem I added the `connect_mapped` function to the AXIInterface, which applies a function to the address signals before connecting the two interfaces together.

Such a function would, for example, add or subtract an offset.
