### PR TITLE
Add Arch Linux setup support for RISC-V and OpenRISC toolchains

### DIFF
--- a/litex_setup.py
+++ b/litex_setup.py
@@ -341,7 +341,6 @@ def riscv_gcc_install():
     # ------
     if sys.platform.startswith("linux"):
         os_release = (open("/etc/os-release").read()).lower()
-        print(os_release)
         # Fedora.
         if "fedora" in os_release:
             os.system("dnf install gcc-riscv64-linux-gnu")
@@ -475,3 +474,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+    

--- a/litex_setup.py
+++ b/litex_setup.py
@@ -372,6 +372,9 @@ def powerpc_gcc_install():
         # Fedora.
         if "fedora" in os_release:
             os.system("dnf install gcc-powerpc64le-linux-gnu") # FIXME: binutils-multiarch?
+        # Arch (AUR repository).
+        elif "arch" in os_release:
+            os.system("yay -S powerpc64le-linux-gnu-gcc")
         # Ubuntu.
         else:
             os.system("apt install gcc-powerpc64le-linux-gnu binutils-multiarch")

--- a/litex_setup.py
+++ b/litex_setup.py
@@ -341,9 +341,13 @@ def riscv_gcc_install():
     # ------
     if sys.platform.startswith("linux"):
         os_release = (open("/etc/os-release").read()).lower()
+        print(os_release)
         # Fedora.
         if "fedora" in os_release:
             os.system("dnf install gcc-riscv64-linux-gnu")
+        # Arch.
+        elif "arch" in os_release:
+            os.system("pacman -S riscv64-linux-gnu-gcc")
         # Ubuntu.
         else:
             os.system("apt install gcc-riscv64-linux-gnu")
@@ -389,6 +393,9 @@ def openrisc_gcc_install():
         # Fedora.
         if "fedora" in os_release:
             os.system("dnf install gcc-or1k-elf")
+        # Arch.
+        elif "arch" in os_release:
+            os.system("pacman -S or1k-elf-gcc")
         # Ubuntu.
         else:
             os.system("apt install gcc-or1k-elf")


### PR DESCRIPTION
The current setup script does not install the needed dependencies for Arch Linux machines (such as Risc-V and OpenRISC).
This PR adds support, installing these packages:
- riscv : https://archlinux.org/packages/community/x86_64/riscv64-linux-gnu-gcc/
- openrisc : https://archlinux.org/packages/community/x86_64/or1k-elf-gcc/

I also found [this](https://aur.archlinux.org/packages/powerpc-linux-gnu-gcc) AUR package for the PowerPC toolchain, but since its AUR, I'm not sure if I should include it.

