### PR TITLE
soc/cores/spi_mmap: Fix clock divider

### DIFF
--- a/litex/soc/cores/spi/spi_mmap.py
+++ b/litex/soc/cores/spi/spi_mmap.py
@@ -124,7 +124,7 @@ class SPIMaster(LiteXModule):
         self.sync += [
             If(clk_enable,
                 clk_count.eq(clk_count + 1),
-                If(clk_count == self.clk_divider[2:],
+                If(clk_count == self.clk_divider[1:],
                     clk.eq(~clk),
                     clk_count.eq(0)
                 ),


### PR DESCRIPTION
This change ensures clk_divider represents the true divider. Alternately could test: clk_count == self.clk_divider and document that the actual divide is 2x clk_divider.