### PR TITLE
Improve HyperRAM core to allow IO Reg inference.

### DIFF
--- a/litex/soc/cores/hyperbus.py
+++ b/litex/soc/cores/hyperbus.py
@@ -91,16 +91,22 @@ class HyperRAM(LiteXModule):
             self.comb += pads.rst_n.eq(1 & ~self.conf_rst)
 
         # CSn.
-        self.comb += pads.cs_n[0].eq(~cs)
-        assert len(pads.cs_n) <= 2
-        if len(pads.cs_n) == 2:
-            self.comb += pads.cs_n[1].eq(1)
+        self.comb += [
+            # Set reset value.
+            pads.cs_n.eq(2**len(pads.cs_n)),
+            # Set CSn.
+            pads.cs_n[0].eq(~cs)
+        ]
 
         # Clk.
         if hasattr(pads, "clk"):
+            # Single Ended Clk.
             self.comb += pads.clk.eq(clk)
-        else:
+        elif hastattr(pads, "clk_p"):
+            # Differential Clk.
             self.specials += DifferentialOutput(clk, pads.clk_p, pads.clk_n)
+        else:
+            raise ValueError
 
         # Burst Timer ------------------------------------------------------------------------------
         if sys_clk_freq is None:

--- a/litex/soc/cores/hyperbus.py
+++ b/litex/soc/cores/hyperbus.py
@@ -107,7 +107,7 @@ class HyperRAM(LiteXModule):
 
         # Rst.
         if hasattr(pads, "rst_n"):
-            self.comb += pads.rst_n.eq(1 & ~self.conf_rst)
+            self.sync += pads.rst_n.eq(1 & ~self.conf_rst)
 
         # CSn.
         self.comb += [

--- a/litex/soc/cores/hyperbus.py
+++ b/litex/soc/cores/hyperbus.py
@@ -44,7 +44,7 @@ class HyperRAM(LiteXModule):
         pads (Record)            : Platform pads of HyperRAM.
         bus (wishbone.Interface) : Wishbone Interface.
 """
-    def __init__(self, pads, latency=6, latency_mode="variable", sys_clk_freq=None, with_csr=True):
+    def __init__(self, pads, latency=6, latency_mode="variable", sys_clk_freq=10e6, with_csr=True):
         self.pads = pads
         self.bus  = bus = wishbone.Interface(data_width=32, address_width=32, addressing="word")
 
@@ -128,8 +128,6 @@ class HyperRAM(LiteXModule):
             raise ValueError
 
         # Burst Timer ------------------------------------------------------------------------------
-        if sys_clk_freq is None:
-            sys_clk_freq = 10e6 # Defaults to 10MHz if not specified.
         self.burst_timer = burst_timer = WaitTimer(sys_clk_freq * self.tCSM)
 
         # Clock Generation (sys_clk/4) -------------------------------------------------------------

--- a/litex/soc/cores/hyperbus.py
+++ b/litex/soc/cores/hyperbus.py
@@ -121,7 +121,7 @@ class HyperRAM(LiteXModule):
         if hasattr(pads, "clk"):
             # Single Ended Clk.
             self.comb += pads.clk.eq(clk)
-        elif hastattr(pads, "clk_p"):
+        elif hasattr(pads, "clk_p"):
             # Differential Clk.
             self.specials += DifferentialOutput(clk, pads.clk_p, pads.clk_n)
         else:
@@ -146,7 +146,7 @@ class HyperRAM(LiteXModule):
             # Command/Address: On 8-bit, so 8-bit shift and no input.
             If(ca_oe,
                 sr_next[8:].eq(sr),
-            # Data: dw-bit shift.
+            # Data: On dw-bit, so dw-bit shift.
             ).Else(
                 sr_next[:dw].eq(dqi),
                 sr_next[dw:].eq(sr),
@@ -159,9 +159,12 @@ class HyperRAM(LiteXModule):
         self.comb += [
             bus.dat_r.eq(sr_next),
             If(dq_oe,
-                dq_o.eq(sr[-dw:]),
+                # Command/Address: 8-bit.
                 If(ca_oe,
-                    dq_o.eq(sr[-8:]) # Only use 8-bit for Command/Address.
+                    dq_o.eq(sr[-8:]),
+                # Data: dw-bit.
+                ).Else(
+                    dq_o.eq(sr[-dw:]),
                 )
             )
         ]

--- a/litex/soc/cores/hyperbus.py
+++ b/litex/soc/cores/hyperbus.py
@@ -89,8 +89,8 @@ class HyperRAM(LiteXModule):
 
         # Tristates.
         # ----------
-        dq        = self.add_tristate(pads.dq)   if not hasattr(pads.dq,   "oe") else pads.dq
-        rwds      = self.add_tristate(pads.rwds) if not hasattr(pads.rwds, "oe") else pads.rwds
+        dq        = self.add_tristate(pads.dq,   register=False) if not hasattr(pads.dq,   "oe") else pads.dq
+        rwds      = self.add_tristate(pads.rwds, register=False) if not hasattr(pads.rwds, "oe") else pads.rwds
         self.comb += [
             # DQ.
             dq.o.eq( dq_o),
@@ -357,10 +357,11 @@ class HyperRAM(LiteXModule):
         t = TristatePads(len(pad))
         if register:
             for n in range(len(pad)):
-                self.specials += SDRTristate(pad,
-                    o  = t.o[n],
-                    oe = t.oe,
-                    i  = t.i[n],
+                self.specials += SDRTristate(pad[n],
+                    o   = t.o[n],
+                    oe  = t.oe,
+                    i   = t.i[n],
+                    clk = ClockSignal("sys"),
                 )
         else:
             self.specials += Tristate(pad,

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -38,6 +38,7 @@
 #include <libbase/spiflash.h>
 #include <libbase/uart.h>
 #include <libbase/i2c.h>
+#include <libbase/hyperram.h>
 
 #include <liblitedram/sdram.h>
 #include <liblitedram/utils.h>
@@ -173,88 +174,10 @@ __attribute__((__used__)) int main(int i, char **c)
 	printf("\n");
 #endif
 
-        sdr_ok = 1;
+    sdr_ok = 1;
 
-#ifdef CSR_HYPERRAM_BASE /* FIXME: Move to libbase/hyperram.h/c? */
-    /* Helper Functions */
-
-    printf("HyperRAM init...\n");
-    void hyperram_write_reg(uint16_t reg_addr, uint16_t data) {
-        /* Write data to the register */
-        hyperram_reg_wdata_write(data);
-        hyperram_reg_control_write(
-            1        << CSR_HYPERRAM_REG_CONTROL_WRITE_OFFSET |
-            0        << CSR_HYPERRAM_REG_CONTROL_READ_OFFSET  |
-            reg_addr << CSR_HYPERRAM_REG_CONTROL_ADDR_OFFSET
-        );
-        /* Wait for write to complete */
-        while ((hyperram_reg_status_read() & (1 << CSR_HYPERRAM_REG_STATUS_WRITE_DONE_OFFSET)) == 0);
-    }
-
-    uint16_t hyperram_read_reg(uint16_t reg_addr) {
-        /* Read data from the register */
-        hyperram_reg_control_write(
-            0        << CSR_HYPERRAM_REG_CONTROL_WRITE_OFFSET |
-            1        << CSR_HYPERRAM_REG_CONTROL_READ_OFFSET  |
-            reg_addr << CSR_HYPERRAM_REG_CONTROL_ADDR_OFFSET
-        );
-        /* Wait for read to complete */
-        while ((hyperram_reg_status_read() & (1 << CSR_HYPERRAM_REG_STATUS_READ_DONE_OFFSET)) == 0);
-        return hyperram_reg_rdata_read();
-    }
-
-    /* Configuration and Utility Functions */
-
-    uint16_t hyperram_get_core_latency_setting(uint32_t clk_freq) {
-        /* Raw clock latency settings for the HyperRAM core */
-        if (clk_freq <=  85000000) return 3; /* 3 Clock Latency */
-        if (clk_freq <= 104000000) return 4; /* 4 Clock Latency */
-        if (clk_freq <= 133000000) return 5; /* 5 Clock Latency */
-        if (clk_freq <= 166000000) return 6; /* 6 Clock Latency */
-        if (clk_freq <= 250000000) return 7; /* 7 Clock Latency */
-        return 7; /* Default to highest latency for safety */
-    }
-
-    uint16_t hyperram_get_chip_latency_setting(uint32_t clk_freq) {
-        /* LUT/Translated settings for the HyperRAM chip */
-        if (clk_freq <=  85000000) return 0b1110; /* 3 Clock Latency */
-        if (clk_freq <= 104000000) return 0b1111; /* 4 Clock Latency */
-        if (clk_freq <= 133000000) return 0b0000; /* 5 Clock Latency */
-        if (clk_freq <= 166000000) return 0b0001; /* 6 Clock Latency */
-        if (clk_freq <= 250000000) return 0b0010; /* 7 Clock Latency */
-        return 0b0010; /* Default to highest latency for safety */
-    }
-
-    void hyperram_configure_latency(void) {
-        uint16_t config_reg_0 = 0x8f2f;
-        uint16_t core_latency_setting;
-        uint16_t chip_latency_setting;
-
-        /* Compute Latency settings */
-        core_latency_setting = hyperram_get_core_latency_setting(CONFIG_CLOCK_FREQUENCY/4);
-        chip_latency_setting = hyperram_get_chip_latency_setting(CONFIG_CLOCK_FREQUENCY/4);
-
-        /* Write Latency to HyperRAM Core */
-        printf("HyperRAM Core Latency: %d CK (X1).\n", core_latency_setting);
-        hyperram_config_write(core_latency_setting << CSR_HYPERRAM_CONFIG_LATENCY_OFFSET);
-
-        /* Enable Variable Latency on HyperRAM Chip */
-        if (hyperram_status_read() & 0x1)
-            config_reg_0 &= ~(0b1 << 3); /* Enable Variable Latency */
-
-        /* Update Latency on HyperRAM Chip */
-        config_reg_0 &= ~(0b1111 << 4);
-        config_reg_0 |= chip_latency_setting << 4;
-
-        /* Write Configuration Register 0 to HyperRAM Chip */
-        hyperram_write_reg(2, config_reg_0);
-
-        /* Read current configuration */
-        config_reg_0 = hyperram_read_reg(2);
-        printf("HyperRAM Configuration Register 0: %08x\n", config_reg_0);
-    }
-    hyperram_configure_latency();
-    printf("\n");
+#ifdef CSR_HYPERRAM_BASE
+    hyperram_init();
 #endif
 
 #if defined(CSR_ETHMAC_BASE) || defined(MAIN_RAM_BASE) || defined(CSR_SPIFLASH_CORE_BASE)

--- a/litex/soc/software/libbase/Makefile
+++ b/litex/soc/software/libbase/Makefile
@@ -11,7 +11,8 @@ OBJECTS =  \
 	uart.o     \
 	spiflash.o \
 	i2c.o \
-	isr.o
+	isr.o \
+	hyperram.o
 
 all: libbase.a
 

--- a/litex/soc/software/libbase/hyperram.c
+++ b/litex/soc/software/libbase/hyperram.c
@@ -1,0 +1,89 @@
+// This file is Copyright (c) 2024 Florent Kermarrec <florent@enjoy-digital.fr>
+// License: BSD
+
+#include <stdio.h>
+
+#include <libbase/hyperram.h>
+
+#include <generated/csr.h>
+
+static void hyperram_write_reg(uint16_t reg_addr, uint16_t data) {
+    /* Write data to the register */
+    hyperram_reg_wdata_write(data);
+    hyperram_reg_control_write(
+        1        << CSR_HYPERRAM_REG_CONTROL_WRITE_OFFSET |
+        0        << CSR_HYPERRAM_REG_CONTROL_READ_OFFSET  |
+        reg_addr << CSR_HYPERRAM_REG_CONTROL_ADDR_OFFSET
+    );
+    /* Wait for write to complete */
+    while ((hyperram_reg_status_read() & (1 << CSR_HYPERRAM_REG_STATUS_WRITE_DONE_OFFSET)) == 0);
+ }
+
+static uint16_t hyperram_read_reg(uint16_t reg_addr) {
+    /* Read data from the register */
+    hyperram_reg_control_write(
+        0        << CSR_HYPERRAM_REG_CONTROL_WRITE_OFFSET |
+        1        << CSR_HYPERRAM_REG_CONTROL_READ_OFFSET  |
+        reg_addr << CSR_HYPERRAM_REG_CONTROL_ADDR_OFFSET
+    );
+    /* Wait for read to complete */
+    while ((hyperram_reg_status_read() & (1 << CSR_HYPERRAM_REG_STATUS_READ_DONE_OFFSET)) == 0);
+    return hyperram_reg_rdata_read();
+}
+
+/* Configuration and Utility Functions */
+
+static uint16_t hyperram_get_core_latency_setting(uint32_t clk_freq) {
+    /* Raw clock latency settings for the HyperRAM core */
+    if (clk_freq <=  85000000) return 3; /* 3 Clock Latency */
+    if (clk_freq <= 104000000) return 4; /* 4 Clock Latency */
+    if (clk_freq <= 133000000) return 5; /* 5 Clock Latency */
+    if (clk_freq <= 166000000) return 6; /* 6 Clock Latency */
+    if (clk_freq <= 250000000) return 7; /* 7 Clock Latency */
+    return 7; /* Default to highest latency for safety */
+}
+
+static uint16_t hyperram_get_chip_latency_setting(uint32_t clk_freq) {
+    /* LUT/Translated settings for the HyperRAM chip */
+    if (clk_freq <=  85000000) return 0b1110; /* 3 Clock Latency */
+    if (clk_freq <= 104000000) return 0b1111; /* 4 Clock Latency */
+    if (clk_freq <= 133000000) return 0b0000; /* 5 Clock Latency */
+    if (clk_freq <= 166000000) return 0b0001; /* 6 Clock Latency */
+    if (clk_freq <= 250000000) return 0b0010; /* 7 Clock Latency */
+    return 0b0010; /* Default to highest latency for safety */
+}
+
+static void hyperram_configure_latency(void) {
+    uint16_t config_reg_0 = 0x8f2f;
+    uint16_t core_latency_setting;
+    uint16_t chip_latency_setting;
+
+    /* Compute Latency settings */
+    core_latency_setting = hyperram_get_core_latency_setting(CONFIG_CLOCK_FREQUENCY/4);
+    chip_latency_setting = hyperram_get_chip_latency_setting(CONFIG_CLOCK_FREQUENCY/4);
+
+    /* Write Latency to HyperRAM Core */
+    printf("HyperRAM Core Latency: %d CK (X1).\n", core_latency_setting);
+    hyperram_config_write(core_latency_setting << CSR_HYPERRAM_CONFIG_LATENCY_OFFSET);
+
+    /* Enable Variable Latency on HyperRAM Chip */
+    if (hyperram_status_read() & 0x1)
+        config_reg_0 &= ~(0b1 << 3); /* Enable Variable Latency */
+
+    /* Update Latency on HyperRAM Chip */
+    config_reg_0 &= ~(0b1111 << 4);
+    config_reg_0 |= chip_latency_setting << 4;
+
+    /* Write Configuration Register 0 to HyperRAM Chip */
+    hyperram_write_reg(2, config_reg_0);
+
+    /* Read current configuration */
+    config_reg_0 = hyperram_read_reg(2);
+    printf("HyperRAM Configuration Register 0: %08x\n", config_reg_0);
+}
+
+void hyperram_init(void) {
+	printf("HyperRAM init...\n");
+	hyperram_configure_latency();
+	printf("\n");
+}

--- a/litex/soc/software/libbase/hyperram.c
+++ b/litex/soc/software/libbase/hyperram.c
@@ -7,6 +7,8 @@
 
 #include <generated/csr.h>
 
+#ifdef CSR_HYPERRAM_BASE
+
 static void hyperram_write_reg(uint16_t reg_addr, uint16_t data) {
     /* Write data to the register */
     hyperram_reg_wdata_write(data);
@@ -87,3 +89,5 @@ void hyperram_init(void) {
 	hyperram_configure_latency();
 	printf("\n");
 }
+
+#endif

--- a/litex/soc/software/libbase/hyperram.h
+++ b/litex/soc/software/libbase/hyperram.h
@@ -1,0 +1,17 @@
+// This file is Copyright (c) 2024 Florent Kermarrec <florent@enjoy-digital.fr>
+// License: BSD
+
+#ifndef __HYPERRAM_H
+#define __HYPERRAM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void hyperram_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __HYPERRAM_H */

--- a/test/test_hyperbus.py
+++ b/test/test_hyperbus.py
@@ -45,8 +45,6 @@ class TestHyperBus(unittest.TestCase):
             dq_o    = "002000048d0000000000000000000000000000000000000000deadbeef000000"
             rwds_oe = "__________________________________________________--------______"
             rwds_o  = "____________________________________________________----________"
-            for i in range(3):
-                yield
             for i in range(len(clk)):
                 self.assertEqual(c2bool(clk[i]), (yield dut.pads.clk))
                 self.assertEqual(c2bool(cs_n[i]), (yield dut.pads.cs_n))
@@ -71,8 +69,6 @@ class TestHyperBus(unittest.TestCase):
             dq_o    = "002000048d000000000000000000000000000000000000000000000000deadbeef000000"
             rwds_oe = "__________________________________________________________--------______"
             rwds_o  = "____________________________________________________________----________"
-            for i in range(3):
-                yield
             for i in range(len(clk)):
                 self.assertEqual(c2bool(clk[i]), (yield dut.pads.clk))
                 self.assertEqual(c2bool(cs_n[i]), (yield dut.pads.cs_n))
@@ -97,8 +93,6 @@ class TestHyperBus(unittest.TestCase):
             dq_o    = "002000048d00000000000000000000000000000000000000000000000000000000deadbeef000000"
             rwds_oe = "__________________________________________________________________--------______"
             rwds_o  = "____________________________________________________________________----________"
-            for i in range(3):
-                yield
             for i in range(len(clk)):
                 self.assertEqual(c2bool(clk[i]), (yield dut.pads.clk))
                 self.assertEqual(c2bool(cs_n[i]), (yield dut.pads.cs_n))
@@ -123,8 +117,6 @@ class TestHyperBus(unittest.TestCase):
             dq_o    = "002000048d0000000000000000000000000000deadbeef000000"
             rwds_oe = "______________________________________--------______"
             rwds_o  = "________________________________________----________"
-            for i in range(3):
-                yield
             for i in range(len(clk)):
                 self.assertEqual(c2bool(clk[i]), (yield dut.pads.clk))
                 self.assertEqual(c2bool(cs_n[i]), (yield dut.pads.cs_n))
@@ -151,8 +143,6 @@ class TestHyperBus(unittest.TestCase):
             dq_o    = "00a000048d0000000000000000000000000000000000000000000000000000000000000000"
             dq_i    = "00000000000000000000000000000000000000000000000000deadbeefcafefade00000000"
             rwds_oe = "__________________________________________________________________________"
-            for i in range(3):
-                yield
             for i in range(len(clk)):
                 yield dut.pads.dq.i.eq(int(dq_i[2*(i//2):2*(i//2)+2], 16))
                 self.assertEqual(c2bool(clk[i]), (yield dut.pads.clk))
@@ -179,8 +169,6 @@ class TestHyperBus(unittest.TestCase):
             dq_o    = "00a000048d000000000000000000000000000000000000000000000000000000000000000000000000"
             dq_i    = "0000000000000000000000000000000000000000000000000000000000deadbeefcafefade00000000"
             rwds_oe = "__________________________________________________________________________________"
-            for i in range(3):
-                yield
             for i in range(len(clk)):
                 yield dut.pads.dq.i.eq(int(dq_i[2*(i//2):2*(i//2)+2], 16))
                 self.assertEqual(c2bool(clk[i]), (yield dut.pads.clk))
@@ -207,8 +195,6 @@ class TestHyperBus(unittest.TestCase):
             dq_o    = "00a000048d00000000000000000000000000000000000000000000000000000000000000000000000000000000"
             dq_i    = "000000000000000000000000000000000000000000000000000000000000000000deadbeefcafefade00000000"
             rwds_oe = "__________________________________________________________________________________________"
-            for i in range(3):
-                yield
             for i in range(len(clk)):
                 yield dut.pads.dq.i.eq(int(dq_i[2*(i//2):2*(i//2)+2], 16))
                 self.assertEqual(c2bool(clk[i]), (yield dut.pads.clk))
@@ -235,8 +221,6 @@ class TestHyperBus(unittest.TestCase):
             dq_o    = "00a000048d0000000000000000000000000000000000000000000000000000"
             dq_i    = "00000000000000000000000000000000000000deadbeefcafefade00000000"
             rwds_oe = "______________________________________________________________"
-            for i in range(3):
-                yield
             for i in range(len(clk)):
                 yield dut.pads.dq.i.eq(int(dq_i[2*(i//2):2*(i//2)+2], 16))
                 self.assertEqual(c2bool(clk[i]), (yield dut.pads.clk))
@@ -261,14 +245,12 @@ class TestHyperBus(unittest.TestCase):
                 yield
 
         def hyperram_gen(dut):
-            clk     = "___--__--__--__--___________"
-            cs_n    = "--________________----------"
-            dq_oe   = "__----------------__________"
-            dq_o    = "0060000100000012340000000000"
-            rwds_oe = "____________________________"
-            rwds_o  = "____________________________"
-            for i in range(3):
-                yield
+            clk     = "_____--__--__--__--___________"
+            cs_n    = "----________________----------"
+            dq_oe   = "____----------------__________"
+            dq_o    = "000060000100000012340000000000"
+            rwds_oe = "______________________________"
+            rwds_o  = "______________________________"
             for i in range(len(clk)):
                 self.assertEqual(c2bool(clk[i]), (yield dut.pads.clk))
                 self.assertEqual(c2bool(cs_n[i]), (yield dut.pads.cs_n))


### PR DESCRIPTION
- Make Rst/Clk/CS synchronous.
- Prepare for use of SDRTristate.
- Avoid waiting for clk_phase in IDLE state.
- Move HyperRAM init to libbase/hyperram.c.