### PR TITLE
soc/cores/vexiiriscv: update clocks + add video framebuffer support

### DIFF
--- a/litex/soc/cores/cpu/vexiiriscv/core.py
+++ b/litex/soc/cores/cpu/vexiiriscv/core.py
@@ -152,7 +152,7 @@ class VexiiRiscv(CPU):
         vdir = get_data_mod("cpu", "vexiiriscv").data_location
         ndir = os.path.join(vdir, "ext", "VexiiRiscv")
 
-        NaxRiscv.git_setup("VexiiRiscv", ndir, "https://github.com/SpinalHDL/VexiiRiscv.git", "dev", "a15ea92c", args.update_repo)
+        NaxRiscv.git_setup("VexiiRiscv", ndir, "https://github.com/SpinalHDL/VexiiRiscv.git", "dev", "e7c9f4a3", args.update_repo)
 
         if not args.cpu_variant:
             args.cpu_variant = "standard"

--- a/litex/soc/cores/cpu/vexiiriscv/core.py
+++ b/litex/soc/cores/cpu/vexiiriscv/core.py
@@ -59,6 +59,8 @@ class VexiiRiscv(CPU):
     with_axi3        = False
     jtag_tap         = False
     jtag_instruction = False
+    with_cpu_clk     = False
+    vexii_video      = []
     vexii_args       = ""
 
 
@@ -131,12 +133,14 @@ class VexiiRiscv(CPU):
         cpu_group.add_argument("--with-jtag-instruction", action="store_true",   help="Add a JTAG instruction port which implement tunneling for debugging (TAP not included).")
         cpu_group.add_argument("--update-repo",           default="recommended", choices=["latest","wipe+latest","recommended","wipe+recommended","no"], help="Specify how the VexiiRiscv & SpinalHDL repo should be updated (latest: update to HEAD, recommended: Update to known compatible version, no: Don't update, wipe+*: Do clean&reset before checkout)")
         cpu_group.add_argument("--no-netlist-cache",      action="store_true",   help="Always (re-)build the netlist.")
+        cpu_group.add_argument("--with-cpu-clk",          action="store_true",   help="The CPUs will use a decoupled clock")
         # cpu_group.add_argument("--with-fpu",              action="store_true",   help="Enable the F32/F64 FPU.")
         # cpu_group.add_argument("--with-rvc",              action="store_true",   help="Enable the Compress ISA extension.")
         cpu_group.add_argument("--l2-bytes",              default=0,             help="VexiiRiscv L2 bytes, default 128 KB.")
         cpu_group.add_argument("--l2-ways",               default=0,             help="VexiiRiscv L2 ways, default 8.")
         cpu_group.add_argument("--l2-self-flush",         default=None,          help="VexiiRiscv L2 ways will self flush on from,to,cycles")
         cpu_group.add_argument("--with-axi3",             action="store_true",   help="mbus will be axi3 instead of axi4")
+        cpu_group.add_argument("--vexii-video",           action="append",  default=[], help="Add the memory coherent video controller")
 
 
 
@@ -148,7 +152,7 @@ class VexiiRiscv(CPU):
         vdir = get_data_mod("cpu", "vexiiriscv").data_location
         ndir = os.path.join(vdir, "ext", "VexiiRiscv")
 
-        NaxRiscv.git_setup("VexiiRiscv", ndir, "https://github.com/SpinalHDL/VexiiRiscv.git", "dev", "36dad634", args.update_repo)
+        NaxRiscv.git_setup("VexiiRiscv", ndir, "https://github.com/SpinalHDL/VexiiRiscv.git", "dev", "a15ea92c", args.update_repo)
 
         if not args.cpu_variant:
             args.cpu_variant = "standard"
@@ -196,10 +200,12 @@ class VexiiRiscv(CPU):
             VexiiRiscv.cpu_count = args.cpu_count
         if args.l2_bytes:
             VexiiRiscv.l2_bytes = args.l2_bytes
+        VexiiRiscv.with_cpu_clk = args.with_cpu_clk
         if args.l2_ways:
             VexiiRiscv.l2_ways = args.l2_ways
         if args.l2_self_flush:
             VexiiRiscv.l2_self_flush = args.l2_self_flush
+        VexiiRiscv.vexii_video = args.vexii_video
 
 
     def __init__(self, platform, variant):
@@ -220,8 +226,8 @@ class VexiiRiscv(CPU):
         # CPU Instance.
         self.cpu_params = dict(
             # Clk/Rst.
-            i_system_clk   = ClockSignal("sys"),
-            i_system_reset = ResetSignal("sys") | self.reset,
+            i_litex_clk   = ClockSignal("sys"),
+            i_litex_reset = ResetSignal("sys") | self.reset,
 
             # Patcher/Tracer.
             # o_patcher_tracer_valid   = self.tracer_valid,
@@ -251,6 +257,12 @@ class VexiiRiscv(CPU):
             i_pBus_rdata   = pbus.r.data,
             i_pBus_rresp   = pbus.r.resp,
         )
+
+        if VexiiRiscv.with_cpu_clk:
+            self.cpu_clk = Signal()
+            self.cpu_params.update(
+                i_cpu_clk = self.cpu_clk
+            )
 
         if VexiiRiscv.with_dma:
             self.dma_bus = dma_bus = axi.AXIInterface(data_width=VexiiRiscv.internal_bus_width, address_width=32, id_width=4)
@@ -306,6 +318,31 @@ class VexiiRiscv(CPU):
                 o_dma_bus_rlast   = dma_bus.r.last,
             )
 
+        for video in VexiiRiscv.vexii_video:
+            args = {}
+            for i, val in enumerate(video.split(",")):
+                name, value = val.split("=")
+                args.update({name: value})
+            name = args["name"]
+            clk = Signal()
+            hsync = Signal()
+            vsync = Signal()
+            color_en = Signal()
+            color = Signal(16)
+            setattr(self, name + "_clk", clk)
+            setattr(self, name + "_hsync", hsync)
+            setattr(self, name + "_vsync", vsync)
+            setattr(self, name + "_color_en", color_en)
+            setattr(self, name + "_color", color)
+            self.cpu_params["o_" + name + "_clk"] = clk
+            self.cpu_params["o_" + name + "_hSync"] = hsync
+            self.cpu_params["o_" + name + "_vSync"] = vsync
+            self.cpu_params["o_" + name + "_colorEn"] = color_en
+            self.cpu_params["o_" + name + "_color"] = color
+
+
+
+
     def set_reset_address(self, reset_address):
         VexiiRiscv.reset_address = reset_address
         VexiiRiscv.vexii_args += f" --reset-vector {reset_address}"
@@ -319,6 +356,7 @@ class VexiiRiscv(CPU):
         md5_hash.update(str(VexiiRiscv.xlen).encode('utf-8'))
         md5_hash.update(str(VexiiRiscv.cpu_count).encode('utf-8'))
         md5_hash.update(str(VexiiRiscv.l2_bytes).encode('utf-8'))
+        md5_hash.update(str(VexiiRiscv.with_cpu_clk).encode('utf-8'))
         md5_hash.update(str(VexiiRiscv.l2_ways).encode('utf-8'))
         md5_hash.update(str(VexiiRiscv.l2_self_flush).encode('utf-8'))
         md5_hash.update(str(VexiiRiscv.jtag_tap).encode('utf-8'))
@@ -327,6 +365,8 @@ class VexiiRiscv(CPU):
         md5_hash.update(str(VexiiRiscv.with_axi3).encode('utf-8'))
         md5_hash.update(str(VexiiRiscv.memory_regions).encode('utf-8'))
         md5_hash.update(str(VexiiRiscv.vexii_args).encode('utf-8'))
+        md5_hash.update(str(VexiiRiscv.vexii_video).encode('utf-8'))
+
         # md5_hash.update(str(VexiiRiscv.internal_bus_width).encode('utf-8'))
 
 
@@ -346,6 +386,8 @@ class VexiiRiscv(CPU):
         gen_args.append(VexiiRiscv.vexii_args)
         gen_args.append(f"--cpu-count={VexiiRiscv.cpu_count}")
         gen_args.append(f"--l2-bytes={VexiiRiscv.l2_bytes}")
+        if VexiiRiscv.with_cpu_clk:
+            gen_args.append("--with-cpu-clk")
         gen_args.append(f"--l2-ways={VexiiRiscv.l2_ways}")
         if VexiiRiscv.l2_self_flush:
             gen_args.append(f"--l2-self-flush={VexiiRiscv.l2_self_flush}")
@@ -361,6 +403,9 @@ class VexiiRiscv(CPU):
             gen_args.append(f"--with-dma")
         if(VexiiRiscv.with_axi3) :
             gen_args.append(f"--with-axi3")
+        for arg in VexiiRiscv.vexii_video:
+            gen_args.append(f"--video {arg}")
+
 
         cmd = f"""cd {ndir} && sbt "runMain vexiiriscv.soc.litex.SocGen {" ".join(gen_args)}\""""
         print("VexiiRiscv generation command :")
@@ -469,7 +514,12 @@ class VexiiRiscv(CPU):
             if soc.get_build_name() == "sim":
                 self.comb += If(debug_ndmreset_rise, soc.crg.cd_sys.rst.eq(1))
             else:
-                self.comb += If(debug_ndmreset_rise, soc.crg.rst.eq(1))
+                if hasattr(soc.crg.pll, "locked"):
+                    self.comb += If(debug_ndmreset, soc.crg.pll.locked.eq(0))
+                elif hasattr(soc.crg, "rst"):
+                    self.comb += If(debug_ndmreset_rise, soc.crg.rst.eq(1))
+                else:
+                    raise Exception("Pll has no reset ?")
 
         self.soc_bus = soc.bus # FIXME: Save SoC Bus instance to retrieve the final mem layout on finalization.
 
@@ -482,6 +532,7 @@ class VexiiRiscv(CPU):
             id_width      = 8,
             version       = "axi3" if VexiiRiscv.with_axi3 else "axi4"
         )
+        self.mBus_awallStrb = Signal()
         self.memory_buses.append(mbus)
 
         self.comb += mbus.aw.cache.eq(0xF)
@@ -507,7 +558,7 @@ class VexiiRiscv(CPU):
             o_mBus_awlen     = mbus.aw.len,
             o_mBus_awsize    = mbus.aw.size,
             o_mBus_awburst   = mbus.aw.burst,
-            o_mBus_awallStrb = Open(),
+            o_mBus_awallStrb = self.mBus_awallStrb,
             # W Channel.
             o_mBus_wvalid    = mbus.w.valid,
             i_mBus_wready    = mbus.w.ready,
@@ -572,6 +623,10 @@ class VexiiRiscv(CPU):
             mode = region.mode
             mode += "c" if region.cached else ""
             VexiiRiscv.memory_regions.append( (region.origin, region.size, mode, bus) )
+
+        from litex.build.efinix import EfinixPlatform
+        if isinstance(self.platform, EfinixPlatform):
+            VexiiRiscv.vexii_args = "--mmu-sync-read " + VexiiRiscv.vexii_args
 
         self.generate_netlist_name()
 


### PR DESCRIPTION
The clock rework allows the CPU to work with a different clock than litex (higher fmax)
the video support add a memory coherent video output (will need to add more parametrization later, currently it is ycbcr 4:2:2 800x600@60hz