### PR TITLE
soc/integration/soc_core: add new parameters --with-uartbone and --with-jtagbone, deprecate crossover+uartbone

### DIFF
--- a/litex/build/anlogic/platform.py
+++ b/litex/build/anlogic/platform.py
@@ -13,7 +13,8 @@ from litex.build.anlogic import common, anlogic
 # AnlogicPlatform ----------------------------------------------------------------------------------
 
 class AnlogicPlatform(GenericPlatform):
-    _bitstream_ext = ".bit"
+    _bitstream_ext  = ".bit"
+    _jtag_support  = False
 
     _supported_toolchains = ["td"]
 

--- a/litex/build/colognechip/platform.py
+++ b/litex/build/colognechip/platform.py
@@ -13,6 +13,7 @@ from litex.build.colognechip import common, colognechip
 
 class CologneChipPlatform(GenericPlatform):
     bitstream_ext = "_00.cfg.bit"
+    _jtag_support = False
 
     _supported_toolchains = ["colognechip"]
 

--- a/litex/build/generic_platform.py
+++ b/litex/build/generic_platform.py
@@ -329,6 +329,7 @@ class ConstraintManager:
 
 class GenericPlatform:
     device_family  = None
+    _jtag_support  = True # JTAGBone can't be used with all FPGAs.
     _bitstream_ext = None # None by default, overridden by vendor platform, may
                           # be a string when same extension is used for sram and
                           # flash. A dict must be provided otherwise
@@ -503,6 +504,16 @@ class GenericPlatform:
 
     def create_programmer(self):
         raise NotImplementedError
+
+    @property
+    def jtag_support(self):
+        if isinstance(self._jtag_support, str):
+            return self._jtag_support
+        else:
+            for dev in self._jtag_support:
+                if self.device.startswith(dev):
+                    return True
+            return False
 
     @property
     def support_mixed_language(self):

--- a/litex/build/gowin/platform.py
+++ b/litex/build/gowin/platform.py
@@ -14,6 +14,7 @@ from litex.build.gowin import common, gowin
 
 class GowinPlatform(GenericPlatform):
     _bitstream_ext = ".fs"
+    _jtag_support  = False
 
     _supported_toolchains = ["gowin", "apicula"]
 

--- a/litex/build/microsemi/platform.py
+++ b/litex/build/microsemi/platform.py
@@ -11,6 +11,7 @@ from litex.build.microsemi import common, libero_soc
 
 class MicrosemiPlatform(GenericPlatform):
     _bitstream_ext = ".bit"
+    _jtag_support  = False
 
     _supported_toolchains = ["libero_soc_polarfire"]
 

--- a/litex/build/quicklogic/platform.py
+++ b/litex/build/quicklogic/platform.py
@@ -13,6 +13,7 @@ from litex.build.quicklogic import common, f4pga
 
 class QuickLogicPlatform(GenericPlatform):
     _bitstream_ext = ".bit"
+    _jtag_support  = False
 
     _supported_toolchains = ["f4pga"]
 

--- a/litex/build/xilinx/platform.py
+++ b/litex/build/xilinx/platform.py
@@ -26,6 +26,12 @@ class XilinxPlatform(GenericPlatform):
         "ultrascale+" : ["vivado"],
     }
 
+    _jtag_support = [
+        "xc6",
+        "xc7a", "xc7k", "xc7v", "xc7z",
+        "xcau", "xcku", "xcvu", "xczu"
+    ]
+
     def __init__(self, *args, toolchain="ise", **kwargs):
         GenericPlatform.__init__(self, *args, **kwargs)
         self.edifs = set()
@@ -125,6 +131,7 @@ class XilinxPlatform(GenericPlatform):
             return vivado.vivado_build_argdict(args)
         else:
             return dict()
+
 
 # XilinxSpartan6Platform ---------------------------------------------------------------------------
 

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -108,6 +108,13 @@ class SoCCore(LiteXSoC):
         # Controller parameters
         with_ctrl                = True,
 
+        # JTAGBone
+        with_jtagbone            = False,
+        jtagbone_chain           = 1,
+
+        # UARTBone
+        with_uartbone            = False,
+
         # Others
         **kwargs):
 
@@ -174,6 +181,31 @@ class SoCCore(LiteXSoC):
         # Wishbone Slaves.
         self.wb_slaves = {}
 
+        # Parameters check validity ----------------------------------------------------------------
+
+        # Check if jtagbone is supported (SPI only device or no user access).
+        if with_jtagbone:
+            if not platform.jtag_support:
+                self.logger.error("{} {} with {} FPGA".format(
+                    colorer("JTAGBone isn't supported for platform", color="red"),
+                    platform.name, platform.device))
+                raise SoCError()
+        if with_uart:
+            # crossover+uartbone is kept as backward compatibility
+            if uart_name == "crossover+uartbone":
+                self.logger.warning("{} UART: is deprecated {}".format(
+                    colorer(uart_name, color="yellow"),
+                    colorer("please use --uart-name=\"crossover\" --with-uartbone", color="red")))
+                time.sleep(2)
+                # Already configured.
+                self._uartbone = True
+                uart_name      = "crossover"
+
+            # JTAGBone and jtag_uart can't be used at the same time.
+            assert not (with_jtagbone and uart_name == "jtag_uart")
+            # UARTBone and serial can't be used at the same time.
+            assert not (with_uartbone and uart_name == "serial")
+
         # Modules instances ------------------------------------------------------------------------
 
         # Add SoCController
@@ -220,9 +252,17 @@ class SoCCore(LiteXSoC):
         if ident != "":
             self.add_identifier("identifier", identifier=ident, with_build_time=ident_version)
 
+        # Add UARTBone
+        if with_uartbone:
+            self.add_uartbone(baudrate=uart_baudrate)
+
         # Add UART
         if with_uart:
             self.add_uart(name="uart", uart_name=uart_name, baudrate=uart_baudrate, fifo_depth=uart_fifo_depth)
+
+        # Add JTAGBone
+        if with_jtagbone:
+            self.add_jtagbone(chain=jtagbone_chain)
 
         # Add Timer
         if with_timer:
@@ -293,6 +333,13 @@ def soc_core_args(parser):
     soc_group.add_argument("--uart-name",       default="serial",    type=str,      help="UART type/name.")
     soc_group.add_argument("--uart-baudrate",   default=115200,      type=auto_int, help="UART baudrate.")
     soc_group.add_argument("--uart-fifo-depth", default=16,          type=auto_int, help="UART FIFO depth.")
+
+    # UARTBone parameters
+    soc_group.add_argument("--with-uartbone",   action="store_true",                help="Enable UARTbone.")
+
+    # JTAGBone parameters
+    soc_group.add_argument("--with-jtagbone",  action="store_true", help="Enable Jtagbone support.")
+    soc_group.add_argument("--jtagbone-chain", default=1, type=int, help="Jtagbone chain index.")
 
     # Timer parameters
     soc_group.add_argument("--no-timer",        action="store_true", help="Disable Timer.")


### PR DESCRIPTION
- `--with-jtagbone` and `--with-uartbone` are now integrated in SoCCore arguments. This class also handle `add_jtagbone` and `add_uartbone`
- when a target try to add one of this option a warning is displayed and insertion is bypassed
- `crossover+uartbone` is deprecated -> `--uart-name=crossover --with-uartbone`
- jtag capability ((un)supported) is now handled at platform level