### PR TITLE
Expand litex_sim JTAG support to more CPUs

### DIFF
--- a/litex/soc/cores/cpu/naxriscv/core.py
+++ b/litex/soc/cores/cpu/naxriscv/core.py
@@ -462,6 +462,14 @@ class NaxRiscv(CPU):
 
         self.soc_bus = soc.bus # FIXME: Save SoC Bus instance to retrieve the final mem layout on finalization.
 
+    def add_jtag(self, pads):
+        self.comb += [
+            self.jtag_tms.eq(pads.tms),
+            self.jtag_clk.eq(pads.tck),
+            self.jtag_tdi.eq(pads.tdi),
+            pads.tdo.eq(self.jtag_tdo),
+        ]
+
     def add_memory_buses(self, address_width, data_width):
         NaxRiscv.litedram_width = data_width
         nax_data_width = 64

--- a/litex/soc/cores/cpu/vexiiriscv/core.py
+++ b/litex/soc/cores/cpu/vexiiriscv/core.py
@@ -527,6 +527,14 @@ class VexiiRiscv(CPU):
             i_mBus_rlast     = mbus.r.last,
         )
 
+    def add_jtag(self, pads):
+        self.comb += [
+            self.jtag_tms.eq(pads.tms),
+            self.jtag_clk.eq(pads.tck),
+            self.jtag_tdi.eq(pads.tdi),
+            pads.tdo.eq(self.jtag_tdo),
+        ]
+
     def do_finalize(self):
         assert hasattr(self, "reset_address")
 

--- a/litex/soc/cores/cpu/vexriscv_smp/core.py
+++ b/litex/soc/cores/cpu/vexriscv_smp/core.py
@@ -463,6 +463,14 @@ class VexRiscvSMP(CPU):
         add_synthesis_define(cluster_filename)
         platform.add_source(cluster_filename, "verilog")
 
+    def add_jtag(self, pads):
+        self.comb += [
+            self.jtag_tms.eq(pads.tms),
+            self.jtag_clk.eq(pads.tck),
+            self.jtag_tdi.eq(pads.tdi),
+            pads.tdo.eq(self.jtag_tdo),
+        ]
+
     def add_soc_components(self, soc):
         if self.variant == "linux":
             # Set UART/Timer0 CSRs to the ones used by OpenSBI.

--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -135,6 +135,7 @@ _io = [
         Subsignal("tms", Pins(1)),
         Subsignal("tdi", Pins(1)),
         Subsignal("tdo", Pins(1)),
+        Subsignal("ntrst", Pins(1)),
     ),
 
     # Video (VGA).
@@ -277,10 +278,7 @@ class SimSoC(SoCCore):
         # JTAG -------------------------------------------------------------------------------------
         if with_jtag:
             jtag_pads = platform.request("jtag")
-            self.comb += self.cpu.jtag_clk.eq(jtag_pads.tck)
-            self.comb += self.cpu.jtag_tms.eq(jtag_pads.tms)
-            self.comb += self.cpu.jtag_tdi.eq(jtag_pads.tdi)
-            self.comb += jtag_pads.tdo.eq(self.cpu.jtag_tdo)
+            self.cpu.add_jtag(jtag_pads)
 
         # SDCard -----------------------------------------------------------------------------------
         if with_sdcard:


### PR DESCRIPTION
Hi all,

This series expanded litex_sim JTAG support to any CPU with `add_jtag` hook.

It is tested against naxriscv, cortex_m0, and gs232 in #1990.

Please review.
Thanks