### PR TITLE
soc/integration/soc.py: Fix creation of AHB2Wishbone bridge

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -30,6 +30,7 @@ from litex.soc.interconnect import csr_bus
 from litex.soc.interconnect import stream
 from litex.soc.interconnect import wishbone
 from litex.soc.interconnect import axi
+from litex.soc.interconnect import ahb
 
 
 # Helpers ------------------------------------------------------------------------------------------
@@ -364,8 +365,8 @@ class SoCBusHandler(LiteXModule):
             # Same Addressing, return un-modified interface.
             if interface.addressing == self.addressing:
                 return interface
-            # AXI/AXI-Lite interface, Bus-Addressing conversion already handled in Bus-Standard conversion.
-            elif isinstance(interface, (axi.AXIInterface, axi.AXILiteInterface)):
+            # AXI/AXI-Lite/AHB interface, Bus-Addressing conversion already handled in Bus-Standard conversion.
+            elif isinstance(interface, (axi.AXIInterface, axi.AXILiteInterface, ahb.AHBInterface)):
                 return interface
             # Different Addressing: Return adapted interface.
             else:
@@ -419,6 +420,7 @@ class SoCBusHandler(LiteXModule):
                     (axi.AXILiteInterface, axi.AXIInterface)    : axi.AXILite2AXI,
                     (axi.AXIInterface,     axi.AXILiteInterface): axi.AXI2AXILite,
                     (axi.AXIInterface,     wishbone.Interface)  : axi.AXI2Wishbone,
+                    (ahb.AHBInterface,     wishbone.Interface)  : ahb.AHB2Wishbone,
                 }[type(master), type(slave)]
                 bridge = bridge_cls(master, slave)
                 self.submodules += bridge
@@ -436,6 +438,7 @@ class SoCBusHandler(LiteXModule):
                 wishbone.Interface:   "Wishbone",
                 axi.AXILiteInterface: "AXI-Lite",
                 axi.AXIInterface:     "AXI",
+                ahb.AHBInterface:     "AHB",
             }
             self.logger.info(fmt.format(
                 name      = colorer(name),

--- a/litex/soc/interconnect/ahb.py
+++ b/litex/soc/interconnect/ahb.py
@@ -41,11 +41,12 @@ def ahb_description(data_width, address_width):
 ]
 
 class AHBInterface(Record):
-    def __init__(self, data_width=32, address_width=32):
+    def __init__(self, data_width=32, address_width=32, addressing="byte"):
+        assert addressing == "byte"
         Record.__init__(self, ahb_description(data_width, address_width))
         self.data_width    = data_width
         self.address_width = address_width
-        self.addressing    = "byte"
+        self.addressing    = addressing
 
 # AHB to Wishbone  ---------------------------------------------------------------------------------
 


### PR DESCRIPTION
Don't do bus_addressing_convert as it's being handled in AHB2Wishbone logic.

Add addressing parameters for AHBInterface constructor as required by soc code.

This is split from #1990, I would like to get those independent features merged first.