### PR TITLE
sim/video: Change pixel format to RGBA

### DIFF
--- a/litex/build/sim/core/modules/video/sim_fb.c
+++ b/litex/build/sim/core/modules/video/sim_fb.c
@@ -17,7 +17,7 @@ bool fb_init(unsigned width, unsigned height, bool vsync, fb_handle_t *handle)
     if (!handle->renderer)
       return false;
 
-    handle->texture = SDL_CreateTexture(handle->renderer, SDL_PIXELFORMAT_BGRA32, SDL_TEXTUREACCESS_TARGET, width, height);
+    handle->texture = SDL_CreateTexture(handle->renderer, SDL_PIXELFORMAT_RGBA32, SDL_TEXTUREACCESS_TARGET, width, height);
     if (!handle->texture)
       return false;
 

--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -178,6 +178,7 @@ class SimSoC(SoCCore):
         with_gpio             = False,
         with_video_framebuffer = False,
         with_video_terminal = False,
+        with_video_colorbars = False,
         sim_debug             = False,
         trace_reset_on        = False,
         with_jtag             = False,
@@ -313,6 +314,11 @@ class SimSoC(SoCCore):
             self.submodules.videophy = VideoGenericPHY(platform.request("vga"))
             self.add_video_terminal(phy=self.videophy, timings="640x480@60Hz")
 
+        # Video test pattern -----------------------------------------------------------------------
+        if with_video_colorbars:
+            self.submodules.videophy = VideoGenericPHY(platform.request("vga"))
+            self.add_video_colorbars(phy=self.videophy, timings="640x480@60Hz")
+
         # Simulation debugging ----------------------------------------------------------------------
         if sim_debug:
             platform.add_debug(self, reset=1 if trace_reset_on else 0)
@@ -428,6 +434,7 @@ def sim_args(parser):
     # Video.
     parser.add_argument("--with-video-framebuffer", action="store_true",   help="Enable Video Framebuffer.")
     parser.add_argument("--with-video-terminal",    action="store_true",   help="Enable Video Terminal.")
+    parser.add_argument("--with-video-colorbars",   action="store_true",   help="Enable Video test pattern.")
 
     # Debug/Waveform.
     parser.add_argument("--sim-debug",            action="store_true",     help="Add simulation debugging modules.")
@@ -510,7 +517,7 @@ def main():
         sim_config.add_module("jtagremote", "jtag", args={'port': 44853})
 
     # Video.
-    if args.with_video_framebuffer or args.with_video_terminal:
+    if args.with_video_framebuffer or args.with_video_terminal or args.with_video_colorbars:
         sim_config.add_module("video", "vga")
 
     # SoC ------------------------------------------------------------------------------------------
@@ -528,6 +535,7 @@ def main():
         with_gpio              = args.with_gpio,
         with_video_framebuffer = args.with_video_framebuffer,
         with_video_terminal    = args.with_video_terminal,
+        with_video_colorbars   = args.with_video_colorbars,
         sim_debug              = args.sim_debug,
         trace_reset_on         = int(float(args.trace_start)) > 0 or int(float(args.trace_end)) > 0,
         spi_flash_init         = None if args.spi_flash_init is None else get_mem_data(args.spi_flash_init, endianness="big"),
@@ -551,7 +559,7 @@ def main():
     builder.build(
         sim_config       = sim_config,
         interactive      = not args.non_interactive,
-        video            = args.with_video_framebuffer or args.with_video_terminal,
+        video            = args.with_video_framebuffer or args.with_video_terminal or args.with_video_colorbars,
         pre_run_callback = pre_run_callback,
         **parser.toolchain_argdict,
     )


### PR DESCRIPTION
The framebuffer gets filled out in RGB order (https://github.com/enjoy-digital/litex/blob/master/litex/build/sim/core/modules/video/video.c#L156-L159), but the texture format was set to BGR, swapping the colour channels.

I also added a `--with-video-colorbars` option to `litex_sim` to make this easier to test.

Before:

![Screenshot 2024-03-26 200834](https://github.com/enjoy-digital/litex/assets/24291/6bb98089-86b2-4334-96b8-b3ed50aca58b)

After:

![Screenshot 2024-03-26 202011](https://github.com/enjoy-digital/litex/assets/24291/09739ce8-f7b3-4bdf-9f95-a73853d3da55)

Note that the order is supposed to be (https://github.com/enjoy-digital/litex/blob/master/litex/soc/cores/video.py#L341-L348):

White Yellow Cyan Green Purple Red Blue Black