### PR TITLE
integration/soc: data_width_convert: Inherit more bus properties

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -346,11 +346,24 @@ class SoCBusHandler(LiteXModule):
                     axi.AXILiteInterface : axi.AXILiteConverter,
                     axi.AXIInterface     : axi.AXIConverter,
                 }[interface_cls]
-                adapted_interface = interface_cls(
-                    data_width    = self.data_width,
-                    address_width = self.address_width,
-                    addressing    = interface.addressing,
-                )
+                args = {
+                    'data_width': self.data_width,
+                    'address_width': self.address_width,
+                    'addressing': interface.addressing,
+                    'bursting' : interface.bursting,
+                }
+                if isinstance(interface, axi.AXIInterface):
+                    args.update({
+                        'version' : interface.version,
+                        'id_width': interface.id_width,
+                        'aw_user_width': interface.aw.user_width,
+                        'w_user_width': interface.w.user_width,
+                        'b_user_width': interface.b.user_width,
+                        'ar_user_width': interface.ar.user_width,
+                        'r_user_width': interface.r.user_width,
+                    })
+                adapted_interface = interface_cls(**args)
+
                 if direction == "m2s":
                     master, slave = interface, adapted_interface
                 elif direction == "s2m":


### PR DESCRIPTION
For data_width converter we need to ensure that adapted interface have same properties as it's parent interface, so that id and user signals for AXI will be propagated properly from parent to adapted interface.