### PR TITLE
cores/arm: Fix computed goto in boot helpers

### DIFF
--- a/litex/soc/cores/cpu/cortex_m1/boot-helper.c
+++ b/litex/soc/cores/cpu/cortex_m1/boot-helper.c
@@ -1,5 +1,5 @@
 void boot_helper(unsigned long r1, unsigned long r2, unsigned long r3, unsigned long addr);
 
 void boot_helper(unsigned long r1, unsigned long r2, unsigned long r3, unsigned long addr) {
-    goto *addr;
+    goto *(void*)addr;
 }

--- a/litex/soc/cores/cpu/cortex_m3/boot-helper.c
+++ b/litex/soc/cores/cpu/cortex_m3/boot-helper.c
@@ -1,5 +1,5 @@
 void boot_helper(unsigned long r1, unsigned long r2, unsigned long r3, unsigned long addr);
 
 void boot_helper(unsigned long r1, unsigned long r2, unsigned long r3, unsigned long addr) {
-    goto *addr;
+    goto *(void*)addr;
 }

--- a/litex/soc/cores/cpu/eos_s3/boot-helper.c
+++ b/litex/soc/cores/cpu/eos_s3/boot-helper.c
@@ -1,5 +1,5 @@
 void boot_helper(unsigned long r1, unsigned long r2, unsigned long r3, unsigned long addr);
 
 void boot_helper(unsigned long r1, unsigned long r2, unsigned long r3, unsigned long addr) {
-    goto *addr;
+    goto *(void*)addr;
 }

--- a/litex/soc/cores/cpu/gowin_emcu/boot-helper.c
+++ b/litex/soc/cores/cpu/gowin_emcu/boot-helper.c
@@ -1,5 +1,5 @@
 void boot_helper(unsigned long r1, unsigned long r2, unsigned long r3, unsigned long addr);
 
 void boot_helper(unsigned long r1, unsigned long r2, unsigned long r3, unsigned long addr) {
-    goto *addr;
+    goto *(void*)addr;
 }

--- a/litex/soc/cores/cpu/zynq7000/boot-helper.c
+++ b/litex/soc/cores/cpu/zynq7000/boot-helper.c
@@ -1,5 +1,5 @@
 void boot_helper(unsigned long r1, unsigned long r2, unsigned long r3, unsigned long addr);
 
 void boot_helper(unsigned long r1, unsigned long r2, unsigned long r3, unsigned long addr) {
-    goto *addr;
+    goto *(void*)addr;
 }


### PR DESCRIPTION
This pull request fixes the computed goto of all ARM boot helpers. The issue is identical to #1724.