### PR TITLE
Add baremetal IRQ support to VexRiscv-SMP and NaxRiscv.

### DIFF
--- a/litex/soc/cores/cpu/naxriscv/core.py
+++ b/litex/soc/cores/cpu/naxriscv/core.py
@@ -93,7 +93,7 @@ class NaxRiscv(CPU):
     def gcc_flags(self):
         flags =  f" -march={NaxRiscv.get_arch()} -mabi={NaxRiscv.get_abi()}"
         flags += f" -D__NaxRiscv__"
-        flags += f" -DUART_POLLING"
+        flags += f" -D__riscv_plic__"
         return flags
 
     # Reserved Interrupts.

--- a/litex/soc/cores/cpu/naxriscv/crt0.S
+++ b/litex/soc/cores/cpu/naxriscv/crt0.S
@@ -113,8 +113,10 @@ bss_loop:
   j bss_loop
 bss_done:
 
-  li a0, 0x880  //880 enable timer + external interrupt sources (until mstatus.MIE is set, they will never trigger an interrupt)
-  csrw mie,a0
+  call plic_init // initialize external interrupt controller
+  li t0, 0x800   // external interrupt sources only (using LiteX timer);
+                 // NOTE: must still enable mstatus.MIE!
+  csrw mie,t0
 
   call main
 infinit_loop:

--- a/litex/soc/cores/cpu/naxriscv/irq.h
+++ b/litex/soc/cores/cpu/naxriscv/irq.h
@@ -9,30 +9,40 @@ extern "C" {
 #include <generated/csr.h>
 #include <generated/soc.h>
 
+// NaxRiscv uses a Platform-Level Interrupt Controller (PLIC) which
+// is programmed and queried via a set of MMIO registerss
+
+#define PLIC_BASE    0xf0c00000L // Base address and per-pin priority array
+#define PLIC_PENDING 0xf0c01000L // Bit field matching currently pending pins
+#define PLIC_ENABLED 0xf0c02000L // Bit field corresponding to the current mask
+#define PLIC_THRSHLD 0xf0e00000L // Per-pin priority must be >= this to trigger
+#define PLIC_CLAIM   0xf0e00004L // Claim & completion register address
+
+#define PLIC_EXT_IRQ_BASE 0
+
 static inline unsigned int irq_getie(void)
 {
-	return 0;
+	return (csrr(mstatus) & CSR_MSTATUS_MIE) != 0;
 }
 
 static inline void irq_setie(unsigned int ie)
 {
-
+	if(ie) csrs(mstatus,CSR_MSTATUS_MIE); else csrc(mstatus,CSR_MSTATUS_MIE);
 }
 
 static inline unsigned int irq_getmask(void)
 {
-
-	return 0;
+	return *((unsigned int *)PLIC_ENABLED) >> PLIC_EXT_IRQ_BASE;
 }
 
 static inline void irq_setmask(unsigned int mask)
 {
-
+	*((unsigned int *)PLIC_ENABLED) = mask << PLIC_EXT_IRQ_BASE;
 }
 
 static inline unsigned int irq_pending(void)
 {
-	return 0;
+	return *((unsigned int *)PLIC_PENDING) >> PLIC_EXT_IRQ_BASE;
 }
 
 #ifdef __cplusplus

--- a/litex/soc/cores/cpu/openc906/core.py
+++ b/litex/soc/cores/cpu/openc906/core.py
@@ -89,6 +89,7 @@ class OpenC906(CPU):
         flags =  "-mno-save-restore "
         flags += "-march=rv64gc -mabi=lp64d "
         flags += "-D__openc906__ "
+        flags += "-D__riscv_plic__ "
         flags += "-mcmodel=medany"
         return flags
 

--- a/litex/soc/cores/cpu/openc906/irq.h
+++ b/litex/soc/cores/cpu/openc906/irq.h
@@ -18,6 +18,8 @@ extern "C" {
 #define PLIC_THRSHLD 0x90200000L // Per-pin priority must be >= this to trigger
 #define PLIC_CLAIM   0x90200004L // Claim & completion register address
 
+#define PLIC_EXT_IRQ_BASE 16
+
 static inline unsigned int irq_getie(void)
 {
 	return (csrr(mstatus) & CSR_MSTATUS_MIE) != 0;

--- a/litex/soc/cores/cpu/rocket/core.py
+++ b/litex/soc/cores/cpu/rocket/core.py
@@ -113,6 +113,7 @@ class Rocket(CPU):
         flags =  "-mno-save-restore "
         flags += f"-march={self.get_arch(self.variant)} -mabi=lp64 "
         flags += "-D__rocket__ "
+        flags += "-D__riscv_plic__ "
         flags += "-mcmodel=medany"
         return flags
 

--- a/litex/soc/cores/cpu/rocket/irq.h
+++ b/litex/soc/cores/cpu/rocket/irq.h
@@ -18,6 +18,8 @@ extern "C" {
 #define PLIC_THRSHLD 0x0c200000L // Per-pin priority must be >= this to trigger
 #define PLIC_CLAIM   0x0c200004L // Claim & completion register address
 
+#define PLIC_EXT_IRQ_BASE 1
+
 static inline unsigned int irq_getie(void)
 {
 	return (csrr(mstatus) & CSR_MSTATUS_MIE) != 0;

--- a/litex/soc/cores/cpu/vexriscv_smp/core.py
+++ b/litex/soc/cores/cpu/vexriscv_smp/core.py
@@ -169,7 +169,6 @@ class VexRiscvSMP(CPU):
     def gcc_flags(self):
         flags =  f" -march={VexRiscvSMP.get_arch()} -mabi={VexRiscvSMP.get_abi()}"
         flags += f" -D__vexriscv_smp__"
-        #flags += f" -DUART_POLLING"
         return flags
 
     # Reserved Interrupts.

--- a/litex/soc/cores/cpu/vexriscv_smp/core.py
+++ b/litex/soc/cores/cpu/vexriscv_smp/core.py
@@ -168,8 +168,8 @@ class VexRiscvSMP(CPU):
     @property
     def gcc_flags(self):
         flags =  f" -march={VexRiscvSMP.get_arch()} -mabi={VexRiscvSMP.get_abi()}"
-        flags += f" -D__vexriscv__"
-        flags += f" -DUART_POLLING"
+        flags += f" -D__vexriscv_smp__"
+        #flags += f" -DUART_POLLING"
         return flags
 
     # Reserved Interrupts.

--- a/litex/soc/cores/cpu/vexriscv_smp/core.py
+++ b/litex/soc/cores/cpu/vexriscv_smp/core.py
@@ -169,6 +169,7 @@ class VexRiscvSMP(CPU):
     def gcc_flags(self):
         flags =  f" -march={VexRiscvSMP.get_arch()} -mabi={VexRiscvSMP.get_abi()}"
         flags += f" -D__vexriscv_smp__"
+        flags += f" -D__riscv_plic__"
         return flags
 
     # Reserved Interrupts.

--- a/litex/soc/cores/cpu/vexriscv_smp/crt0.S
+++ b/litex/soc/cores/cpu/vexriscv_smp/crt0.S
@@ -102,6 +102,11 @@ bss_loop:
   j bss_loop
 bss_done:
 
+  call plic_init // initialize external interrupt controller
+  li t0, 0x800   // external interrupt sources only (using LiteX timer);
+                 // NOTE: must still enable mstatus.MIE!
+  csrw mie,t0
+
   call main
 infinit_loop:
   j infinit_loop

--- a/litex/soc/cores/cpu/vexriscv_smp/irq.h
+++ b/litex/soc/cores/cpu/vexriscv_smp/irq.h
@@ -18,7 +18,7 @@ extern "C" {
 #define PLIC_THRSHLD 0xf0e00000L // Per-pin priority must be >= this to trigger
 #define PLIC_CLAIM   0xf0e00004L // Claim & completion register address
 
-#define PLIC_EXT_IRQ_BASE 0 // CHECKME/FIXME.
+#define PLIC_EXT_IRQ_BASE 0
 
 static inline unsigned int irq_getie(void)
 {

--- a/litex/soc/cores/cpu/vexriscv_smp/irq.h
+++ b/litex/soc/cores/cpu/vexriscv_smp/irq.h
@@ -18,7 +18,7 @@ extern "C" {
 #define PLIC_THRSHLD 0xf0e00000L // Per-pin priority must be >= this to trigger
 #define PLIC_CLAIM   0xf0e00004L // Claim & completion register address
 
-#define PLIC_EXT_IRQ_BASE 1 // CHECKME/FIXME.
+#define PLIC_EXT_IRQ_BASE 0 // CHECKME/FIXME.
 
 static inline unsigned int irq_getie(void)
 {
@@ -32,17 +32,17 @@ static inline void irq_setie(unsigned int ie)
 
 static inline unsigned int irq_getmask(void)
 {
-	return *((unsigned int *)PLIC_ENABLED) >> 1;
+	return *((unsigned int *)PLIC_ENABLED) >> PLIC_EXT_IRQ_BASE;
 }
 
 static inline void irq_setmask(unsigned int mask)
 {
-	*((unsigned int *)PLIC_ENABLED) = mask << 1;
+	*((unsigned int *)PLIC_ENABLED) = mask << PLIC_EXT_IRQ_BASE;
 }
 
 static inline unsigned int irq_pending(void)
 {
-	return *((unsigned int *)PLIC_PENDING) >> 1;
+	return *((unsigned int *)PLIC_PENDING) >> PLIC_EXT_IRQ_BASE;
 }
 
 #ifdef __cplusplus

--- a/litex/soc/cores/cpu/vexriscv_smp/irq.h
+++ b/litex/soc/cores/cpu/vexriscv_smp/irq.h
@@ -9,30 +9,40 @@ extern "C" {
 #include <generated/csr.h>
 #include <generated/soc.h>
 
+// VexRiscv-SMP uses a Platform-Level Interrupt Controller (PLIC) which
+// is programmed and queried via a set of MMIO registerss
+
+#define PLIC_BASE    0xf0c00000L // Base address and per-pin priority array
+#define PLIC_PENDING 0xf0c01000L // Bit field matching currently pending pins
+#define PLIC_ENABLED 0xf0c02000L // Bit field corresponding to the current mask
+#define PLIC_THRSHLD 0xf0e00000L // Per-pin priority must be >= this to trigger
+#define PLIC_CLAIM   0xf0e00004L // Claim & completion register address
+
+#define PLIC_EXT_IRQ_BASE 1 // CHECKME/FIXME.
+
 static inline unsigned int irq_getie(void)
 {
-	return 0;
+	return (csrr(mstatus) & CSR_MSTATUS_MIE) != 0;
 }
 
 static inline void irq_setie(unsigned int ie)
 {
-
+	if(ie) csrs(mstatus,CSR_MSTATUS_MIE); else csrc(mstatus,CSR_MSTATUS_MIE);
 }
 
 static inline unsigned int irq_getmask(void)
 {
-
-	return 0;
+	return *((unsigned int *)PLIC_ENABLED) >> 1;
 }
 
 static inline void irq_setmask(unsigned int mask)
 {
-
+	*((unsigned int *)PLIC_ENABLED) = mask << 1;
 }
 
 static inline unsigned int irq_pending(void)
 {
-	return 0;
+	return *((unsigned int *)PLIC_PENDING) >> 1;
 }
 
 #ifdef __cplusplus

--- a/litex/soc/software/libbase/isr.c
+++ b/litex/soc/software/libbase/isr.c
@@ -29,7 +29,7 @@ void isr(void)
     onetime++;
   }
 }
-#elif defined(__rocket__) || defined(__openc906__) || defined(__vexriscv_smp__)
+#elif defined(__riscv_plic__)
 
 // PLIC initialization.
 void plic_init(void);

--- a/litex/soc/software/libbase/isr.c
+++ b/litex/soc/software/libbase/isr.c
@@ -29,7 +29,7 @@ void isr(void)
     onetime++;
   }
 }
-#elif defined(__rocket__) || defined(__openc906__)
+#elif defined(__rocket__) || defined(__openc906__) || defined(__vexriscv_smp__)
 
 // PLIC initialization.
 void plic_init(void);

--- a/litex/soc/software/libbase/isr.c
+++ b/litex/soc/software/libbase/isr.c
@@ -30,35 +30,37 @@ void isr(void)
   }
 }
 #elif defined(__rocket__) || defined(__openc906__)
-#if defined(__openc906__)
-#define PLIC_EXT_IRQ_BASE 16
-#else
-#define PLIC_EXT_IRQ_BASE 1
-#endif
+
+// PLIC initialization.
 void plic_init(void);
 void plic_init(void)
 {
 	int i;
 
-	// priorities for first 8 external interrupts
+	// Set priorities for the first 8 external interrupts to 1.
 	for (i = 0; i < 8; i++)
 		*((unsigned int *)PLIC_BASE + PLIC_EXT_IRQ_BASE + i) = 1;
-	// enable first 8 external interrupts
+
+	// Enable the first 8 external interrupts
 	*((unsigned int *)PLIC_ENABLED) = 0xff << PLIC_EXT_IRQ_BASE;
-	// set priority threshold to 0 (any priority > 0 triggers interrupt)
+
+	// Set priority threshold to 0 (any priority > 0 triggers an interrupt).
 	*((unsigned int *)PLIC_THRSHLD) = 0;
 }
 
+// Interrupt Service Routine.
 void isr(void)
 {
 	unsigned int claim;
 
+	// Claim and handle pending interrupts.
 	while ((claim = *((unsigned int *)PLIC_CLAIM))) {
 		switch (claim - PLIC_EXT_IRQ_BASE) {
 		case UART_INTERRUPT:
-			uart_isr();
+			uart_isr(); // Handle UART interrupt.
 			break;
 		default:
+			// Unhandled interrupt source, print diagnostic information.
 			printf("## PLIC: Unhandled claim: %d\n", claim);
 			printf("# plic_enabled:    %08x\n", irq_getmask());
 			printf("# plic_pending:    %08x\n", irq_pending());
@@ -70,6 +72,7 @@ void isr(void)
 			printf("###########################\n\n");
 			break;
 		}
+		// Acknowledge the interrupt.
 		*((unsigned int *)PLIC_CLAIM) = claim;
 	}
 }


### PR DESCRIPTION
- Add `__risc_plic__` define for CPUs using PLIC.
- Move `PLIC_EXT_IRQ_BASE` definition to CPUs.
- Add baremetal IRQ support to VexRiscv-SMP.
- Add baremetal IRQ support to NaxRiscv.