### PR TITLE
FIX #1530: add explicit `.re` for axi-lite busses

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1197,13 +1197,19 @@ class SoC(LiteXModule, SoCCoreCompat):
                 delattr(self, name)
 
         # SoC CSR Interconnect ---------------------------------------------------------------------
+        if self.bus.standard == 'axi-lite':
+            use_re = True
+        else:
+            use_re = False
         self.csr_bankarray = csr_bus.CSRBankArray(self,
             address_map        = self.csr.address_map,
             data_width         = self.csr.data_width,
             address_width      = self.csr.address_width,
             alignment          = self.csr.alignment,
             paging             = self.csr.paging,
-            ordering           = self.csr.ordering)
+            ordering           = self.csr.ordering,
+            use_re             = use_re,
+        )
         if len(self.csr.masters):
             self.csr_interconnect = csr_bus.InterconnectShared(
                 masters = list(self.csr.masters.values()),

--- a/litex/soc/interconnect/axi/axi_lite.py
+++ b/litex/soc/interconnect/axi/axi_lite.py
@@ -118,7 +118,7 @@ class AXILiteInterface:
 
 # AXI-Lite to Simple Bus ---------------------------------------------------------------------------
 
-def axi_lite_to_simple(axi_lite, port_adr, port_dat_r, port_dat_w=None, port_we=None):
+def axi_lite_to_simple(axi_lite, port_adr, port_dat_r, port_dat_w=None, port_we=None, port_re=None):
     """Connection of AXILite to simple bus with 1-cycle latency, such as CSR bus or Memory port"""
     bus_data_width = axi_lite.data_width
     adr_shift      = log2_int(bus_data_width//8)

--- a/litex/soc/interconnect/axi/axi_lite_to_csr.py
+++ b/litex/soc/interconnect/axi/axi_lite_to_csr.py
@@ -32,6 +32,8 @@ class AXILite2CSR(Module):
             port_adr   = self.csr.adr,
             port_dat_r = self.csr.dat_r,
             port_dat_w = self.csr.dat_w,
-            port_we    = self.csr.we)
+            port_we    = self.csr.we,
+            port_re    = self.csr.re,
+        )
         self.submodules.fsm = fsm
         self.comb += comb


### PR DESCRIPTION
The current CSR implementation infers the "read enable" signal (which is, oddly enough, called `.we` in the code) by taking the inverse of the write enable and combining it with the current address on the bus.

This causes a problem for AXI-lite per issue #1530, where the read enable signal can be asserted for several cycles instead of exactly one per the CSR specification.

I tried addressing this in PR#1531 but the patch isn't good enough; especially with third-party (non-Litex) IP, it is legal to have the address be present on the bus for much longer than one cycle, which leads to the read enable signal being asserted for longer than one cycle.

This commit adds an explicit `.re` signal to the bus, so that this can be derived from the "ready" signal on the AXI-lite bus, allowing us to have a robust solution to guaranteeing the CSR abstraction is met.

This PR is preferred over #1531, which is now being abandoned.