### PR TITLE
litex_json2dts_linux: Add support for multiple Ethernet interfaces

### DIFF
--- a/litex/tools/litex_json2dts_linux.py
+++ b/litex/tools/litex_json2dts_linux.py
@@ -393,10 +393,14 @@ def generate_dts(d, initrd_start=None, initrd_size=None, initrd=None, root_devic
     uart_interrupt = "" if polling else "interrupts = <{}>;".format(d["constants"]["uart_interrupt"]))
 
     # Ethernet -------------------------------------------------------------------------------------
+    for i in [''] + list(range(0, 10)):
+        idx = (0 if i == '' else i)
+        ethphy_name = "ethphy" + str(i)
+        ethmac_name = "ethmac" + str(i)
+        if ethphy_name in d["csr_bases"] and ethmac_name in d["csr_bases"]:
 
-    if "ethphy" in d["csr_bases"] and "ethmac" in d["csr_bases"]:
-        dts += """
-            mac0: mac@{ethmac_csr_base:x} {{
+            dts += """
+            mac{idx}: mac@{ethmac_csr_base:x} {{
                 compatible = "litex,liteeth";
                 reg = <0x{ethmac_csr_base:x} 0x7c>,
                       <0x{ethphy_csr_base:x} 0x0a>,
@@ -409,14 +413,15 @@ def generate_dts(d, initrd_start=None, initrd_size=None, initrd=None, root_devic
                 status = "okay";
             }};
 """.format(
-    ethphy_csr_base  = d["csr_bases"]["ethphy"],
-    ethmac_csr_base  = d["csr_bases"]["ethmac"],
-    ethmac_mem_base  = d["memories"]["ethmac"]["base"],
-    ethmac_mem_size  = d["memories"]["ethmac"]["size"],
-    ethmac_rx_slots  = d["constants"]["ethmac_rx_slots"],
-    ethmac_tx_slots  = d["constants"]["ethmac_tx_slots"],
-    ethmac_slot_size  = d["constants"]["ethmac_slot_size"],
-    ethmac_interrupt = "" if polling else "interrupts = <{}>;".format(d["constants"]["ethmac_interrupt"]))
+    idx = idx,
+    ethphy_csr_base  = d["csr_bases"][ethphy_name],
+    ethmac_csr_base  = d["csr_bases"][ethmac_name],
+    ethmac_mem_base  = d["memories"][ethmac_name]["base"],
+    ethmac_mem_size  = d["memories"][ethmac_name]["size"],
+    ethmac_rx_slots  = d["constants"][ethmac_name + "_rx_slots"],
+    ethmac_tx_slots  = d["constants"][ethmac_name + "_tx_slots"],
+    ethmac_slot_size  = d["constants"][ethmac_name + "_slot_size"],
+    ethmac_interrupt = "" if polling else "interrupts = <{}>;".format(d["constants"][ethmac_name + "_interrupt"]))
 
     # USB OHCI -------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR is intended to add support in the litex_json2dts_linux tool for multiple Ethernet interfaces, hopefully it doesn't break anything. I have tested this with [Vivaldi](https://github.com/machdyne/vivaldi) and it appears to work.