### PR TITLE
soc/software/bios/boot: serialboot: increase CMD_TIMEOUT_DELAY

### DIFF
--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -99,7 +99,7 @@ void romboot(void)
 #ifdef CSR_UART_BASE
 
 #define ACK_TIMEOUT_DELAY CONFIG_CLOCK_FREQUENCY/4
-#define CMD_TIMEOUT_DELAY CONFIG_CLOCK_FREQUENCY/16
+#define CMD_TIMEOUT_DELAY CONFIG_CLOCK_FREQUENCY/4
 
 static void timer0_load(unsigned int value) {
 	timer0_en_write(0);


### PR DESCRIPTION
When using *jtag_uart* with a big file, `serialboot` fails due to a timeout. since JTAG is slower than classic UART, the timeout delay must increased to avoid this failure.
Tested with an arty, femtorv and 1.2MB file