### PR TITLE
build/efinix/common.py: ClkInput: added ClockSignal support

### DIFF
--- a/litex/build/efinix/ifacewriter.py
+++ b/litex/build/efinix/ifacewriter.py
@@ -212,8 +212,17 @@ design.create("{2}", "{3}", "./../gateware", overwrite=True)
                 for i, pad in enumerate(block["location"]):
                     cmd += f'design.assign_pkg_pin("{name}[{i}]","{pad}")\n'
             if "in_reg" in block:
+                in_clk_pin = block["in_clk_pin"]
+                if isinstance(in_clk_pin, ClockSignal):
+                    # Try to find cd name
+                    in_clk_pin_name = self.platform.clks.get(in_clk_pin.cd, None)
+                    # If not found cd name has been updated with "_clk" as suffix.
+                    if in_clk_pin_name is None:
+                        in_clk_pin_name = self.platform.clks.get(in_clk_pin.cd + "_clk")
+                    in_clk_pin = in_clk_pin_name
+
                 cmd += f'design.set_property("{name}","IN_REG","{block["in_reg"]}")\n'
-                cmd += f'design.set_property("{name}","IN_CLK_PIN","{block["in_clk_pin"]}")\n'
+                cmd += f'design.set_property("{name}","IN_CLK_PIN","{in_clk_pin}")\n'
                 if "in_delay" in block:
                     cmd += f'design.set_property("{name}","INDELAY","{block["in_delay"]}")\n'
             if prop:


### PR DESCRIPTION
`ClkInput` specials is currently only uses as PLL's clkin. The current approach is to uses a string for `create_clkin`. This way is valid because both `ClkInput`'s o name and PLL's `clkin` must match at *iface* level and nothing is known in a generated verilog file. But when this specials is used for a `ClockDomain` this way is no more valid and it's requires to connect `.o` to the `ClockSignal`.
The first commit address this limitation by allowing the use of a `ClockSignal`, converted to a signal when the class contructor is called. In this situation, the constructor adopt the same approach done for PLL's `create_clkout` method. string is kept as backward compatibility to avoid breaking all existing code.

Second commit address another issue: when a gpio out (ddio f.i.) is used through specials: `ClockSignal` is resolved and the Signal contains an `name_override` attribute. But when this primitive is instanciated directly by a module, cd remains a `ClockSignal` and conversion between signal and name must be done in ifacewriter script. Also the `ClockSignal` only provides `ClockDomain` name (not resolved) so a first search for the name is done, but if no results are found: the `_clk` suffix is added to the name.