### PR TITLE
json2dts_zephyr: omit disable handler

### DIFF
--- a/litex/tools/litex_json2dts_zephyr.py
+++ b/litex/tools/litex_json2dts_zephyr.py
@@ -273,26 +273,31 @@ overlay_handlers = {
         'handler': peripheral_handler,
         'alias': 'sdcard_block2mem',
         'size': 0x18,
+        'disable_handler': False,
     },
     'sdcard_core': {
         'handler': peripheral_handler,
         'alias': 'sdcard_core',
         'size': 0x2C,
+        'disable_handler': False,
     },
     'sdcard_irq': {
         'handler': peripheral_handler,
         'alias': 'sdcard_irq',
         'size': 0x0C,
+        'disable_handler': False,
     },
     'sdcard_mem2block': {
         'handler': peripheral_handler,
         'alias': 'sdcard_mem2block',
         'size': 0x18,
+        'disable_handler': False,
     },
     'sdcard_phy': {
         'handler': peripheral_handler,
         'alias': 'sdcard_phy',
         'size': 0x10,
+        'disable_handler': False,
     },
     'i2c0' : {
         'handler': i2c_handler,
@@ -333,10 +338,14 @@ def generate_dts_config(csr):
         try:
             dtsi += parm['handler'](name, parm, csr)
         except KeyError as e:
-            print('  dtsi key', e, 'not found, disable', name)
             enable = 'n'
-            dtsi += disabled_handler(name, parm, csr)
-
+            if parm.get('disable_handler', True):
+                print('  dtsi key', e, 'not found, disable', name)
+                dtsi += disabled_handler(name, parm, csr)
+            else:
+                print('  dtsi key', e, 'not found, skip', name)
+                continue
+        
         dtsi += dts_close()
         dts += dtsi
         if 'config_entry' in parm:


### PR DESCRIPTION
omit disable handler for the sdcard peripherals,
as they still don't have a driver in zephyr and are not in the board dts.

This way the build in zephyr will not fail.

Currently you had to manually remove the parts for the sdcard in the overlay, because the build in zephyr fails if there are overlays for unknown peripherals.