### PR TITLE
Add octo variants for Rocket

### DIFF
--- a/litex/soc/cores/cpu/rocket/core.py
+++ b/litex/soc/cores/cpu/rocket/core.py
@@ -55,6 +55,9 @@ CPU_VARIANTS = {
     "full4d":   "freechips.rocketchip.system.LitexFull4DConfig",
     "fullq":    "freechips.rocketchip.system.LitexFullQConfig",
     "full4q":   "freechips.rocketchip.system.LitexFull4QConfig",
+    "fullo":    "freechips.rocketchip.system.LitexFullOConfig",
+    "full4o":   "freechips.rocketchip.system.LitexFull4OConfig",
+    "full6o":   "freechips.rocketchip.system.LitexFull6OConfig",
 }
 
 # GCC Flags-----------------------------------------------------------------------------------------
@@ -72,6 +75,9 @@ GCC_FLAGS = {
     "full4d":   "-march=rv64imafdc -mabi=lp64 ",
     "fullq":    "-march=rv64imafdc -mabi=lp64 ",
     "full4q":   "-march=rv64imafdc -mabi=lp64 ",
+    "fullo":    "-march=rv64imafdc -mabi=lp64 ",
+    "full4o":   "-march=rv64imafdc -mabi=lp64 ",
+    "full6o":   "-march=rv64imafdc -mabi=lp64 ",
 }
 
 # CPU Size Params ----------------------------------------------------------------------------------
@@ -90,6 +96,9 @@ CPU_SIZE_PARAMS = {
     "full4d":   (   128,      64,         4),
     "fullq":    (   256,      64,         1),
     "full4q":   (   256,      64,         4),
+    "fullo":    (   512,      64,         1),
+    "full4o":   (   512,      64,         4),
+    "full6o":   (   512,      64,         6),
 }
 
 # Rocket  ------------------------------------------------------------------------------------------


### PR DESCRIPTION
Add some Octo-width (512bit) memory bus variants for Rocket, which is useful for Xilinx 7-series FPGAs with DDR3 DIMMs (1:4, DDR, 64-bit, which results in 4*2*64=512 bits)

See https://github.com/litex-hub/pythondata-cpu-rocket/pull/5 for corresponding pythondata-cpu-rocket change.