### PR TITLE
support TQFP144 ECP5 package

### DIFF
--- a/litex/build/lattice/trellis.py
+++ b/litex/build/lattice/trellis.py
@@ -128,6 +128,8 @@ class LatticeTrellisToolchain(YosysNextPNRToolchain):
             package = "CABGA554"
         elif "756" in package:
             package = "CABGA756"
+        elif "144" in package:
+            package = "TQFP144"
         else:
            raise ValueError("Invalid package {}".format(package))
         return (family, size, speed_grade, package)


### PR DESCRIPTION
Hello. I had to add this in order to use the TQFP144 ECP5 package, with the [Vanille](https://github.com/machdyne/vanille) board.

This detects if the device is set to "LFE5U-12F-6TG144", etc. I don't think there is a 144-pin BGA package for ECP5.