### PR TITLE
soc/cores/cpu/zynqmp/core.py: added csr into mem_map, added M_AXI_HPM0_FPD by default

### DIFF
--- a/litex/soc/cores/cpu/zynq7000/core.py
+++ b/litex/soc/cores/cpu/zynq7000/core.py
@@ -40,6 +40,7 @@ class Zynq7000(CPU):
     def mem_map(self):
         return {
             "sram": 0x0010_0000,  # DDR in fact
+            "csr":  0x4000_0000,  # default GP0 address on Zynq
             "rom":  0xfc00_0000,
         }
 
@@ -170,6 +171,10 @@ class Zynq7000(CPU):
         if ps7_sdio0_wp_pads is not None:
             self.cpu_params.update(i_SDIO0_WP = ps7_sdio0_wp_pads.wp)
 
+        # GP0 as Bus master ------------------------------------------------------------------------
+        self.pbus = self.add_axi_gp_master()
+        self.periph_buses.append(self.pbus)
+
     def set_ps7_xci(self, xci):
         # Add .xci as Vivado IP and set ps7_name from .xci filename.
         self.ps7_xci  = xci
@@ -177,9 +182,6 @@ class Zynq7000(CPU):
         self.platform.add_ip(xci)
 
     def add_ps7_config(self, config):
-        # Check that PS7 has been set.
-        if self.ps7_name is None:
-            raise Exception("Please set PS7 with set_ps7 method first.")
         # Config must be provided as a config, value dict.
         assert isinstance(config, dict)
         self.config.update(config)

--- a/litex/soc/cores/cpu/zynqmp/core.py
+++ b/litex/soc/cores/cpu/zynqmp/core.py
@@ -39,6 +39,7 @@ class ZynqMP(CPU):
     def mem_map(self):
         return {
             "sram": 0x0000_0000,  # DDR low in fact
+            "csr":  0xA000_0000,  # ZynqMP M_AXI_HPM0_FPD (HPM0)
             "rom":  0xc000_0000,  # Quad SPI memory
         }
 
@@ -68,6 +69,7 @@ class ZynqMP(CPU):
             'PSU__NUM_F2P0__INTR__INPUTS': 8,
             'PSU__USE__IRQ1'             : 1, # enable PL_PS_Group1
             'PSU__NUM_F2P1__INTR__INPUTS': 8,
+            'PSU__USE__M_AXI_GP1'        : 0,
         }
         rst_n = Signal()
         self.cpu_params = dict(
@@ -76,6 +78,11 @@ class ZynqMP(CPU):
             i_pl_ps_irq0 = self.interrupt[0: 8],
             i_pl_ps_irq1 = self.interrupt[8:16]
         )
+
+        # Use GP0 as peripheral bus / CSR
+        self.pbus = self.add_axi_gp_master(0)
+        self.periph_buses.append(self.pbus)
+
         self.comb += ResetSignal("ps").eq(~rst_n)
         self.ps_tcl.append(f"set ps [create_ip -vendor xilinx.com -name zynq_ultra_ps_e -module_name {self.ps_name}]")
 


### PR DESCRIPTION
By default and unlike others CPUs, for zynq (7000 and MP) based board, CSR and corresponding bus  are added at target level.
Also, for these CPU family, a converter between AXI and wishbone is added: this is no more required: LiteX is now able to convert between native bus type and `bus_standard`.

This PR has for goal to change this behavior: csr base address is now directly added at CPU level and the corresponding bus is added in peripheral_buses: no more to add these hook at board level.

Targets update is done with this [PR](https://github.com/litex-hub/litex-boards/pull/590).