### PR TITLE
CSR ordering support in generated files

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1145,6 +1145,8 @@ class SoC(LiteXModule, SoCCoreCompat):
         self.csr.add_master(name=name, master=csr_bridge.csr)
         self.add_config("CSR_DATA_WIDTH", self.csr.data_width)
         self.add_config("CSR_ALIGNMENT",  self.csr.alignment)
+        self.add_config("CSR_ORDERING",  self.csr.ordering)
+        self.add_config(f"CSR_ORDERING_{self.csr.ordering.upper()}")
 
     # Add CPU --------------------------------------------------------------------------------------
     def add_cpu(self, name="vexriscv", variant="standard", reset_address=None, cfu=None):

--- a/litex/tools/litex_json2dts_linux.py
+++ b/litex/tools/litex_json2dts_linux.py
@@ -54,6 +54,11 @@ def generate_dts(d, initrd_start=None, initrd_size=None, initrd=None, root_devic
 
     cpu_mmu  = d["constants"].get("config_cpu_mmu", None)
 
+    # CSR Parameters -------------------------------------------------------------------------------
+    csr_ordering = d["constants"].get("config_csr_ordering", "big")
+    assert csr_ordering in ["big", "little"]
+    dts_endian = f"{csr_ordering}-endian;"
+
     # Header ---------------------------------------------------------------------------------------
     dts = """
 /dts-v1/;
@@ -521,6 +526,7 @@ def generate_dts(d, initrd_start=None, initrd_size=None, initrd=None, root_devic
                 vmmc-supply = <&vreg_mmc>;
                 bus-width = <0x04>;
                 {sdcard_irq_interrupt}
+                {dts_endian}
                 status = "okay";
             }};
 """.format(
@@ -530,6 +536,7 @@ def generate_dts(d, initrd_start=None, initrd_size=None, initrd=None, root_devic
         sdcard_block2mem     = d["csr_bases"]["sdcard_block2mem"],
         sdcard_mem2block     = d["csr_bases"]["sdcard_mem2block"],
         sdcard_irq           = d["csr_bases"]["sdcard_irq"],
+        dts_endian           = dts_endian,
         sdcard_irq_interrupt = "" if polling else "interrupts = <{}>;".format(d["constants"]["sdcard_irq_interrupt"])
 )
     # Leds -----------------------------------------------------------------------------------------


### PR DESCRIPTION
Add CSR_ORDERING constants and update access functions. Unchanged behaviour with default csr_ordering="big".

Can use `--csr-ordering little` on command line or `parser.set_defaults(csr_ordering="little")`.

Note that this only affects the addressing of CSR that are 64bit or wider.

This is a proof of concept implementation - only confirmed by inspection so far.