### PR TITLE
liblitespi: fix xor-used-as-pow bug

### DIFF
--- a/litex/soc/software/liblitespi/spiflash.c
+++ b/litex/soc/software/liblitespi/spiflash.c
@@ -76,11 +76,11 @@ void spiflash_dummy_bits_setup(unsigned int dummy_bits)
 
 static void spiflash_len_mask_width_write(uint32_t len, uint32_t width, uint32_t mask)
 {
-	uint32_t tmp = len & ((2 ^ CSR_SPIFLASH_CORE_MASTER_PHYCONFIG_LEN_SIZE) - 1);
+	uint32_t tmp = len & ((1 <<  CSR_SPIFLASH_CORE_MASTER_PHYCONFIG_LEN_SIZE) - 1);
 	uint32_t word = tmp << CSR_SPIFLASH_CORE_MASTER_PHYCONFIG_LEN_OFFSET;
-	tmp = width & ((2 ^ CSR_SPIFLASH_CORE_MASTER_PHYCONFIG_WIDTH_SIZE) - 1);
+	tmp = width & ((1 << CSR_SPIFLASH_CORE_MASTER_PHYCONFIG_WIDTH_SIZE) - 1);
 	word |= tmp << CSR_SPIFLASH_CORE_MASTER_PHYCONFIG_WIDTH_OFFSET;
-	tmp = mask & ((2 ^ CSR_SPIFLASH_CORE_MASTER_PHYCONFIG_MASK_SIZE) - 1);
+	tmp = mask & ((1 <<  CSR_SPIFLASH_CORE_MASTER_PHYCONFIG_MASK_SIZE) - 1);
 	word |= tmp << CSR_SPIFLASH_CORE_MASTER_PHYCONFIG_MASK_OFFSET;
 	spiflash_core_master_phyconfig_write(word);
 }


### PR DESCRIPTION
This fixes the following:

when `CSR_SPIFLASH_CORE_MASTER_PHYCONFIG_MASK_SIZE = 8`

`tmp = mask & ((2 ^ CSR_SPIFLASH_CORE_MASTER_PHYCONFIG_MASK_SIZE) - 1);`

using GCC 13 and 14 (Im not sure of the compiler version relationship to the bug here) gave `tmp` the result of 9.

This is because 2 ^(xor) 8 is 10.

This patch makes the shift explicit to fix the bug and avoid confusion.