### PR TITLE
integration/soc: Warn on MemBus <-> LiteDRAM AXI width conversion

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1529,6 +1529,10 @@ class LiteXSoC(SoC):
                 # Check if bus is an AXI bus and connect it.
                 if isinstance(mem_bus, axi.AXIInterface):
                     data_width_ratio = int(port.data_width/mem_bus.data_width)
+                    if data_width_ratio != 1:
+                        self.logger.warning("Converting MemBus({}) data width to LiteDRAM({}).".format(
+                            colorer(mem_bus.data_width, color="yellow"),
+                            colorer(port.data_width,    color="yellow")))
                     # If same data_width, connect it directly.
                     if data_width_ratio == 1:
                         self.submodules += LiteDRAMAXI2Native(


### PR DESCRIPTION
CPUs with a dedicated memory port (bus) can be connected directly to the LiteDRAM port. Some models (e.g., Rocket) have otherwise equivalent variants specifically pre-generated to fit the various "standard" LiteDRAM port widths (so far, 64, 128, and 256 bits).

This patch introduces a warning when the CPU variant's dedicated memory bus width doesn't exactly match the width of LiteDRAM, requiring explicit Up- or Down-conversion.

The goal is to inform the user and give them the opportunity to pick a more suitable CPU variant (of a matching MemBus width), if available.