### PR TITLE
Fix sim module build on MacOS arm64

### DIFF
--- a/litex/build/sim/core/Makefile
+++ b/litex/build/sim/core/Makefile
@@ -1,9 +1,15 @@
 include variables.mak
 UNAME_S := $(shell uname -s)
+UNAME_M := $(shell uname -m)
 
 ifeq ($(UNAME_S),Darwin)
-	CFLAGS += -I/usr/local/include/
-	LDFLAGS += -L/usr/local/lib
+	ifeq ($(UNAME_M),x86_64)
+		CFLAGS += -I/usr/local/include
+		LDFLAGS += -L/usr/local/lib
+	else
+		CFLAGS += -I/opt/homebrew/include
+		LDFLAGS += -L/opt/homebrew/lib
+	endif
 	LDFLAGS += -lpthread -ljson-c -lz -lm -lstdc++ -ldl -levent
 else
 	CC ?= gcc

--- a/litex/build/sim/core/modules/gmii_ethernet/Makefile
+++ b/litex/build/sim/core/modules/gmii_ethernet/Makefile
@@ -4,6 +4,7 @@ UNAME_S := $(shell uname -s)
 include $(SRC_DIR)/modules/rules.mak
 
 CFLAGS += -I$(TAPCFG_DIRECTORY)/src/include
+LDFLAGS += -lz
 OBJS = $(MOD).o tapcfg.o taplog.o
 
 $(MOD).so: $(OBJS)

--- a/litex/build/sim/core/modules/rules.mak
+++ b/litex/build/sim/core/modules/rules.mak
@@ -1,12 +1,19 @@
 CC ?= gcc
 UNAME_S := $(shell uname -s)
+UNAME_M := $(shell uname -m)
 
 ifeq ($(UNAME_S),Darwin)
-    CFLAGS += -I/usr/local/include/
-    LDFLAGS += -L/usr/local/lib -ljson-c
-    CFLAGS += -Wall -O3 -ggdb -fPIC
+	ifeq ($(UNAME_M),x86_64)
+		CFLAGS += -I/usr/local/include
+		LDFLAGS += -L/usr/local/lib
+	else
+		CFLAGS += -I/opt/homebrew/include
+		LDFLAGS += -L/opt/homebrew/lib
+	endif
+	LDFLAGS += -ljson-c
+	CFLAGS += -Wall -O3 -ggdb -fPIC
 else
-    CFLAGS += -Wall -O3 -ggdb -fPIC -Werror
+	CFLAGS += -Wall -O3 -ggdb -fPIC -Werror
 endif
 LDFLAGS += -levent -shared -fPIC
 

--- a/litex/build/sim/core/modules/xgmii_ethernet/Makefile
+++ b/litex/build/sim/core/modules/xgmii_ethernet/Makefile
@@ -4,6 +4,7 @@ UNAME_S := $(shell uname -s)
 include $(SRC_DIR)/modules/rules.mak
 
 CFLAGS += -I$(TAPCFG_DIRECTORY)/src/include
+LDFLAGS += -lz
 OBJS = $(MOD).o tapcfg.o taplog.o
 
 $(MOD).so: $(OBJS)


### PR DESCRIPTION
Homebrew on arm64 Mac is now in /opt/homebrew by default.