### PR TITLE
soc/integration: Allow 0x400 CSR paging

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -652,7 +652,7 @@ class SoCCSRHandler(SoCLocHandler):
     supported_data_width    = [8, 32]
     supported_address_width = [14+i for i in range(4)]
     supported_alignment     = [32]
-    supported_paging        = [0x800*2**i for i in range(4)]
+    supported_paging        = [0x400*2**i for i in range(5)]
     supported_ordering      = ["big", "little"]
 
     # Creation -------------------------------------------------------------------------------------


### PR DESCRIPTION
It's a convenient way to get more CSR locations without changing the whole address space layout (i.e. more space for CSR).

It still leaves 256 full 32b registers in each location which I've never encountered a device even coming close to this, so it should be fairly safe to do.

This doesn't change the default, just allow the user to select it.