### PR TITLE
soc: add_spi_master: make spi_clk_freq an int

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1973,6 +1973,8 @@ class LiteXSoC(SoC):
 
         self.check_if_exists(f"{name}")
 
+        spi_clk_freq = int(spi_clk_freq)
+
         if pads is None:
             pads = self.platform.request(name)
 


### PR DESCRIPTION
convert spi_clk_freq to an int. this way the constant is also an int.

this is important as that constant is used in the dts converters and there it should not end with a `.0` 