### PR TITLE
Generate DTS with XIP support for running Zephyr from flash

### DIFF
--- a/litex/tools/litex_json2dts_zephyr.py
+++ b/litex/tools/litex_json2dts_zephyr.py
@@ -208,9 +208,9 @@ overlay_handlers = {
         'config_entry': 'ETH_LITEETH'
     },
     'spiflash': {
-        'handler': peripheral_handler,
-        'alias': 'spi0',
-        'config_entry': 'SPI_LITESPI'
+        'handler': ram_handler,
+        'alias': 'flash0',
+        'config_entry': 'XIP'
     },
     'sdcard_block2mem': {
         'handler': peripheral_handler,


### PR DESCRIPTION
This incidentally remove the `-DCONFIG_SPI_LITESPI=y` flag altogether, which I can add back in another commit to this pull request. Should there be some extra command line flag to choose if the SPI flash should be used for XIP or for user data storage like a filesystem? Or support both by default/

No support for partitions yet: this does not yet support cohabitating the bitstream and firmware yet, so the bitstream has to be loaded to CRAM directly for now (default for --load).

This allows loading larger Zephyr examples, and was required to fit the shell on the Crosslink-NX board.

See https://github.com/litex-hub/zephyr-on-litex-vexriscv/pull/13