### PR TITLE
build/efinix/platform: fix get_pin_name()

### DIFF
--- a/litex/build/efinix/platform.py
+++ b/litex/build/efinix/platform.py
@@ -125,26 +125,24 @@ class EfinixPlatform(GenericPlatform):
             sig = sig.value
         return sig
 
-    def get_pin_name(self, sig, without_index=False):
+    def get_pin_name(self, sig):
         if sig is None:
             return None
         assert len(sig) == 1
         idx = 0
         slc = False
         while isinstance(sig, _Slice) and hasattr(sig, "value"):
-            slc = True
             idx = sig.start
             sig = sig.value
+            slc = hasattr(sig, "nbits") and sig.nbits > 1
         sc = self.constraint_manager.get_sig_constraints()
         for s, pins, others, resource in sc:
             if s == sig:
+                name = resource[0] + (f"{resource[1]}" if resource[1] is not None else "")
                 if resource[2]:
-                    name = resource[0] + "_" + resource[2]
-                    if without_index is False:
-                        name = name + (f"{idx}" if slc else "")
-                    return name
-                else:
-                    return resource[0] + (f"{idx}" if slc else "")
+                    name = name + "_" + resource[2]
+                name = name + (f"{idx}" if slc else "")
+                return name
         return None
 
     def get_pad_name(self, sig):


### PR DESCRIPTION
get_pin_name did not include the resource index, so additional core instances were generated with identical pin names. See below for examples.

Also only adds slice index for slices with more than one io for cleaner naming.

("i2c", 0,
    Subsignal("scl", Pins(...)),
    Subsignal("sda", Pins(...)),
),
("i2c", 1,
    Subsignal("scl", Pins(...)),
    Subsignal("sda", Pins(...)),
),

Before:
    output wire          i2c0_oe,
    input  wire          i2c0_scl,
    input  wire          i2c0_sda,
    input  wire          i2c1_scl,
    input  wire          i2c1_sda,
    input  wire          i2c_scl0_IN,
    input  wire          i2c_scl0_IN_1,
    input  wire          i2c_scl0_IN_2,
    output wire          i2c_scl0_OE,
    output wire          i2c_scl0_OE_1,
    output wire          i2c_scl0_OE_2,
    input  wire          i2c_sda0_IN,
    input  wire          i2c_sda0_IN_1,
    input  wire          i2c_sda0_IN_2,
    output wire          i2c_sda0_OE,
    output wire          i2c_sda0_OE_1,
    output wire          i2c_sda0_OE_2,

After:
    output wire          i2c0_oe,
    input  wire          i2c0_scl,
    input  wire          i2c0_scl_IN,
    output wire          i2c0_scl_OE,
    output wire          i2c0_scl_OUT,
    input  wire          i2c0_sda,
    input  wire          i2c0_sda_IN,
    output wire          i2c0_sda_OE,
    output wire          i2c0_sda_OUT,
    input  wire          i2c1_scl,
    input  wire          i2c1_scl_IN,
    output wire          i2c1_scl_OE,
    output wire          i2c1_scl_OUT,
    input  wire          i2c1_sda,
    input  wire          i2c1_sda_IN,
    output wire          i2c1_sda_OE,
    output wire          i2c1_sda_OUT,