### PR TITLE
Update NeoRV32 CPU to v1.9.7

### DIFF
--- a/litex/soc/cores/cpu/neorv32/core.py
+++ b/litex/soc/cores/cpu/neorv32/core.py
@@ -171,11 +171,14 @@ class NEORV32(CPU):
                 "neorv32_application_image.vhd",
                 "neorv32_bootloader_image.vhd",
                 "neorv32_boot_rom.vhd",
+                "neorv32_cache.vhd",
                 "neorv32_cfs.vhd",
+                "neorv32_clockgate.vhd",
                 "neorv32_cpu_alu.vhd",
                 "neorv32_cpu_control.vhd",
                 "neorv32_cpu_cp_bitmanip.vhd",
                 "neorv32_cpu_cp_cfu.vhd",
+                "neorv32_cpu_cp_cond.vhd",
                 "neorv32_cpu_cp_fpu.vhd",
                 "neorv32_cpu_cp_muldiv.vhd",
                 "neorv32_cpu_cp_shifter.vhd",
@@ -185,7 +188,6 @@ class NEORV32(CPU):
                 "neorv32_cpu_regfile.vhd",
                 "neorv32_cpu.vhd",
                 "neorv32_crc.vhd",
-                "neorv32_dcache.vhd",
                 "neorv32_debug_dm.vhd",
                 "neorv32_debug_dtm.vhd",
                 "neorv32_dma.vhd",
@@ -193,7 +195,6 @@ class NEORV32(CPU):
                 "neorv32_fifo.vhd",
                 "neorv32_gpio.vhd",
                 "neorv32_gptmr.vhd",
-                "neorv32_icache.vhd",
                 "neorv32_imem.entity.vhd",
                 "neorv32_intercon.vhd",
                 "neorv32_mtime.vhd",
@@ -210,7 +211,7 @@ class NEORV32(CPU):
                 "neorv32_twi.vhd",
                 "neorv32_uart.vhd",
                 "neorv32_wdt.vhd",
-                "neorv32_wishbone.vhd",
+                "neorv32_xbus.vhd",
                 "neorv32_xip.vhd",
                 "neorv32_xirq.vhd",
             ],
@@ -226,8 +227,8 @@ class NEORV32(CPU):
         }
 
         # Download VHDL sources (if not already present).
-        # Version 1.8.9
-        sha1 = "fdb00a5d24e256ac9a9cb29410f2653c95068c91"
+        # Version 1.9.7
+        sha1 = "ed17ae4df64e6a5221562e4adf4de378eaf0c2e8"
         for directory, vhds in sources.items():
             for vhd in vhds:
                 self.vhd2v_converter.add_source(os.path.join(cdir, vhd))


### PR DESCRIPTION
This updates the NeoRV32 CPU to the latest (current) version.

This also fixes a constant issue with Whishbone that I have been having where the data is always corrupted.

I have tested this update on my ULX3S using the latest oss-cad-toolchain build.