### PR TITLE
builder: Fix logic for determining meson version compatibility

### DIFF
--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -262,7 +262,7 @@ class Builder:
             msg = "Unable to find valid Meson build system, please install it with:\n"
             msg += "- pip3 install meson.\n"
             raise OSError(msg)
-        if (int(meson_version[0]) < meson_major_min) or (int(meson_version[1]) < meson_minor_min):
+        if (int(meson_version[0]) < meson_major_min) or (int(meson_version[0]) == meson_major_min and int(meson_version[1]) < meson_minor_min):
             msg = f"Meson version to old. Found: {meson_version[0]}.{meson_version[1]}. Required: {meson_major_min}.{meson_minor_min}.\n"
             msg += "Try updating with:\n"
             msg += "- pip3 install -U meson.\n"


### PR DESCRIPTION
Recently PyPi version of meson changed to 1.0.0 which uncovered this bug which caused the error condition to triggger falsely. 