### PR TITLE
Avalon2Wishbone: Burst can only advance if write is high and waitrequest low

### DIFF
--- a/litex/soc/interconnect/avalon/avalon_mm_to_wishbone.py
+++ b/litex/soc/interconnect/avalon/avalon_mm_to_wishbone.py
@@ -100,7 +100,7 @@ class AvalonMM2Wishbone(Module):
             If(burst_count == 1,
                 wb.cti.eq(wishbone.CTI_BURST_END)
             ),
-            If(~avl.waitrequest,
+            If(~avl.waitrequest & avl.write,
                 NextValue(burst_address, burst_address + burst_increment),
                 NextValue(burst_count, burst_count - 1),
             ),


### PR DESCRIPTION
![image](https://github.com/enjoy-digital/litex/assets/148607/8fdf6d11-2bf1-48f9-bfbc-2341827febe7)
I just realized this was missing