### PR TITLE
soc/software: fix i2c_write

### DIFF
--- a/litex/soc/software/libbase/i2c.c
+++ b/litex/soc/software/libbase/i2c.c
@@ -48,7 +48,7 @@ int i2c_send_init_cmds(void)
 				data[0] = i2c_cmd->init_table[(i*2) + 1] & 0xff;
 			}
 
-			if (!i2c_write(i2c_cmd->i2c_addr, addr, data, len))
+			if (!i2c_write(i2c_cmd->i2c_addr, addr, data, len, 1))
 				printf("Error during write at address 0x%04x on i2c dev %d\n",
 						addr, current_i2c_dev);
 		}


### PR DESCRIPTION
commit 3fa3080e introduced an additional address length paramater to i2c_write to support non 8bit memory addresses.
But the parameter wasn't added to the call of i2c_write in i2c_send_init_cmds.

This commit fixes the issue by adding the address length parameter to the call of i2c_write.