### PR TITLE
litex/soc/cores/cpu/__init__, litex/soc/integration/soc: modifying CPUNone to adapt data_width and io_regions according to bus data_width/address_width

### DIFF
--- a/litex/soc/cores/cpu/__init__.py
+++ b/litex/soc/cores/cpu/__init__.py
@@ -50,11 +50,9 @@ class CPU(LiteXModule):
 
 class CPUNone(CPU):
     variants            = ["standard"]
-    data_width          = 32
     endianness          = "little"
     reset_address       = 0x00000000
     reset_address_check = False
-    io_regions          = {0x0000_0000: 0x1_0000_0000} # origin, length
     periph_buses        = []
     memory_buses        = []
     mem_map             = {
@@ -62,6 +60,10 @@ class CPUNone(CPU):
         "ethmac"   : 0x0002_0000, # FIXME: Remove.
         "spiflash" : 0x1000_0000, # FIXME: Remove.
     }
+
+    def __init__(self, data_width=32, addr_width=32):
+        self.io_regions = {0: int(2**float(addr_width))} # origin, length
+        self.data_width = data_width
 
 # CPUs GCC Triples ---------------------------------------------------------------------------------
 

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1082,7 +1082,10 @@ class SoC(LiteXModule, SoCCoreCompat):
                 colorer("\n - ".join(sorted(cpu_cls.variants)))))
             raise SoCError()
         self.check_if_exists("cpu")
-        self.cpu = cpu_cls(self.platform, variant)
+        if cpu_cls is cpu.CPUNone:
+            self.cpu = cpu_cls(self.bus.data_width, self.bus.address_width)
+        else:
+            self.cpu = cpu_cls(self.platform, variant)
         self.logger.info("CPU {} {}.".format(
             colorer(name, color="underline"),
             colorer("added", color="green")))


### PR DESCRIPTION
`CPUNone` has a fixed data width and io_regions.
By adding a constructor with data_width and address_width it's now possible to adapts CPU according to args provided by user.