### PR TITLE
soc/software/libXX/YY.h: adding extern C (required to link with cpp code)

### DIFF
--- a/litex/soc/software/libbase/memtest.h
+++ b/litex/soc/software/libbase/memtest.h
@@ -1,6 +1,10 @@
 #ifndef __MEMTEST_H
 #define __MEMTEST_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdbool.h>
 
 #include <generated/csr.h>
@@ -32,5 +36,9 @@ int memtest_data(unsigned int *addr, unsigned long size, int random, struct memt
 
 void memspeed(unsigned int *addr, unsigned long size, bool read_only, bool random);
 int memtest(unsigned int *addr, unsigned long maxsize);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __MEMTEST_H */

--- a/litex/soc/software/libbase/progress.h
+++ b/litex/soc/software/libbase/progress.h
@@ -2,6 +2,10 @@
 #ifndef __PROGRSS_H
 #define __PROGRSS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Initialize a progress bar. If max > 0 a one line progress
  * bar is printed where 'max' corresponds to 100%. If max == 0
  * a multi line progress bar is printed.
@@ -12,5 +16,9 @@ void init_progression_bar(int max);
  * spinner is printed.
  */
 void show_progress(int now);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /*  __PROGRSS_H */

--- a/litex/soc/software/libbase/spiflash.h
+++ b/litex/soc/software/libbase/spiflash.h
@@ -1,9 +1,17 @@
 #ifndef __SPIFLASH_H
 #define __SPIFLASH_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void write_to_flash_page(unsigned int addr, const unsigned char *c, unsigned int len);
 void erase_flash_sector(unsigned int addr);
 void erase_flash(void);
 void write_to_flash(unsigned int addr, const unsigned char *c, unsigned int len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SPIFLASH_H */

--- a/litex/soc/software/liblitedram/bist.h
+++ b/litex/soc/software/liblitedram/bist.h
@@ -4,9 +4,17 @@
 #ifndef __SDRAM_BIST_H
 #define __SDRAM_BIST_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 
 void sdram_bist(uint32_t burst_length, uint32_t random);
 int sdram_hw_test(uint64_t origin, uint64_t size, uint64_t burst_length);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SDRAM_BIST_H */

--- a/litex/soc/software/liblitedram/sdram.h
+++ b/litex/soc/software/liblitedram/sdram.h
@@ -1,6 +1,10 @@
 #ifndef __SDRAM_H
 #define __SDRAM_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <generated/csr.h>
 
 /*-----------------------------------------------------------------------*/
@@ -52,5 +56,9 @@ int sdram_init(void);
 /* Debugging                                                             */
 /*-----------------------------------------------------------------------*/
 void sdram_debug(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SDRAM_H */

--- a/litex/soc/software/liblitedram/sdram_dbg.h
+++ b/litex/soc/software/liblitedram/sdram_dbg.h
@@ -1,6 +1,10 @@
 #ifndef __SDRAM_DBG_H
 #define __SDRAM_DBG_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <generated/csr.h>
 
 #ifdef CSR_SDRAM_BASE
@@ -53,5 +57,9 @@ int readback_add(struct readback *readback, unsigned int max_len, struct memory_
 int readback_compare(struct readback *readback, struct readback *other, int verbose);
 
 #endif /* CSR_SDRAM_BASE */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SDRAM_DBG_H */

--- a/litex/soc/software/liblitedram/sdram_spd.h
+++ b/litex/soc/software/liblitedram/sdram_spd.h
@@ -4,6 +4,10 @@
 #ifndef __SDRAM_SPD_H
 #define __SDRAM_SPD_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <libbase/i2c.h>
@@ -33,5 +37,9 @@
 #endif /* CSR_SDRAM_BASE && CONFIG_HAS_I2C */
 
 bool sdram_read_spd(uint8_t spd, uint16_t addr, uint8_t *buf, uint16_t len, bool send_stop);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SDRAM_SPD_H */

--- a/litex/soc/software/liblitedram/utils.h
+++ b/litex/soc/software/liblitedram/utils.h
@@ -4,11 +4,19 @@
 #ifndef __SDRAM_UTILS_H
 #define __SDRAM_UTILS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 
 void print_size(uint64_t size);
 void print_progress(const char * header, uint64_t origin, uint64_t size);
 
 uint64_t sdram_get_supported_memory(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SDRAM_UTILS_H */

--- a/litex/soc/software/libliteeth/inet.h
+++ b/litex/soc/software/libliteeth/inet.h
@@ -23,6 +23,10 @@
 #ifndef __INET_H
 #define __INET_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 
 static __inline uint16_t __bswap_16(uint16_t __x)
@@ -67,5 +71,9 @@ static uint16_t ntohs(uint16_t n)
     union { int i; char c; } u = { 1 };
     return u.c ? bswap_16(n) : n;
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __INET_H */

--- a/litex/soc/software/libliteeth/mdio.h
+++ b/litex/soc/software/libliteeth/mdio.h
@@ -1,6 +1,10 @@
 #ifndef __MDIO_H
 #define __MDIO_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define MDIO_CLK 0x01
 #define MDIO_OE	0x02
 #define MDIO_DO	0x04
@@ -15,5 +19,9 @@
 
 void mdio_write(int phyadr, int reg, int val);
 int mdio_read(int phyadr, int reg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __MDIO_H */

--- a/litex/soc/software/libliteeth/tftp.h
+++ b/litex/soc/software/libliteeth/tftp.h
@@ -1,12 +1,20 @@
 #ifndef __TFTP_H
 #define __TFTP_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 
 int tftp_get(uint32_t ip, uint16_t server_port, const char *filename,
     void *buffer);
 int tftp_put(uint32_t ip, uint16_t server_port, const char *filename,
     const void *buffer, int size);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __TFTP_H */
 

--- a/litex/soc/software/libliteeth/udp.h
+++ b/litex/soc/software/libliteeth/udp.h
@@ -1,6 +1,10 @@
 #ifndef __UDP_H
 #define __UDP_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define ETHMAC_EV_SRAM_WRITER	0x1
 #define ETHMAC_EV_SRAM_READER	0x1
 
@@ -21,5 +25,9 @@ void udp_service(void);
 
 void eth_init(void);
 void eth_mode(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __UDP_H */

--- a/litex/soc/software/liblitesata/sata.h
+++ b/litex/soc/software/liblitesata/sata.h
@@ -4,6 +4,10 @@
 #ifndef __SATA_H
 #define __SATA_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <generated/csr.h>
 
 /*-----------------------------------------------------------------------*/
@@ -27,6 +31,10 @@ void sata_read(uint32_t sector, uint32_t count, uint8_t* buf);
 
 void sata_write(uint32_t sector, uint32_t count, uint8_t* buf);
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* __SATA_H */

--- a/litex/soc/software/liblitesdcard/sdcard.h
+++ b/litex/soc/software/liblitesdcard/sdcard.h
@@ -4,6 +4,10 @@
 #ifndef __SDCARD_H
 #define __SDCARD_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <generated/csr.h>
 
 #define CLKGEN_STATUS_BUSY		0x1
@@ -106,5 +110,9 @@ void sdcard_write(uint32_t sector, uint32_t count, uint8_t* buf);
 void fatfs_set_ops_sdcard(void);
 
 #endif /* CSR_SDCORE_BASE */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SDCARD_H */

--- a/litex/soc/software/liblitesdcard/spisdcard.h
+++ b/litex/soc/software/liblitesdcard/spisdcard.h
@@ -5,6 +5,10 @@
 #ifndef __SPISDCARD_H
 #define __SPISDCARD_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <generated/csr.h>
 
 #ifdef CSR_SPISDCARD_BASE
@@ -53,5 +57,9 @@ uint8_t spisdcard_init(void);
 void fatfs_set_ops_spisdcard(void);
 
 #endif /* CSR_SPISDCARD_BASE */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SPISDCARD_H */

--- a/litex/soc/software/liblitespi/spiflash.h
+++ b/litex/soc/software/liblitespi/spiflash.h
@@ -1,6 +1,10 @@
 #ifndef __LITESPI_FLASH_H
 #define __LITESPI_FLASH_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define SPI_FLASH_BLOCK_SIZE 256
 #define CRC32_ERASED_FLASH	 0xFEA8A821
 
@@ -8,5 +12,9 @@ int spiflash_freq_init(void);
 void spiflash_dummy_bits_setup(unsigned int dummy_bits);
 void spiflash_memspeed(void);
 void spiflash_init(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __LITESPI_FLASH_H */


### PR DESCRIPTION
I'm trying to use LiteX libraries with a cpp code (a simulation using verilator), but at link step compilation fails with error like:
```
/usr/lib/gcc/x86_64-pc-linux-gnu/11/../../../../x86_64-pc-linux-gnu/bin/ld: top_tb.o: in function `main':
top_tb.cpp:(.text.startup+0x1ca): undefined reference to `sdram_init()'
collect2: error: ld returned 1 exit status
make[1]: *** [Vtop_tb.mk:66: Vtop_tb] Error 1
```
This is due to a different naming between C and CPP

by adding, before functions declaration in headers:
```C
#ifdef __cplusplus
extern "C" {
#endif
```

And, these lines, at the header end
```
#ifdef __cplusplus
}
#endif
```

The problem is fixed and cpp code may be linked to LiteX libraries.