### PR TITLE
Fix CSR register definition for the CV32E41P core

### DIFF
--- a/litex/soc/cores/cpu/cv32e41p/crt0.S
+++ b/litex/soc/cores/cpu/cv32e41p/crt0.S
@@ -116,10 +116,8 @@ bss_loop:
   add a0,a0,4
   j bss_loop
 bss_done:
-
-  li a0, 0x7FFF0880  //7FFF0880 enable timer + external interrupt + fast interrupt sources (until mstatus.MIE is set, they will never trigger an interrupt)
+  li a0, 0xFFFF0880  //FFFF0880 enable timer + external interrupt + fast interrupt sources (until mstatus.MIE is set, they will never trigger an interrupt)
   csrw mie,a0
-
   j main
 infinit_loop:
   j infinit_loop

--- a/litex/soc/cores/cpu/cv32e41p/csr-defs.h
+++ b/litex/soc/cores/cpu/cv32e41p/csr-defs.h
@@ -4,8 +4,8 @@
 
 #define CSR_MSTATUS_MIE 0x8
 
-#define CSR_IRQ_MASK    0x344
-#define CSR_IRQ_PENDING 0x304
+#define CSR_IRQ_MASK    0x304
+#define CSR_IRQ_PENDING 0x344
 #define FIRQ_OFFSET     16
 #define CSR_DCACHE_INFO 0xCC0
 
@@ -13,7 +13,7 @@
 
 
 /*
-For CV32E41P from https://docs.openhwgroup.org/projects/openhw-group-cv32e41p/control_status_registers.html
-Machine Interrupt Pending Register (mip): CSR_IRQ_MASK: 0x344
-Machine Interrupt Enable Register (mie): CSR_IRQ_PENDING: 0x304
+For CV32E41P from https://docs.openhwgroup.org/projects/cv32e41p-user-manual/control_status_registers.html
+Machine Interrupt Pending Register (mip): CSR_IRQ_PENDING: 0x344
+Machine Interrupt Enable Register (mie): CSR_IRQ_MASK: 0x304
 */


### PR DESCRIPTION
This pull request corrects the CSR register definition for the CV32E41P core based on the official manual ([link](https://docs.openhwgroup.org/projects/cv32e41p-user-manual/control_status_registers.html#machine-interrupt-enable-register-mie) and [link](https://docs.openhwgroup.org/projects/cv32e41p-user-manual/control_status_registers.html#machine-interrupt-pending-register-mip)).