### PR TITLE
build/xilinx/vivado: fix verilog include paths

### DIFF
--- a/litex/build/xilinx/vivado.py
+++ b/litex/build/xilinx/vivado.py
@@ -281,7 +281,7 @@ class XilinxVivadoToolchain(GenericToolchain):
             tcl.append("\n# Synthesis\n")
             synth_cmd = f"synth_design -directive {self.vivado_synth_directive} -top {self._build_name} -part {self.platform.device}"
             if self.platform.verilog_include_paths:
-                synth_cmd += f" -include_dirs \{{" ".join(self.platform.verilog_include_paths)}\}"
+                synth_cmd += f" -include_dirs {{{' '.join(self.platform.verilog_include_paths)}}}"
             tcl.append(synth_cmd)
         elif self._synth_mode == "yosys":
             tcl.append("\n# Read Yosys EDIF\n")


### PR DESCRIPTION
a286d77e introduced a bug, where `-include_dirs` parameter is incorrectly defined.

Following TCL code is being generated:
```tcl
synth_design -directive default -top digilent_arty -part xc7a35ticsg324-1L -include_dirs \{.join(self.platform.verilog_include_paths)}\}
```

Below is an explanation why it didn't work:
Python's f-strings escape curly braces using double curly braces like so `{{` instead of using backslash `\{`.
What's more, you need to alternate single and double quotations marks when using strings in curly braces expression otherwise two string objects are being generated and errors like this one can happen.

Signed-off-by: Michal Sieron <msieron@antmicro.com>