### PR TITLE
SDRAM SPD fixes

### DIFF
--- a/litex/soc/software/bios/cmds/cmd_litedram.c
+++ b/litex/soc/software/bios/cmds/cmd_litedram.c
@@ -403,10 +403,9 @@ static void sdram_spd_handler(int nb_params, char **params)
 	unsigned char spdaddr;
 	unsigned char buf[SDRAM_SPD_SIZE];
 	int len = sizeof(buf);
-	bool send_stop = true;
 
 	if (nb_params < 1) {
-		printf("sdram_spd <spdaddr> [<send_stop>]");
+		printf("sdram_spd <spdaddr>");
 		return;
 	}
 
@@ -420,15 +419,7 @@ static void sdram_spd_handler(int nb_params, char **params)
 		return;
 	}
 
-	if (nb_params > 1) {
-		send_stop = strtoul(params[1], &c, 0) != 0;
-		if (*c != 0) {
-			printf("Incorrect send_stop value");
-			return;
-		}
-	}
-
-	if (!sdram_read_spd(spdaddr, 0, buf, (uint16_t)len, send_stop)) {
+	if (!sdram_read_spd(spdaddr, 0, buf, (uint16_t)len)) {
 		printf("Error when reading SPD EEPROM");
 		return;
 	}

--- a/litex/soc/software/liblitedram/sdram_spd.c
+++ b/litex/soc/software/liblitedram/sdram_spd.c
@@ -28,11 +28,10 @@ static bool sdram_select_spd_page(uint8_t page) {
 }
 #endif
 
-bool sdram_read_spd(uint8_t spd, uint16_t addr, uint8_t *buf, uint16_t len, bool send_stop) {
+bool sdram_read_spd(uint8_t spd, uint16_t addr, uint8_t *buf, uint16_t len) {
 	uint8_t page;
 	uint16_t offset;
 	uint16_t temp_len, read_bytes = 0;
-	bool temp_send_stop = false;
 
 	bool ok = true;
 
@@ -43,12 +42,10 @@ bool sdram_read_spd(uint8_t spd, uint16_t addr, uint8_t *buf, uint16_t len, bool
 		offset = addr % SDRAM_SPD_PAGE_SIZE;
 
 		temp_len = SDRAM_SPD_PAGE_SIZE - offset;
-		if (temp_len >= len) {
-			temp_send_stop = send_stop;
+		if (temp_len > len)
 			temp_len = len;
-		}
 
-		ok &= i2c_read(SPD_RW_ADDR(spd), offset, &buf[read_bytes], temp_len, temp_send_stop, 1);
+		ok &= i2c_read(SPD_RW_ADDR(spd), offset, &buf[read_bytes], temp_len, false, 1);
 		len -= temp_len;
 		read_bytes += temp_len;
 		addr += temp_len;

--- a/litex/soc/software/liblitedram/sdram_spd.c
+++ b/litex/soc/software/liblitedram/sdram_spd.c
@@ -48,7 +48,7 @@ bool sdram_read_spd(uint8_t spd, uint16_t addr, uint8_t *buf, uint16_t len, bool
 			temp_len = len;
 		}
 
-		ok &= i2c_read(SPD_RW_ADDR(spd), offset, &buf[read_bytes], len, temp_send_stop, 1);
+		ok &= i2c_read(SPD_RW_ADDR(spd), offset, &buf[read_bytes], temp_len, temp_send_stop, 1);
 		len -= temp_len;
 		read_bytes += temp_len;
 		addr += temp_len;

--- a/litex/soc/software/liblitedram/sdram_spd.c
+++ b/litex/soc/software/liblitedram/sdram_spd.c
@@ -54,7 +54,7 @@ bool sdram_read_spd(uint8_t spd, uint16_t addr, uint8_t *buf, uint16_t len) {
 	return ok;
 }
 #else /* no CSR_SDRAM_BASE && CONFIG_HAS_I2C */
-bool sdram_read_spd(uint8_t spd, uint16_t addr, uint8_t *buf, uint16_t len, bool send_stop) {
+bool sdram_read_spd(uint8_t spd, uint16_t addr, uint8_t *buf, uint16_t len) {
 	return false;
 }
 #endif /* CSR_SDRAM_BASE && CONFIG_HAS_I2C */

--- a/litex/soc/software/liblitedram/sdram_spd.h
+++ b/litex/soc/software/liblitedram/sdram_spd.h
@@ -36,7 +36,7 @@ extern "C" {
 
 #endif /* CSR_SDRAM_BASE && CONFIG_HAS_I2C */
 
-bool sdram_read_spd(uint8_t spd, uint16_t addr, uint8_t *buf, uint16_t len, bool send_stop);
+bool sdram_read_spd(uint8_t spd, uint16_t addr, uint8_t *buf, uint16_t len);
 
 #ifdef __cplusplus
 }

--- a/litex/soc/software/liblitedram/utils.c
+++ b/litex/soc/software/liblitedram/utils.c
@@ -40,7 +40,7 @@ uint64_t sdram_get_supported_memory(void) {
 #if defined(SDRAM_PHY_DDR3) || defined(SDRAM_PHY_DDR4)
 	uint8_t buf;
 
-	if (!sdram_read_spd(0x0, 4, &buf, 1, true)) {
+	if (!sdram_read_spd(0x0, 4, &buf, 1)) {
 		printf("Couldn't read SDRAM size from the SPD, defaulting to 256 MB.\n");
 		return 256 << 20;
 	}


### PR DESCRIPTION
This PR provides two fixes for the `sdram_spd` interface.

The most important one is f84ecaf707d2102dc2e2572b45ded465a236c19b, which disables sending STOP signal after setting address counter during the read operation. Turns out, some SPDs allow operation when STOP is being sent, but spec specifies that the STOP symbol shouldn't be sent.
I removed the option to select `send_stop` value from the API and the BIOS command.

[The second fix](cdc1152162d5c2bdb773dd31915a7aef4de8f1f0) is not that impactful. When implementing `sdram_spd` interface for the first time, by mistake, I made it so that in one loop iteration `len` bytes are being read instead of `temp_len`. This worked, because we never read more bytes total than requested and `len - temp_len` extra bytes that were being read in one iteration were being overwritten in the next iteration.