### PR TITLE
sim: add HW_PREAMBLE_CRC for ethernet

### DIFF
--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -237,6 +237,7 @@ class SimSoC(SoCCore):
         if with_ethernet or with_etherbone:
             if ethernet_phy_model == "sim":
                 self.ethphy = LiteEthPHYModel(self.platform.request("eth", 0))
+                self.add_constant("HW_PREAMBLE_CRC");
             elif ethernet_phy_model == "xgmii":
                 self.ethphy = LiteEthPHYXGMII(None, self.platform.request("xgmii_eth", 0), model=True)
             elif ethernet_phy_model == "gmii":


### PR DESCRIPTION
This fixes the behavior of `ethernet_phy_model` `"sim"`. As the preamble is automatically attached by the tap, there is no need to add it from the BIOS. To let the BIOS know, `HW_PREAMBLE_CRC` needs to be set.

Fixes #2067 