### PR TITLE
Fix AXI version of the Zynq7000 busses and add mapped connect fuction

### DIFF
--- a/litex/soc/cores/cpu/zynq7000/core.py
+++ b/litex/soc/cores/cpu/zynq7000/core.py
@@ -214,7 +214,7 @@ class Zynq7000(CPU):
     def add_axi_gp_master(self):
         assert len(self.axi_gp_masters) < 2
         n       = len(self.axi_gp_masters)
-        axi_gpn = axi.AXIInterface(data_width=32, address_width=32, id_width=12)
+        axi_gpn = axi.AXIInterface(data_width=32, address_width=32, id_width=12, version = "axi3")
         self.axi_gp_masters.append(axi_gpn)
         self.cpu_params.update({
             # AXI GP clk.

--- a/litex/soc/cores/cpu/zynq7000/core.py
+++ b/litex/soc/cores/cpu/zynq7000/core.py
@@ -275,7 +275,7 @@ class Zynq7000(CPU):
     def add_axi_gp_slave(self, clock_domain="ps7"):
         assert len(self.axi_gp_slaves) < 2
         n       = len(self.axi_gp_slaves)
-        axi_gpn = axi.AXIInterface(data_width=32, address_width=32, id_width=12, clock_domain=clock_domain)
+        axi_gpn = axi.AXIInterface(data_width=32, address_width=32, id_width=12, version = "axi3", clock_domain=clock_domain)
         self.axi_gp_slaves.append(axi_gpn)
         self.cpu_params.update({
             #AXI S GP clk.
@@ -333,14 +333,14 @@ class Zynq7000(CPU):
 
     # AXI High Performance Slave -------------------------------------------------------------------
 
-    def add_axi_hp_slave(self):
+    def add_axi_hp_slave(self, clock_domain="ps7"):
         assert len(self.axi_hp_slaves) < 4
         n       = len(self.axi_hp_slaves)
-        axi_hpn = axi.AXIInterface(data_width=64, address_width=32, id_width=6)
+        axi_hpn = axi.AXIInterface(data_width=64, address_width=32, id_width=6, version = "axi3", clock_domain=clock_domain)
         self.axi_hp_slaves.append(axi_hpn)
         self.cpu_params.update({
             # AXI HP0 clk.
-            f"i_S_AXI_HP{n}_ACLK"    : ClockSignal("ps7"),
+            f"i_S_AXI_HP{n}_ACLK"    : ClockSignal(clock_domain),
 
             # AXI HP0 aw.
             f"i_S_AXI_HP{n}_AWVALID" : axi_hpn.aw.valid,

--- a/litex/soc/interconnect/axi/axi_full.py
+++ b/litex/soc/interconnect/axi/axi_full.py
@@ -137,6 +137,13 @@ class AXIInterface:
     def connect(self, slave, **kwargs):
         return connect_axi(self, slave, **kwargs)
 
+    def connect_mapped(self, slave, map_fct):
+        comb = []
+        comb += self.connect(slave, omit={"addr"})
+        comb += [slave.ar.addr.eq(map_fct(self.ar.addr))]
+        comb += [slave.aw.addr.eq(map_fct(self.aw.addr))]
+        return comb
+
     def layout_flat(self):
         return list(axi_layout_flat(self))
 


### PR DESCRIPTION
This PR fixes the bugs I was encountering while playing around with PS7 block connected to the soft SoC, it also adds a way to connect the softcore to the PS7 using the connect_mapped function. The AXI4 lacks WID which is needed in AXI3 in some rare cases. PR to litex-boards will also be created with the files for any Zynq7000 board to have a way to use the PS7 blocks DDR as MAIN_RAM for the soft SoC. I successfully use it to boot Debian on RV64GC softcores.