### PR TITLE
Add `sdram_hw_test` command

### DIFF
--- a/litex/soc/software/bios/cmds/cmd_litedram.c
+++ b/litex/soc/software/bios/cmds/cmd_litedram.c
@@ -89,6 +89,46 @@ static void sdram_bist_handler(int nb_params, char **params)
 define_command(sdram_bist, sdram_bist_handler, "Run SDRAM Build-In Self-Test", LITEDRAM_CMDS);
 #endif
 
+/**
+ * Command "sdram_hw_test"
+ *
+ * Run SDRAM HW-accelerated memtest
+ *
+ */
+#if defined(CSR_SDRAM_GENERATOR_BASE) && defined(CSR_SDRAM_CHECKER_BASE)
+static void sdram_hw_test_handler(int nb_params, char **params)
+{
+	char *c;
+	uint64_t origin;
+	uint64_t size;
+	uint64_t burst_length = 1;
+	if (nb_params < 2) {
+		printf("sdram_hw_test <origin> <size> [<burst_length>]");
+		return;
+	}
+	origin = strtoull(params[0], &c, 0);
+	if (*c != 0) {
+		printf("Incorrect origin");
+		return;
+	}
+	size = strtoull(params[1], &c, 0);
+	if (*c != 0) {
+		printf("Incorrect size");
+		return;
+	}
+	if (nb_params > 2) {
+		burst_length = strtoull(params[2], &c, 0);
+		if (*c != 0) {
+			printf("Incorrect burst length");
+			return;
+		}
+	}
+	int errors = sdram_hw_test(origin, size, burst_length);
+	printf("%d errors found\n", errors);
+}
+define_command(sdram_hw_test, sdram_hw_test_handler, "Run SDRAM HW-accelerated memtest", LITEDRAM_CMDS);
+#endif
+
 #ifdef CSR_DDRPHY_RDPHASE_ADDR
 /**
  * Command "sdram_force_rdphase"

--- a/litex/soc/software/liblitedram/bist.c
+++ b/litex/soc/software/liblitedram/bist.c
@@ -126,7 +126,7 @@ void sdram_bist(uint32_t burst_length, uint32_t random)
 	uint64_t total_length;
 	uint32_t total_errors;
 
-	printf("Starting SDRAM BIST with burst_length=%lu and random=%lu\n", burst_length, random);
+	printf("Starting SDRAM BIST with burst_length=%" PRIu32 " and random=%" PRIu32 "\n", burst_length, random);
 
 	total_length = 0;
 	total_errors = 0;
@@ -139,7 +139,7 @@ void sdram_bist(uint32_t burst_length, uint32_t random)
 			printf("WR-SPEED(MiB/s) RD-SPEED(MiB/s)  TESTED(MiB)       ERRORS\n");
 		}
 		if (i%100 == 100-1) {
-			printf("%15lu %15lu %12llu %12lu\n",
+			printf("%15" PRIu32 " %15" PRIu32 "%12" PRIu64 "%12" PRIu32 "\n",
 				compute_speed_mibs(wr_length, wr_ticks),
 				compute_speed_mibs(rd_length, rd_ticks),
 				total_length/(1024*1024),

--- a/litex/soc/software/liblitedram/bist.h
+++ b/litex/soc/software/liblitedram/bist.h
@@ -5,6 +5,8 @@
 #define __SDRAM_BIST_H
 
 #include <stdint.h>
+
 void sdram_bist(uint32_t burst_length, uint32_t random);
+int sdram_hw_test(uint64_t origin, uint64_t size, uint64_t burst_length);
 
 #endif /* __SDRAM_BIST_H */

--- a/litex/soc/software/liblitedram/bist.h
+++ b/litex/soc/software/liblitedram/bist.h
@@ -4,7 +4,7 @@
 #ifndef __SDRAM_BIST_H
 #define __SDRAM_BIST_H
 
-void sdram_bist_loop(uint32_t loop, uint32_t burst_length, uint32_t random);
+#include <stdint.h>
 void sdram_bist(uint32_t burst_length, uint32_t random);
 
 #endif /* __SDRAM_BIST_H */

--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -149,6 +149,7 @@ class SimSoC(SoCCore):
         sdram_data_width      = 32,
         sdram_spd_data        = None,
         sdram_verbosity       = 0,
+        with_bist             = False,
         with_i2c              = False,
         with_sdcard           = False,
         with_spi_flash        = False,
@@ -195,7 +196,8 @@ class SimSoC(SoCCore):
                 module                  = sdram_module,
                 l2_cache_size           = kwargs.get("l2_size", 8192),
                 l2_cache_min_data_width = kwargs.get("min_l2_data_width", 128),
-                l2_cache_reverse        = False
+                l2_cache_reverse        = False,
+                with_bist               = with_bist
             )
             if sdram_init != []:
                 # Skip SDRAM test to avoid corrupting pre-initialized contents.
@@ -373,6 +375,7 @@ def sim_args(parser):
     parser.add_argument("--sdram-init",           default=None,            help="SDRAM init file (.bin or .json).")
     parser.add_argument("--sdram-from-spd-dump",  default=None,            help="Generate SDRAM module based on data from SPD EEPROM dump.")
     parser.add_argument("--sdram-verbosity",      default=0,               help="Set SDRAM checker verbosity.")
+    parser.add_argument("--with-bist",            action="store_true",     help="Enable SDRAM BIST modules.")
 
     # Ethernet /Etherbone.
     parser.add_argument("--with-ethernet",        action="store_true",     help="Enable Ethernet support.")
@@ -476,6 +479,7 @@ def main():
     # SoC ------------------------------------------------------------------------------------------
     soc = SimSoC(
         with_sdram         = args.with_sdram,
+        with_bist          = args.with_bist,
         with_ethernet      = args.with_ethernet,
         ethernet_phy_model = args.ethernet_phy_model,
         with_etherbone     = args.with_etherbone,


### PR DESCRIPTION
This PR adds `sdram_hw_test` command, which uses BIST modules that are enabled when `with_bist=True` in `add_sdram` method.

It allows performing a memtest (similar to `sdram_test`), but using DMAs and bypassing system bus. This way, one can test ranges above 4 GiB, which was the limit with `sdram_test` due to address_width being limited to 32 bits.

Additionally I reworked already existing BIST functions a little bit:
- fixed `SDRAM_TEST_DATA_BYTES` definition
- extracted code to `sdram_bist_[write|read]` functions
- made global variables static
- fixed formatting

It would be best if https://github.com/enjoy-digital/litedram/pull/321 would be merged as well, although they should be independent.