### PR TITLE
gowin mcufw option

### DIFF
--- a/litex/build/openfpgaloader.py
+++ b/litex/build/openfpgaloader.py
@@ -25,8 +25,10 @@ class OpenFPGALoader(GenericProgrammer):
         if index_chain is not None:
             self.cmd += ["--index-chain", str(int(index_chain))]
 
-    def load_bitstream(self, bitstream_file):
+    def load_bitstream(self, bitstream_file, mcu_firmware=None):
         cmd = self.cmd + ["--bitstream", bitstream_file]
+        if mcu_firmware is not None:
+            cmd += ["--mcufw", mcu_firmware]
         self.call(cmd)
 
     def flash(self, address, data_file, external=False):


### PR DESCRIPTION
This PR adds an `mcu_firmware` option to the OpenFPGALoader `load_bitstream()` function. Adding a string to this field adds it as a `--mcufw` flag which loads it into the internal user flash of Gowin FPGAs.

Sadly this flag has to be set when the bitstream is loaded so it can't go into the `flash()` function and follow the load command pattern used for other boards.