### PR TITLE
cpu: rocket, cva6: Fix compilation with newer binutils

### DIFF
--- a/litex/soc/cores/cpu/cva6/core.py
+++ b/litex/soc/cores/cpu/cva6/core.py
@@ -31,7 +31,7 @@ GCC_FLAGS = {
     #                       ||||/--- Single-Precision Floating-Point
     #                       |||||/-- Double-Precision Floating-Point
     #                       imacfd
-    "standard": "-march=rv64imac -mabi=lp64 ",
+    "standard": "-march=rv64i2p0_mac -mabi=lp64 ",
     "full":     "-march=rv64gc   -mabi=lp64 ",
 }
 

--- a/litex/soc/cores/cpu/rocket/core.py
+++ b/litex/soc/cores/cpu/rocket/core.py
@@ -67,21 +67,21 @@ CPU_VARIANTS = {
 # GCC Flags-----------------------------------------------------------------------------------------
 
 GCC_FLAGS = {
-    "standard" : "-march=rv64imac   -mabi=lp64 ",
-    "linux"    : "-march=rv64imac   -mabi=lp64 ",
-    "linux4"   : "-march=rv64imac   -mabi=lp64 ",
-    "linuxd"   : "-march=rv64imac   -mabi=lp64 ",
-    "linux2d"  : "-march=rv64imac   -mabi=lp64 ",
-    "linuxq"   : "-march=rv64imac   -mabi=lp64 ",
-    "linux2q"  : "-march=rv64imac   -mabi=lp64 ",
-    "full"     : "-march=rv64imafdc -mabi=lp64 ",
-    "fulld"    : "-march=rv64imafdc -mabi=lp64 ",
-    "full4d"   : "-march=rv64imafdc -mabi=lp64 ",
-    "fullq"    : "-march=rv64imafdc -mabi=lp64 ",
-    "full4q"   : "-march=rv64imafdc -mabi=lp64 ",
-    "fullo"    : "-march=rv64imafdc -mabi=lp64 ",
-    "full4o"   : "-march=rv64imafdc -mabi=lp64 ",
-    "full8o"   : "-march=rv64imafdc -mabi=lp64 ",
+    "standard" : "-march=rv64i2p0_mac   -mabi=lp64 ",
+    "linux"    : "-march=rv64i2p0_mac   -mabi=lp64 ",
+    "linux4"   : "-march=rv64i2p0_mac   -mabi=lp64 ",
+    "linuxd"   : "-march=rv64i2p0_mac   -mabi=lp64 ",
+    "linux2d"  : "-march=rv64i2p0_mac   -mabi=lp64 ",
+    "linuxq"   : "-march=rv64i2p0_mac   -mabi=lp64 ",
+    "linux2q"  : "-march=rv64i2p0_mac   -mabi=lp64 ",
+    "full"     : "-march=rv64i2p0_mafdc -mabi=lp64 ",
+    "fulld"    : "-march=rv64i2p0_mafdc -mabi=lp64 ",
+    "full4d"   : "-march=rv64i2p0_mafdc -mabi=lp64 ",
+    "fullq"    : "-march=rv64i2p0_mafdc -mabi=lp64 ",
+    "full4q"   : "-march=rv64i2p0_mafdc -mabi=lp64 ",
+    "fullo"    : "-march=rv64i2p0_mafdc -mabi=lp64 ",
+    "full4o"   : "-march=rv64i2p0_mafdc -mabi=lp64 ",
+    "full8o"   : "-march=rv64i2p0_mafdc -mabi=lp64 ",
 }
 
 # CPU Params ----------------------------------------------------------------------------------
@@ -146,7 +146,7 @@ class Rocket(CPU):
     @property
     def gcc_flags(self):
         flags =  "-mno-save-restore "
-        flags += f"-march={self.get_arch(self.variant)}   -mabi=lp64 "
+        flags += GCC_FLAGS[self.variant]
         flags += "-D__rocket__ "
         flags += "-mcmodel=medany"
         return flags


### PR DESCRIPTION
Resolves the error:

 cpu/rocket/irq.h:23: Error: unrecognized opcode `csrr a4,mstatus',
 extension `zicsr' required

Rocket and cva6 missed this in commit 0e2a1b54a454bcbf as they are 64bit CPUs, and that change only updated the 32bit CPUs.

Tested with litex_sim and riscv64-unknown-elf-ld 2.40-2+4+b1 (Debian Bookworm).