### PR TITLE
Reset register for edge catching at the same time as pending register

### DIFF
--- a/litex/soc/interconnect/csr_eventmanager.py
+++ b/litex/soc/interconnect/csr_eventmanager.py
@@ -87,12 +87,11 @@ class EventSourceProcess(Module, _EventSource):
         _EventSource.__init__(self, name, description)
         self.comb += self.status.eq(self.trigger)
         trigger_d = Signal()
-        self.sync += If(self.clear, self.pending.eq(0))
-        self.sync += trigger_d.eq(self.trigger)
+        self.sync += If(self.clear, trigger_d.eq(0)).Else(trigger_d.eq(self.trigger))
         if edge == "falling":
-            self.sync += If(~self.trigger & trigger_d, self.pending.eq(1))
+            self.sync += If(self.clear, self.pending.eq(0)).Elif(~self.trigger &  trigger_d, self.pending.eq(1))
         if edge == "rising":
-            self.sync += If(self.trigger & ~trigger_d, self.pending.eq(1))
+            self.sync += If(self.clear, self.pending.eq(0)).Elif( self.trigger & ~trigger_d, self.pending.eq(1))
 
 
 class EventSourceLevel(Module, _EventSource):

--- a/litex/soc/interconnect/csr_eventmanager.py
+++ b/litex/soc/interconnect/csr_eventmanager.py
@@ -85,13 +85,13 @@ class EventSourceProcess(Module, _EventSource):
     def __init__(self, name=None, description=None, edge="falling"):
         assert edge in ["falling", "rising"]
         _EventSource.__init__(self, name, description)
+        trigger_d   = Signal()
+        trigger_irq = Signal()
         self.comb += self.status.eq(self.trigger)
-        trigger_d = Signal()
         self.sync += If(self.clear, trigger_d.eq(0)).Else(trigger_d.eq(self.trigger))
-        if edge == "falling":
-            self.sync += If(self.clear, self.pending.eq(0)).Elif(~self.trigger &  trigger_d, self.pending.eq(1))
-        if edge == "rising":
-            self.sync += If(self.clear, self.pending.eq(0)).Elif( self.trigger & ~trigger_d, self.pending.eq(1))
+        self.sync += If(trigger_irq, self.pending.eq(1)).Elif(self.clear, self.pending.eq(0))
+        if edge == "falling": self.comb += trigger_irq.eq(~self.trigger &  trigger_d)
+        if edge == "rising" : self.comb += trigger_irq.eq( self.trigger & ~trigger_d)
 
 
 class EventSourceLevel(Module, _EventSource):


### PR DESCRIPTION
If trigger source stays the same, no interrupt will arise even when clear is set to 1. Resetting trigger_d register will allow such interrupts arise. Seen such behavior with liteuart: after reset sink.ready always stays at 1 and no interrupt will appear.
Also combine register control under one If/Elif block, which makes more correct verilog code.