### PR TITLE
[RFC] remove SD-card support, absent from Zephyr

### DIFF
--- a/litex/tools/litex_json2dts_zephyr.py
+++ b/litex/tools/litex_json2dts_zephyr.py
@@ -212,36 +212,6 @@ overlay_handlers = {
         'alias': 'spi0',
         'config_entry': 'SPI_LITESPI'
     },
-    'sdcard_block2mem': {
-        'handler': peripheral_handler,
-        'alias': 'sdcard_block2mem',
-        'size': 0x18,
-        'config_entry': 'SD_LITESD'
-    },
-    'sdcard_core': {
-        'handler': peripheral_handler,
-        'alias': 'sdcard_core',
-        'size': 0x2C,
-        'config_entry': 'SD_LITESD'
-    },
-    'sdcard_irq': {
-        'handler': peripheral_handler,
-        'alias': 'sdcard_irq',
-        'size': 0x0C,
-        'config_entry': 'SD_LITESD'
-    },
-    'sdcard_mem2block': {
-        'handler': peripheral_handler,
-        'alias': 'sdcard_mem2block',
-        'size': 0x18,
-        'config_entry': 'SD_LITESD'
-    },
-    'sdcard_phy': {
-        'handler': peripheral_handler,
-        'alias': 'sdcard_phy',
-        'size': 0x10,
-        'config_entry': 'SD_LITESD'
-    },
     'i2c0' : {
         'handler': i2c_handler,
         'config_entry': 'I2C_LITEX'


### PR DESCRIPTION
This is an illustration around which discuss for a fix:

Zephyr on LiteX VecRiscv did not work out of the box for me.

This patch is a fix for this error:

    $ xargs <overlay.config west build -p -b litex_vexriscv zephyr/samples/subsys/shell/shell_module -- -DDTC_OVERLAY_FILE="$PWD/overlay.dts"
    [...]
    -- Found devicetree overlay: /home/zephyr/overlay.dts
    devicetree error: /home/zephyr/overlay.dts:49 (column 1): parse error: undefined node label 'sdcard_block2mem'
    -- In: /home/zephyr/build/zephyr, command: /home/zephyr/.venv/bin/python3.11;/home/zephyr/zephyr/scripts/dts/gen_defines.py;--dts;/home/zephyr/build/zephyr/zephyr.dts.pre;--dtc-flags;'';--bindings-dirs;/home/zephyr/zephyr/dts/bindings;--header-out;/home/zephyr/build/zephyr/include/generated/devicetree_generated.h.new;--dts-out;/home/zephyr/build/zephyr/zephyr.dts.new;--edt-pickle-out;/home/zephyr/build/zephyr/edt.pickle;--vendor-prefixes;/home/zephyr/zephyr/dts/bindings/vendor-prefixes.txt
    CMake Error at /home/zephyr/zephyr/cmake/modules/dts.cmake:276 (message):
      gen_defines.py failed with return code: 1
    Call Stack (most recent call first):
      /home/zephyr/zephyr/cmake/modules/zephyr_default.cmake:115 (include)
      /home/zephyr/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:66 (include)
      /home/zephyr/zephyr/share/zephyr-package/cmake/ZephyrConfig.cmake:92 (include_boilerplate)
      CMakeLists.txt:4 (find_package)
    -- Configuring incomplete, errors occurred!
    FATAL ERROR: command exited with status 1: /usr/bin/cmake -DWEST_PYTHON=/home/zephyr/.venv/bin/python3.11 -B/home/zephyr/build -GNinja -DBOARD=litex_vexriscv -DDTC_OVERLAY_FILE=/home/zephyr/overlay.dts -DCONFIG_UART_LITEUART=y -DCONFIG_LITEX_TIMER=y -DCONFIG_ETH_LITEETH=n -DCONFIG_SPI_LITESPI=n -DCONFIG_SD_LITESD=n -DCONFIG_SD_LITESD=n -DCONFIG_SD_LITESD=n -DCONFIG_SD_LITESD=n -DCONFIG_SD_LITESD=n -DCONFIG_I2C_LITEX=n -DCONFIG_I2S_LITEX=n -DCONFIG_I2S_LITEX=n -DCONFIG_CLOCK_CONTROL_LITEX=n -DCONFIG_LITEX_CSR_DATA_WIDTH=32 -S/home/zephyr/zephyr/samples/subsys/shell/shell_module
    $

What I cannot understand is why would there be SD-Card support in `zephyr-on-litex-vexriscv` if there is no support on upstream `zephyr`?

https://github.com/search?q=repo%3Azephyrproject-rtos%2Fzephyr+litesd&type=code

Did I miss something?