### PR TITLE
give human readable error messages if a connector or pin is not available

### DIFF
--- a/litex/build/generic_platform.py
+++ b/litex/build/generic_platform.py
@@ -167,7 +167,8 @@ class ConnectorManager:
                     raise ValueError(f"\"{identifier}\" {err}") from err
                 if pn.isdigit():
                     pn = int(pn)
-
+                assert conn in self.connector_table, f"No connector named '{conn}' is available"
+                assert pn in self.connector_table[conn], f"There is no pin '{pn}' on connector '{conn}'"
                 conn_pn = self.connector_table[conn][pn]
                 if ":" in conn_pn:
                     conn_pn = self.resolve_identifiers([conn_pn])[0]


### PR DESCRIPTION
Spares the user to have to debug the litex code if a pin or
connector is not found, which happens for example on enclustra boards,
where the HDMI is connected on the baseboard, but not on the KX2 core module.