### PR TITLE
add a proxy method to access bitstream extension

### DIFF
--- a/litex/build/altera/platform.py
+++ b/litex/build/altera/platform.py
@@ -13,7 +13,10 @@ from litex.build.altera import common, quartus
 # AlteraPlatform -----------------------------------------------------------------------------------
 
 class AlteraPlatform(GenericPlatform):
-    bitstream_ext = ".sof"
+    _bitstream_ext = {
+        "sram"  : ".sof",
+        "flash" : ".rbf"
+    }
     create_rbf    = True
 
     _supported_toolchains = ["quartus"]

--- a/litex/build/anlogic/platform.py
+++ b/litex/build/anlogic/platform.py
@@ -13,7 +13,7 @@ from litex.build.anlogic import common, anlogic
 # AnlogicPlatform ----------------------------------------------------------------------------------
 
 class AnlogicPlatform(GenericPlatform):
-    bitstream_ext = ".fs"
+    bitstream_ext = ".bit"
 
     _supported_toolchains = ["td"]
 

--- a/litex/build/anlogic/platform.py
+++ b/litex/build/anlogic/platform.py
@@ -13,7 +13,7 @@ from litex.build.anlogic import common, anlogic
 # AnlogicPlatform ----------------------------------------------------------------------------------
 
 class AnlogicPlatform(GenericPlatform):
-    bitstream_ext = ".bit"
+    _bitstream_ext = ".bit"
 
     _supported_toolchains = ["td"]
 

--- a/litex/build/efinix/platform.py
+++ b/litex/build/efinix/platform.py
@@ -16,7 +16,10 @@ from litex.build.efinix import EfinixDbParser
 # EfinixPlatform -----------------------------------------------------------------------------------
 
 class EfinixPlatform(GenericPlatform):
-    bitstream_ext = ".bit"
+    _bitstream_ext = {
+        "sram"  : ".bit",
+        "flash" : ".hex"
+    }
 
     _supported_toolchains = ["efinity"]
 

--- a/litex/build/generic_platform.py
+++ b/litex/build/generic_platform.py
@@ -323,6 +323,9 @@ class ConstraintManager:
 
 class GenericPlatform:
     device_family = None
+    _bitstream_ext = None # None by default, overridden by vendor platform, may
+                          # be a string when same extension is used for sram and
+                          # flash. A dict must be provided otherwise
 
     def __init__(self, device, io, connectors=[], name=None):
         self.toolchain          = None
@@ -462,6 +465,31 @@ class GenericPlatform:
 
     def build(self, fragment):
         raise NotImplementedError("GenericPlatform.build must be overloaded")
+
+    def get_bitstream_extension(self, mode="sram"):
+        """
+        Return the bitstream's extension according to mode (sram / flash).
+        The default (generic) implementation check if `self._bitstream_ext`
+        is a dict or a string. For former case it return extension using `mode`
+        parameter, in latter case simply return `self._bitstream_ext`'s value.
+        When this behaviour is not adapted this method must be overriden by
+        a specific one at vendor level.
+
+        Parameters
+        ----------
+        mode: str
+            bitstream destination (must be sram or flash)
+
+        Returns
+        -------
+            bitstream extension: str
+        """
+        if self._bitstream_ext is None:
+            return None
+        elif type(self._bitstream_ext) == dict:
+            return self._bitstream_ext[mode]
+        else:
+            return self._bitstream_ext
 
     def create_programmer(self):
         raise NotImplementedError

--- a/litex/build/gowin/platform.py
+++ b/litex/build/gowin/platform.py
@@ -13,7 +13,7 @@ from litex.build.gowin import common, gowin
 # GowinPlatform ------------------------------------------------------------------------------------
 
 class GowinPlatform(GenericPlatform):
-    bitstream_ext = ".fs"
+    _bitstream_ext = ".fs"
 
     _supported_toolchains = ["gowin", "apicula"]
 

--- a/litex/build/lattice/platform.py
+++ b/litex/build/lattice/platform.py
@@ -11,7 +11,7 @@ from litex.build.lattice import common, diamond, icestorm, trellis, radiant, oxi
 # LatticePlatform ----------------------------------------------------------------------------------
 
 class LatticePlatform(GenericPlatform):
-    bitstream_ext = ".bit"
+    _bitstream_ext = ".bit"
 
     _supported_toolchains = {
         "ice40" : ["icestorm"],
@@ -26,7 +26,7 @@ class LatticePlatform(GenericPlatform):
         elif toolchain == "trellis":
             self.toolchain = trellis.LatticeTrellisToolchain()
         elif toolchain == "icestorm":
-            self.bitstream_ext = ".bin"
+            self._bitstream_ext = ".bin"
             self.toolchain = icestorm.LatticeIceStormToolchain()
         elif toolchain == "radiant":
             self.toolchain = radiant.LatticeRadiantToolchain()

--- a/litex/build/microsemi/platform.py
+++ b/litex/build/microsemi/platform.py
@@ -10,7 +10,7 @@ from litex.build.microsemi import common, libero_soc
 # MicrosemiPlatform --------------------------------------------------------------------------------
 
 class MicrosemiPlatform(GenericPlatform):
-    bitstream_ext = ".bit"
+    _bitstream_ext = ".bit"
 
     _supported_toolchains = ["libero_soc_polarfire"]
 

--- a/litex/build/osfpga/platform.py
+++ b/litex/build/osfpga/platform.py
@@ -12,7 +12,7 @@ from litex.build.osfpga import common, osfpga
 # OSFPGAPlatform -----------------------------------------------------------------------------------
 
 class OSFPGAPlatform(GenericPlatform):
-    bitstream_ext = ".bin"
+    _bitstream_ext = ".bin"
 
     _supported_toolchains = ["osfpga"]
 

--- a/litex/build/quicklogic/platform.py
+++ b/litex/build/quicklogic/platform.py
@@ -12,7 +12,7 @@ from litex.build.quicklogic import common, f4pga
 # QuickLogicPlatform -------------------------------------------------------------------------------
 
 class QuickLogicPlatform(GenericPlatform):
-    bitstream_ext = ".bit"
+    _bitstream_ext = ".bit"
 
     _supported_toolchains = ["f4pga"]
 

--- a/litex/build/xilinx/platform.py
+++ b/litex/build/xilinx/platform.py
@@ -14,7 +14,10 @@ from litex.build.xilinx import common, vivado, ise, yosys_nextpnr
 # XilinxPlatform -----------------------------------------------------------------------------------
 
 class XilinxPlatform(GenericPlatform):
-    bitstream_ext = ".bit"
+    _bitstream_ext = {
+        "sram"  : ".bit",
+        "flash" : ".bin"
+    }
 
     _supported_toolchains = {
         "spartan6"    : ["ise"],

--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -382,10 +382,7 @@ class Builder:
     def get_bitstream_filename(self, mode="sram", ext=None):
         assert mode in ["sram", "flash"]
         if ext is None:
-            ext = {
-                "sram"  : self.soc.platform.bitstream_ext,
-                "flash" : ".bin" # FIXME.
-            }[mode]
+            ext = self.soc.platform.get_bitstream_extension(mode)
         return os.path.join(self.gateware_dir, self.soc.get_build_name() + ext)
 
 # Builder Arguments --------------------------------------------------------------------------------


### PR DESCRIPTION
When getting bitstream's filename the current behaviour for *soc/integration/builder* is to use directly `soc.platform.bitstream_ext` for **sram** mode and returning **bin** for flash. This imply, at **targets** level, for flash mode, to use `get_bitstream_filename`'s *ext* parameter to force correct extension.

This PR add, at *build/generic_platform* a method to return extension according to `mode` (may be the same extension for both case when *build/vendor/platform.py* declare `_bitstream_ext` as a string or two different extension when `_bitstream_ext` is a dict).

This also fix extension for anlogic (*fs* is for *gowin* FPGA).