### PR TITLE
VideoS7HDMIPhy: add option to flip the polarity of the differential pairs

### DIFF
--- a/litex/soc/cores/video.py
+++ b/litex/soc/cores/video.py
@@ -961,7 +961,7 @@ class VideoS7HDMI10to1Serializer(Module):
 
 
 class VideoS7HDMIPHY(Module):
-    def __init__(self, pads, clock_domain="sys"):
+    def __init__(self, pads, clock_domain="sys", flip_diff_pairs=False):
         self.sink = sink = stream.Endpoint(video_data_layout)
 
         # # #
@@ -994,7 +994,7 @@ class VideoS7HDMIPHY(Module):
             self.submodules += serializer
             pad_p = getattr(pads, f"data{channel}_p")
             pad_n = getattr(pads, f"data{channel}_n")
-            self.specials += Instance("OBUFDS", i_I=pad_o, o_O=pad_p, o_OB=pad_n)
+            self.specials += Instance("OBUFDS", i_I=(~pad_o if flip_diff_pairs else pad_o), o_O=pad_p, o_OB=pad_n)
 
 
 class VideoS7GTPHDMIPHY(Module):


### PR DESCRIPTION
I have the HDMI Pmod of Muselab, but its diff pairs  polarity
is the opposite of the FPGA pins polarity,
so the only fix is to invert the differential pair signal.