### PR TITLE
I2C fixes

### DIFF
--- a/litex/soc/software/libbase/i2c.c
+++ b/litex/soc/software/libbase/i2c.c
@@ -274,7 +274,12 @@ bool i2c_poll(unsigned char slave_addr)
 
     i2c_start();
     result  = i2c_transmit_byte(I2C_ADDR_WR(slave_addr));
-    result |= i2c_transmit_byte(I2C_ADDR_RD(slave_addr));
+    if (!result) {
+        i2c_start();
+        result |= i2c_transmit_byte(I2C_ADDR_RD(slave_addr));
+        if (result)
+           i2c_receive_byte(false);
+    }
     i2c_stop();
 
     return result;

--- a/litex/soc/software/libbase/i2c.c
+++ b/litex/soc/software/libbase/i2c.c
@@ -7,11 +7,14 @@
 #include <generated/soc.h>
 #include <generated/csr.h>
 
+#include <system.h>
+
 #ifdef CONFIG_HAS_I2C
 #include <generated/i2c.h>
 
-#define I2C_PERIOD_CYCLES (CONFIG_CLOCK_FREQUENCY / I2C_FREQ_HZ)
-#define I2C_DELAY(n)	  cdelay((n)*I2C_PERIOD_CYCLES/4)
+#define U_SECOND	(1000000)
+#define I2C_PERIOD	(U_SECOND / I2C_FREQ_HZ)
+#define I2C_DELAY(n)	busy_wait_us(n * I2C_PERIOD / 4)
 
 int current_i2c_dev = DEFAULT_I2C_DEV;
 
@@ -19,14 +22,6 @@ struct i2c_dev *get_i2c_devs(void) { return i2c_devs; }
 int get_i2c_devs_count(void)       { return I2C_DEVS_COUNT; }
 void set_i2c_active_dev(int dev)   { current_i2c_dev = dev; }
 int get_i2c_active_dev(void)       { return current_i2c_dev; }
-
-static inline void cdelay(int i)
-{
-	while(i > 0) {
-		__asm__ volatile(CONFIG_CPU_NOP);
-		i--;
-	}
-}
 
 int i2c_send_init_cmds(void)
 {

--- a/litex/soc/software/libbase/i2c.c
+++ b/litex/soc/software/libbase/i2c.c
@@ -15,7 +15,7 @@
 
 int current_i2c_dev = DEFAULT_I2C_DEV;
 
-struct i2c_dev *get_i2c_devs(void) { return &i2c_devs; }
+struct i2c_dev *get_i2c_devs(void) { return i2c_devs; }
 int get_i2c_devs_count(void)       { return I2C_DEVS_COUNT; }
 void set_i2c_active_dev(int dev)   { current_i2c_dev = dev; }
 int get_i2c_active_dev(void)       { return current_i2c_dev; }


### PR DESCRIPTION
**More lengthy explanations are in the commit messages. Below is a summary of my changes.**

---

Fix invalid return type in `get_i2c_devs`:
```
/some/path/litex/litex/soc/software/libbase/i2c.c: In function 'get_i2c_devs':
/some/path/litex/litex/soc/software/libbase/i2c.c:21:45: warning: returning 'struct i2c_dev (*)[1]' from a function with incompatible return type 'struct i2c_dev *' [-Wincompatible-pointer-types]
   21 | struct i2c_dev *get_i2c_devs(void) { return &i2c_devs; }
      |                                             ^~~~~~~~~
```

---

Fix for `i2c_poll`.

Change made in 1989d85 was supposed to poll I2C devices using both writes and reads.
But a bug was introduced and not only did the read not happen, but a potentially harmful write was happening.

---

Be more careful about enabling SDA pull-up.

Instead of enabling pull-up after every sent bit, enable it only after
sending all 8 bits.

This prevents some glitches from happening, where transition between
bits 0 to 0, produces a short spike.

---

Use busy_wait_us instead of cdelay.

vexriscv variant | requested I2C speed | actual (cdelay) | actual (busy_wait_us)
-----------------|---------------------|-----------------|----------------------
minimal          |  50 kHz             |  4 kHz          |  38 kHz
minimal          | 200 kHz             | 15 kHz          |  96 kHz
minimal          | 400 kHz             | 28 kHz          | 137 kHz
lite             |  50 kHz             | 12 kHz          |  40 kHz
lite             | 200 kHz             | 43 kHz          | 115 kHz
lite             | 400 kHz             | 74 kHz          | 180 kHz
standard         |  50 kHz             | 12 kHz          |  45 kHz
standard         | 200 kHz             | 48 kHz          | 159 kHz
standard         | 400 kHz             | 84 kHz          | 311 kHz