### PR TITLE
Fix litex.build.gowin's __init__.py; closes #2034

### DIFF
--- a/litex/build/gowin/__init__.py
+++ b/litex/build/gowin/__init__.py
@@ -1,0 +1,5 @@
+# Platforms.
+from litex.build.gowin.platform import GowinPlatform
+
+# Programmers.
+from litex.build.gowin.programmer import GowinProgrammer


### PR DESCRIPTION
This fixes the empty `__init__.py` in `litex.build.gowin`: https://github.com/enjoy-digital/litex/blob/6309f30e0b3ff807249a6003730d3920bc88d0c0/litex/build/gowin/__init__.py / https://github.com/enjoy-digital/litex/blob/master/litex/build/gowin/__init__.py