### PR TITLE
Revert LitexModule for AXILiteSRAM as well. 

### DIFF
--- a/litex/soc/interconnect/axi/axi_lite.py
+++ b/litex/soc/interconnect/axi/axi_lite.py
@@ -218,7 +218,7 @@ def axi_lite_to_simple(axi_lite, port_adr, port_dat_r, port_dat_w=None, port_we=
 
 # AXI-Lite SRAM ------------------------------------------------------------------------------------
 
-class AXILiteSRAM(LiteXModule):
+class AXILiteSRAM(Module):
     def __init__(self, mem_or_size, read_only=None, init=None, bus=None, name=None):
         if bus is None:
             bus = AXILiteInterface()
@@ -257,7 +257,7 @@ class AXILiteSRAM(LiteXModule):
             port_dat_r = port.dat_r,
             port_dat_w = port.dat_w if not read_only else None,
             port_we    = port.we if not read_only else None)
-        self.fsm = fsm
+        self.submodules.fsm = fsm
         self.comb += comb
 
 # AXI-Lite Data-Width Converter --------------------------------------------------------------------


### PR DESCRIPTION
Follows revert d021564fca8ac6d239dad2b18b5531cc9ee249c6 for wishbone.

Original bug is within multi-drive of some memories.  At least sdram is twice assigned from different always blocks. This happens because in csr_bus.py function CSRBankArray.scan scans all objects with get_memories attribute, which now present in every LiteXModule instance. Thus making some memories appear in slave regions of interconnect and in CSR banks! Don't know how to fix this duplicate correctly but at least revert to allow AXI-Lite as top interconnect.
