### PR TITLE
Improve LiteXArgumentParser

### DIFF
--- a/litex/build/parser.py
+++ b/litex/build/parser.py
@@ -177,7 +177,14 @@ class LiteXArgumentParser(argparse.ArgumentParser):
             if platform is None: # no user selection: try default
                 platform = self.get_default_value_from_actions("platform", None)
             if platform is not None:
-                self.set_platform(importlib.import_module(platform).Platform)
+                try:
+                    platform_cls = importlib.import_module(platform).Platform
+                except ModuleNotFoundError as e:
+                    # platform not found: try litex-boards package
+                    platform = "litex_boards.platforms." + platform
+                    platform_cls = importlib.import_module(platform).Platform
+                self.set_platform(platform_cls)
+
                 self.add_target_group()
 
         # When platform provided/set, set builder/soc_core args.

--- a/litex/build/parser.py
+++ b/litex/build/parser.py
@@ -174,6 +174,8 @@ class LiteXArgumentParser(argparse.ArgumentParser):
         # When platform is None try to search for a user input
         if self._platform is None:
             platform = self.get_value_from_key("--platform", None)
+            if platform is None: # no user selection: try default
+                platform = self.get_default_value_from_actions("platform", None)
             if platform is not None:
                 self.set_platform(importlib.import_module(platform).Platform)
                 self.add_target_group()
@@ -244,3 +246,23 @@ class LiteXArgumentParser(argparse.ArgumentParser):
         except IndexError:
             value = default
         return value
+
+    def get_default_value_from_actions(self, key, default=None):
+        """
+        search key into ArgumentParser _actions list
+
+        Parameters
+        ==========
+        key: str
+            key to search
+        default: str
+            default value when key is not in _actions list
+
+        Return
+        ======
+            default value or default when key is not present
+        """
+        for act in self._actions:
+            if act.dest == key:
+                return act.default
+        return default


### PR DESCRIPTION
For mostly targets platform name is passed to the `LiteXArgumentParser`'s constructor but it sometime a same target may be used for more than one platform (For example with *colorlight i5* and *colorlight 5a-75b*). In this situation, as done for **simple.py** a `--platform` argument is added, with potentially a default value.
Current `LiteXArgumentParser` policy, when the platform name isn't provided, is to search into sys.argv for an user entry. It's fine with *simple.py* where no default value is provided for `--platform` argument, but when the user didn't provides this argument (to use default value) `LiteXArgumentParser` doesn't search into argument list to extracts the default value resulting in a `NoneType` platform.
The first commit address this issue by adding a new method used to search for an argument and to return default value.

Again, related to the platform argument: currently the platform name must be provided with the full path. This behaviour make sense for custom platforms located somewhere in a package, but make less sense when this is an official platform.
The second commit try to provides an answer by searching first the class platform using the name and when not found append the name with `litex_boards.platorms` to search again.