### PR TITLE
Zynq7000 litex_server OpenOCD JTAG fixes

### DIFF
--- a/litex/build/generic_programmer.py
+++ b/litex/build/generic_programmer.py
@@ -24,6 +24,7 @@ class GenericProgrammer:
         self.flash_proxy_repos = [
             "https://github.com/quartiq/bscan_spi_bitstreams/raw/master/",
         ]
+        self.config_dirs = ["prog"]
         self.config_repos = [
             "https://raw.githubusercontent.com/litex-hub/litex-boards/master/litex_boards/prog/",
         ]
@@ -65,9 +66,11 @@ class GenericProgrammer:
         if os.path.exists(fullname):
             return self.config
         # Search in local config directory
-        fullname = tools.cygpath(os.path.join(self.prog_local, self.config))
-        if os.path.exists(fullname):
-            return fullname
+        for d in self.config_dirs:
+            fulldir  = os.path.abspath(os.path.expanduser(d))
+            fullname = tools.cygpath(os.path.join(fulldir, self.config))
+            if os.path.exists(fullname):
+                return fullname
         # Search in repositories and download it
         import requests
         os.makedirs(self.prog_local, exist_ok=True)

--- a/litex/build/openocd.py
+++ b/litex/build/openocd.py
@@ -40,6 +40,12 @@ class OpenOCD(GenericProgrammer):
         ])
         self.call(["openocd", "-f", config, "-c", script])
 
+    def get_tap_name(self, config):
+        cfg_str = open(config).read()
+        if "zynq_7000" in cfg_str:
+            return "zynq_pl.bs"
+        return "$_CHIPNAME.tap"
+
     def get_ir(self, chain, config):
         cfg_str = open(config).read()
         # Lattice ECP5.
@@ -98,6 +104,7 @@ class OpenOCD(GenericProgrammer):
           - TX valid : bit 9
         """
         config   = self.find_config()
+        tap_name = self.get_tap_name(config)
         ir       = self.get_ir(chain, config)
         endstate = self.get_endstate(config)
         cfg = """
@@ -186,8 +193,8 @@ proc jtagstream_serve {tap port} {
         script = "; ".join([
             "init",
             "poll off",
-            "irscan $_CHIPNAME.tap {:d}".format(ir),
-            "jtagstream_serve $_CHIPNAME.tap {:d}".format(port),
+            "irscan {} {:d}".format(tap_name, ir),
+            "jtagstream_serve {} {:d}".format(tap_name, port),
             "exit",
         ])
         self.call(["openocd", "-f", config, "-f", "stream.cfg", "-c", script])

--- a/litex/build/openocd.py
+++ b/litex/build/openocd.py
@@ -17,6 +17,8 @@ class OpenOCD(GenericProgrammer):
     def __init__(self, config, flash_proxy_basename=None):
         GenericProgrammer.__init__(self, flash_proxy_basename)
         self.config = config
+        self.config_dirs.append("/usr/share/openocd/scripts")
+        self.config_dirs.append("/usr/local/share/openocd/scripts")
 
     def load_bitstream(self, bitstream):
         config = self.find_config()

--- a/litex/build/openocd.py
+++ b/litex/build/openocd.py
@@ -185,6 +185,7 @@ proc jtagstream_serve {tap port} {
         write_to_file("stream.cfg", cfg)
         script = "; ".join([
             "init",
+            "poll off",
             "irscan $_CHIPNAME.tap {:d}".format(ir),
             "jtagstream_serve $_CHIPNAME.tap {:d}".format(port),
             "exit",


### PR DESCRIPTION
Hi all,

This PR fixes some issues preventing litex_server being connected to Zynq 7000 series JTAG.

Here is the working log now:
```
(.venv) ➜  rv litex_server --jtag-config /usr/share/openocd/scripts/board/digilent_zedboard.cfg --jtag 
Open On-Chip Debugger 0.12.0
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Info : auto-selecting first available session transport "jtag". To override use 'transport select <transport>'.
zynqpl_program
jtagstream_serve
Info : clock speed 1000 kHz
Info : JTAG tap: zynq_pl.bs tap/device found: 0x23727093 (mfg: 0x049 (Xilinx), part: 0x3727, ver: 0x2)
Info : JTAG tap: zynq.cpu tap/device found: 0x4ba00477 (mfg: 0x23b (ARM Ltd), part: 0xba00, ver: 0x4)
Info : zynq.cpu0: hardware has 6 breakpoints, 4 watchpoints
Info : zynq.cpu1: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for zynq.cpu0 on 3333
Info : Listening on port 3333 for gdb connections
[CommUART] port: JTAG / tcp port: 1234
```

Please review.

Thanks