### PR TITLE
software/demo: Add .got and .toc to .rodata in linker script

### DIFF
--- a/litex/soc/software/demo/linker.ld
+++ b/litex/soc/software/demo/linker.ld
@@ -26,6 +26,8 @@ SECTIONS
 		_frodata = .;
 		*(.rodata .rodata.* .gnu.linkonce.r.*)
 		*(.rodata1)
+		*(.got .got.*)
+		*(.toc .toc.*)
 		. = ALIGN(8);
 		_erodata = .;
 	} > main_ram


### PR DESCRIPTION
When using printf in the demo application, gcc emits .got and .toc sections which are placed in SRAM by default. This breaks printf and other functions relying on the GOT if the demo is loaded into flash or ROM. This pull request matches the demo's .rodata section to that of the BIOS.