### PR TITLE
csr_bus: Honour re signal from the upstream bus

### DIFF
--- a/litex/soc/interconnect/axi/axi_lite.py
+++ b/litex/soc/interconnect/axi/axi_lite.py
@@ -148,7 +148,7 @@ class AXILiteRemapper(LiteXModule):
 
 # AXI-Lite to Simple Bus ---------------------------------------------------------------------------
 
-def axi_lite_to_simple(axi_lite, port_adr, port_dat_r, port_dat_w=None, port_we=None):
+def axi_lite_to_simple(axi_lite, port_adr, port_dat_r, port_dat_w=None, port_re=None, port_we=None):
     """Connection of AXILite to simple bus with 1-cycle latency, such as CSR bus or Memory port"""
     bus_data_width = axi_lite.data_width
     adr_shift      = log2_int(bus_data_width//8)
@@ -167,6 +167,9 @@ def axi_lite_to_simple(axi_lite, port_adr, port_dat_r, port_dat_w=None, port_we=
                 comb.append(port_we[i].eq(axi_lite.w.valid & axi_lite.w.ready & axi_lite.w.strb[i]))
         else:
             comb.append(port_we.eq(axi_lite.w.valid & axi_lite.w.ready & (axi_lite.w.strb != 0)))
+
+    if port_re is not None:
+        comb.append(port_re.eq(axi_lite.ar.valid & axi_lite.ar.ready))
 
     port_adr_reg = Signal(len(port_adr))
 

--- a/litex/soc/interconnect/axi/axi_lite_to_csr.py
+++ b/litex/soc/interconnect/axi/axi_lite_to_csr.py
@@ -32,6 +32,7 @@ class AXILite2CSR(LiteXModule):
         fsm, comb = axi_lite_to_simple(
             axi_lite   = self.axi_lite,
             port_adr   = self.csr.adr,
+            port_re    = self.csr.re,
             port_dat_r = self.csr.dat_r,
             port_dat_w = self.csr.dat_w,
             port_we    = self.csr.we)

--- a/litex/soc/interconnect/wishbone.py
+++ b/litex/soc/interconnect/wishbone.py
@@ -602,12 +602,14 @@ class Wishbone2CSR(LiteXModule):
                 NextValue(self.csr.dat_w, self.wishbone.dat_w),
                 If(self.wishbone.cyc & self.wishbone.stb,
                     NextValue(self.csr.adr, self.wishbone.adr[wishbone_adr_shift:]),
-                    NextValue(self.csr.we, self.wishbone.we & (self.wishbone.sel != 0)),
+                    NextValue(self.csr.re, ~self.wishbone.we & (self.wishbone.sel != 0)),
+                    NextValue(self.csr.we,  self.wishbone.we & (self.wishbone.sel != 0)),
                     NextState("WRITE-READ")
                 )
             )
             fsm.act("WRITE-READ",
                 NextValue(self.csr.adr, 0),
+                NextValue(self.csr.re, 0),
                 NextValue(self.csr.we, 0),
                 NextState("ACK")
             )
@@ -623,7 +625,8 @@ class Wishbone2CSR(LiteXModule):
                 self.csr.dat_w.eq(self.wishbone.dat_w),
                 If(self.wishbone.cyc & self.wishbone.stb,
                     self.csr.adr.eq(self.wishbone.adr[wishbone_adr_shift:]),
-                    self.csr.we.eq(self.wishbone.we & (self.wishbone.sel != 0)),
+                    self.csr.re.eq(~self.wishbone.we & (self.wishbone.sel != 0)),
+                    self.csr.we.eq( self.wishbone.we & (self.wishbone.sel != 0)),
                     NextState("ACK")
                 )
             )

--- a/test/test_csr.py
+++ b/test/test_csr.py
@@ -19,9 +19,9 @@ def csr32_write(dut, adr, dat):
 
 def csr32_read(dut, adr):
     dat = 0
-    for i in range(4):
+    for i in range(5):
         dat |= ((yield from dut.csr.read(adr + 3 - i)) << 8*i)
-    return dat
+    return dat >> 8
 
 
 class CSRModule(Module, csr.AutoCSR):


### PR DESCRIPTION
Currently CSR bus assumed that ~we means reading, that created a problem that when for a CSR if reading has side effects and adr parked unintentionally at that CSR, the reading side effect will be triggered.

For SoCs, this happened when upstream bus issued a write transaction with wishbone.sel, then on CSR bus it will be translated as adr = addr, we = 0, which will be interpreted as a read to such address, and trigger undesired side effect for such CSR.

Such upstream transaction will be generated by our bus width converter.

Given that we signal already presents in CSR Interface, the easiest way to handle such situation is to generate re signal at bus bridges and propagate it all the way down to the Interface.