### PR TITLE
fixes for apicula support

### DIFF
--- a/litex/build/gowin/apicula.py
+++ b/litex/build/gowin/apicula.py
@@ -25,16 +25,27 @@ class GowinApiculaToolchain(YosysNextPNRToolchain):
         return (self._build_name + ".cst", "CST")
 
     def finalize(self):
+        devicename = self.platform.devicename
+        # Non-exhaustive list of family aliases that Gowin IDE supports but don't have a unique database
+        if devicename == "GW1NR-9C":
+            devicename = "GW1N-9C"
+        elif devicename == "GW1NR-9":
+            devicename = "GW1N-9"
+        elif devicename == "GW1NSR-4C" or devicename == "GW1NSR-4":
+            devicename = "GW1NS-4"
+        elif devicename == "GW1NR-4C" or devicename == "GW1NR-4":
+            devicename = "GW1N-4"
+
         pnr_opts = "--write {top}_routed.json --top {top} --device {device}" + \
             " --vopt family={devicename} --vopt cst={top}.cst"
         self._pnr_opts += pnr_opts.format(
             top        = self._build_name,
             device     = self.platform.device,
-            devicename = self.platform.devicename
+            devicename = devicename
         )
 
         self._packer_opts += "-d {devicename} -o {top}.fs {top}_routed.json".format(
-            devicename = self.platform.devicename,
+            devicename = devicename,
             top        = self._build_name
         )
 

--- a/litex/build/gowin/apicula.py
+++ b/litex/build/gowin/apicula.py
@@ -35,6 +35,10 @@ class GowinApiculaToolchain(YosysNextPNRToolchain):
             devicename = "GW1NS-4"
         elif devicename == "GW1NR-4C" or devicename == "GW1NR-4":
             devicename = "GW1N-4"
+        elif devicename == "GW2AR-18C":
+            devicename = "GW2A-18C"
+        elif devicename == "GW2AR-18":
+            devicename = "GW2A-18"
 
         pnr_opts = "--write {top}_routed.json --top {top} --device {device}" + \
             " --vopt family={devicename} --vopt cst={top}.cst"

--- a/litex/soc/cores/clock/gowin_gw1n.py
+++ b/litex/soc/cores/clock/gowin_gw1n.py
@@ -255,11 +255,7 @@ class GW1NPLL(LiteXModule):
             instance_name = 'PLLVR'
             self.params.update(i_VREN=1)
         else:
-            instance_name = 'PLL'
-            self.params.update(
-                i_RESET_I = 0,          # IDIV reset.
-                i_RESET_S = 0,          # SDIV and DIV3 reset.
-            )
+            instance_name = 'rPLL'
         for clk_name in ["CLKOUT", "CLKOUTP", "CLKOUTD", "CLKOUTD3"]:
             self.params[f"o_{clk_name}"] = config.get(clk_name, Open()) # Clock output.
             if clk_name in ["CLKOUTD", "CLKOUTD3"]: # Recopy CLKOUTx to CLKOUTDx


### PR DESCRIPTION
This maps Gowin IDE device families to Apicula database names, and updates the PLL generator to use the "revised PLL" primitive, which is basically the same as the PLL primitive but I guess they made some breaking changes to the implementation.

Stand by while I test more Gowin boards on Apicula in https://github.com/litex-hub/litex-boards/pull/603/files