### PR TITLE
soc/cores/cpu/vexriscv_smp/core.py: fix variants for external incoming values and remove default timer0 and uart in standard mode.

### DIFF
--- a/litex/soc/cores/cpu/vexriscv_smp/core.py
+++ b/litex/soc/cores/cpu/vexriscv_smp/core.py
@@ -275,7 +275,7 @@ class VexRiscvSMP(CPU):
 
     def __init__(self, platform, variant):
         self.platform         = platform
-        self.variant          = "linux"
+        self.variant          = variant
         self.human_name       = self.human_name + "-" + self.variant.upper()
         self.reset            = Signal()
         self.jtag_clk         = Signal()
@@ -388,15 +388,16 @@ class VexRiscvSMP(CPU):
         platform.add_source(os.path.join(vdir,  self.cluster_name + ".v"), "verilog")
 
     def add_soc_components(self, soc):
-        # Set UART/Timer0 CSRs/IRQs to the ones used by OpenSBI.
-        soc.csr.add("uart",   n=2)
-        soc.csr.add("timer0", n=3)
+        if self.variant == "linux":
+            # Set UART/Timer0 CSRs/IRQs to the ones used by OpenSBI.
+            soc.csr.add("uart",   n=2)
+            soc.csr.add("timer0", n=3)
 
-        soc.irq.add("uart",   n=0)
-        soc.irq.add("timer0", n=1)
+            soc.irq.add("uart",   n=0)
+            soc.irq.add("timer0", n=1)
 
-        # Add OpenSBI region.
-        soc.bus.add_region("opensbi", SoCRegion(origin=self.mem_map["main_ram"] + 0x00f0_0000, size=0x8_0000, cached=True, linker=True))
+            # Add OpenSBI region.
+            soc.bus.add_region("opensbi", SoCRegion(origin=self.mem_map["main_ram"] + 0x00f0_0000, size=0x8_0000, cached=True, linker=True))
 
         # Define number of CPUs
         soc.add_config("CPU_COUNT", VexRiscvSMP.cpu_count)


### PR DESCRIPTION
Fix: VexRiscvSMP core variants for external incoming values and remove default timer0 and uart in standard mode.