### PR TITLE
Add I2S example code and function to add an I2S peripheral in soc.py

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -23,6 +23,7 @@ from litex.gen.fhdl.hierarchy import LiteXHierarchyExplorer
 from litex.compat.soc_core import *
 
 from litex.soc.cores import cpu
+from litex.soc.cores.i2s import S7I2S, I2S_FORMAT
 
 from litex.soc.interconnect.csr import *
 from litex.soc.interconnect.csr_eventmanager import *
@@ -2108,6 +2109,22 @@ class LiteXSoC(SoC):
         self.add_constant("VIDEO_FRAMEBUFFER_HRES", hres)
         self.add_constant("VIDEO_FRAMEBUFFER_VRES", vres)
         self.add_constant("VIDEO_FRAMEBUFFER_DEPTH", vfb.depth)
+
+    # Add I2S ------------------------------------------------------------------------
+    def add_i2s_peripheral(self, name="i2s", sample_width=24, frame_format=I2S_FORMAT.I2S_STANDARD, concatenate_channels=False, toolchain=None):
+        channels = 2
+        i2s_mem_size = 16 * 1024 * channels # Size of the FIFO 16kB * channels
+        mem_origin = 0xb1000000 # use an origin which is not used yet in the current SoC's mem_map
+
+        self.submodules.i2s = i2s = S7I2S(
+            pads=self.platform.request(name),
+            sample_width=sample_width,
+            frame_format=frame_format,
+            concatenate_channels=concatenate_channels,
+            toolchain=toolchain
+        )
+        self.bus.add_slave(name, self.i2s.bus, SoCRegion(origin=mem_origin, size=i2s_mem_size, cached=False))
+
 
 # LiteXSoCArgumentParser ---------------------------------------------------------------------------
 


### PR DESCRIPTION
It took me quite some time to figure out how the I2S core S7I2S is supposed to be used. The current documentation only tells to read the fifo, however no information how to do so. 
I was eventually able to add the I2S core after finding the usages in these SoCs:
* [betrusted-soc](https://github.com/betrusted-io/betrusted-soc/blob/70190e2049393d3823bad5cdc93164f3dc44ffb5/betrusted_soc.py#L1598)
* [Zephyr on litex VexRiscv](https://github.com/litex-hub/zephyr-on-litex-vexriscv/blob/5b125d0b51db26545ee0d4aa62120bf74c0370d5/soc_zephyr.py#L93)

And the following usages of the API
* C: [Zephyr i2s_litex.c](https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/i2s/i2s_litex.c)
* Rust [Betrusted SoC hal_audio.rs](https://github.com/betrusted-io/betrusted-soc/blob/70190e2049393d3823bad5cdc93164f3dc44ffb5/fw/betrusted-hal/src/hal_audio.rs#L539)

To help utilizing the I2S core, I thought it might be nice to add some example to the documentation. Please let me know, if you want me to include it in a different format or how you would like to get it beautified.

Thanks!
