### PR TITLE
litex_setup: explain how to update permanently PATH env variable (#1589)

### DIFF
--- a/litex_setup.py
+++ b/litex_setup.py
@@ -289,7 +289,8 @@ def litex_setup_install_repos(config="standard", user_mode=False):
     if user_mode:
         if ".local/bin" not in os.environ.get("PATH", ""):
             print_status("Make sure that ~/.local/bin is in your PATH")
-            print_status("export PATH=$PATH:~/.local/bin")
+            print_status("export PATH=$PATH:~/.local/bin # temporary (limited to the current terminal)")
+            print_status("or add the previous line into your ~/.bashrc to permanently update PATH")
 
 # Git repositories freeze --------------------------------------------------------------------------
 


### PR DESCRIPTION
Has mentioned in issue #1589, `litex_setup`'s message about `PATH` env variable is limited to the temporary update (current terminal only).

This PR update this message to explains  how to add *~/.local/bin* permanently into `PATH`. 