### PR TITLE
Colognechip improve

### DIFF
--- a/litex/build/colognechip/colognechip.py
+++ b/litex/build/colognechip/colognechip.py
@@ -44,18 +44,6 @@ class CologneChipToolchain(GenericToolchain):
 
     # IO Constraints (.ccf) ------------------------------------------------------------------------
 
-    def _get_pin_direction(self, pinname):
-        pins = self.platform.constraint_manager.get_io_signals()
-        for pin in sorted(pins, key=lambda x: x.duid):
-            if (pinname.split("[")[0] == pin.name):
-                if pin.direction == "output":
-                    return "Pin_out"
-                elif pin.direction == "input":
-                    return "Pin_in"
-                else:
-                    return "Pin_inout"
-        return "Unknown"
-
     def build_io_constraints(self):
         ccf = []
 
@@ -70,8 +58,7 @@ class CologneChipToolchain(GenericToolchain):
         for name, pin, other in flat_sc:
             pin_cst = ""
             if pin != "X":
-                direction = self._get_pin_direction(name)
-                pin_cst = f"{direction} \"{name}\" Loc = \"{pin}\""
+                pin_cst = f"Net \"{name}\" Loc = \"{pin}\""
 
             for c in other:
                 if isinstance(c, Misc):

--- a/litex/soc/cores/clock/colognechip.py
+++ b/litex/soc/cores/clock/colognechip.py
@@ -130,6 +130,8 @@ class GateMatePLL(LiteXModule):
         freqInMHz  = self._clkin_freq/1e6
         freqOutMHz = clkout_freq/1e6
 
+        locked_s1 = Signal()
+
         self.specials += Instance("CC_PLL",
             p_REF_CLK             = str(freqInMHz),   # reference input in MHz
             p_OUT_CLK             = str(freqOutMHz),  # pll output frequency in MHz
@@ -141,11 +143,12 @@ class GateMatePLL(LiteXModule):
             i_CLK_REF             = self._clkin if not self._usr_clk_ref else Open(),
             i_USR_CLK_REF         = self._clkin if self._usr_clk_ref else Open(),
             i_CLK_FEEDBACK        = 0,
-            i_USR_LOCKED_STDY_RST = self.reset,
+            i_USR_LOCKED_STDY_RST = 0,
             o_CLK_REF_OUT         = Open(),
-            o_USR_PLL_LOCKED_STDY = self.locked,
-            o_USR_PLL_LOCKED      = Open(),
+            o_USR_PLL_LOCKED_STDY = Open(),
+            o_USR_PLL_LOCKED      = locked_s1,
             **{f"o_CLK{p}"        : c for (p, (c, _)) in self._clkouts.items()},
             **{f"p_CLK{p}_DOUB"   : v for (p, v) in clk_doub.items()},
         )
 
+        self.comb += self.locked.eq(locked_s1 & ~self.reset)


### PR DESCRIPTION
This PR fix and simplify colognechip's FPGA support:

The PLL's `locked` signal must be connected to `USR_PLL_LOCKED` instead of `USR_PLL_LOCKED_STDY`. `xx_STDY` signals are for debug purpose: `USR_PLL_LOCKED_STDY` is set to high at boot time when PLL is locked, goes low if lock is lost and remains low until `USER_LOCKED_STDY_RST` is asserted. An intermediate signal is added to have `locked` signal driven by both PLL and input reset: PLL has no input reset signal.

With latest toolchain release `Pin_in`, `Pin_out` and `Pin_inout` become obsolete and replaced by `Net`: `p_r` is now able to detect direction thanks to verilog top module: *build/colognechip/colognechip.py* is simplified to use this new behavior.