### PR TITLE
Fix GPIO IRQ CSR generation

### DIFF
--- a/litex/soc/cores/gpio.py
+++ b/litex/soc/cores/gpio.py
@@ -40,6 +40,7 @@ class _GPIOIRQ:
                 )
             ]
             setattr(self.ev, f"i{n}", esp)
+            self.ev.finalize()
 
 # GPIO Input ---------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Hello, in relation to this issue (#1612)  I suggest a fix for other people who may have the same problem.
It seems that the generation of CSR for GPIOIN with IRQ enable is changed with the updates.
I hope I helped.