### PR TITLE
litex_setup: use current version of migen

### DIFF
--- a/litex_setup.py
+++ b/litex_setup.py
@@ -70,7 +70,7 @@ class GitRepo:
 git_repos = {
     # HDL.
     # ----
-    "migen":    GitRepo(url="https://github.com/m-labs/", clone="recursive", sha1=0xccaee68e14d3636e1d8fb2e0864dd89b1b1f7384),
+    "migen":    GitRepo(url="https://github.com/m-labs/", clone="recursive"),
 
     # LiteX SoC builder.
     # ------------------


### PR DESCRIPTION
use current version of migen. Use already install migen via pip (line 286), which supports `setup.py` and `pyproject.toml`, so it should make no difference, what migen is using.

Reverts: 6c30cb8695aa3f0760c627993031a1f4fa772416