### PR TITLE
Slow but reliable ecpprog

### DIFF
--- a/litex/build/lattice/programmer.py
+++ b/litex/build/lattice/programmer.py
@@ -196,7 +196,7 @@ class EcpprogProgrammer(GenericProgrammer):
     needs_bitreverse = False
 
     def flash(self, address, bitstream_file):
-        self.call(["ecpprog", "-o", str(address), bitstream_file])
+        self.call(["ecpprog", "-s", "-o", str(address), bitstream_file])
 
     def load_bitstream(self, bitstream_file):
-        self.call(["ecpprog", "-S", bitstream_file])
+        self.call(["ecpprog", "-s", "-S", bitstream_file])


### PR DESCRIPTION
I noticed that running `ecpprog -t` and `ecpprog -t -s` (slow) does not yield the same result.
If running slower shows a different ID, I suppose there is some data integrity problem.

```
(josuah-3.11) lap1$ ecpprog -t
[...]
flash ID: 0xE1 0x10 0x18
```

```
(josuah-3.11) lap1$ ecpprog -t -s
[...]
flash ID: 0xC2 0x20 0x18
```

`0xC2 0x20 0x18` (obtained when reading slow) is the correct ID:
> ![2023-08-18-194551_1648x492_scrot](https://github.com/enjoy-digital/litex/assets/55351021/37fe8c19-59a9-470a-ab2a-85a635ac4d50)


Is it reasonable to go all the way using the very slow mode `-s`, or is a fine-tuned clock divisor (`-k 8` still seems to work), `-k 2` does not) better?