### PR TITLE
Builder enhancements

### DIFF
--- a/litex/build/parser.py
+++ b/litex/build/parser.py
@@ -99,8 +99,9 @@ class LiteXArgumentParser(argparse.ArgumentParser):
                 help    = "FPGA toolchain ({}).".format(" or ".join(self.toolchains)))
         else:
             self.add_target_argument("-toolchain", help="FPGA toolchain")
-        self.add_target_argument("--build", action="store_true", help="Build design.")
-        self.add_target_argument("--load",  action="store_true", help="Load bitstream.")
+        bool_action = argparse.BooleanOptionalAction
+        self.add_target_argument("--build", action=bool_action, default=False, help="Build design.")
+        self.add_target_argument("--load",  action=bool_action, default=False, help="Load bitstream.")
 
     def add_target_argument(self, *args, **kwargs):
         """ wrapper to add argument to "Target options group" from outer of this

--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -353,8 +353,14 @@ class Builder:
                 self._prepare_rom_software()
                 self._generate_rom_software(compile_bios=use_bios)
 
+                # Allow soc to override the memory initialisation.
+                # For example load a program to rom and/or main ram
+                # TODO: add initialize_memory() stub to the soc and document the usage
+                if hasattr(self.soc, 'initialize_memory') and callable(self.soc.initialize_memory):
+                    self.soc.initialize_memory(self.software_dir)
+
                 # Initialize ROM.
-                if use_bios and self.soc.integrated_rom_size:
+                if use_bios and self.soc.integrated_rom_size and not getattr(self.soc, "rom").mem.init:
                     self._initialize_rom_software()
 
         # Translate compile_gateware to run.


### PR DESCRIPTION
Various enhancements to reduce boilerplate code in target arguments and to cleanly allow a target to initialise memory with a custom firmware (for example).

Custom firmware example:

class MySimSoC(SoCCore):
    def __init__(self, firmware, **kwargs):

        self.firmware = firmware

        if self.firmware:
            self.add_config("MAIN_RAM_INIT") # target software is in ram
           self.add_constant("ROM_BOOT_ADDRESS", self.bus.regions["main_ram"].origin)

    def initialize_memory(self, software_dir, **kwargs):
        if not self.firmware:
            return

        filename  = os.path.join(software_dir, "firmware", "firmware.bin")
        data = get_mem_data(filename, endianness="little")
        # This can not generate MAIN_RAM_INIT so must set it manually in soc.__init__()
        self.init_rom(name="main_ram", contents=data, auto_size=False)

# Build --------------------------------------------------------------------------------------------

def main():
    from litex.build.parser import LiteXArgumentParser
    bool_action = argparse.BooleanOptionalAction
    parser = LiteXArgumentParser(platform=Platform, soc=MySimSoC, description="My simulation.")

    # NOTE: all target arguments have a default here, not in soc.__init__(), so they are documented.
    parser.add_target_argument("--firmware", default=True, action=bool_action,      help="compile and load firmware in main_ram.")

    # Create SoC.
    soc = MySimSoC(**parser.soc_argdict)

    # add custom firmware: compiled by connecting here and stored in initialize_memory()
    src="firmware"
    src_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), src)
    builder = Builder(soc, **parser.builder_argdict)
    builder.add_software_package(src, src_dir)

    # Build/Run SoC
    builder.build(sim_config=sim_config, **parser.toolchain_argdict, run=True)
