### PR TITLE
core/vexriscv_smp add reset vector support

### DIFF
--- a/litex/soc/cores/cpu/vexriscv_smp/core.py
+++ b/litex/soc/cores/cpu/vexriscv_smp/core.py
@@ -60,6 +60,7 @@ class VexRiscvSMP(CPU):
     csr_base             = 0xf000_0000
     clint_base           = 0xf001_0000
     plic_base            = 0xf0c0_0000
+    reset_vector         = 0
 
     # Command line configuration arguments.
     @staticmethod
@@ -178,6 +179,7 @@ class VexRiscvSMP(CPU):
     def generate_cluster_name():
         ldw = f"Ldw{VexRiscvSMP.litedram_width}"
         VexRiscvSMP.cluster_name = f"VexRiscvLitexSmpCluster_" \
+        f"{'R' + hex(VexRiscvSMP.reset_vector) if VexRiscvSMP.reset_vector else ''}"\
         f"Cc{VexRiscvSMP.cpu_count}"    \
         "_" \
         f"Iw{VexRiscvSMP.icache_width}" \
@@ -276,6 +278,7 @@ class VexRiscvSMP(CPU):
         if(VexRiscvSMP.coherent_dma):
             gen_args.append("--coherent-dma")
         gen_args.append(f"--cpu-count={VexRiscvSMP.cpu_count}")
+        gen_args.append(f"--reset-vector={VexRiscvSMP.reset_vector}")
         gen_args.append(f"--ibus-width={VexRiscvSMP.icache_width}")
         gen_args.append(f"--dbus-width={VexRiscvSMP.dcache_width}")
         gen_args.append(f"--dcache-size={VexRiscvSMP.dcache_size}")
@@ -394,7 +397,7 @@ class VexRiscvSMP(CPU):
 
     def set_reset_address(self, reset_address):
         self.reset_address = reset_address
-        assert reset_address == 0x0000_0000
+        VexRiscvSMP.reset_vector = reset_address
 
     def add_sources(self, platform):
         vdir = get_data_mod("cpu", "vexriscv_smp").data_location


### PR DESCRIPTION
--cpu-reset-address  can now be used to set the reset vector of vexriscv-smp

For instance, you can skip the litex bios and go directly to opensbi via  :
litex_sim --cpu-type=vexriscv_smp --with-sdram --sdram-init boot.json --with-rvc  --with-privileged-debug --hardware-breakpoints 4  --cpu-reset-address 0x40f00000 --integrated-rom-size 0
