### PR TITLE
Spiflash fixes for issues exposed by sys_clk = 200MHz and L2 cache

### DIFF
--- a/litex/build/openfpgaloader.py
+++ b/litex/build/openfpgaloader.py
@@ -71,4 +71,8 @@ class OpenFPGALoader(GenericProgrammer):
                 cmd.append(str(value))
 
         # Execute Command.
-        self.call(cmd)
+        try:
+            self.call(cmd)
+        except OSError as e:
+            print(' '.join(cmd))
+            raise

--- a/litex/build/openfpgaloader.py
+++ b/litex/build/openfpgaloader.py
@@ -66,7 +66,7 @@ class OpenFPGALoader(GenericProgrammer):
 
         # Handle kwargs for specific, less common cases.
         for key, value in kwargs.items():
-            cmd.append(f"--{key}")
+            cmd.append(f"--{key.replace('_', '-')}")
             if value is not None:
                 cmd.append(str(value))
 

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1884,17 +1884,21 @@ class LiteXSoC(SoC):
         from litespi import LiteSPI
         from litespi.phy.generic import LiteSPIPHY
         from litespi.opcodes import SpiNorFlashOpCodes
+        import math
 
         # Checks/Parameters.
         assert mode in ["1x", "4x"]
         if clk_freq is None: clk_freq = self.sys_clk_freq
+        # From LiteSPIClkGen: clk_freq will be ``sys_clk_freq/(2*(1+div))``.
+        default_divisor = math.ceil(self.sys_clk_freq/(clk_freq*2))-1
+        clk_freq = int(self.sys_clk_freq/(2*(1+default_divisor)))
 
         # PHY.
         spiflash_phy = phy
         if spiflash_phy is None:
             self.check_if_exists(f"{name}_phy")
             spiflash_pads = self.platform.request(name if mode == "1x" else name + mode)
-            spiflash_phy = LiteSPIPHY(spiflash_pads, module, device=self.platform.device, default_divisor=int(self.sys_clk_freq/clk_freq), rate=rate)
+            spiflash_phy = LiteSPIPHY(spiflash_pads, module, device=self.platform.device, default_divisor=default_divisor, rate=rate)
             self.add_module(name=f"{name}_phy", module=spiflash_phy)
 
         # Core.

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1879,7 +1879,7 @@ class LiteXSoC(SoC):
             self.add_constant("ETH_PHY_NO_RESET") # Disable reset from BIOS to avoid disabling Hardware Interface.
 
     # Add SPI Flash --------------------------------------------------------------------------------
-    def add_spi_flash(self, name="spiflash", mode="4x", clk_freq=None, module=None, phy=None, rate="1:1", software_debug=False, **kwargs):
+    def add_spi_flash(self, name="spiflash", mode="4x", clk_freq=20e6, module=None, phy=None, rate="1:1", software_debug=False, **kwargs):
         # Imports.
         from litespi import LiteSPI
         from litespi.phy.generic import LiteSPIPHY
@@ -1888,7 +1888,6 @@ class LiteXSoC(SoC):
 
         # Checks/Parameters.
         assert mode in ["1x", "4x"]
-        if clk_freq is None: clk_freq = self.sys_clk_freq
         # From LiteSPIClkGen: clk_freq will be ``sys_clk_freq/(2*(1+div))``.
         default_divisor = math.ceil(self.sys_clk_freq/(clk_freq*2))-1
         clk_freq = int(self.sys_clk_freq/(2*(1+default_divisor)))

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1909,10 +1909,11 @@ class LiteXSoC(SoC):
         self.add_constant(f"{name}_MODULE_NAME",       module.name.upper())
         self.add_constant(f"{name}_MODULE_TOTAL_SIZE", module.total_size)
         self.add_constant(f"{name}_MODULE_PAGE_SIZE",  module.page_size)
-        if SpiNorFlashOpCodes.READ_1_1_4 in module.supported_opcodes:
-            self.add_constant(f"{name}_MODULE_QUAD_CAPABLE")
-        if SpiNorFlashOpCodes.READ_4_4_4 in module.supported_opcodes:
-            self.add_constant(f"{name}_MODULE_QPI_CAPABLE")
+        if mode in [ "4x" ]:
+            if SpiNorFlashOpCodes.READ_1_1_4 in module.supported_opcodes:
+                self.add_constant(f"{name}_MODULE_QUAD_CAPABLE")
+            if SpiNorFlashOpCodes.READ_4_4_4 in module.supported_opcodes:
+                self.add_constant(f"{name}_MODULE_QPI_CAPABLE")
         if software_debug:
             self.add_constant(f"{name}_DEBUG")
 

--- a/litex/soc/software/bios/cmds/cmd_bios.c
+++ b/litex/soc/software/bios/cmds/cmd_bios.c
@@ -115,6 +115,8 @@ static void crc_handler(int nb_params, char **params)
 		return;
 	}
 
+	flush_cpu_dcache();
+	flush_l2_cache();
 	printf("CRC32: %08x", crc32((unsigned char *)addr, length));
 }
 

--- a/litex/soc/software/liblitespi/spiflash.c
+++ b/litex/soc/software/liblitespi/spiflash.c
@@ -25,6 +25,8 @@ int spiflash_freq_init(void)
 	unsigned int lowest_div, crc, crc_test;
 
 	lowest_div = spiflash_phy_clk_divisor_read();
+	flush_cpu_dcache();
+	flush_l2_cache();
 	crc        = crc32((unsigned char *)SPIFLASH_BASE, SPI_FLASH_BLOCK_SIZE);
 	crc_test   = crc;
 
@@ -40,6 +42,8 @@ int spiflash_freq_init(void)
 
 	while((crc == crc_test) && (lowest_div-- > 0)) {
 		spiflash_phy_clk_divisor_write((uint32_t)lowest_div);
+		flush_cpu_dcache();
+		flush_l2_cache();
 		crc_test = crc32((unsigned char *)SPIFLASH_BASE, SPI_FLASH_BLOCK_SIZE);
 #ifdef SPIFLASH_DEBUG
 		printf("[DIV: %d] %08x\n\r", lowest_div, crc_test);

--- a/litex/soc/software/liblitespi/spiflash.c
+++ b/litex/soc/software/liblitespi/spiflash.c
@@ -46,13 +46,13 @@ int spiflash_freq_init(void)
 #endif
 	}
 	lowest_div++;
-	printf("SPI Flash clk configured to %d MHz\n", (SPIFLASH_PHY_FREQUENCY/(2*(1 + lowest_div)))/1000000);
+	printf("SPI Flash clk configured to %d MHz\n", CONFIG_CLOCK_FREQUENCY/(2*(1+lowest_div)*1000000));
 
 	spiflash_phy_clk_divisor_write(lowest_div);
 
 #else
 
-	printf("SPI Flash clk configured to %ld MHz\n", (unsigned long)(SPIFLASH_PHY_FREQUENCY/1e6));
+	printf("SPI Flash clk configured to %ld MHz\n", SPIFLASH_PHY_FREQUENCY/1000000);
 
 #endif
 

--- a/litex/soc/software/liblitespi/spiflash.c
+++ b/litex/soc/software/liblitespi/spiflash.c
@@ -1,6 +1,7 @@
 // This file is Copyright (c) 2020 Antmicro <www.antmicro.com>
 // License: BSD
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -67,7 +68,7 @@ void spiflash_dummy_bits_setup(unsigned int dummy_bits)
 {
 	spiflash_core_mmap_dummy_bits_write((uint32_t)dummy_bits);
 #ifdef SPIFLASH_DEBUG
-	printf("Dummy bits set to: %d\n\r", spiflash_core_mmap_dummy_bits_read());
+	printf("Dummy bits set to: %" PRIx32 "\n\r", spiflash_core_mmap_dummy_bits_read());
 #endif
 }
 
@@ -111,7 +112,7 @@ static uint32_t transfer_byte(uint8_t b)
 	return spiflash_core_master_rxtx_read();
 }
 
-static void transfer_cmd(uint8_t *bs, uint8_t *resp, int len)
+static void transfer_cmd(volatile uint8_t *bs, volatile uint8_t *resp, int len)
 {
 	spiflash_core_master_phyconfig_len_write(8);
 	spiflash_core_master_phyconfig_width_write(1);
@@ -174,7 +175,7 @@ static void page_program(uint32_t addr, uint8_t *data, int len)
 	w_buf[1] = addr>>16;
 	w_buf[2] = addr>>8;
 	w_buf[3] = addr>>0;
-	memcpy(w_buf+4, data, len);
+	memcpy((void *)w_buf+4, (void *)data, len);
 	transfer_cmd(w_buf, r_buf, len+4);
 }
 


### PR DESCRIPTION
This is a set of several changes to fix various issues identified when debugging why the mmap
spiflash data read with the bios did not match the data written with openfpgaloader.

Example boot with the fixes on a Efinix Ti60 based design:
```
litex> reboot

        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
   Build your hardware, easily!

 (c) Copyright 2012-2024 Enjoy-Digital
 (c) Copyright 2007-2015 M-Labs

 BIOS built on Feb  1 2024 15:12:36
 BIOS CRC passed (0adc116a)

 LiteX git sha1: 8678b7af

--=============== SoC ==================--
CPU:            VexRiscv SMP-LINUX @ 200MHz
BUS:            WISHBONE 32-bit @ 4GiB
CSR:            32-bit data
ROM:            128.0KiB
SRAM:           8.0KiB
FLASH:          16.0MiB
MAIN-RAM:       32.0MiB

--========== Initialization ============--
Ethernet init...
Memtest at 0x40000000 (2.0MiB)...
  Write: 0x40000000-0x40200000 2.0MiB     
   Read: 0x40000000-0x40200000 2.0MiB     
Memtest OK
Memspeed at 0x40000000 (Sequential, 2.0MiB)...
  Write speed: 87.9MiB/s
   Read speed: 49.2MiB/s

Initializing W25Q128JV SPI Flash @0x01000000...
[ID: ff ef 60 18]Enabling Quad mode...
Testing against CRC32: 0bc9f423
[DIV: 3] 0bc9f423
[DIV: 2] 0bc9f423
[DIV: 1] 0bc9f423
[DIV: 0] 5b89d331
SPI Flash clk configured to 50 MHz
Memspeed at 0x1000000 (Sequential, 4.0KiB)...
   Read speed: 19.2MiB/s
Memspeed at 0x1000000 (Random, 4.0KiB)...
   Read speed: 6.4MiB/s
```
