### PR TITLE
Update gcc installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,10 @@ $ ./litex_setup.py --update
 
 3. Install a RISC-V toolchain (Only if you want to test/create a SoC with a CPU):
 ```sh
-$ pip3 install meson ninja
-$ ./litex_setup.py --gcc=riscv
+$ git clone --recursive https://github.com/riscv/riscv-gnu-toolchain
+$ cd riscv-gnu-toolchain
+$ ./configure --prefix=$HOME/RISCV --enable-multilib
+$ make newlib linux
 ```
 
 4. Build the target of your board...:


### PR DESCRIPTION
Current installation instruction installs an older gcc which does not support all ISA instruction types passed in `-march` flags