### PR TITLE
soc/interconnect/packet: Don’t bypass dispatcher with a single slave if it can be deselected.

### DIFF
--- a/litex/soc/interconnect/packet.py
+++ b/litex/soc/interconnect/packet.py
@@ -62,7 +62,7 @@ class Dispatcher(Module):
     def __init__(self, master, slaves, one_hot=False):
         if len(slaves) == 0:
             self.sel = Signal()
-        elif len(slaves) == 1:
+        elif len(slaves) == 1 and not one_hot:
             self.comb += master.connect(slaves.pop())
             self.sel = Signal()
         else:


### PR DESCRIPTION
A dispatcher using one hot encoding can deselect all slaves, meaning that with a single slave we effectively get one select bit that decides whether to pass or drop a packet. For this reason, a single slave dispatcher can still be useful, and we shouldn't bypass the dispatch logic when using one hot encoding.

This allows e.g. `LiteEthCrossbar` to still filter traffic when only a single port is instanced.