### PR TITLE
Add support for custom attributes on Signals

### DIFF
--- a/litex/build/generic_toolchain.py
+++ b/litex/build/generic_toolchain.py
@@ -182,3 +182,20 @@ class GenericToolchain:
             to.attr.add("keep")
         if (to, from_) not in self.false_paths:
             self.false_paths.add((from_, to))
+
+    def custom_attributes(self):
+        return CustomAttributes(self.attr_translate)
+
+class CustomAttributes:
+    def __init__(self, attributes):
+        self.attributes = attributes
+
+    def get(self, k, v=None):
+        if k in self.attributes:
+            return self.attributes[k]
+        elif "=" in k:
+            parts = k.split("=", 1)
+            return parts[0].strip(), parts[1].strip()
+        elif v is not None:
+            return k, v
+        return None

--- a/litex/build/xilinx/platform.py
+++ b/litex/build/xilinx/platform.py
@@ -87,7 +87,7 @@ class XilinxPlatform(GenericPlatform):
         so.update(special_overrides)
         return GenericPlatform.get_verilog(self, *args,
             special_overrides = so,
-            attr_translate    = self.toolchain.attr_translate,
+            attr_translate    = self.toolchain.custom_attributes(),
             **kwargs
         )
 


### PR DESCRIPTION
Recently I needed to add some attributes to IO ports to make my module work nicely in Vivado block design. Something like this:
```verilog
    (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 AXI_LITE ARADDR" *)
    input  wire   [31:0] axi_lite_araddr,
    (* X_INTERFACE_INFO = "xilinx.com:interface:aximm:1.0 AXI_LITE ARREADY" *)
    output wire          axi_lite_arready,
...
    (* X_INTERFACE_INFO = "xilinx.com:signal:clock:1.0 sys_clock CLK", X_INTERFACE_PARAMETER = "ASSOCIATED_BUSIF AXI_LITE, ASSOCIATED_RESET sys_reset" *)
    input  wire          sys_clock,
    (* X_INTERFACE_INFO = "xilinx.com:signal:reset:1.0 sys_reset RST", X_INTERFACE_PARAMETER = "POLARITY ACTIVE_HIGH" *)
    input  wire          sys_reset
```

If there is more than one clock in the module and some AXI interfaces need to use a different clock, Vivado can't detect which clock is associated to which interface and throws errors in the block design.

I couldn't find a way to generate this automatically in the current Litex version, so here is a custom wrapper for `attr_translate`.

It accepts any attribute in the form `"name = my value"` and will output it like this `(* name = "my value" *)` in verilog.

To annotate the axi interface like in example above, you can just do this:

```python
    self.axi_lite = axi.AXILiteInterface(data_width=32, address_width=32)
    platform.add_extension(self.axi_lite.get_ios("axi_lite"))
    axi_lite_pads = platform.request("axi_lite")

    for name in vars(axi_lite_pads):
        pad = getattr(axi_lite_pads, name)
        if type(pad) is Signal:
            pad.attr.add(f"X_INTERFACE_INFO = xilinx.com:interface:aximm:1.0 AXI_LITE {name.upper()}")
```
