### PR TITLE
build/efinix: added argument to change synthesis options configurations

### DIFF
--- a/litex/build/efinix/efinity.py
+++ b/litex/build/efinix/efinity.py
@@ -50,7 +50,23 @@ class EfinityToolchain(GenericToolchain):
         if self.platform.verilog_include_paths:
             self.options["includ_path"] = "{" + ";".join(self.platform.verilog_include_paths) + "}"
 
-    def build(self, platform, fragment, **kwargs):
+    def build(self, platform, fragment,
+        synth_mode,
+        infer_clk_enable,
+        bram_output_regs_packing,
+        retiming,
+        seq_opt,
+        mult_input_regs_packing,
+        mult_output_regs_packing,
+        **kwargs):
+
+        self._synth_mode               = synth_mode,
+        self._infer_clk_enable         = infer_clk_enable,
+        self._bram_output_regs_packing = bram_output_regs_packing,
+        self._retiming                 = retiming,
+        self._seq_opt                  = seq_opt,
+        self._mult_input_regs_packing  = mult_input_regs_packing,
+        self._mult_output_regs_packing = mult_output_regs_packing,
 
         # Apply FullMemoryWE on Design (Efiniy does not infer memories correctly otherwise).
         FullMemoryWE()(fragment)
@@ -295,18 +311,18 @@ class EfinityToolchain(GenericToolchain):
             "--binary-db",                  f"{self._build_name}.vdb",
             "--family",                     self.platform.family,
             "--device",                     self.platform.device,
-            "--mode",                       "speed",
+            "--mode",                       self._synth_mode,
             "--max_ram",                    "-1",
             "--max_mult",                   "-1",
-            "--infer-clk-enable",           "3",
+            "--infer-clk-enable",           self._infer_clk_enable,
             "--infer-sync-set-reset",       "1",
             "--fanout-limit",               "0",
-            "--bram_output_regs_packing",   "1",
-            "--retiming",                   "1",
-            "--seq_opt",                    "1",
+            "--bram_output_regs_packing",   self._bram_output_regs_packaging,
+            "--retiming",                   self._retiming,
+            "--seq_opt",                    self._seq_opt,
             "--blast_const_operand_adders", "1",
-            "--mult_input_regs_packing",    "1",
-            "--mult_output_regs_packing",   "1",
+            "--mult_input_regs_packing",    self._mult_input_regs_packaging,
+            "--mult_output_regs_packing",   self._mult_output_regs_packaing,
             "--veri_option",                "verilog_mode=verilog_2k,vhdl_mode=vhdl_2008",
             "--work-dir",                   "work_syn",
             "--output-dir",                 "outflow",
@@ -377,3 +393,32 @@ class EfinityToolchain(GenericToolchain):
         ], common.colors)
         if r != 0:
            raise OSError("Error occurred during export_bitstream execution.")
+
+def build_args(parser):
+    toolchain = parser.add_argument_group(title="Efinity toolchain options")
+    toolchain.add_argument("--synth-mode",               default="speed", help="Synthesis optimization mode.",
+        choices=["speed", "area", "area2"])
+    toolchain.add_argument("--infer-clk-enable",         default="3",     help="infers the flip-flop clock enable signal.",
+        choices=["0", "1", "2", "3", "4",])
+    toolchain.add_argument("--infer-sync-set-reset",     default="1",     help="Infer synchronous set/reset signals.",
+        choices=["0", "1"])
+    toolchain.add_argument("--bram-output-regs-packing", default="1",     help="Pack registers into the output of BRAM.",
+        choices=["0", "1"])
+    toolchain.add_argument("--retiming",                 default="1",     help="Perform retiming optimization.",
+        choices=["0", "1", "2"])
+    toolchain.add_argument("--seq-opt",                  default="1",     help="Turn on sequential optimization.",
+        choices=["0", "1"])
+    toolchain.add_argument("--mult-input-regs-packing",  default="1",     help="Allow packing of multiplier input registers.",
+        choices=["0", "1"]),
+    toolchain.add_argument("--mult-output-regs-packing", default="1",     help="Allow packing of multiplier output registers.",
+        choices=["0", "1"])
+def build_argdict(args):
+    return {
+        "synth_mode"               : args.synth_mode,
+        "infer_clk_enable"         : args.infer_clk_enable,
+        "bram_output_regs_packing" : args.bram_output_regs_packing,
+        "retiming"                 : args.retiming,
+        "seq_opt"                  : args.seq_opt,
+        "mult_input_regs_packing"  : args.mult_input_regs_packing,
+        "mult_output_regs_packing" : args.mult_output_regs_packing,
+    }

--- a/litex/build/efinix/platform.py
+++ b/litex/build/efinix/platform.py
@@ -185,3 +185,34 @@ class EfinixPlatform(GenericPlatform):
         pll = self.pll_available[0]
         self.get_pll_resource(pll)
         return pll
+
+    @classmethod
+    def fill_args(cls, toolchain, parser):
+        """
+        pass parser to the specific toolchain to
+        fill this with toolchain args
+
+        Parameters
+        ==========
+        toolchain: str
+            toolchain name
+        parser: argparse.ArgumentParser
+            parser to be filled
+        """
+        efinity.build_args(parser)
+
+    @classmethod
+    def get_argdict(cls, toolchain, args):
+        """
+        return a dict of args
+
+        Parameters
+        ==========
+        toolchain: str
+            toolchain name
+
+        Return
+        ======
+        a dict of key/value for each args or an empty dict
+        """
+        return efinity.build_argdict(args)


### PR DESCRIPTION
As mentioned in #1971, synthesis options like `--mode` may be adapted/configured at build time instead of hardcoded.

Solution proposed in #1971 imply to modify target and/or platform to set these options.

This PR address this issue by adding arguments to configure `efx_map` at build time.

*Note*: add `efx_map` aren't updated to use argument approach and it may make sense to have the same thing, at least, `efx_pgm`.