### PR TITLE
Add spi master

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1965,6 +1965,27 @@ class LiteXSoC(SoC):
             add_ip_address_constants(self,  "REMOTEIP", ethmac_remote_ip)
             add_mac_address_constants(self, "MACADDR",  ethmac_address)
 
+    # Add SPI Master --------------------------------------------------------------------------------
+    def add_spi_master(self, name="spimaster", pads=None, data_width=8, spi_clk_freq=1e6, with_clk_divider=True, **kwargs):
+        # Imports.
+        from litex.soc.cores.spi import SPIMaster
+
+        self.check_if_exists(f"{name}")
+
+        if pads is None:
+            pads = self.platform.request(name)
+
+        spim = SPIMaster(pads, data_width, self.sys_clk_freq, spi_clk_freq, **kwargs)
+
+        if with_clk_divider:
+            spim.add_clk_divider()
+
+        self.add_module(name=f"{name}", module=spim)
+
+        self.add_constant(f"{name}_FREQUENCY",     spi_clk_freq)
+        self.add_constant(f"{name}_DATA_WIDTH",     data_width)
+        self.add_constant(f"{name}_MAX_CS",    len(pads.cs_n))
+
     # Add SPI Flash --------------------------------------------------------------------------------
     def add_spi_flash(self, name="spiflash", mode="4x", clk_freq=20e6, module=None, phy=None, rate="1:1", software_debug=False, **kwargs):
         # Imports.

--- a/litex/tools/litex_json2dts_zephyr.py
+++ b/litex/tools/litex_json2dts_zephyr.py
@@ -181,6 +181,26 @@ def i2s_handler(name, parm, csr):
     return dtsi
 
 
+def spimaster_handler(name, parm, csr):
+    registers = get_registers_of(name, csr)
+    if len(registers) == 0:
+        raise KeyError
+
+    dtsi = dts_reg(registers)
+    dtsi += dts_reg_names(registers)
+
+    dtsi += indent("clock-frequency = <{}>;\n".format(
+        csr['constants'][name + '_frequency']))
+
+    dtsi += indent("data-width = <{}>;\n".format(
+        csr['constants'][name + '_data_width']))
+
+    dtsi += indent("max-cs = <{}>;\n".format(
+        csr['constants'][name + '_max_cs']))
+
+    return dtsi
+
+
 def peripheral_handler(name, parm, csr):
     registers = get_registers_of(name, csr)
     if len(registers) == 0:
@@ -219,10 +239,13 @@ overlay_handlers = {
         'alias': 'eth0',
         'config_entry': 'ETH_LITEETH'
     },
+    'spimaster': {
+        'handler': spimaster_handler,
+        'alias': 'spi0',
+    },
     'spiflash': {
         'handler': peripheral_handler,
-        'alias': 'spi0',
-        'config_entry': 'SPI_LITESPI'
+        'alias': 'spi1',
     },
     'sdcard_block2mem': {
         'handler': peripheral_handler,


### PR DESCRIPTION
- add a function to add a spi master to `soc.py`
- add a custom function to litex_json2dts_zephyr.py for the future litespi spiflash driver.

Related PRs in zephyr:
- https://github.com/zephyrproject-rtos/zephyr/pull/73446
- https://github.com/zephyrproject-rtos/zephyr/pull/73482