### PR TITLE
[RFC] litex_sim: move most code from main() to SimSoC()

### DIFF
--- a/litex/build/lattice/programmer.py
+++ b/litex/build/lattice/programmer.py
@@ -196,7 +196,7 @@ class EcpprogProgrammer(GenericProgrammer):
     needs_bitreverse = False
 
     def flash(self, address, bitstream_file):
-        self.call(["ecpprog", "-o", str(address), bitstream_file])
+        self.call(["ecpprog", "-s", "-o", str(address), bitstream_file])
 
     def load_bitstream(self, bitstream_file):
-        self.call(["ecpprog", "-S", bitstream_file])
+        self.call(["ecpprog", "-s", "-S", bitstream_file])

--- a/litex/tools/litex_json2dts_zephyr.py
+++ b/litex/tools/litex_json2dts_zephyr.py
@@ -207,11 +207,6 @@ overlay_handlers = {
         'alias': 'eth0',
         'config_entry': 'ETH_LITEETH'
     },
-    'spiflash': {
-        'handler': peripheral_handler,
-        'alias': 'spi0',
-        'config_entry': 'SPI_LITESPI'
-    },
     'i2c0' : {
         'handler': i2c_handler,
         'config_entry': 'I2C_LITEX'
@@ -232,6 +227,11 @@ overlay_handlers = {
     'main_ram': {
         'handler': ram_handler,
         'alias': 'ram0',
+    },
+    'spiflash': {
+        'handler': ram_handler,
+        'alias': 'flash0',
+        'config_entry': 'XIP'
     },
     'identifier_mem': {
         'handler': peripheral_handler,

--- a/litex/tools/litex_json2dts_zephyr.py
+++ b/litex/tools/litex_json2dts_zephyr.py
@@ -212,36 +212,6 @@ overlay_handlers = {
         'alias': 'spi0',
         'config_entry': 'SPI_LITESPI'
     },
-    'sdcard_block2mem': {
-        'handler': peripheral_handler,
-        'alias': 'sdcard_block2mem',
-        'size': 0x18,
-        'config_entry': 'SD_LITESD'
-    },
-    'sdcard_core': {
-        'handler': peripheral_handler,
-        'alias': 'sdcard_core',
-        'size': 0x2C,
-        'config_entry': 'SD_LITESD'
-    },
-    'sdcard_irq': {
-        'handler': peripheral_handler,
-        'alias': 'sdcard_irq',
-        'size': 0x0C,
-        'config_entry': 'SD_LITESD'
-    },
-    'sdcard_mem2block': {
-        'handler': peripheral_handler,
-        'alias': 'sdcard_mem2block',
-        'size': 0x18,
-        'config_entry': 'SD_LITESD'
-    },
-    'sdcard_phy': {
-        'handler': peripheral_handler,
-        'alias': 'sdcard_phy',
-        'size': 0x10,
-        'config_entry': 'SD_LITESD'
-    },
     'i2c0' : {
         'handler': i2c_handler,
         'config_entry': 'I2C_LITEX'


### PR DESCRIPTION
I was on my way to bring support for the simulator on [Zephyr-on-LitexVexriscv](https://github.com/litex-hub/zephyr-on-litex-vexriscv), then I saw this: https://github.com/litex-hub/linux-on-litex-vexriscv/blob/master/sim.py#L70

This means that currently, `./make.py` has nothing to do with `./sim.py`, and any pull request to `./make.py` needs maintainers to always update `./sim.py`... time-consuming for little added-value?

So why not allow the simulator to be configured as a regular boards? `import litex.tools.litex_sim`

Supersedes https://github.com/litex-hub/litex-boards/pull/525