### PR TITLE
efinix: Fix PLL with external clock input ifacewriter

### DIFF
--- a/litex/build/efinix/ifacewriter.py
+++ b/litex/build/efinix/ifacewriter.py
@@ -295,6 +295,8 @@ design.create("{2}", "{3}", "./../gateware", overwrite=True)
             else:
                 cmd += 'design.gen_pll_ref_clock("{}", pll_res="{}", refclk_src="{}", refclk_name="{}", ext_refclk_no="{}")\n\n' \
                     .format(name, block["resource"], block["input_clock"], block["input_clock_name"], block["clock_no"])
+            for p, val in block["input_properties"]:
+                cmd += 'design.set_property("{}","{}","{}")\n'.format(block["input_clock_name"], p, val)
         else:
             cmd += 'design.gen_pll_ref_clock("{}", pll_res="{}", refclk_name="{}", refclk_src="CORE")\n'.format(name, block["resource"], block["input_signal"])
             cmd += 'design.set_property("{}", "CORE_CLK_PIN", "{}", block_type="PLL")\n\n'.format(name, block["input_signal"])

--- a/litex/soc/cores/clock/efinix.py
+++ b/litex/soc/cores/clock/efinix.py
@@ -85,6 +85,7 @@ class EFINIXPLL(LiteXModule):
             block["input_refclk_name"] = refclk_name
             block["resource"]        = pll_res
             block["clock_no"]        = clock_no
+            block["input_properties"] = self.platform.get_pin_properties(clkin)
             self.logger.info("Clock source: {}, using EXT_CLK{}".format(block["input_clock"], clock_no))
             self.platform.get_pll_resource(pll_res)
         else:


### PR DESCRIPTION
Efinity tool was complaining of bad pin voltage for the PLL clock input.
The issue was only comming up when the pll input clock was using a different bank voltage than the default.

In practice this PR will add pin definition to the generated iface.py : 

```
# This line is still the same
design.gen_pll_ref_clock("pll0", pll_res="PLL_BL0", refclk_src="EXTERNAL", refclk_name="clk100", ext_refclk_no="1")

# add the following line : 
design.set_property("clk100","IO_STANDARD","3.3_V_LVCMOS")
```
