### PR TITLE
Add dynamic mux for UARTBone / normal UART

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1512,8 +1512,7 @@ class LiteXSoC(SoC):
 
         # Crossover + UARTBone.
         elif uart_name in ["crossover+uartbone"]:
-            self.add_uartbone(baudrate=baudrate)
-            uart = UARTCrossover(**uart_kwargs)
+            uart = self.add_uartbone(baudrate=baudrate, with_crossover=True, **uart_kwargs)
 
         # JTAG UART.
         elif uart_name in ["jtag_uart"]:
@@ -1566,16 +1565,21 @@ class LiteXSoC(SoC):
             self.add_constant("UART_POLLING")
 
     # Add UARTbone ---------------------------------------------------------------------------------
-    def add_uartbone(self, name="uartbone", uart_name="serial", clk_freq=None, baudrate=115200, cd="sys"):
+    def add_uartbone(self, name="uartbone", uart_name="serial", clk_freq=None, baudrate=115200, cd="sys", with_crossover=False, **uart_kwargs):
         # Imports.
         from litex.soc.cores import uart
 
         # Core.
         if clk_freq is None:
             clk_freq = self.sys_clk_freq
+
         self.check_if_exists(name)
         uartbone_phy = uart.UARTPHY(self.platform.request(uart_name), clk_freq, baudrate)
-        uartbone     = uart.UARTBone(
+
+        if with_crossover:
+            crossover = uart.UARTCrossover(pad_phy=uartbone_phy, **uart_kwargs)
+
+        uartbone = uart.UARTBone(
             phy           = uartbone_phy,
             clk_freq      = clk_freq,
             cd            = cd,
@@ -1583,6 +1587,9 @@ class LiteXSoC(SoC):
         self.add_module(name=f"{name}_phy", module=uartbone_phy)
         self.add_module(name=name,          module=uartbone)
         self.bus.add_master(name=name, master=uartbone.wishbone)
+
+        if with_crossover:
+            return crossover
 
     # Add JTAGbone ---------------------------------------------------------------------------------
     def add_jtagbone(self, name="jtagbone", chain=1):

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -187,14 +187,14 @@ class SoCCore(LiteXSoC):
 
         if with_uart:
             # crossover+uartbone is kept as backward compatibility
-            if uart_name == "crossover+uartbone":
-                self.logger.warning("{} UART: is deprecated {}".format(
-                    colorer(uart_name, color="yellow"),
-                    colorer("please use --uart-name=\"crossover\" --with-uartbone", color="red")))
-                time.sleep(2)
-                # Already configured.
-                self._uartbone = True
-                uart_name      = "crossover"
+            #if uart_name == "crossover+uartbone":
+            #    self.logger.warning("{} UART: is deprecated {}".format(
+            #        colorer(uart_name, color="yellow"),
+            #        colorer("please use --uart-name=\"crossover\" --with-uartbone", color="red")))
+            #    time.sleep(2)
+            #    # Already configured.
+            #    self._uartbone = True
+            #    uart_name      = "crossover"
 
             # JTAGBone and jtag_uart can't be used at the same time.
             assert not (with_jtagbone and uart_name == "jtag_uart")


### PR DESCRIPTION
One problem with debugging a single-UART system is that the system will always block if a UARTBone client is not connected.  This is particularly annoying if, for instance, your vendor's RAM update tools do not work right (I'm looking at you, Efinix...), and you need the UARTBone to iterate on firmware -- but, once you have a build, you would like to have a UART that does not block.  (In my system, I have two FPGAs talking to each other, and I am probably developing one or the other at a time, and I would like to be able to distribute a bitstream to the customer that just happily boots without any drama, for instance.)

This PR solves this by modifying the `UARTCrossover` to have a `debug_en` CSR, and a `pad_phy` input.  When `debug_en` is turned on (the default, on reset), then the system behaves exactly like it previously did.  However, switching off `debug_en` means that the crossover internal UART and UARTbone are disconnected, and the `UARTCrossover`'s `source` and `sink` are actually connected to the pads of the outer world -- basically, passing the UART straight through.

To use this, I do something like this:

```c
int main(void)
{
#ifdef CONFIG_CPU_HAS_INTERRUPT
        irq_setmask(0);
        irq_setie(1);
#endif
        // As soon as the CPU is running, before we try to write to the UART
        // (and potentially block the system), then we disable uart_debug_en.
        // Now, just connect to the system with picocom to get a console.
        uart_debug_en_write(0);
/* ... system setup ... */

/* ... main loop ... */
        str = readstr();
        if(str == NULL) return;
        token = get_token(&str);
/* ... */
        // Have a CLI command to reenable the uartbone.  As soon as this
        // command is issued, you will need to start up a litex-server and
        // litex-term.
        else if(strcmp(token, "debug") == 0) 
                uart_debug_en_write(1);
```

There is a little bit of WIP here: the simplest way to wire this up was through the old `crossover+uartbone` path that is now deprecated.  I undeprecate this by commenting out the deprecation!  But obviously I would like feedback on what you think the better way is to do this.