### PR TITLE
build/gowin/common.py: re-add tristate impl and SDRxxx for GW5A/Arora family (required for SDRAM use)

### DIFF
--- a/litex/build/gowin/platform.py
+++ b/litex/build/gowin/platform.py
@@ -34,6 +34,8 @@ class GowinPlatform(GenericPlatform):
 
     def get_verilog(self, *args, special_overrides=dict(), **kwargs):
         so = dict(common.gowin_special_overrides)
+        if self.device[:4] == "GW5A":
+            so.update(common.gw5a_special_overrides)
         so.update(special_overrides)
         return GenericPlatform.get_verilog(self, *args,
             special_overrides = so,


### PR DESCRIPTION
This PR adds some GW5A primitives for SDRInput/SDROutput and SDRTristate.
Input/Output are simple `DFFSE` (no clocked in / out for arora) and may (or not) be inferred for sync blocks but without these SDRAM are not working.

Tested with @sipeed Tang Primer 25k and Tang Mega 138k pro