### PR TITLE
Tx write only

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1646,6 +1646,7 @@ class LiteXSoC(SoC):
         data_width              = 8,
         nrxslots                = 2,
         ntxslots                = 2,
+        tx_write_only           = False,
         with_timestamp          = False,
         with_timing_constraints = True):
         # Imports
@@ -1665,6 +1666,7 @@ class LiteXSoC(SoC):
             endianness = self.cpu.endianness,
             nrxslots   = nrxslots,
             ntxslots   = ntxslots,
+            tx_write_only = tx_write_only,
             timestamp  = None if not with_timestamp else self.timer0.uptime_cycles,
             with_preamble_crc = not software_debug,
             with_sys_datapath = with_sys_datapath)

--- a/litex/soc/interconnect/wishbone.py
+++ b/litex/soc/interconnect/wishbone.py
@@ -362,7 +362,7 @@ class Converter(Module):
 # Wishbone SRAM ------------------------------------------------------------------------------------
 
 class SRAM(Module):
-    def __init__(self, mem_or_size, read_only=None, init=None, bus=None, name=None):
+    def __init__(self, mem_or_size, read_only=None, write_only=None, init=None, bus=None, name=None):
         if bus is None:
             bus = Interface()
         self.bus = bus
@@ -468,11 +468,12 @@ class SRAM(Module):
             self.comb += If(adr_burst & adr_latched,
                 port.adr.eq(adr_next[:len(port.adr)]),
             )
-        self.comb += [
-            self.bus.dat_r.eq(port.dat_r)
-        ]
+
+        if not write_only:
+            self.comb += self.bus.dat_r.eq(port.dat_r)
+
         if not read_only:
-            self.comb += port.dat_w.eq(self.bus.dat_w),
+            self.comb += port.dat_w.eq(self.bus.dat_w)
 
         # Generate Ack.
         self.sync += [


### PR DESCRIPTION
Allow liteeth txslots to be write only. Enable it in case the firmware does not need to read back the buffer. This can save a substantial amount of resources. Tested on Spartan6. Without it, txbuffers are implemented as distributed RAM, probably due to the 2 read ports. With this patch, it is implemented as BRAM.
Needs to be pulled in conjunction with the corresponding litex patch.