### PR TITLE
UARTBone addr width

### DIFF
--- a/litex/soc/cores/uart.py
+++ b/litex/soc/cores/uart.py
@@ -311,7 +311,7 @@ class Stream2Wishbone(LiteXModule):
 
         # # #
         assert data_width    in [8, 16, 32]
-        assert address_width in [8, 16, 32]
+        assert address_width in [8, 16, 32, 64]
 
         cmd              = Signal(8,                           reset_less=True)
         incr             = Signal()

--- a/litex/soc/cores/uart.py
+++ b/litex/soc/cores/uart.py
@@ -431,17 +431,17 @@ class Stream2Wishbone(LiteXModule):
 
 
 class UARTBone(Stream2Wishbone):
-    def __init__(self, phy, clk_freq, cd="sys"):
+    def __init__(self, phy, clk_freq, cd="sys", address_width=32):
         if cd == "sys":
             self.phy = phy
-            Stream2Wishbone.__init__(self, self.phy, clk_freq=clk_freq)
+            Stream2Wishbone.__init__(self, self.phy, clk_freq=clk_freq, address_width=address_width)
         else:
             self.phy = ClockDomainsRenamer(cd)(phy)
             self.tx_cdc = stream.ClockDomainCrossing([("data", 8)], cd_from="sys", cd_to=cd)
             self.rx_cdc = stream.ClockDomainCrossing([("data", 8)], cd_from=cd,    cd_to="sys")
             self.comb += self.phy.source.connect(self.rx_cdc.sink)
             self.comb += self.tx_cdc.source.connect(self.phy.sink)
-            Stream2Wishbone.__init__(self, clk_freq=clk_freq)
+            Stream2Wishbone.__init__(self, clk_freq=clk_freq, address_width=address_width)
             self.comb += self.rx_cdc.source.connect(self.sink)
             self.comb += self.source.connect(self.tx_cdc.sink)
 

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1481,7 +1481,11 @@ class LiteXSoC(SoC):
             clk_freq = self.sys_clk_freq
         self.check_if_exists(name)
         uartbone_phy = uart.UARTPHY(self.platform.request(uart_name), clk_freq, baudrate)
-        uartbone     = uart.UARTBone(phy=uartbone_phy, clk_freq=clk_freq, cd=cd)
+        uartbone     = uart.UARTBone(
+            phy        = uartbone_phy,
+            clk_freq   = clk_freq,
+            cd         = cd,
+            addr_width = self.bus.address_width)
         self.add_module(name=f"{name}_phy", module=uartbone_phy)
         self.add_module(name=name,          module=uartbone)
         self.bus.add_master(name=name, master=uartbone.wishbone)


### PR DESCRIPTION
This PR contains 3 commits:
- `Stream2Wishbone`: update allowed address_width list to support 64bits (since number of iterations is based on this parameter any size multiple of 8bits may works)
- `UARTBone`: now it's possible to pass address_width to the constructor (this param is used for Stream2Wishbone)
- soc: `self.bus.address_width` is now used at `UARTBone` constructor time 