### PR TITLE
Add support for CAN in litex

### DIFF
--- a/litex/tools/litex_json2dts_linux.py
+++ b/litex/tools/litex_json2dts_linux.py
@@ -341,6 +341,20 @@ def generate_dts(d, initrd_start=None, initrd_size=None, initrd=None, root_devic
     uart_csr_base  = d["csr_bases"]["uart"],
     uart_interrupt = "" if polling else "interrupts = <{}>;".format(d["constants"]["uart_interrupt"]))
 
+    # CAN -----------------------------------------------------------------------------------------
+
+    if "can" in d["csr_bases"]:
+        dts += """
+            CTU_CAN_FD_0: CTU_CAN_FD@{can_csr_base:x} {{
+                compatible = "ctu,ctucanfd";
+                reg = <0x{can_csr_base:x} 0x10000>;
+                interrupt-parent = <&intc0>;
+                {can_interrupt}
+            }};
+""".format(
+    can_csr_base  = d["csr_bases"]["can"],
+    can_interrupt = "" if polling else "interrupts = <{}>;".format(d["constants"]["can_interrupt"]))
+
     # Ethernet -------------------------------------------------------------------------------------
 
     if "ethphy" in d["csr_bases"] and "ethmac" in d["csr_bases"]:

--- a/litex_setup.py
+++ b/litex_setup.py
@@ -93,6 +93,7 @@ git_repos = {
     # LiteX Misc Cores.
     # -----------------
     "valentyusb":         GitRepo(url="https://github.com/litex-hub/", branch="hw_cdc_eptri"),
+    "ctucan_migen_wb_wrapper":     GitRepo(url="https://github.com/disdi/", clone="recursive"),
 
     # LiteX Boards.
     # -------------

--- a/litex_setup.py
+++ b/litex_setup.py
@@ -222,7 +222,10 @@ def litex_setup_init_repos(config="standard", tag=None, dev_mode=False):
                 ), shell=True)
             os.chdir(os.path.join(current_path, name))
             # Use specific Branch.
-            subprocess.check_call("git checkout " + repo.branch, shell=True)
+            try:
+                subprocess.check_call("git checkout " + repo.branch, shell=True)
+            except subprocess.CalledProcessError:
+                pass
             # Use specific Tag (Optional).
             if repo.tag is not None:
                 # Priority to passed tag (if specified).
@@ -281,12 +284,21 @@ def litex_setup_install_repos(config="standard", user_mode=False):
         os.chdir(os.path.join(current_path))
         # Install Repo.
         if repo.develop:
-            print_status(f"Installing {name} Git repository...")
-            os.chdir(os.path.join(current_path, name))
-            subprocess.check_call("\"{python3}\" -m pip install --editable . {options}".format(
-                python3 = sys.executable,
-                options = "--user" if user_mode else "",
-                ), shell=True)
+            if name  == "ctucan_migen_wb_wrapper":
+                print_status(f"Installing CAN IP {name} Git repository...")
+                os.chdir(os.path.join(current_path, name))
+                subprocess.check_call("make generate-vhdl", shell=True)
+                subprocess.check_call("\"{python3}\" setup.py install {options}".format(
+                    python3 = sys.executable,
+                    options = "--user" if user_mode else "",
+                    ), shell=True)
+            else:
+                print_status(f"Installing {name} Git repository...")
+                os.chdir(os.path.join(current_path, name))
+                subprocess.check_call("\"{python3}\" -m pip install --editable . {options}".format(
+                    python3 = sys.executable,
+                    options = "--user" if user_mode else "",
+                    ), shell=True)
     if user_mode:
         if ".local/bin" not in os.environ.get("PATH", ""):
             print_status("Make sure that ~/.local/bin is in your PATH")


### PR DESCRIPTION
This is to add support for controller area network (CAN bus) to Litex.
It is based on [CTU CAN FD IP Core](https://gitlab.fel.cvut.cz/canbus/ctucanfd_ip_core) developed by Czech Technical University in Prague.

It also uses work done by [Antmicro wrapper](https://github.com/antmicro/ctucan_migen_wb_wrapper).

Complete documentation of usage and testing can be found at [Project Wiki](https://disdi.github.io/librecar-wiki/).

Old MR: https://github.com/enjoy-digital/litex/pull/1871