### PR TITLE
[enh] generate SVD CSR enumeratedValue based on fields values

### DIFF
--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -848,6 +848,8 @@ def _svd_enumerated_values(field):
     values = []
     used_names = set()
     for value in field.values:
+        if not isinstance(value, (list, tuple)):
+            continue
         if len(value) == 2:
             raw_value, description = value
             name = description

--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -826,6 +826,49 @@ def _svd_cdata(description):
     # across two CDATA sections (standard XML escaping technique).
     return "<![CDATA[{}]]>".format(str(description).replace("]]>", "]]]]><![CDATA[>"))
 
+def _svd_identifier(name):
+    identifier = re.sub(r"[^A-Za-z0-9_]+", "_", str(name).strip("` "))
+    identifier = identifier.strip("_")
+    if not identifier:
+        return None
+    if not re.match(r"[A-Za-z_]", identifier):
+        identifier = "Value_" + identifier
+    return identifier
+
+def _svd_enumerated_value(value):
+    value = str(value).strip("` ")
+    if re.fullmatch(r"[+]?(0[xX][0-9a-fA-F]+|(0[bB]|#)[01xX]+|[0-9]+)", value):
+        return value
+    return None
+
+def _svd_enumerated_values(field):
+    if field.values is None:
+        return []
+
+    values = []
+    used_names = set()
+    for value in field.values:
+        if len(value) == 2:
+            raw_value, description = value
+            name = description
+        elif len(value) == 3:
+            raw_value, name, description = value
+        else:
+            continue
+
+        value = _svd_enumerated_value(raw_value)
+        name  = _svd_identifier(name)
+        if value is None or name is None:
+            continue
+
+        if name in used_names:
+            name = _svd_identifier("{}_{}".format(name, value))
+        used_names.add(name)
+
+        values.append((name, description, value))
+
+    return values
+
 def get_csr_svd(soc, vendor="litex", name="soc", description=None):
     def sub_csr_bit_range(busword, csr, offset):
         nwords = (csr.size + busword - 1)//busword
@@ -858,6 +901,17 @@ def get_csr_svd(soc, vendor="litex", name="soc", description=None):
                 if field.description is not None:
                     svd.append('                            <description>{}</description>'.format(
                         _svd_cdata(reflow(field.description))))
+                enumerated_values = _svd_enumerated_values(field)
+                if len(enumerated_values) != 0:
+                    svd.append('                            <enumeratedValues>')
+                    for name, description, value in enumerated_values:
+                        svd.append('                                <enumeratedValue>')
+                        svd.append('                                    <name>{}</name>'.format(name))
+                        svd.append('                                    <description>{}</description>'.format(
+                            _svd_cdata(reflow(description))))
+                        svd.append('                                    <value>{}</value>'.format(value))
+                        svd.append('                                </enumeratedValue>')
+                    svd.append('                            </enumeratedValues>')
                 svd.append('                        </field>')
         else:
             field_size = csr.size

--- a/test/soc/test_export.py
+++ b/test/soc/test_export.py
@@ -62,6 +62,25 @@ def _get_svd_registers(svd):
     return registers
 
 
+def _get_svd_field_enums(svd, register_name, field_name):
+    root = ET.fromstring(svd)
+    for register in root.findall("./peripherals/peripheral/registers/register"):
+        if register.findtext("name") != register_name:
+            continue
+        for field in register.findall("./fields/field"):
+            if field.findtext("name") != field_name:
+                continue
+            return [
+                {
+                    "name":        enum.findtext("name"),
+                    "description": enum.findtext("description"),
+                    "value":       enum.findtext("value"),
+                }
+                for enum in field.findall("./enumeratedValues/enumeratedValue")
+            ]
+    return []
+
+
 class TestCSRExport(unittest.TestCase):
     def test_soc_header_formats_int_constants(self):
         header = get_soc_header({
@@ -233,6 +252,63 @@ class TestCSRExport(unittest.TestCase):
         self.assertEqual(registers["WIDE0"], {
             "middle": {"msb": "31", "lsb": "16", "bitRange": "[31:16]"},
         })
+
+    def test_svd_exports_csr_field_enumerated_values(self):
+        csr = CSRStorage(name="mode", fields=[
+            CSRField("select", size=1, offset=0, values=[
+                ("``0b0``", "Software (CPU) control."),
+                ("``0b1``", "Hardware control (default)."),
+            ]),
+        ])
+
+        svd   = _get_csr_svd(csr)
+        enums = _get_svd_field_enums(svd, "MODE", "select")
+
+        self.assertEqual(enums, [
+            {
+                "name":        "Software_CPU_control",
+                "description": "Software (CPU) control.",
+                "value":       "0b0",
+            },
+            {
+                "name":        "Hardware_control_default",
+                "description": "Hardware control (default).",
+                "value":       "0b1",
+            },
+        ])
+
+    def test_svd_sanitizes_and_filters_csr_field_enums(self):
+        csr = CSRStatus(name="state", fields=[
+            CSRField("fsm", size=2, offset=0, description="FSM state.", values=[
+                ("``0b00``",   "Idle State",     "Waiting for work."),
+                ("``0b01``",   "Active/State",   "Running ]]> work."),
+                ("``0b0..1``", "Unsupported",    "Non-SVD wildcard."),
+                ("``0b10``",   "Active/State",   "Duplicate name."),
+                ("``0xxxxx``", "UnsupportedRaw", "Missing binary prefix."),
+                "invalid",
+            ]),
+        ])
+
+        svd   = _get_csr_svd(csr)
+        enums = _get_svd_field_enums(svd, "STATE", "fsm")
+
+        self.assertEqual(enums, [
+            {
+                "name":        "Idle_State",
+                "description": "Waiting for work.",
+                "value":       "0b00",
+            },
+            {
+                "name":        "Active_State",
+                "description": "Running ]]> work.",
+                "value":       "0b01",
+            },
+            {
+                "name":        "Active_State_0b10",
+                "description": "Duplicate name.",
+                "value":       "0b10",
+            },
+        ])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The [SVD schema](https://www.keil.com/pack/doc/CMSIS/SVD/html/schema_1_2_gr.html) supports listing possible values for CSR fields, as can be seen in [Keil's example](https://www.keil.com/pack/doc/CMSIS/SVD/html/svd_Example_pg.html).

Ideally, all existing field documented should be formatted as SVD schema expects it.
However, invalid values are filtered out using the schema's regex, guaranteeing a valid SVD output will be generated regardless.

Here is a snippet of a generated SVD (from linux-on-litex-vexriscv)

```xml
        <peripheral>
            <name>SDRAM</name>
...
            <registers>
                <register>
                    <name>DFII_CONTROL</name>
...
                    <fields>
                        <field>
                            <name>sel</name>
...
                            <enumeratedValues>
                                <enumeratedValue>
                                    <name>Software</name>
                                    <description>Software (CPU) control.</description>
                                    <value>0b0</value>
                                </enumeratedValue>
                                <enumeratedValue>
                                    <name>Hardware</name>
                                    <description>Hardware control (default).</description>
                                    <value>0b1</value>
                                </enumeratedValue>
                            </enumeratedValues>
```