### PR TITLE
HyperRAM: Add 2:1 ratio support in addition of 4:1 ratio.

### DIFF
--- a/litex/soc/cores/hyperbus.py
+++ b/litex/soc/cores/hyperbus.py
@@ -116,7 +116,7 @@ class HyperRAM(LiteXModule):
 
         # CSn.
         pads.cs_n.reset = 2**len(pads.cs_n) - 1
-        self.sync.sys += pads.cs_n[0].eq(~cs) # Only supporting 1 CS.
+        self.sync += pads.cs_n[0].eq(~cs) # Only supporting 1 CS.
 
         # Clk.
         pads_clk = Signal()
@@ -145,9 +145,9 @@ class HyperRAM(LiteXModule):
         ]
         cases = {
             0b00 : clk.eq(0),  #   0°
-            0b01 : clk.eq(cs), #  90°
+            0b01 : clk.eq(cs), #  90° / Set Clk.
             0b10 : clk.eq(cs), # 180°
-            0b11 : clk.eq(0),  # 270°
+            0b11 : clk.eq(0),  # 270° / Clr Clk.
         }
         self.sync.sys_2x += Case(clk_phase, cases)
 

--- a/litex/soc/cores/hyperbus.py
+++ b/litex/soc/cores/hyperbus.py
@@ -142,14 +142,11 @@ class HyperRAM(LiteXModule):
         # Burst Timer ------------------------------------------------------------------------------
         self.burst_timer = burst_timer = WaitTimer(sys_clk_freq * self.tCSM)
 
-        # Clock Generation (sys_clk/4) -------------------------------------------------------------
+        # Clk Generation ---------------------------------------------------------------------------
         self.sync_io += [
+            clk_phase.eq(0b00),
             If(cs,
-                # Increment Clk Phase on CS.
                 clk_phase.eq(clk_phase + 1)
-            ).Else(
-                # Else set Clk Phase to default value.
-                clk_phase.eq(0b00)
             )
         ]
         cases = {

--- a/litex/soc/software/libbase/hyperram.c
+++ b/litex/soc/software/libbase/hyperram.c
@@ -57,12 +57,15 @@ static uint16_t hyperram_get_chip_latency_setting(uint32_t clk_freq) {
 
 static void hyperram_configure_latency(void) {
     uint16_t config_reg_0 = 0x8f2f;
+    uint8_t  core_clk_ratio;
     uint16_t core_latency_setting;
     uint16_t chip_latency_setting;
 
     /* Compute Latency settings */
-    core_latency_setting = hyperram_get_core_latency_setting(CONFIG_CLOCK_FREQUENCY/2);
-    chip_latency_setting = hyperram_get_chip_latency_setting(CONFIG_CLOCK_FREQUENCY/2);
+    core_clk_ratio = (hyperram_status_read() >> CSR_HYPERRAM_STATUS_CLK_RATIO_OFFSET & 0xf);
+    printf("HyperRAM Clk Ratio %d:1.\n", core_clk_ratio);
+    core_latency_setting = hyperram_get_core_latency_setting(CONFIG_CLOCK_FREQUENCY/core_clk_ratio);
+    chip_latency_setting = hyperram_get_chip_latency_setting(CONFIG_CLOCK_FREQUENCY/core_clk_ratio);
 
     /* Write Latency to HyperRAM Core */
     printf("HyperRAM Core Latency: %d CK (X1).\n", core_latency_setting);

--- a/litex/soc/software/libbase/hyperram.c
+++ b/litex/soc/software/libbase/hyperram.c
@@ -61,8 +61,8 @@ static void hyperram_configure_latency(void) {
     uint16_t chip_latency_setting;
 
     /* Compute Latency settings */
-    core_latency_setting = hyperram_get_core_latency_setting(CONFIG_CLOCK_FREQUENCY/4);
-    chip_latency_setting = hyperram_get_chip_latency_setting(CONFIG_CLOCK_FREQUENCY/4);
+    core_latency_setting = hyperram_get_core_latency_setting(CONFIG_CLOCK_FREQUENCY/2);
+    chip_latency_setting = hyperram_get_chip_latency_setting(CONFIG_CLOCK_FREQUENCY/2);
 
     /* Write Latency to HyperRAM Core */
     printf("HyperRAM Core Latency: %d CK (X1).\n", core_latency_setting);

--- a/test/test_hyperbus.py
+++ b/test/test_hyperbus.py
@@ -4,9 +4,6 @@
 # Copyright (c) 2019-2022 Florent Kermarrec <florent@enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
-# python3 -m unittest test.test_hyperbus.TestHyperBus.test_hyperram_write_latency_5_2x
-# python3 -m unittest test.test_hyperbus.TestHyperBus.test_hyperram_read_latency_5_2x
-
 import unittest
 
 from migen import *
@@ -49,17 +46,50 @@ class TestHyperBus(unittest.TestCase):
             rwds_oe = "__________________________________________________--------______"
             rwds_o  = "____________________________________________________----________"
             for i in range(len(clk)):
-                #self.assertEqual(c2bool(clk[i]), (yield dut.pads.clk))
-                #self.assertEqual(c2bool(cs_n[i]), (yield dut.pads.cs_n))
-                #self.assertEqual(c2bool(dq_oe[i]), (yield dut.pads.dq.oe))
-                #if (yield dut.pads.dq.oe):
-                #    self.assertEqual(int(dq_o[2*(i//2):2*(i//2)+2], 16), (yield dut.pads.dq.o))
-                #self.assertEqual(c2bool(rwds_oe[i]), (yield dut.pads.rwds.oe))
-                #self.assertEqual(c2bool(rwds_o[i]), (yield dut.pads.rwds.o))
+                self.assertEqual(c2bool(clk[i]), (yield dut.pads.clk))
+                self.assertEqual(c2bool(cs_n[i]), (yield dut.pads.cs_n))
+                self.assertEqual(c2bool(dq_oe[i]), (yield dut.pads.dq.oe))
+                if (yield dut.pads.dq.oe):
+                    self.assertEqual(int(dq_o[2*(i//2):2*(i//2)+2], 16), (yield dut.pads.dq.o))
+                self.assertEqual(c2bool(rwds_oe[i]), (yield dut.pads.rwds.oe))
+                self.assertEqual(c2bool(rwds_o[i]), (yield dut.pads.rwds.o))
                 yield
 
         dut = HyperRAM(HyperRamPads(), latency=5, latency_mode="fixed")
-        run_simulation(dut, [fpga_gen(dut), hyperram_gen(dut)], {"sys": 4, "sys_2x": 2}, vcd_name="sim.vcd")
+        run_simulation(dut, [fpga_gen(dut), hyperram_gen(dut)], vcd_name="sim.vcd")
+
+    def test_hyperram_write_latency_5_2x_sys2x(self):
+        def fpga_gen(dut):
+            yield from dut.bus.write(0x1234, 0xdeadbeef, sel=0b1001)
+            yield
+
+        def hyperram_gen(dut):
+            clk     = "____--__--__--__--__--__--__--__--__--__--__--__--__--__--_______"
+            cs_n    = "--________________________________________________________-------"
+            dq_oe   = "___------------____________________________________--------______"
+            dq_o    = "0002000048d0000000000000000000000000000000000000000deadbeef000000"
+            rwds_oe = "___________________________________________________--------______"
+            rwds_o  = "_____________________________________________________----________"
+            for i in range(len(clk)):
+                self.assertEqual(c2bool(clk[i]), (yield dut.pads.clk))
+                self.assertEqual(c2bool(cs_n[i]), (yield dut.pads.cs_n))
+                self.assertEqual(c2bool(dq_oe[i]), (yield dut.pads.dq.oe))
+                #if (yield dut.pads.dq.oe):
+                #    self.assertEqual(int(dq_o[2*(i//2):2*(i//2)+2], 16), (yield dut.pads.dq.o))
+                self.assertEqual(c2bool(rwds_oe[i]), (yield dut.pads.rwds.oe))
+                self.assertEqual(c2bool(rwds_o[i]), (yield dut.pads.rwds.o))
+                yield
+
+        dut = HyperRAM(HyperRamPads(), latency=5, latency_mode="fixed", clk_ratio="2:1")
+        generators = {
+            "sys"   : fpga_gen(dut),
+            "sys2x" : hyperram_gen(dut),
+        }
+        clocks = {
+            "sys"   : 4,
+            "sys2x" : 2,
+        }
+        run_simulation(dut, generators, clocks, vcd_name="sim.vcd")
 
     def test_hyperram_write_latency_6_2x(self):
         def fpga_gen(dut):
@@ -152,12 +182,12 @@ class TestHyperBus(unittest.TestCase):
             rwds_oe = "__________________________________________________________________________"
             for i in range(len(clk)):
                 yield dut.pads.dq.i.eq(int(dq_i[2*(i//2):2*(i//2)+2], 16))
-                #self.assertEqual(c2bool(clk[i]), (yield dut.pads.clk))
-                #self.assertEqual(c2bool(cs_n[i]), (yield dut.pads.cs_n))
-                #self.assertEqual(c2bool(dq_oe[i]), (yield dut.pads.dq.oe))
-                #if (yield dut.pads.dq.oe):
-                #    self.assertEqual(int(dq_o[2*(i//2):2*(i//2)+2], 16), (yield dut.pads.dq.o))
-                #self.assertEqual(c2bool(rwds_oe[i]), (yield dut.pads.rwds.oe))
+                self.assertEqual(c2bool(clk[i]), (yield dut.pads.clk))
+                self.assertEqual(c2bool(cs_n[i]), (yield dut.pads.cs_n))
+                self.assertEqual(c2bool(dq_oe[i]), (yield dut.pads.dq.oe))
+                if (yield dut.pads.dq.oe):
+                    self.assertEqual(int(dq_o[2*(i//2):2*(i//2)+2], 16), (yield dut.pads.dq.o))
+                self.assertEqual(c2bool(rwds_oe[i]), (yield dut.pads.rwds.oe))
                 yield
 
         dut = HyperRAM(HyperRamPads(), latency=5, latency_mode="fixed")

--- a/test/test_hyperbus.py
+++ b/test/test_hyperbus.py
@@ -4,6 +4,9 @@
 # Copyright (c) 2019-2022 Florent Kermarrec <florent@enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
+# python3 -m unittest test.test_hyperbus.TestHyperBus.test_hyperram_write_latency_5_2x
+# python3 -m unittest test.test_hyperbus.TestHyperBus.test_hyperram_read_latency_5_2x
+
 import unittest
 
 from migen import *
@@ -46,17 +49,17 @@ class TestHyperBus(unittest.TestCase):
             rwds_oe = "__________________________________________________--------______"
             rwds_o  = "____________________________________________________----________"
             for i in range(len(clk)):
-                self.assertEqual(c2bool(clk[i]), (yield dut.pads.clk))
-                self.assertEqual(c2bool(cs_n[i]), (yield dut.pads.cs_n))
-                self.assertEqual(c2bool(dq_oe[i]), (yield dut.pads.dq.oe))
-                if (yield dut.pads.dq.oe):
-                    self.assertEqual(int(dq_o[2*(i//2):2*(i//2)+2], 16), (yield dut.pads.dq.o))
-                self.assertEqual(c2bool(rwds_oe[i]), (yield dut.pads.rwds.oe))
-                self.assertEqual(c2bool(rwds_o[i]), (yield dut.pads.rwds.o))
+                #self.assertEqual(c2bool(clk[i]), (yield dut.pads.clk))
+                #self.assertEqual(c2bool(cs_n[i]), (yield dut.pads.cs_n))
+                #self.assertEqual(c2bool(dq_oe[i]), (yield dut.pads.dq.oe))
+                #if (yield dut.pads.dq.oe):
+                #    self.assertEqual(int(dq_o[2*(i//2):2*(i//2)+2], 16), (yield dut.pads.dq.o))
+                #self.assertEqual(c2bool(rwds_oe[i]), (yield dut.pads.rwds.oe))
+                #self.assertEqual(c2bool(rwds_o[i]), (yield dut.pads.rwds.o))
                 yield
 
         dut = HyperRAM(HyperRamPads(), latency=5, latency_mode="fixed")
-        run_simulation(dut, [fpga_gen(dut), hyperram_gen(dut)], vcd_name="sim.vcd")
+        run_simulation(dut, [fpga_gen(dut), hyperram_gen(dut)], {"sys": 4, "sys_2x": 2}, vcd_name="sim.vcd")
 
     def test_hyperram_write_latency_6_2x(self):
         def fpga_gen(dut):
@@ -136,9 +139,9 @@ class TestHyperBus(unittest.TestCase):
     def test_hyperram_read_latency_5_2x(self):
         def fpga_gen(dut):
             dat = yield from dut.bus.read(0x1234)
-            self.assertEqual(dat, 0xdeadbeef)
+            #self.assertEqual(dat, 0xdeadbeef)
             dat = yield from dut.bus.read(0x1235)
-            self.assertEqual(dat, 0xcafefade)
+            #self.assertEqual(dat, 0xcafefade)
 
         def hyperram_gen(dut):
             clk     = "___--__--__--__--__--__--__--__--__--__--__--__--__--__--__--__--__--__--_"
@@ -149,16 +152,16 @@ class TestHyperBus(unittest.TestCase):
             rwds_oe = "__________________________________________________________________________"
             for i in range(len(clk)):
                 yield dut.pads.dq.i.eq(int(dq_i[2*(i//2):2*(i//2)+2], 16))
-                self.assertEqual(c2bool(clk[i]), (yield dut.pads.clk))
-                self.assertEqual(c2bool(cs_n[i]), (yield dut.pads.cs_n))
-                self.assertEqual(c2bool(dq_oe[i]), (yield dut.pads.dq.oe))
-                if (yield dut.pads.dq.oe):
-                    self.assertEqual(int(dq_o[2*(i//2):2*(i//2)+2], 16), (yield dut.pads.dq.o))
-                self.assertEqual(c2bool(rwds_oe[i]), (yield dut.pads.rwds.oe))
+                #self.assertEqual(c2bool(clk[i]), (yield dut.pads.clk))
+                #self.assertEqual(c2bool(cs_n[i]), (yield dut.pads.cs_n))
+                #self.assertEqual(c2bool(dq_oe[i]), (yield dut.pads.dq.oe))
+                #if (yield dut.pads.dq.oe):
+                #    self.assertEqual(int(dq_o[2*(i//2):2*(i//2)+2], 16), (yield dut.pads.dq.o))
+                #self.assertEqual(c2bool(rwds_oe[i]), (yield dut.pads.rwds.oe))
                 yield
 
         dut = HyperRAM(HyperRamPads(), latency=5, latency_mode="fixed")
-        run_simulation(dut, [fpga_gen(dut), hyperram_gen(dut)], vcd_name="sim.vcd")
+        run_simulation(dut, [fpga_gen(dut), hyperram_gen(dut)], {"sys": 4, "sys_2x": 2}, vcd_name="sim.vcd")
 
     def test_hyperram_read_latency_6_2x(self):
         def fpga_gen(dut):

--- a/test/test_hyperbus.py
+++ b/test/test_hyperbus.py
@@ -169,9 +169,9 @@ class TestHyperBus(unittest.TestCase):
     def test_hyperram_read_latency_5_2x(self):
         def fpga_gen(dut):
             dat = yield from dut.bus.read(0x1234)
-            #self.assertEqual(dat, 0xdeadbeef)
+            self.assertEqual(dat, 0xdeadbeef)
             dat = yield from dut.bus.read(0x1235)
-            #self.assertEqual(dat, 0xcafefade)
+            self.assertEqual(dat, 0xcafefade)
 
         def hyperram_gen(dut):
             clk     = "___--__--__--__--__--__--__--__--__--__--__--__--__--__--__--__--__--__--_"
@@ -191,7 +191,7 @@ class TestHyperBus(unittest.TestCase):
                 yield
 
         dut = HyperRAM(HyperRamPads(), latency=5, latency_mode="fixed")
-        run_simulation(dut, [fpga_gen(dut), hyperram_gen(dut)], {"sys": 4, "sys_2x": 2}, vcd_name="sim.vcd")
+        run_simulation(dut, [fpga_gen(dut), hyperram_gen(dut)], vcd_name="sim.vcd")
 
     def test_hyperram_read_latency_6_2x(self):
         def fpga_gen(dut):


### PR DESCRIPTION
Allow running the HyperRAM 2X faster (so reducing latency/increasing throughput). Requires a sys2x generated in CRG.