### PR TITLE
build/gowin/common: Fix DDRInput

### DIFF
--- a/litex/build/gowin/common.py
+++ b/litex/build/gowin/common.py
@@ -48,7 +48,7 @@ class GowinDDRInputImpl(Module):
 class GowinDDRInput:
     @staticmethod
     def lower(dr):
-        return GowinInputImpl(dr.i, dr.o1, dr.o2, dr.clk)
+        return GowinDDRInputImpl(dr.i, dr.o1, dr.o2, dr.clk)
 
 # Gowin DDR Output ---------------------------------------------------------------------------------
 


### PR DESCRIPTION
The DDRInput of Gowin seems to be never used and contains a typo that prevents it from being really used.

Fix this typo.