### PR TITLE
soc/cores/clock/gowin_gw1n: fix size for ODSEL, FBDSEL, IDSEL, PSDA, DUTYDA, FDLY

### DIFF
--- a/litex/soc/cores/clock/gowin_gw1n.py
+++ b/litex/soc/cores/clock/gowin_gw1n.py
@@ -175,16 +175,16 @@ class GW1NPLL(Module):
             p_CLKOUTD3_SRC     = "CLKOUT",                 # Recopy CLKOUT to CLKOUTD3.
 
             # Inputs.
-            i_CLKIN   = self.clkin, # Clk Input.
-            i_CLKFB   = 0,          # Clk Feedback.
-            i_RESET   = self.reset, # PLL Reset.
-            i_RESET_P = 0,          # PLL Power Down.
-            i_ODSEL   = 0,          # Dynamic ODIV control.
-            i_FBDSEL  = 0,          # Dynamic IDIV control.
-            i_IDSEL   = 0,          # Dynamic FDIV control.
-            i_PSDA    = 0,          # Dynamic phase control.
-            i_DUTYDA  = 0,          # Dynamic duty cycle control.
-            i_FDLY    = 0,          # Dynamic CLKOUTP delay control.
+            i_CLKIN   = self.clkin,     # Clk Input.
+            i_CLKFB   = 0,              # Clk Feedback.
+            i_RESET   = self.reset,     # PLL Reset.
+            i_RESET_P = 0,              # PLL Power Down.
+            i_ODSEL   = Constant(0, 6), # Dynamic ODIV control.
+            i_FBDSEL  = Constant(0, 6), # Dynamic IDIV control.
+            i_IDSEL   = Constant(0, 6), # Dynamic FDIV control.
+            i_PSDA    = Constant(0, 4), # Dynamic phase control.
+            i_DUTYDA  = Constant(0, 4), # Dynamic duty cycle control.
+            i_FDLY    = Constant(0, 4), # Dynamic CLKOUTP delay control.
         )
         if self.device.startswith('GW1NS'):
             instance_name = 'PLLVR'


### PR DESCRIPTION
I'm doing some simulations for Gowin *gw2a* using *verilator* but it complains about wrong size for some PLL's signals like:
```
%Warning-WIDTH: build/gateware/test_oserdese2.v:10451:3: Input port connection 'ODSEL' expects 6 bits on the pin connection, but pin connection's CONST '1'h0' generates 1 bits.
                                                       : ... In instance top_tb.dut
10451 |  .ODSEL(1'd0),
      |   ^~~~~ 
``` 
This is, also, confirmed by Gowin's tool:
```
WARN  (EX3670) : Actual bit length 1 differs from formal bit length 6 for port 'ODSEL'("/somewhere/build/sipeed_tang_primer_20k/gateware/sipeed_tang_primer_20k.v":11651)
```

This patch replace *int* values by a `Constant` to explicitly specify signals size.