### PR TITLE
core: i2c: add i2c master

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -2049,6 +2049,18 @@ class LiteXSoC(SoC):
             add_ip_address_constants(self,  "REMOTEIP", ethmac_remote_ip)
             add_mac_address_constants(self, "MACADDR",  ethmac_address)
 
+    # Add I2C Master -------------------------------------------------------------------------------
+    def add_i2c_master(self, name="i2cmaster", pads=None, **kwargs):
+        # Imports.
+        from litei2c import LiteI2C
+
+        # Core.
+        self.check_if_exists(name)
+        if pads is None:
+            pads = self.platform.request(name)
+        i2c = LiteI2C(self.sys_clk_freq, pads=pads, **kwargs)
+        self.add_module(name=name, module=i2c)
+
     # Add SPI Master --------------------------------------------------------------------------------
     def add_spi_master(self, name="spimaster", pads=None, data_width=8, spi_clk_freq=1e6, with_clk_divider=True, **kwargs):
         # Imports.

--- a/litex_setup.py
+++ b/litex_setup.py
@@ -89,6 +89,7 @@ git_repos = {
     "litescope":    GitRepo(url="https://github.com/enjoy-digital/", tag=True),
     "litejesd204b": GitRepo(url="https://github.com/enjoy-digital/", tag=True),
     "litespi":      GitRepo(url="https://github.com/litex-hub/",     tag=True),
+    "litei2c":      GitRepo(url="https://github.com/litex-hub/",     tag=True, branch="main"),
 
     # LiteX Misc Cores.
     # -----------------


### PR DESCRIPTION
add a i2c master similar to LiteSPI.

This has the big benefit by using crossbar, that the i2c bus can be used at the same time by drivers, that are in logic, and from the CPU.

The driver for zephyr can be found here: https://github.com/zephyrproject-rtos/zephyr/pull/76554