### PR TITLE
Use bump2version to keep code and tag in sync, small cleanups and enhancements

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,12 @@
+[bumpversion]
+current_version = 2023.08
+commit = True
+tag = True
+
+[bumpversion:file:litex/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:setup.py]
+search = version="{current_version}"
+replace = version="{new_version}"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           sudo apt-get install libevent-dev libjson-c-dev flex bison
           sudo apt-get install libfl-dev libfl2 zlib1g-dev
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
           python-version: "3.9"

--- a/litex/__init__.py
+++ b/litex/__init__.py
@@ -20,3 +20,6 @@ pythondata-{dt}-{dn} module not installed! Unable to use {dn} {dt}.
 You can install this by running;
  pip3 install git+https://github.com/litex-hub/pythondata-{dt}-{dn}.git
 """.format(dt=data_type, dn=data_name, e=e))
+
+
+__version__ = "2023.08"

--- a/litex_setup.py
+++ b/litex_setup.py
@@ -199,7 +199,11 @@ def git_checkout(sha1=None, tag=None):
 
 def git_tag(tag=None):
     assert tag is not None
-    os.system(f"git tag {tag}")
+    if os.path.exists(".bumpversion.cfg"):
+        # Use bump2version to increment tag
+        os.system(f"bump2version --new-version {tag} setup.py")
+    else:
+        os.system(f"git tag {tag}")
     os.system(f"git push --tags")
 
 # Git repositories initialization ------------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as fp:
 
 setup(
     name="litex",
-    version="2023.04",
+    version="2023.08",
     description="Python SoC/Core builder for building FPGA based systems.",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -29,10 +29,11 @@ setup(
     ],
     extras_require={
         "develop": [
-          "meson"
-          "pexpect"
-          "setuptools"
-          "requests"
+          "bump2version",
+          "meson",
+          "pexpect",
+          "setuptools",
+          "requests",
         ]
     },
     packages=find_packages(exclude=("test*", "sim*", "doc*")),


### PR DESCRIPTION
- use `bump2version` instead of raw `git tag` to both change code and git tag, when `.bumpversion.cfg` file is present in dependencies
- cleanup develop extras in setup.py, was a multiline string instead of a list of strings
- add dependabot auto updater to CI