### PR TITLE
Fix false path clock constraints

### DIFF
--- a/litex/build/generic_toolchain.py
+++ b/litex/build/generic_toolchain.py
@@ -180,5 +180,6 @@ class GenericToolchain:
         if keep:
             from_.attr.add("keep")
             to.attr.add("keep")
-        if (to, from_) not in self.false_paths:
-            self.false_paths.add((from_, to))
+        clk_tuple = (to, from_)
+        if clk_tuple not in self.false_paths:
+            self.false_paths.add(clk_tuple)


### PR DESCRIPTION
If two clock already included in false path list then swapped tuple pair of clocks won't be added. Fix this by adding temporary variable with tuple