### PR TITLE
soc/integration/builder: use output_dir for csr

### DIFF
--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -109,9 +109,9 @@ class Builder:
         self.build_backend    = build_backend
 
         # Exports.
-        self.csr_csv  = csr_csv
-        self.csr_json = csr_json
-        self.csr_svd  = csr_svd
+        self.csr_csv  = os.path.join(self.output_dir, csr_csv)  if output_dir and csr_csv  else csr_csv
+        self.csr_json = os.path.join(self.output_dir, csr_json) if output_dir and csr_json else csr_json
+        self.csr_svd  = os.path.join(self.output_dir, csr_svd)  if output_dir and csr_svd  else csr_svd
         self.memory_x = memory_x
 
         # BIOS.


### PR DESCRIPTION
Currently `csr` files are always generated in the current working directory. This changes the behaviour to ensure all output from the build is relative to `output_dir` if it is set.

Otherwise the existing behaviour is preserved.

