### PR TITLE
soc/cores/cpu/naxriscv fix arch definition and small adjust

### DIFF
--- a/litex/soc/cores/cpu/naxriscv/core.py
+++ b/litex/soc/cores/cpu/naxriscv/core.py
@@ -115,6 +115,7 @@ class NaxRiscv(CPU):
         cpu_group.add_argument("--update-repo",           default="recommended", choices=["latest","wipe+latest","recommended","wipe+recommended","no"], help="Specify how the NaxRiscv & SpinalHDL repo should be updated (latest: update to HEAD, recommended: Update to known compatible version, no: Don't update, wipe+*: Do clean&reset before checkout)")
         cpu_group.add_argument("--no-netlist-cache",      action="store_true",   help="Always (re-)build the netlist.")
         cpu_group.add_argument("--with-fpu",              action="store_true",   help="Enable the F32/F64 FPU.")
+        cpu_group.add_argument("--with-rvc",              action="store_true",   help="Enable the Compress ISA extension.")
         cpu_group.add_argument("--l2-bytes",              default=128*1024,      help="NaxRiscv L2 bytes, default 128 KB.")
         cpu_group.add_argument("--l2-ways",               default=8,             help="NaxRiscv L2 ways, default 8.")
 
@@ -127,6 +128,7 @@ class NaxRiscv(CPU):
         NaxRiscv.update_repo      = args.update_repo
         NaxRiscv.no_netlist_cache = args.no_netlist_cache
         NaxRiscv.with_fpu         = args.with_fpu
+        NaxRiscv.with_rvc         = args.with_rvc
         if args.scala_file:
             NaxRiscv.scala_files = args.scala_file
         if args.scala_args:
@@ -344,6 +346,8 @@ class NaxRiscv(CPU):
             gen_args.append(f"--scala-file={file}")
         if(NaxRiscv.with_fpu):
             gen_args.append(f"--scala-args=rvf=true,rvd=true")
+        if(NaxRiscv.with_rvc):
+            gen_args.append(f"--scala-args=rvc=true")
 
         cmd = f"""cd {ndir} && sbt "runMain naxriscv.platform.litex.NaxGen {" ".join(gen_args)}\""""
         print("NaxRiscv generation command :")

--- a/litex/soc/cores/cpu/naxriscv/core.py
+++ b/litex/soc/cores/cpu/naxriscv/core.py
@@ -302,10 +302,12 @@ class NaxRiscv(CPU):
             ), shell=True)
             # Use specific SHA1 (Optional).
         print(f"Updating {name} Git repository...")
+        cwd = os.getcwd()
         os.chdir(os.path.join(dir))
         wipe_cmd = "&& git clean --force -d -x && git reset --hard" if "wipe" in NaxRiscv.update_repo else ""
         checkout_cmd = f"&& git checkout {hash}" if hash is not None else ""
         subprocess.check_call(f"cd {dir} {wipe_cmd} && git checkout {branch} && git submodule init && git pull --recurse-submodules {checkout_cmd}", shell=True)
+        os.chdir(cwd)
 
     # Netlist Generation.
     @staticmethod

--- a/litex/soc/cores/cpu/naxriscv/core.py
+++ b/litex/soc/cores/cpu/naxriscv/core.py
@@ -69,7 +69,7 @@ class NaxRiscv(CPU):
     # Arch.
     @staticmethod
     def get_arch():
-        arch = f"rv{NaxRiscv.xlen}ima"
+        arch = f"rv{NaxRiscv.xlen}i2p0_ma"
         if NaxRiscv.with_fpu:
             arch += "fd"
         if NaxRiscv.with_rvc:


### PR DESCRIPTION
With recent gcc software fails with:
```
litex/litex/soc/cores/cpu/naxriscv/system.h:12: Error: unrecognized opcode `fence.i', extension `zifencei' required
```
`fence.i` seems have been moved out of **i** ISA

`rvXXima` **arch** must be replaced by `rvXXi2p0_ma`