### PR TITLE
linux dts: add vexii clint support

### DIFF
--- a/litex/tools/litex_json2dts_linux.py
+++ b/litex/tools/litex_json2dts_linux.py
@@ -328,7 +328,7 @@ def generate_dts(d, initrd_start=None, initrd_size=None, initrd=None, root_devic
 
     # Interrupt Controller -------------------------------------------------------------------------
 
-    if (cpu_arch == "riscv") and ("rocket" in cpu_name):
+    if (cpu_arch == "riscv") and ("rocket" in cpu_name or "vexiiriscv" in cpu_name):
         # FIXME  : L4 definitiion?
         # CHECKME: interrupts-extended.
         dts += """


### PR DESCRIPTION
With this change, the DTS generated when using VexiiRiscv is good out of the box and can be used with upstream generic opensbi