### PR TITLE
Revert "soc/interconnect/packet: Don’t bypass dispatcher with a singl…

### DIFF
--- a/litex/soc/interconnect/packet.py
+++ b/litex/soc/interconnect/packet.py
@@ -62,7 +62,7 @@ class Dispatcher(Module):
     def __init__(self, master, slaves, one_hot=False):
         if len(slaves) == 0:
             self.sel = Signal()
-        elif len(slaves) == 1 and not one_hot:
+        elif len(slaves) == 1:
             self.comb += master.connect(slaves.pop())
             self.sel = Signal()
         else:


### PR DESCRIPTION
…e slave if it can be deselected."

This reverts commit 91f56aaf0ec9d5f15193fa817ba6024e76085531.

I was updating litex in my project and the udpraw core stopped working while still responding to pings. After bisecting I found that this is the offending commit.

I'm not sure whether the udpraw core code is wrong or this is wrong... For now I have reverted this locally. If this is not the correct way forward please let me know as well. 