### PR TITLE
[fix] T8Q144 PLL input instance reference

### DIFF
--- a/litex/build/efinix/dbparser.py
+++ b/litex/build/efinix/dbparser.py
@@ -107,9 +107,9 @@ class EfinixDbParser:
         peri = root.findall('efxpt:periphery_instance', namespaces)
         for p in peri:
             # T20/T120 have instance attribute in single_conn
-            # not true for T4/T8 -> search in dependency subnode
+            # not true for T4/T8 (except for TQFP144 package) -> search in dependency subnode
             if p.get('block') == 'pll':
-                if self.device[0:2] not in ['T4', 'T8']:
+                if self.device[0:2] not in ['T4', 'T8'] or self.device[0:6] == "T8Q144":
                     conn = p.findall('efxpt:single_conn', namespaces)
                     for c in conn:
                         i = c.get('instance')

--- a/litex/build/efinix/ifacewriter.py
+++ b/litex/build/efinix/ifacewriter.py
@@ -289,7 +289,7 @@ design.create("{2}", "{3}", "./../gateware", overwrite=True)
 
         elif block["input_clock"] == "EXTERNAL":
             # PLL V1 has a different configuration
-            if partnumber[0:2] in ["T4", "T8"]:
+            if partnumber[0:2] in ["T4", "T8"] and partnumber != "T8Q144":
                 cmd += 'design.gen_pll_ref_clock("{}", pll_res="{}", refclk_res="{}", refclk_name="{}", ext_refclk_no="{}")\n\n' \
                     .format(name, block["resource"], block["input_clock_pad"], block["input_clock_name"], block["clock_no"])
             else:


### PR DESCRIPTION
According to the documentation, Trion T8 have a V1 PLL in BGA packages, but a V2 PLL in TQFP package.
The DB files varies accordingly.

Thus, LiteX doesn't properly reference the PLL source.
Example when using pin 75 'GPIOR_157' as clock input:

Currently (doesn't build):
```python
design.gen_pll_ref_clock("pll0", pll_res="PLL_BR0", refclk_src="EXTERNAL", refclk_name="clk25", ext_refclk_no="3")
```

Fixed:
```python
design.gen_pll_ref_clock("pll0", pll_res="PLL_BR0", refclk_src="EXTERNAL", refclk_name="clk25", ext_refclk_no="1")
```

This fix has been validated to work properly on a custom hardware.