### PR TITLE
Support isr for cv32e41p core

### DIFF
--- a/litex/soc/software/libbase/isr.c
+++ b/litex/soc/software/libbase/isr.c
@@ -73,7 +73,7 @@ void isr(void)
 		*((unsigned int *)PLIC_CLAIM) = claim;
 	}
 }
-#elif defined(__cv32e40p__)
+#elif defined(__cv32e40p__)  || defined(__cv32e41p__)
 
 #define FIRQ_OFFSET 16
 #define IRQ_MASK 0x7FFFFFFF


### PR DESCRIPTION
Hi, 

I would like to execute a program in main_ram using CV32E41P core on Digilent Arty A7 100t and Digilent Genesys 2 boards. However, the program does not boot in both boards and whatever the system frequency. Sometimes, I had an issue coming from the libbase/isr.c code.

So, I include the isr's piece of code made for cv32e40p to be used for 41p too. It works for both boards at 75 MHz (don't test other frequencies yet).

_fyi, as cv32e41p is blocked ([issue](https://github.com/enjoy-digital/litex/issues/1914#issuecomment-2043008534)), I checkout the python-cpu-41p_ 

