### PR TITLE
Fix for: More than one DFU capable USB device found! Error #1709

### DIFF
--- a/litex/build/dfu.py
+++ b/litex/build/dfu.py
@@ -23,7 +23,7 @@ class DFUProg(GenericProgrammer):
         subprocess.call(["cp", bitstream_file, bitstream_file + ".dfu"])
         subprocess.call(["dfu-suffix", "-v", self.vid, "-p", self.pid, "-a", bitstream_file + ".dfu"])
 
-        flash_cmd = ["dfu-util", "--download", bitstream_file + ".dfu"]
+        flash_cmd = ["dfu-util", "--device", "1209:5af0", "--alt", "0", "--download", bitstream_file + ".dfu"]
         if reset:
             flash_cmd.append("-R")
         if self.alt is not None:


### PR DESCRIPTION
Fix for issue #1709. I have edited the dfu-util command that python uses to specify the device ID and the alt to point to where the bitstream should be placed on the orangecrab. This is the result or running dfu-util --list that I got after running the command recommended by the error message: 

```
jamesmeech@Jamess-MacBook-Pro-10 LiteX % dfu-util --list
dfu-util 0.11

Copyright 2005-2009 Weston Schmidt, Harald Welte and OpenMoko Inc.
Copyright 2010-2021 Tormod Volden and Stefan Schmidt
This program is Free Software and has ABSOLUTELY NO WARRANTY
Please report bugs to http://sourceforge.net/p/dfu-util/tickets/

Found DFU: [1209:5af0] ver=0101, devnum=4, cfg=1, intf=0, path="20-3.1", alt=1, name="0x00100000 RISC-V Firmware", serial="UNKNOWN"
Found DFU: [1209:5af0] ver=0101, devnum=4, cfg=1, intf=0, path="20-3.1", alt=0, name="0x00080000 Bitstream", serial="UNKNOWN"
```