### PR TITLE
build/efinix/efinity: delays iface.py execution after project xml was written

### DIFF
--- a/litex/build/efinix/efinity.py
+++ b/litex/build/efinix/efinity.py
@@ -204,21 +204,6 @@ class EfinityToolchain(GenericToolchain):
 
         tools.write_to_file("iface.py", header + gen + gpio + add + footer)
 
-        if tools.subprocess_call_filtered([self.efinity_path + "/bin/python3", "iface.py"], common.colors) != 0:
-            raise OSError("Error occurred during Efinity peri script execution.")
-
-        # Some IO blocks don't have Python API so we need to configure them
-        # directly in the peri.xml file
-        # We also need to configure the bank voltage here
-        if self.ifacewriter.xml_blocks or self.platform.iobank_info:
-            self.ifacewriter.generate_xml_blocks()
-
-        # Because the Python API is sometimes bugged, we need to tweak the generated xml
-        if self.ifacewriter.fix_xml:
-            self.ifacewriter.fix_xml_values()
-
-
-
     # Project configuration (.xml) -----------------------------------------------------------------
 
     def build_project(self):
@@ -267,6 +252,19 @@ class EfinityToolchain(GenericToolchain):
         xml_str = expatbuilder.parseString(xml_str, False)
         xml_str = xml_str.toprettyxml(indent="  ")
         tools.write_to_file("{}.xml".format(self._build_name), xml_str)
+
+        if tools.subprocess_call_filtered([self.efinity_path + "/bin/python3", "iface.py"], common.colors) != 0:
+            raise OSError("Error occurred during Efinity peri script execution.")
+
+        # Some IO blocks don't have Python API so we need to configure them
+        # directly in the peri.xml file
+        # We also need to configure the bank voltage here
+        if self.ifacewriter.xml_blocks or self.platform.iobank_info:
+            self.ifacewriter.generate_xml_blocks()
+
+        # Because the Python API is sometimes bugged, we need to tweak the generated xml
+        if self.ifacewriter.fix_xml:
+            self.ifacewriter.fix_xml_values()
 
     def build_script(self):
         return "" # not used


### PR DESCRIPTION
The first time an efinix's target is executed `iface.py` produces errors like:

```
Efinity project file does not exists : ../gateware/efinix_titanium_ti60_f225_dev_kit.xml
File error : Efinity project file does not exists : ../gateware/efinix_titanium_ti60_f225_dev_kit.xml
Efinity project file does not exists : ../gateware/efinix_titanium_ti60_f225_dev_kit.xml
File error : Efinity project file does not exists : ../gateware/efinix_titanium_ti60_f225_dev_kit.xml
```

The second time these errors disapears.

This is due to the order where scripts are build. Currently:
- `peri.xml` is build by `build_io_constraints()`, `iface.py` is also called here
- `project.xml` is build by `build_project()`

But since `build_io_constaints()` is called before `build_project()` `iface.py` can't have access to the project's xml. This is no more true for next build because files are already written at the previous run.

This PR delays `iface.py` call after project's xml was build to fix this dependency.