### PR TITLE
AvalonMM2Wishbone: use same addressing on avalon and wishbone, leave address translation to the user

### DIFF
--- a/test/test_avalon_mm.py
+++ b/test/test_avalon_mm.py
@@ -17,16 +17,16 @@ class TestAvalon2Wishbone(unittest.TestCase):
     def test_sram(self):
         def generator(dut):
             yield from dut.avl.bus_write(0x0000, 0x01234567)
-            yield from dut.avl.bus_write(0x0004, 0x89abcdef)
-            yield from dut.avl.bus_write(0x0008, 0xdeadbeef)
-            yield from dut.avl.bus_write(0x000c, 0xc0ffee00)
-            yield from dut.avl.bus_write(0x0010, 0x76543210)
+            yield from dut.avl.bus_write(0x0001, 0x89abcdef)
+            yield from dut.avl.bus_write(0x0002, 0xdeadbeef)
+            yield from dut.avl.bus_write(0x0003, 0xc0ffee00)
+            yield from dut.avl.bus_write(0x0004, 0x76543210)
             yield
             self.assertEqual((yield from dut.avl.bus_read(0x0000)), 0x01234567)
-            self.assertEqual((yield from dut.avl.bus_read(0x0004)), 0x89abcdef)
-            self.assertEqual((yield from dut.avl.bus_read(0x0008)), 0xdeadbeef)
-            self.assertEqual((yield from dut.avl.bus_read(0x000c)), 0xc0ffee00)
-            self.assertEqual((yield from dut.avl.bus_read(0x0010)), 0x76543210)
+            self.assertEqual((yield from dut.avl.bus_read(0x0001)), 0x89abcdef)
+            self.assertEqual((yield from dut.avl.bus_read(0x0002)), 0xdeadbeef)
+            self.assertEqual((yield from dut.avl.bus_read(0x0003)), 0xc0ffee00)
+            self.assertEqual((yield from dut.avl.bus_read(0x0004)), 0x76543210)
 
         class DUT(Module):
             def __init__(self):
@@ -53,10 +53,10 @@ class TestAvalon2Wishbone(unittest.TestCase):
             yield
             yield
             self.assertEqual((yield from dut.avl.bus_read(0x0000)), 0x01234567)
-            self.assertEqual((yield from dut.avl.bus_read(0x0004)), 0x89abcdef)
-            self.assertEqual((yield from dut.avl.bus_read(0x0008)), 0xdeadbeef)
-            self.assertEqual((yield from dut.avl.bus_read(0x000c)), 0xc0ffee00)
-            self.assertEqual((yield from dut.avl.bus_read(0x0010)), 0x76543210)
+            self.assertEqual((yield from dut.avl.bus_read(0x0001)), 0x89abcdef)
+            self.assertEqual((yield from dut.avl.bus_read(0x0002)), 0xdeadbeef)
+            self.assertEqual((yield from dut.avl.bus_read(0x0003)), 0xc0ffee00)
+            self.assertEqual((yield from dut.avl.bus_read(0x0004)), 0x76543210)
             yield
             yield
 


### PR DESCRIPTION
As we discussed:
![image](https://user-images.githubusercontent.com/148607/237038589-f905c0cf-61e2-47c6-8446-f4b07b2d4b16.png)
