### PR TITLE
DTS target integration

### DIFF
--- a/litex/gen/common.py
+++ b/litex/gen/common.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from migen import *
+from typing import Union, List
 
 # Coloring Helpers ---------------------------------------------------------------------------------
 
@@ -43,3 +44,32 @@ def reverse_bytes(s):
     n = (len(s) + 7)//8
     return Cat(*[s[i*8:min((i + 1)*8, len(s))]
         for i in reversed(range(n))])
+
+
+# DTS  ---------------------------------------------------------------------------------------------
+
+
+def dts_property(name: str, value: Union[int, str, List[Union[int, str]], List[str], None] = None) -> str:
+    """Returns property 'name' formatted in Devicetree syntax
+
+    value can be:
+      None (default)
+      int
+      str
+      list of str
+      list of int and str: in this case the str is expected to be a phandle.
+    """
+    if value is None:
+        return f"{name};\n"
+    elif isinstance(value, list):
+        if all(isinstance(v, int) or v.startswith("&") for v in value):
+            dts_value = "<" + " ".join(f"{v}" for v in value) + ">"
+        elif all(isinstance(v, str) for v in value):
+            dts_value = ", ".join(f'"{v}"' for v in value)
+        else:
+            raise ValueError(f"unsupported elements in {value}")
+    elif isinstance(value, int) or value.startswith("&"):
+        dts_value = f"<{value}>"
+    else:
+        dts_value = f'"{value}"'
+    return f"{name} = {dts_value};\n"

--- a/litex/soc/cores/i2c.py
+++ b/litex/soc/cores/i2c.py
@@ -10,7 +10,8 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from migen import *
-from litex.gen import *
+
+from litex.gen import LiteXModule, dts_property
 from litex.soc.interconnect import wishbone
 from litex.soc.interconnect.csr_eventmanager import *
 
@@ -203,6 +204,10 @@ class I2CMasterMachine(LiteXModule):
 #     ("idle",  1),
 # ])
 class I2CMaster(LiteXModule):
+    dts_compatible = "litex,cores-i2c" # litex,i2c is used for bitbang.I2CMaster()
+    dts_properties = dts_property("#address-cells", 1)
+    dts_properties += dts_property("#size-cells", 0)
+
     def __init__(self, pads, bus=None):
         if bus is None:
             bus = wishbone.Interface(data_width=32)

--- a/litex/soc/cores/spi/spi_mmap.py
+++ b/litex/soc/cores/spi/spi_mmap.py
@@ -7,7 +7,7 @@
 
 from migen import *
 
-from litex.gen import *
+from litex.gen import dts_property, LiteXModule
 from litex.gen.genlib.misc import WaitTimer
 
 from litex.soc.interconnect.csr import *
@@ -642,6 +642,11 @@ class SPIEngine(LiteXModule):
 # SPIMMAP ------------------------------------------------------------------------------------------
 
 class SPIMMAP(LiteXModule):
+    dts_compatible = "litex,spi_mmap"
+    dts_node = "spi"
+    dts_properties = dts_property("#address-cells", 1)
+    dts_properties += dts_property("#size-cells", 0)
+
     def __init__(self, pads, data_width, sys_clk_freq,
         tx_origin = 0x0000_0000,
         rx_origin = 0x0000_0000,
@@ -650,6 +655,10 @@ class SPIMMAP(LiteXModule):
     ):
         nslots = len(pads.cs_n)
         assert nslots <= _nslots_max
+
+        self.dts_properties += dts_property("tx-fifo-depth", tx_fifo_depth)
+        self.dts_properties += dts_property("rx-fifo-depth", rx_fifo_depth)
+        self.dts_properties += dts_property("num-cs", nslots)
 
         # Ctrl (Control/Status/IRQ) ----------------------------------------------------------------
 

--- a/litex/soc/cores/timer.py
+++ b/litex/soc/cores/timer.py
@@ -19,6 +19,8 @@ from litex.soc.integration.doc import AutoDoc, ModuleDoc
 
 class Timer(LiteXModule):
     with_uptime = False
+    dts_compatible = "litex,timer"
+
     def __init__(self, width=32):
         self.intro = ModuleDoc("""Timer
 

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1025,6 +1025,15 @@ class SoC(LiteXModule, SoCCoreCompat):
         name = "CONFIG_" + name
         self.add_constant(name, value, check_duplicate=check_duplicate)
 
+    def add_dts_node(self, name: str, module) -> None:
+        """Adds device tree information to generate entries for a core / module."""
+        prefix = name + "_dts_"
+        self.add_constant(prefix + "compatible", module.dts_compatible)
+        if hasattr(module, "dts_node"):
+            self.add_constant(prefix + "node", module.dts_node)
+        if hasattr(module, "dts_properties"):
+            self.add_constant(prefix + "properties", module.dts_properties)
+
     def check_bios_requirements(self):
         # Check for required Peripherals.
         for periph in [ "timer0"]:

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1325,6 +1325,7 @@ class SoC(LiteXModule, SoCCoreCompat):
         self.add_module(name=name, module=Timer())
         if self.irq.enabled:
             self.irq.add(name, use_loc_if_exists=True)
+        self.add_dts_node(name, self.get_module(name))
 
     # Add Watchdog ---------------------------------------------------------------------------------
     def add_watchdog(self, name="watchdog0", width=32, crg_rst=None, reset_delay=None):

--- a/litex/tools/litex_json2dts_linux.py
+++ b/litex/tools/litex_json2dts_linux.py
@@ -14,6 +14,8 @@ import json
 import argparse
 
 from litex.gen.common import KILOBYTE, MEGABYTE
+from litex.tools.litex_json2dts_zephyr import dts_reg, dts_reg_names, indent, indent_all
+from litex.gen import dts_property
 
 def csr_base_size(d: dict, name: str) -> int:
     """Calculate size in bytes of csr_base `name` from the contents of d["csr_registers"]."""
@@ -513,6 +515,54 @@ def generate_dts(d, initrd_start=None, initrd_size=None, initrd=None, root_devic
 """.format(
     usb_ohci_mem_base  = d["memories"]["usb_ohci_ctrl"]["base"],
     usb_ohci_interrupt = "" if polling else "interrupts = <{}>;".format(16)) # FIXME
+
+    # GENERIC device mode ---------------------------------------------------------------------------
+    for constant, value in [(k,v) for (k,v) in d["constants"].items() if k.endswith("_dts_compatible")]:
+        prefix = constant.removesuffix("compatible")
+        name = prefix.removesuffix("_dts_")
+
+        # compatible property is first
+        properties = dts_property("compatible", value)
+        # get default node name from first compatible string
+        if isinstance(value, list):
+            node_name = value[0].split(",")[-1]
+        else:
+            node_name = value.split(",")[-1]
+
+        # reg property is second
+        reg = csr_regions(d, name) + mem_regions(d, name)
+        if reg == []:
+            raise ValueError(f"no csr or mem regions for {name}")
+        properties += dts_reg(reg, levels=0)
+        # only add reg_names property for > 1 region
+        if len(reg) > 1 or True:
+            properties += dts_reg_names(reg, levels=0)
+
+        soc = soc_name(name)
+        for constant, value in [(k,v) for (k,v) in d["constants"].items() if k.startswith(prefix)]:
+            constant = constant.removeprefix(prefix)
+            if constant == "compatible":
+                pass
+            elif constant == "node":
+                node_name = value
+            elif constant == "properties":
+                # includes fixup of phandle references when node is in downstream soc
+                properties += value.replace("&", f"&{soc}")
+            else:
+                raise ValueError(f"unexpected constant {name}_dts_{constant}")
+
+        properties += dts_interrupt(d, name)
+        properties += dts_property("clocks", f"&{soc}sys_clk")
+        # omit status property - okay is the default
+        # properties += dts_property("status", "okay")
+
+        dts += indent("{label}: {node_name}@{unit_address:x} {{\n".format(
+            label=name,
+            node_name=node_name,
+            unit_address=reg[0]["addr"],
+        ), levels=3)
+        dts += indent_all(properties, levels=4) + "\n"
+        dts += indent("};\n", levels=3)
 
     # SPI Flash ------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This set of changes follows on from #1972, #1973, #1974 and adds a mechanism to specify DTS information for a core from anywhere within litex.

With these changes we can generate a valid DTS for standard litex cores and custom cores without needing to hard code any support into litex_json2dts_linux.py and implements most of the concepts detailed in #1960.

@enjoy-digital any feedback on style or details would be appreciated.