### PR TITLE
Target hooks

### DIFF
--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -580,7 +580,7 @@ void netboot(int nb_params, char **params)
 /* Flash Boot                                                            */
 /*-----------------------------------------------------------------------*/
 
-#ifdef FLASH_BOOT_ADDRESS
+#if defined(FLASH_BOOT_ADDRESS) || defined(MAIN_RAM_BASE)
 
 static unsigned int check_image_in_flash(unsigned int base_address)
 {
@@ -603,9 +603,10 @@ static unsigned int check_image_in_flash(unsigned int base_address)
 
 	return length;
 }
+#endif
 
-#if defined(MAIN_RAM_BASE) && defined(FLASH_BOOT_ADDRESS)
-static int copy_image_from_flash_to_ram(unsigned int flash_address, unsigned long ram_address)
+#if defined(MAIN_RAM_BASE)
+int copy_image_from_flash_to_ram(unsigned int flash_address, unsigned long ram_address)
 {
 	uint32_t length;
 	uint32_t offset;
@@ -632,6 +633,7 @@ static int copy_image_from_flash_to_ram(unsigned int flash_address, unsigned lon
 }
 #endif
 
+#if defined(FLASH_BOOT_ADDRESS)
 void flashboot(void)
 {
 	uint32_t length;

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -7,6 +7,7 @@
 // This file is Copyright (c) 2018 William D. Jones <thor0505@comcast.net>
 // License: BSD
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -589,14 +590,14 @@ static unsigned int check_image_in_flash(unsigned int base_address)
 
 	length = MMPTR(base_address);
 	if((length < 32) || (length > 16*1024*1024)) {
-		printf("Error: Invalid image length 0x%08x\n", length);
+		printf("Error: Invalid image length 0x%" PRIx32 "\n", length);
 		return 0;
 	}
 
 	crc = MMPTR(base_address + 4);
 	got_crc = crc32((unsigned char *)(base_address + 8), length);
 	if(crc != got_crc) {
-		printf("CRC failed (expected %08x, got %08x)\n", crc, got_crc);
+		printf("CRC failed (expected 0x%" PRIx32 ", got 0x%" PRIx32 ")\n", crc, got_crc);
 		return 0;
 	}
 
@@ -611,7 +612,7 @@ static int copy_image_from_flash_to_ram(unsigned int flash_address, unsigned lon
 
 	length = check_image_in_flash(flash_address);
 	if(length > 0) {
-		printf("Copying 0x%08x to 0x%08lx (%d bytes)...\n", flash_address, ram_address, length);
+		printf("Copying 0x%08x to 0x%08lx (%" PRIu32 " bytes)...\n", flash_address, ram_address, length);
 		offset = 0;
 		init_progression_bar(length);
 		while (length > 0) {

--- a/litex/soc/software/bios/boot.h
+++ b/litex/soc/software/bios/boot.h
@@ -12,5 +12,8 @@ void flashboot(void);
 void romboot(void);
 void sdcardboot(void);
 void sataboot(void);
+extern void target_init(void) __attribute__((weak));
+extern void target_boot(void) __attribute__((weak));
+extern int copy_image_from_flash_to_ram(unsigned int flash_address, unsigned long ram_address);
 
 #endif /* __BOOT_H */

--- a/litex/soc/software/bios/cmds/cmd_bios.c
+++ b/litex/soc/software/bios/cmds/cmd_bios.c
@@ -73,13 +73,13 @@ define_command(ident, ident_handler, "Identifier of the system", SYSTEM_CMDS);
 #ifdef CSR_TIMER0_UPTIME_CYCLES_ADDR
 static void uptime_handler(int nb_params, char **params)
 {
-	unsigned long uptime;
+	uint64_t uptime;
 
 	timer0_uptime_latch_write(1);
 	uptime = timer0_uptime_cycles_read();
-	printf("Uptime: %ld sys_clk cycles / %ld seconds",
-		uptime,
-		uptime/CONFIG_CLOCK_FREQUENCY
+	printf("Uptime: %" PRIu64 " sys_clk cycles / %" PRIu64 " seconds\n",
+				uptime,
+				uptime / CONFIG_CLOCK_FREQUENCY
 	);
 }
 

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -57,6 +57,8 @@ static void boot_sequence(void)
 	if (serialboot() == 0)
 		return;
 #endif
+	if (target_boot)
+		target_boot();
 #ifdef FLASH_BOOT_ADDRESS
 	flashboot();
 #endif
@@ -296,6 +298,10 @@ __attribute__((__used__)) int main(int i, char **c)
 
 	/* Execute  initialization functions */
 	init_dispatcher();
+
+	/* Execute any target specific initialisation (if linked) */
+	if (target_init)
+		target_init();
 
 	/* Execute Boot sequence */
 #ifndef CONFIG_BIOS_NO_BOOT


### PR DESCRIPTION
This allows the target to supply custom target_init() and target_boot() functions, via a library linked with the bios. eg:

```
    # add custom target specific library to the bios:
    src="libtarget"
    src_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), src))
    builder.add_software_package(src, src_dir)
    builder.add_software_library(src)
```