### PR TITLE
tools/litex_json2dts_linux: add all soc sys_clk

### DIFF
--- a/litex/tools/litex_json2dts_linux.py
+++ b/litex/tools/litex_json2dts_linux.py
@@ -118,13 +118,18 @@ def generate_dts(d, initrd_start=None, initrd_size=None, initrd=None, root_devic
 
     # Clocks ------------------------------------------------------------------------------------------
 
-    dts += """
-        sys_clk: pll {{
+    for c in [c for c in d["constants"].keys() if c.endswith("config_clock_frequency")]:
+        name = c.removesuffix("config_clock_frequency") + "sys_clk"
+        dts += """
+        {name}: clock-{freq} {{
             compatible = "fixed-clock";
             #clock-cells = <0>;
-            clock-frequency  = <{sys_clk_freq}>;
+            clock-frequency  = <{freq}>;
         }};
-""".format(sys_clk_freq=d["constants"]["config_clock_frequency"])
+""".format(
+            name=name,
+            freq=d["constants"][c],
+        )
 
     # CPU ------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Adds clocks for a downstream iclink soc, for example when builder.add_json() has imported soc clocks.

Node names are as per devicetree fixed-clock.yaml bindings.

This PR implements a feature we need for our dts usage with the changes in https://github.com/enjoy-digital/litex/issues/1960.