### PR TITLE
build/efinix: add option use active or passive spi mode.

### DIFF
--- a/litex/build/efinix/efinity.py
+++ b/litex/build/efinix/efinity.py
@@ -344,7 +344,7 @@ class EfinityToolchain(GenericToolchain):
             "--spi_low_power_mode",       "off",
             "--io_weak_pullup",           "on",
             "--enable_roms",              "on",
-            "--mode",                     "active",
+            "--mode",                     self.platform.spi_mode,
             "--width",                    "1",
             "--enable_crc_check",         "on"
         ], common.colors)

--- a/litex/build/efinix/platform.py
+++ b/litex/build/efinix/platform.py
@@ -23,12 +23,13 @@ class EfinixPlatform(GenericPlatform):
 
     _supported_toolchains = ["efinity"]
 
-    def __init__(self, *args, iobank_info=None, toolchain="efinity", **kwargs):
+    def __init__(self, *args, iobank_info=None, toolchain="efinity", spi_mode="active", **kwargs):
         GenericPlatform.__init__(self, *args, **kwargs)
 
         self.timing_model = self.device[-2:]
         self.device       = self.device[:-2]
         self.iobank_info  = iobank_info
+        self.spi_mode     = spi_mode
         if self.device[:2] == "Ti":
             self.family = "Titanium"
         else:


### PR DESCRIPTION
we are using spi passive mode to load our image and need to generate a bitstream for it.
adding the value to the platform since it seems the most common practice, but it can be handled by the toolchain instead.