### PR TITLE
Zynqmp aximaster eth i2c uart

### DIFF
--- a/litex/soc/cores/cpu/zynqmp/core.py
+++ b/litex/soc/cores/cpu/zynqmp/core.py
@@ -51,6 +51,7 @@ class ZynqMP(CPU):
         self.axi_gp_masters = [None] * 3  # General Purpose AXI Masters.
         self.gem_mac        = []          # GEM MAC reserved ports.
         self.i2c_use        = []          # I2c reserved ports.
+        self.uart_use       = []          # UART reserved ports.
 
         self.cd_ps = ClockDomain()
 
@@ -294,6 +295,18 @@ class ZynqMP(CPU):
             f"i_emio_i2c{n}_sda_i" : sda_i,
             f"o_emio_i2c{n}_sda_o" : sda_o,
             f"o_emio_i2c{n}_sda_t" : sda_t,
+        })
+
+    def add_uart(self, n, pads):
+        assert n < 2 and not n in self.uart_use
+        assert pads is not None
+
+        self.config[f"PSU__UART{n}__PERIPHERAL__ENABLE"] = 1
+        self.config[f"PSU__UART{n}__PERIPHERAL__IO"]     = "EMIO"
+
+        self.cpu_params.update({
+            f"i_emio_uart{n}_rxd" : pads.rx,
+            f"o_emio_uart{n}_txd" : pads.tx,
         })
 
     def do_finalize(self):

--- a/litex/soc/cores/cpu/zynqmp/core.py
+++ b/litex/soc/cores/cpu/zynqmp/core.py
@@ -4,6 +4,8 @@
 # Copyright (c) 2022 Ilia Sergachev <ilia.sergachev@protonmail.ch>
 # SPDX-License-Identifier: BSD-2-Clause
 
+import os
+
 from migen import *
 
 from litex.gen import *
@@ -60,6 +62,12 @@ class ZynqMP(CPU):
         )
         self.comb += ResetSignal("ps").eq(~rst_n)
         self.ps_tcl.append(f"set ps [create_ip -vendor xilinx.com -name zynq_ultra_ps_e -module_name {self.ps_name}]")
+
+    def set_preset(self, preset):
+        preset = os.path.abspath(preset)
+        self.ps_tcl.append(f"source {preset}")
+        self.ps_tcl.append("set psu_cfg [apply_preset IPINST]")
+        self.ps_tcl.append("set_property -dict $psu_cfg [get_ips {}]".format(self.ps_name))
 
     def add_axi_gp_master(self, n=0, data_width=32):
         assert n < 3 and self.axi_gp_masters[n] is None


### PR DESCRIPTION
This serie address a some improvement / new features for zynqMP:
- a new method `set_preset` to fix the *PSU* default with a tcl script (from Vivado bd)
- a rework to the `add_axi_gp_master` method, similar to zynq7000 way. All signals are explicitly connected instead of using a layout
- zynqMP contains peripherals (ethernet, i2c, uart, ...) able to be connected to PS_MMIO pins (dedicated to PSU) or available at PL side (EMIO mode). This PR contains a serie of commit to enable to activate and route ethernet, i2c, and uart to the logic