### PR TITLE
litex_setup.py: Disable auto-update of litex_setup for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       # Install (n)Migen / LiteX / Cores
       - name: Install LiteX
         run: |
-          python3 litex_setup.py --config=full --init --install --user
+          python3 litex_setup.py --config=full --init --install --user --disable-auto-update
 
       # Install GCC Toolchains
       - name: Install GCC Toolchains

--- a/litex_setup.py
+++ b/litex_setup.py
@@ -429,6 +429,7 @@ def main():
     parser.add_argument("--dev",     action="store_true", help="Development-Mode (no Auto-Update of litex_setup.py / Switch to git@github.com URLs).")
     parser.add_argument("--freeze",  action="store_true", help="Freeze and display current config.")
     parser.add_argument("--release", default=None,        help="Make release.")
+    parser.add_argument("--disable-auto-update", action="store_true", help="Disables Auto-Update of litex_setup.py")
 
     # Retro-compatibility.
     parser.add_argument("compat_args", nargs="*", help="Retro-Compatibility arguments (init, update, install or gcc).")
@@ -444,7 +445,7 @@ def main():
 
     # Location/Auto-Update.
     litex_setup_location_check()
-    if not args.dev:
+    if not args.dev and not args.disable_auto_update:
         litex_setup_auto_update()
 
     # Init.


### PR DESCRIPTION
This adds a new config option to litex_setup (--disable-auto-update) to disable the auto-update mechanism. It further changes the CI flow to use that flag.

Why? The auto-update is a problem for the CI workflow because it will override any (especially branch-specific) changes to the litex_setup script. Then CI is testing the wrong litex_setup script.

This should fix the CI flow for https://github.com/enjoy-digital/litex/pull/1776