### PR TITLE
Adding a weak isr handler to handle non uart interrupts

### DIFF
--- a/litex/soc/software/libbase/isr.c
+++ b/litex/soc/software/libbase/isr.c
@@ -12,10 +12,10 @@
 
 // Weak function that can be overriden in own software for any IRQ that is not the uart.
 // Return true (not zero) if an IRQ was handled, or 0 if not.
-unsigned int __attribute__((weak)) handle_isr(int irqs);
+unsigned int __attribute__((weak)) isr_handler(int irqs);
 
 // Override by default with return 0
-unsigned int handle_isr(int irqs)
+unsigned int isr_handler(int irqs)
 {
 	return 0;
 }
@@ -69,15 +69,18 @@ void isr(void)
 			uart_isr();
 			break;
 		default:
-			printf("## PLIC: Unhandled claim: %d\n", claim);
-			printf("# plic_enabled:    %08x\n", irq_getmask());
-			printf("# plic_pending:    %08x\n", irq_pending());
-			printf("# mepc:    %016lx\n", csrr(mepc));
-			printf("# mcause:  %016lx\n", csrr(mcause));
-			printf("# mtval:   %016lx\n", csrr(mtval));
-			printf("# mie:     %016lx\n", csrr(mie));
-			printf("# mip:     %016lx\n", csrr(mip));
-			printf("###########################\n\n");
+			if(!isr_handler())
+			{
+				printf("## PLIC: Unhandled claim: %d\n", claim);
+				printf("# plic_enabled:    %08x\n", irq_getmask());
+				printf("# plic_pending:    %08x\n", irq_pending());
+				printf("# mepc:    %016lx\n", csrr(mepc));
+				printf("# mcause:  %016lx\n", csrr(mcause));
+				printf("# mtval:   %016lx\n", csrr(mtval));
+				printf("# mie:     %016lx\n", csrr(mie));
+				printf("# mip:     %016lx\n", csrr(mip));
+				printf("###########################\n\n");
+			}
 			break;
 		}
 		*((unsigned int *)PLIC_CLAIM) = claim;
@@ -185,15 +188,18 @@ void isr(void)
 			uart_isr();
 			break;
 		default:
-			printf("## PLIC: Unhandled claim: %d\n", claim);
-			printf("# plic_enabled:    %08x\n", irq_getmask());
-			printf("# plic_pending:    %08x\n", irq_pending());
-			printf("# mepc:    %016lx\n", csrr(mepc));
-			printf("# mcause:  %016lx\n", csrr(mcause));
-			printf("# mtval:   %016lx\n", csrr(mtval));
-			printf("# mie:     %016lx\n", csrr(mie));
-			printf("# mip:     %016lx\n", csrr(mip));
-			printf("###########################\n\n");
+			if(!isr_handler())
+			{
+				printf("## PLIC: Unhandled claim: %d\n", claim);
+				printf("# plic_enabled:    %08x\n", irq_getmask());
+				printf("# plic_pending:    %08x\n", irq_pending());
+				printf("# mepc:    %016lx\n", csrr(mepc));
+				printf("# mcause:  %016lx\n", csrr(mcause));
+				printf("# mtval:   %016lx\n", csrr(mtval));
+				printf("# mie:     %016lx\n", csrr(mie));
+				printf("# mip:     %016lx\n", csrr(mip));
+				printf("###########################\n\n");
+			}
 			break;
 		}
 		*((unsigned int *)PLIC_M_CLAIM) = claim;
@@ -211,7 +217,7 @@ void isr(void)
 	if(irqs & (1 << UART_INTERRUPT))
 		uart_isr();
 	else
-		if(!handle_isr(irqs))
+		if(!isr_handler(irqs))
 			printf("Unhandled irq!\n");
 #endif
 #endif


### PR DESCRIPTION
This would add a weak isr_handler that can be overridden in a user's application to handle interrupts that are not for the build in uart. This would make it possible to use the libbase for your own application and add peripherals with an irq.

For example, in an own application something like this can be added to handle an interrupt from an additional timer:

```
unsigned int isr_handler(int irqs)
{	
	unsigned int irqHandled = 0;
	if(irqs & (1 << TIMER2_INTERRUPT))
	{
		Timer2ClearPendingInterrupt();
		// Some own function to act on a timer interrupt
		irqHandled = 1;
	}
	return irqHandled;
}
```
