### PR TITLE
cores/jtag: Add more Altera part numbers

### DIFF
--- a/litex/soc/cores/jtag.py
+++ b/litex/soc/cores/jtag.py
@@ -238,40 +238,51 @@ class AlteraJTAG(Module):
 
     @staticmethod
     def get_primitive(device):
-        # TODO: Add support for all devices.
+        # TODO: Add support for Stratix 10, Arria 10 SoC and Agilex devices.
         prim_dict = {
             # Primitive Name                Ðevice (startswith)
-            "arriaii_jtag"                : [],
-            "arriaiigz_jtag"              : [],
-            "arriav_jtag"                 : [],
-            "arriavgz_jtag"               : [],
-            "cyclone_jtag"                : [],
+            "arriaii_jtag"                : ["ep2a"],
+            "arriaiigz_jtag"              : ["ep2agz"],
+            "arriav_jtag"                 : ["5a"],
+            "arriavgz_jtag"               : ["5agz"],
+            "cyclone_jtag"                : ["ep1c"],
             "cyclone10lp_jtag"            : ["10cl"],
-            "cycloneii_jtag"              : [],
-            "cycloneiii_jtag"             : [],
-            "cycloneiiils_jtag"           : [],
-            "cycloneiv_jtag"              : [],
-            "cycloneive_jtag"             : ["ep4c"],
+            "cycloneii_jtag"              : ["ep2c"],
+            "cycloneiii_jtag"             : ["ep3c"],
+            "cycloneiiils_jtag"           : ["ep3cls"],
+            "cycloneiv_jtag"              : ["ep4cgx"],
+            "cycloneive_jtag"             : ["ep4ce"],
             "cyclonev_jtag"               : ["5c"],
-            "fiftyfivenm_jtag"            : ["10m"],
-            "maxii_jtag"                  : [],
-            "maxv_jtag"                   : [],
-            "stratix_jtag"                : [],
-            "stratixgx_jtag"              : [],
-            "stratixii_jtag"              : [],
-            "stratixiigx_jtag"            : [],
-            "stratixiii_jtag"             : [],
-            "stratixiv_jtag"              : [],
-            "stratixv_jtag"               : [],
-            "twentynm_jtagblock"          : [],
-            "twentynm_jtag"               : [],
+            "fiftyfivenm_jtag"            : ["10m"], # MAX 10 series
+            "maxii_jtag"                  : ["epm1", "epm2", "epm5"],
+            "maxv_jtag"                   : ["5m"],
+            "stratix_jtag"                : ["ep1s"],
+            "stratixgx_jtag"              : ["ep1sgx"],
+            "stratixii_jtag"              : ["ep2s"],
+            "stratixiigx_jtag"            : ["ep2sgx"],
+            "stratixiii_jtag"             : ["ep3s"],
+            "stratixiv_jtag"              : ["ep4s"],
+            "stratixv_jtag"               : ["5s"],
+            "twentynm_jtagblock"          : [], # Arria 10 series
+            "twentynm_jtag"               : ["10a"],
             "twentynm_hps_interface_jtag" : [],
         }
+
+        matching_prims = {}
+
         for prim, prim_devs in prim_dict.items():
             for prim_dev in prim_devs:
                 if device.lower().startswith(prim_dev):
-                    return prim
-        return None
+                    matching_prims[prim_dev] = prim
+
+        # get the closest match
+        best_device = ""
+
+        for dev, prim in matching_prims.items():
+            if len(dev) > len(best_device):
+                best_device = dev
+
+        return matching_prims.get(best_device)
 
 # Xilinx JTAG --------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This pull request adds more part numbers to the JTAG primitive dictionary. It also changes `get_primitive` to return the closest match to the beginning of a part number.

This is required for parts such as `EP2S`, which shares the same signature as `EP2SGX` while using different JTAG primitives.