### PR TITLE
litex_json2dts_zephyr.py: include ctrl

### DIFF
--- a/litex/tools/litex_json2dts_zephyr.py
+++ b/litex/tools/litex_json2dts_zephyr.py
@@ -193,6 +193,10 @@ def peripheral_handler(name, parm, csr):
 
 
 overlay_handlers = {
+    'ctrl': {
+        'handler': peripheral_handler,
+        'alias': 'ctrl0',
+    },
     'uart': {
         'handler': peripheral_handler,
         'alias': 'uart0',


### PR DESCRIPTION
include ctrl, needed to implement rebooting in zephyr.

PR in zephyr: https://github.com/zephyrproject-rtos/zephyr/pull/73199