### PR TITLE
add crt0.o to BIOS target list

### DIFF
--- a/litex/soc/software/bios/Makefile
+++ b/litex/soc/software/bios/Makefile
@@ -19,7 +19,8 @@ OBJECTS = boot-helper.o	\
 	  cmd_litesdcard.o  \
 	  cmd_litesata.o    \
 	  sim_debug.o		\
-	  main.o
+	  main.o            \
+	  crt0.o
 
 ifneq "$(or $(BIOS_CONSOLE_NO_AUTOCOMPLETE),$(BIOS_CONSOLE_LITE))" ""
 CFLAGS += -DBIOS_CONSOLE_NO_AUTOCOMPLETE
@@ -70,7 +71,6 @@ vpath %.a $(PACKAGES:%=../%)
 
 %.elf: crt0.o $(LIBS:%=%.a)
 	$(CC) $(LDFLAGS) -T $(BIOS_DIRECTORY)/$(LSCRIPT) -N -o $@ \
-		crt0.o \
 		$(OBJECTS) \
 		$(PACKAGES:%=-L../%) \
 		-Wl,--whole-archive \


### PR DESCRIPTION
Without the proposed change, crt0.o is marked by Make as an intermediate file and removed: 
```
Must remake target 'all'.
python3 -m litex.soc.software.memusage bios.elf {file path}/litex/mor1kx_standard_32_F
alse/software/bios/../include/generated/regions.ld or1k-elf
Putting child 0x55a2098374e0 (all) PID 41438 on the chain.
Live child 0x55a2098374e0 (all) PID 41438

ROM usage: 36.54KiB     (57.09%)
RAM usage: 1.74KiB      (21.78%)

Reaping winning child 0x55a2098374e0 PID 41438
Removing child 0x55a2098374e0 PID 41438 from chain.
Successfully remade target file 'all'.
Removing intermediate files...
rm crt0.o
```
crt0.o is potentially valuable for building software for a LiteX sim target (I'm currently working on a script to run Embench on a simulated target), so it would be nice to keep it around. It's possible to use a dedicated Makefile to create ``crt0.o``, but doing so unnecessarily re-compiles a file which LiteX compiles anyway.