### PR TITLE
tools/litex_json2dts_linux.py: adding ip= bootarg when localip and remoteip are provided

### DIFF
--- a/litex/tools/litex_json2dts_linux.py
+++ b/litex/tools/litex_json2dts_linux.py
@@ -68,14 +68,23 @@ def generate_dts(d, initrd_start=None, initrd_size=None, initrd=None, root_devic
         initrd_enabled = True
         initrd_size = os.path.getsize(initrd)
 
+    # if json constants contains localip ethernet has been enabled
+    if "localip1" in d["constants"]:
+        localip  = '.'.join([str(d["constants"][f"localip{i}"]) for i in range(1,5)])
+        remoteip = '.'.join([str(d["constants"][f"remoteip{i}"]) for i in range(1,5)])
+        ip       = f" ip={localip}:{remoteip}:{remoteip}:255.255.255.0::eth0:off:::"
+    else:
+        ip = ""
+
     if root_device is None:
         root_device = "ram0"
 
     dts += """
         chosen {{
-            bootargs = "{console} {rootfs}";""".format(
+            bootargs = "{console} {rootfs}{ip}";""".format(
     console = "console=liteuart earlycon=liteuart,0x{:x}".format(d["csr_bases"]["uart"]),
-    rootfs  = "rootwait root=/dev/{}".format(root_device))
+    rootfs  = "rootwait root=/dev/{}".format(root_device),
+    ip      = ip)
 
     if initrd_enabled is True:
         dts += """


### PR DESCRIPTION
Configuring network interface may be done by three different ways:
1. using `ifconfig` to configure interface and `route` for gateway
2. updating */etc/network/interfaces with all required informations
3. using `ip=` bootargs (requires to have a kernel configured with `CONFIG_IP_PNP=y`

First option needs a user's manual intervention and must be done for each boot. Second is hardcoded and this file must be updated when user change ip configuration.

Last option is more easy since, when ethernet is enabled, json contains all required informations to fill the `ip=` bootargs.