### PR TITLE
Add missing 32-bit variants of RISC-V target triples

### DIFF
--- a/litex/soc/cores/cpu/__init__.py
+++ b/litex/soc/cores/cpu/__init__.py
@@ -79,9 +79,13 @@ CPU_GCC_TRIPLE_RISCV64 = (
 )
 
 CPU_GCC_TRIPLE_RISCV32 = CPU_GCC_TRIPLE_RISCV64 + (
+    "riscv32-pc-linux-musl",
     "riscv32-unknown-elf",
     "riscv32-unknown-linux-gnu",
     "riscv32-elf",
+    "riscv32-linux",
+    "riscv32-linux-gnu",
+    "riscv32-none-elf",
     "riscv-none-embed",
     "riscv-none-elf",
 )


### PR DESCRIPTION
I had to waste another 10-15 minutes building a `riscv64-none-elf` GCC instead after LiteX didn't like my `riscv32-none-elf` one, so I thought I'd quickly add it. (I was using that target triple because it's what Nix's `pkgsCross.riscv32-embedded` package set uses).

I also added 32-bit variants of the rest of the target triples which didn't have them.