### PR TITLE
Update CV32E40P to be based on the OpenHW Group's repo

### DIFF
--- a/litex/soc/cores/cpu/cv32e40p/crt0.S
+++ b/litex/soc/cores/cpu/cv32e40p/crt0.S
@@ -46,7 +46,7 @@ vector_table:
   j trap_entry # 28 firq12
   j trap_entry # 29 firq13
   j trap_entry # 30 firq14
-  j trap_entry # 31 unused
+  j trap_entry # 31 firq15
 
 .global  trap_entry
 trap_entry:
@@ -116,10 +116,8 @@ bss_loop:
   add a0,a0,4
   j bss_loop
 bss_done:
-
-  li a0, 0x7FFF0880  //7FFF0880 enable timer + external interrupt + fast interrupt sources (until mstatus.MIE is set, they will never trigger an interrupt)
+  li a0, 0xFFFF0880  //FFFF0880 enable timer + external interrupt + fast interrupt sources (until mstatus.MIE is set, they will never trigger an interrupt)
   csrw mie,a0
-
   j main
 infinit_loop:
   j infinit_loop

--- a/litex/soc/cores/cpu/cv32e40p/csr-defs.h
+++ b/litex/soc/cores/cpu/cv32e40p/csr-defs.h
@@ -1,11 +1,14 @@
 #ifndef CSR_DEFS__H
 #define CSR_DEFS__H
 
+/*Reference : https://docs.openhwgroup.org/projects/cv32e40p-user-manual/en/latest/control_status_registers.html */
+
 #define CSR_MSTATUS_MIE 0x8
 
-#define CSR_IRQ_MASK 0xBC0
-#define CSR_IRQ_PENDING 0xFC0
-
+#define CSR_IRQ_MASK    0x304
+#define CSR_IRQ_PENDING 0x344
+#define FIRQ_OFFSET     16
 #define CSR_DCACHE_INFO 0xCC0
+
 
 #endif	/* CSR_DEFS__H */

--- a/litex/soc/cores/cpu/cv32e40p/irq.h
+++ b/litex/soc/cores/cpu/cv32e40p/irq.h
@@ -20,17 +20,21 @@ static inline void irq_setie(unsigned int ie)
 
 static inline unsigned int irq_getmask(void)
 {
-    return 0; // FIXME
+	unsigned int mask;
+	asm volatile ("csrr %0, %1" : "=r"(mask) : "i"(CSR_IRQ_MASK));
+	return (mask >> FIRQ_OFFSET);
 }
 
 static inline void irq_setmask(unsigned int mask)
 {
-    // FIXME
+	asm volatile ("csrw %0, %1" :: "i"(CSR_IRQ_MASK), "r"(mask << FIRQ_OFFSET));
 }
 
 static inline unsigned int irq_pending(void)
 {
-    return 0;// FIXME
+	unsigned int pending;
+	asm volatile ("csrr %0, %1" : "=r"(pending) : "i"(CSR_IRQ_PENDING));
+	return (pending >> FIRQ_OFFSET);
 }
 
 #ifdef __cplusplus

--- a/litex/soc/cores/cpu/cv32e40p/system.h
+++ b/litex/soc/cores/cpu/cv32e40p/system.h
@@ -7,17 +7,8 @@
 extern "C" {
 #endif
 
-__attribute__((unused)) static void flush_cpu_icache(void)
-{
-    // FIXME
-	asm volatile("nop");
-}
-
-__attribute__((unused)) static void flush_cpu_dcache(void)
-{
-    // FIXME
-	asm volatile("nop");
-}
+__attribute__((unused)) static void flush_cpu_icache(void){}; /* No instruction cache */
+__attribute__((unused)) static void flush_cpu_dcache(void){}; /* No instruction cache */
 
 void flush_l2_cache(void);
 


### PR DESCRIPTION
This pull request addresses issue #1854 by updating the CV32E40P core to be based on the original OpenHW Group's repository ([link](https://github.com/openhwgroup/cv32e40p)). Another pull request (litex-hub/pythondata-auto#37) has also been created in the pythondata-auto repository to update the core source code. 

This pull request follows the implementation of the CV32E41P and Ibex core. It has been tested on both the simulator and the PYNQ-Z2 FPGA board with the bios and demo example code.