### PR TITLE
csr: add ability to express clusters

### DIFF
--- a/litex/soc/doc/csr.py
+++ b/litex/soc/doc/csr.py
@@ -45,6 +45,7 @@ class DocumentedCSR:
         size                = 8,
         description         = None,
         access              = "read-write",
+        cluster             = None,
         fields              = []):
 
         self.name                = name
@@ -53,6 +54,7 @@ class DocumentedCSR:
         self.address             = address
         self.offset              = offset
         self.size                = size
+        self.cluster             = cluster
         if size == 0:
             print("!!! Warning: creating CSR of size 0 {}".format(name))
         self.description = self.trim(description)
@@ -337,6 +339,7 @@ class DocumentedCSRRegion:
             atomic_write = csr.atomic_write
         size = self.get_csr_size(csr)
         reset = self.get_csr_reset(csr)
+        cluster = csr.cluster
 
         # If the CSR is composed of multiple sub-CSRs, document each
         # one individually.
@@ -366,7 +369,8 @@ class DocumentedCSRRegion:
                         size                = self.csr_data_width,
                         description         = d,
                         fields              = self.split_fields(fields, start, start + length),
-                        access              = access
+                        access              = access,
+                        cluster             = cluster
                     ))
                 else:
                     self.csrs.append(DocumentedCSR(
@@ -379,7 +383,8 @@ class DocumentedCSRRegion:
                         size                = self.csr_data_width,
                         description         = bits_str,
                         fields              = self.split_fields(fields, start, start + length),
-                        access              = access
+                        access              = access,
+                        cluster             = cluster
                     ))
                 self.current_address += 4
         else:
@@ -392,7 +397,8 @@ class DocumentedCSRRegion:
                 size                = size,
                 description         = description,
                 fields              = fields,
-                access              = access
+                access              = access,
+                cluster             = cluster
             ))
             self.current_address += 4
 


### PR DESCRIPTION
This adds the ability to express clusters of registers. This can be very useful for peripherals with repeated groups of registers.

A `CSRCluster` class, emulating a simplified array, is added. Peripherals can add items to the cluster, and the CSRs will, for JSON, CSV, and HTML, be collected as normal.

For SVD, the code is extended to be able to handle outputting clusters directly in the XML structure. This way, code generation tools like `svd2rust` can generate nested array structures, making ergonomics significantly better when working with peripherals.

The code supports nesting of `CSRClusters` too.

An example usecase:
```python
class Sample(Module, AutoCSR):
    def __init__(self):
        self._before = CSRStatus()
        self.subs = CSRCluster()
        for i in range(3):
            self.subs[i] = SampleSub()
        self._after = CSRStatus()

class SampleSub(Module, AutoCSR):
    def __init__(self):
        self._nested = CSRCluster([SampleNested(), SampleNested()])
        self._after_nested = CSRStatus()

class SampleNested(Module, AutoCSR):
    def __init__(self):
        self._field_a = CSRStatus()
        self._field_b = CSRStorage()
        self._field_c = CSRStatus()

class YourSoC(SoCMini):
    def __init__(self):
        self.sample = Sample()
```

I tried to make sure that the touched codebase was as small as possible, to minimize breakage of existing tools. As far as I can tell, everything that doesn't use `CSRCluster` should work as before with no changes.

Best regards,
Lasse