### PR TITLE
cores/zynqmp: Fix boot helper

### DIFF
--- a/litex/soc/cores/cpu/zynqmp/boot-helper.c
+++ b/litex/soc/cores/cpu/zynqmp/boot-helper.c
@@ -1,5 +1,5 @@
 void boot_helper(unsigned long r1, unsigned long r2, unsigned long r3, unsigned long addr);
 
 void boot_helper(unsigned long r1, unsigned long r2, unsigned long r3, unsigned long addr) {
-    goto *addr;
+    goto *(void*)addr;
 }


### PR DESCRIPTION
This pull request fixes a regression where the computed goto causes an error when compiling the boot helper with newer versions of GCC. The behavior of goto has changed since GCC 12 (see https://gcc.gnu.org/gcc-12/porting_to.html).