### PR TITLE
Fix classifiers to satisfy format checks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,12 +43,12 @@ setup(
     platforms                      = ["Any"],
     keywords                       = "HDL ASIC FPGA hardware design",
     classifiers                    = [
-        "Topic                :: Scientific/Engineering :: Electronic Design Automation (EDA)",
-        "Environment          :: Console",
-        "Development Status   :: 3 - Alpha",
-        "Intended Audience    :: Developers",
-        "License              :: OSI Approved :: BSD License",
-        "Operating System     :: OS Independent",
+        "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
+        "Environment :: Console",
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: OS Independent",
         "Programming Language :: Python",
     ],
     entry_points                   = {


### PR DESCRIPTION
```
Invalid value for classifiers. Error: Classifiers ['Development Status   :: 3 - Alpha', 'Environment
:: Console', 'Intended Audience    :: Developers', 'License              :: OSI Approved :: BSD License',
'Operating System     :: OS Independent', 'Topic                :: Scientific/Engineering :: Electronic
Design Automation (EDA)'] are not valid classifiers.
```