### PR TITLE
test_csr: test cases to demonstrate a CSRStatus() issue

### DIFF
--- a/test/test_csr.py
+++ b/test/test_csr.py
@@ -116,10 +116,17 @@ class TestCSR(unittest.TestCase):
             self.assertEqual((yield dut._storage.fields.foo), 0xa)
             self.assertEqual((yield dut._storage.fields.bar), 0x5a)
             self.assertEqual((yield dut._storage.storage), 0x5a000a)
+            self.assertEqual((yield from dut._storage.read()), 0x5a000a)
             yield
             yield
             self.assertEqual((yield dut._status.fields.foo), 0xa)
             self.assertEqual((yield dut._status.fields.bar), 0x5a)
+            try:
+                self.assertEqual((yield dut._status.status), 0x5a000a)
+                self.assertEqual((yield from dut._status.read()), 0x5a000a)
+            except self.failureException as exc:
+                print("Skipping:" + repr(exc))
+                raise self.skipTest("skip known failure") from None
 
         class DUT(Module):
             def __init__(self):


### PR DESCRIPTION
'status' reads as 0 in simulation when CSRStatus has fields that are assigned in the design. This test case demonstrates the issue  but is wrapped in a try/catch so the rest of the tests can run without a CI failure.

I'm not sure how to fix the underlying issue, but can work around it in my core tests that discovered this issue.

