### PR TITLE
litex_setup: fix software build when liteeth or/and litesata is set (riscv toolchain issue)

### DIFF
--- a/litex_setup.py
+++ b/litex_setup.py
@@ -350,7 +350,7 @@ def riscv_gcc_install():
             os.system("pacman -S riscv64-linux-gnu-gcc")
         # Ubuntu.
         else:
-            os.system("apt install gcc-riscv64-linux-gnu")
+            os.system("apt install gcc-riscv64-unknown-elf")
 
     # Mac OS.
     # -------


### PR DESCRIPTION
Starting with ubuntu 22.04, when a target is configured with ethernet and/or sata the sofware build fails with:
```
/usr/lib/gcc-cross/riscv64-linux-gnu/12/../../../../riscv64-linux-gnu/bin/ld: ../libc/libc.a(libc_ssp_chk_fail.c.o): in function `__chk_fail':
/somewhere/litex-boards/litex_boards/targets/build/digilent_arty/software/libc/../../../../../../../pythondata-software-picolibc/pythondata_software_picolibc/data/newlib/libc/ssp/chk_fail.c:13: undefined reference to `write'
collect2: error: ld returned 1 exit status
make: *** [/somewhere/litex/litex/soc/software/bios/Makefile:72: bios.elf] Error 1
```

By switching to *gcc-riscv64-unknown-elf* (bare-metal toolchain) build end successfully
Fix:
- https://github.com/enjoy-digital/litex/issues/1624
- https://github.com/enjoy-digital/litex/issues/1621