### PR TITLE
clock/gowin_gw5a: change allowed frequency range for GW5A- prefix

### DIFF
--- a/litex/soc/cores/clock/gowin_gw5a.py
+++ b/litex/soc/cores/clock/gowin_gw5a.py
@@ -36,7 +36,9 @@ class GW5APLL(LiteXModule):
     @staticmethod
     def get_vco_freq_range(device):
         vco_freq_range = None
-        if device.startswith('GW5A-') or device.startswith('GW5AT-') or device.startswith('GW5AST-'):
+        if device.startswith('GW5A-'):
+            vco_freq_range = (800e6, 1600e6) # As restricted by Gowin toolchain 1.9.9b3
+        elif device.startswith('GW5A-') or device.startswith('GW5AT-') or device.startswith('GW5AST-'):
             vco_freq_range = (800e6, 2000e6) # datasheet values
         if vco_freq_range is None:
             raise ValueError(f"Unsupported device {device}.")
@@ -45,7 +47,9 @@ class GW5APLL(LiteXModule):
     @staticmethod
     def get_pfd_freq_range(device):
         pfd_freq_range = None
-        if device.startswith('GW5A-') or device.startswith('GW5AT-') or device.startswith('GW5AST-'):
+        if device.startswith('GW5A-'):
+            pfd_freq_range = (19e6, 400e6) # As restricted by Gowin toolchain 1.9.9b3
+        elif device.startswith('GW5AT-') or device.startswith('GW5AST-'):
             pfd_freq_range = (10e6, 400e6) # datasheet values
         if pfd_freq_range is None:
             raise ValueError(f"Unsupported device {device}.")


### PR DESCRIPTION
When targeting GW5A-25 ES, the Gowin IDE has a more strict frequency range.

Change the range when GW5A- is matched to this.