### PR TITLE
soc/cores/clock/gowin_gw2a: enable GW2AR support

### DIFF
--- a/litex/soc/cores/clock/gowin_gw2a.py
+++ b/litex/soc/cores/clock/gowin_gw2a.py
@@ -17,7 +17,7 @@ class GW2APLL(GW1NPLL):
     @staticmethod
     def get_vco_freq_range(device):
         vco_freq_range = None
-        if device.startswith('GW2A-'):
+        if device.startswith('GW2A-') or device.startswith('GW2AR-'):
             vco_freq_range = (500e6, 1250e6) # datasheet values
         if vco_freq_range is None:
             raise ValueError(f"Unsupported device {device}.")
@@ -26,7 +26,7 @@ class GW2APLL(GW1NPLL):
     @staticmethod
     def get_pfd_freq_range(device):
         pfd_freq_range = None
-        if device.startswith('GW2A-'):
+        if device.startswith('GW2A-') or device.startswith('GW2AR-'):
             pfd_freq_range = (3e6, 500e6)  # datasheet values
         if pfd_freq_range is None:
             raise ValueError(f"Unsupported device {device}.")


### PR DESCRIPTION
Gowin GW2AR is just GW2A with co-packaged external RAM.

Enable using GW2APLL for GW2AR.