### PR TITLE
build: efinix: allow clk inverting and different in clk on reg tristates

### DIFF
--- a/litex/build/altera/common.py
+++ b/litex/build/altera/common.py
@@ -230,7 +230,7 @@ class Agilex5SDRInput:
 # Agilex5 SDRTristate ------------------------------------------------------------------------------
 
 class Agilex5SDRTristateImpl(Module):
-    def __init__(self, io, o, oe, i, clk):
+    def __init__(self, io, o, oe, i, clk, in_clk):
         _i  = Signal().like(i) if i is not None else None
         _o  = Signal().like(o)
         _oe = Signal().like(oe)
@@ -239,7 +239,7 @@ class Agilex5SDRTristateImpl(Module):
             SDRIO(oe, _oe, clk)
         ]
         if _i is not None:
-            self.specials += SDRIO(_i, i, clk)
+            self.specials += SDRIO(_i, i, in_clk)
 
         for j in range(len(io)):
             if _i is not None:
@@ -259,7 +259,7 @@ class Agilex5SDRTristateImpl(Module):
 class Agilex5SDRTristate(Module):
     @staticmethod
     def lower(dr):
-        return Agilex5SDRTristateImpl(dr.io, dr.o, dr.oe, dr.i, dr.clk)
+        return Agilex5SDRTristateImpl(dr.io, dr.o, dr.oe, dr.i, dr.clk, dr.in_clk)
 
 # Agilex5 Special Overrides ------------------------------------------------------------------------
 

--- a/litex/build/colognechip/common.py
+++ b/litex/build/colognechip/common.py
@@ -159,7 +159,7 @@ class CologneChipSDROutput:
 # CologneChip SDRTristate ---------------------------------------------------------------------------------
 
 class CologneChipSDRTristateImpl(Module):
-    def __init__(self, io, o, oe, i, clk):
+    def __init__(self, io, o, oe, i, clk, in_clk):
         _o    = Signal().like(o)
         _oe_n = Signal().like(oe)
         _i    = Signal().like(i if i is not None else o)
@@ -168,7 +168,7 @@ class CologneChipSDRTristateImpl(Module):
             SDROutput(~oe, _oe_n, clk),
         ]
         if i is not None:
-            self.specials += SDRInput(i, _i, clk)
+            self.specials += SDRInput(i, _i, in_clk)
         for j in range(len(io)):
             self.specials += Instance("CC_IOBUF",
                     p_FF_OBF = 1,
@@ -182,7 +182,7 @@ class CologneChipSDRTristateImpl(Module):
 class CologneChipSDRTristate:
     @staticmethod
     def lower(dr):
-        return CologneChipSDRTristateImpl(dr.io, dr.o, dr.oe, dr.i, dr.clk)
+        return CologneChipSDRTristateImpl(dr.io, dr.o, dr.oe, dr.i, dr.clk, dr.in_clk)
 
 
 # CologneChip Tristate -----------------------------------------------------------------------------

--- a/litex/build/efinix/common.py
+++ b/litex/build/efinix/common.py
@@ -308,6 +308,7 @@ class EfinixDifferentialInput:
 class EfinixTrionDDRTristateImpl(LiteXModule):
     def __init__(self, io, o1, o2, oe1, oe2, i1, i2, clk):
         assert oe2 is None
+        clk, out_clk_inv = check_clk_inverted(clk)
         assert_is_signal_or_clocksignal(clk)
         platform     = LiteXContext.platform
         if len(io) == 1:
@@ -348,8 +349,8 @@ class EfinixTrionDDRTristateImpl(LiteXModule):
             "out_reg"        : "DDIO_RESYNC",
             "out_clk_pin"    : clk,
             "oe_reg"         : "REG",
-            "in_clk_inv"     : 0,
-            "out_clk_inv"    : 0,
+            "in_clk_inv"     : out_clk_inv,
+            "out_clk_inv"    : out_clk_inv,
             "drive_strength" : io_prop_dict.get("DRIVE_STRENGTH", "4")
         }
         if i1 is None and i2 is None:
@@ -360,6 +361,7 @@ class EfinixTrionDDRTristateImpl(LiteXModule):
 class EfinixTitaniumDDRTristateImpl(LiteXModule):
     def __init__(self, io, o1, o2, oe1, oe2, i1, i2, clk):
         assert oe2 is None
+        clk, out_clk_inv = check_clk_inverted(clk)
         assert_is_signal_or_clocksignal(clk)
         platform     = LiteXContext.platform
         if len(io) == 1:
@@ -399,8 +401,8 @@ class EfinixTitaniumDDRTristateImpl(LiteXModule):
             "out_reg"        : "DDIO_RESYNC",
             "out_clk_pin"    : clk,
             "oe_reg"         : "REG",
-            "in_clk_inv"     : 0,
-            "out_clk_inv"    : 0,
+            "in_clk_inv"     : out_clk_inv,
+            "out_clk_inv"    : out_clk_inv,
             "drive_strength" : io_prop_dict.get("DRIVE_STRENGTH", "4")
         }
         if i1 is None and i2 is None:
@@ -419,6 +421,7 @@ class EfinixDDRTristate:
 class EfinixDDRResyncTristateImpl(LiteXModule):
     def __init__(self, io, o1, o2, oe1, oe2, i1, i2, clk):
         assert oe2 is None
+        clk, out_clk_inv = check_clk_inverted(clk)
         assert_is_signal_or_clocksignal(clk)
         platform     = LiteXContext.platform
         if len(io) == 1:
@@ -458,8 +461,8 @@ class EfinixDDRResyncTristateImpl(LiteXModule):
             "out_reg"        : "DDIO_RESYNC",
             "out_clk_pin"    : clk,
             "oe_reg"         : "REG",
-            "in_clk_inv"     : 0,
-            "out_clk_inv"    : 0,
+            "in_clk_inv"     : out_clk_inv,
+            "out_clk_inv"    : out_clk_inv,
             "drive_strength" : io_prop_dict.get("DRIVE_STRENGTH", "4")
         }
         if i1 is None and i2 is None:
@@ -476,6 +479,7 @@ class EfinixDDRResyncTristate(DDRTristate):
 
 class EfinixSDRTristateImpl(LiteXModule):
     def __init__(self, io, o, oe, i, clk):
+        clk, out_clk_inv = check_clk_inverted(clk)
         assert_is_signal_or_clocksignal(clk)
         platform     = LiteXContext.platform
         if len(io) == 1:
@@ -513,8 +517,8 @@ class EfinixSDRTristateImpl(LiteXModule):
             "out_clk_pin"    : clk,
             "const_output"   : const_output,
             "oe_reg"         : "REG",
-            "in_clk_inv"     : 0,
-            "out_clk_inv"    : 0,
+            "in_clk_inv"     : out_clk_inv,
+            "out_clk_inv"    : out_clk_inv,
             "drive_strength" : io_prop_dict.get("DRIVE_STRENGTH", "4")
         }
         if i is None:
@@ -532,6 +536,7 @@ class EfinixSDRTristate(LiteXModule):
 
 class EfinixSDROutputImpl(LiteXModule):
     def __init__(self, i, o, clk):
+        clk, out_clk_inv = check_clk_inverted(clk)
         assert_is_signal_or_clocksignal(clk)
         platform     = LiteXContext.platform
         if len(o) == 1:
@@ -559,7 +564,7 @@ class EfinixSDROutputImpl(LiteXModule):
             "out_reg"        : "REG",
             "out_clk_pin"    : clk,
             "const_output"   : const_output,
-            "out_clk_inv"    : 0,
+            "out_clk_inv"    : out_clk_inv,
             "drive_strength" : io_prop_dict.get("DRIVE_STRENGTH", "4")
         }
         platform.toolchain.ifacewriter.blocks.append(block)
@@ -575,6 +580,7 @@ class EfinixSDROutput(LiteXModule):
 
 class EfinixDDROutputImpl(LiteXModule):
     def __init__(self, i1, i2, o, clk):
+        clk, out_clk_inv = check_clk_inverted(clk)
         assert_is_signal_or_clocksignal(clk)
         platform     = LiteXContext.platform
         if len(o) == 1:
@@ -599,7 +605,7 @@ class EfinixDDROutputImpl(LiteXModule):
             "size"              : len(o),
             "out_reg"           : "DDIO_RESYNC",
             "out_clk_pin"       : clk,
-            "out_clk_inv"       : 0,
+            "out_clk_inv"       : out_clk_inv,
             "drive_strength"    : io_prop_dict.get("DRIVE_STRENGTH", "4")
         }
         platform.toolchain.ifacewriter.blocks.append(block)
@@ -614,6 +620,7 @@ class EfinixDDROutput:
 
 class EfinixSDRInputImpl(LiteXModule):
     def __init__(self, i, o, clk):
+        clk, in_clk_inv = check_clk_inverted(clk)
         assert_is_signal_or_clocksignal(clk)
         platform = LiteXContext.platform
         if len(i) == 1:
@@ -635,7 +642,7 @@ class EfinixSDRInputImpl(LiteXModule):
             "size"              : len(i),
             "in_reg"            : "REG",
             "in_clk_pin"        : clk,
-            "in_clk_inv"        : 0
+            "in_clk_inv"        : in_clk_inv,
         }
         platform.toolchain.ifacewriter.blocks.append(block)
         platform.toolchain.excluded_ios.append(platform.get_pin(i))
@@ -718,6 +725,7 @@ class EfinixDDRInput:
 
 class EfinixDDRResyncInputImpl(LiteXModule):
     def __init__(self, i, o1, o2, clk):
+        clk, in_clk_inv = check_clk_inverted(clk)
         assert_is_signal_or_clocksignal(clk)
         platform  = LiteXContext.platform
         if len(i) == 1:
@@ -741,7 +749,7 @@ class EfinixDDRResyncInputImpl(LiteXModule):
             "size"              : len(i),
             "in_reg"            : "DDIO_RESYNC",
             "in_clk_pin"        : clk,
-            "in_clk_inv"        : 0
+            "in_clk_inv"        : in_clk_inv,
         }
         platform.toolchain.ifacewriter.blocks.append(block)
         platform.toolchain.excluded_ios.append(platform.get_pin(i))

--- a/litex/build/efinix/common.py
+++ b/litex/build/efinix/common.py
@@ -306,9 +306,10 @@ class EfinixDifferentialInput:
 # Efinix DDRTristate -------------------------------------------------------------------------------
 
 class EfinixTrionDDRTristateImpl(LiteXModule):
-    def __init__(self, io, o1, o2, oe1, oe2, i1, i2, clk):
+    def __init__(self, io, o1, o2, oe1, oe2, i1, i2, clk, in_clk):
         assert oe2 is None
         clk, out_clk_inv = check_clk_inverted(clk)
+        in_clk, in_clk_inv = check_clk_inverted(in_clk)
         assert_is_signal_or_clocksignal(clk)
         platform     = LiteXContext.platform
         if len(io) == 1:
@@ -345,11 +346,11 @@ class EfinixTrionDDRTristateImpl(LiteXModule):
             "properties"     : io_prop,
             "size"           : len(io),
             "in_reg"         : "DDIO_RESYNC",
-            "in_clk_pin"     : clk,
+            "in_clk_pin"     : in_clk,
             "out_reg"        : "DDIO_RESYNC",
             "out_clk_pin"    : clk,
             "oe_reg"         : "REG",
-            "in_clk_inv"     : out_clk_inv,
+            "in_clk_inv"     : in_clk_inv,
             "out_clk_inv"    : out_clk_inv,
             "drive_strength" : io_prop_dict.get("DRIVE_STRENGTH", "4")
         }
@@ -362,6 +363,7 @@ class EfinixTitaniumDDRTristateImpl(LiteXModule):
     def __init__(self, io, o1, o2, oe1, oe2, i1, i2, clk):
         assert oe2 is None
         clk, out_clk_inv = check_clk_inverted(clk)
+        in_clk, in_clk_inv = check_clk_inverted(in_clk)
         assert_is_signal_or_clocksignal(clk)
         platform     = LiteXContext.platform
         if len(io) == 1:
@@ -401,7 +403,7 @@ class EfinixTitaniumDDRTristateImpl(LiteXModule):
             "out_reg"        : "DDIO_RESYNC",
             "out_clk_pin"    : clk,
             "oe_reg"         : "REG",
-            "in_clk_inv"     : out_clk_inv,
+            "in_clk_inv"     : in_clk_inv,
             "out_clk_inv"    : out_clk_inv,
             "drive_strength" : io_prop_dict.get("DRIVE_STRENGTH", "4")
         }
@@ -414,14 +416,15 @@ class EfinixDDRTristate:
     @staticmethod
     def lower(dr):
         if LiteXContext.platform.family == "Trion":
-            return EfinixTrionDDRTristateImpl(dr.io, dr.o1, dr.o2, dr.oe1, dr.oe2, dr.i1, dr.i2, dr.clk)
+            return EfinixTrionDDRTristateImpl(dr.io, dr.o1, dr.o2, dr.oe1, dr.oe2, dr.i1, dr.i2, dr.clk, dr.in_clk)
         else:
-            return EfinixTitaniumDDRTristateImpl(dr.io, dr.o1, dr.o2, dr.oe1, dr.oe2, dr.i1, dr.i2, dr.clk)
+            return EfinixTitaniumDDRTristateImpl(dr.io, dr.o1, dr.o2, dr.oe1, dr.oe2, dr.i1, dr.i2, dr.clk, dr.in_clk)
 
 class EfinixDDRResyncTristateImpl(LiteXModule):
     def __init__(self, io, o1, o2, oe1, oe2, i1, i2, clk):
         assert oe2 is None
         clk, out_clk_inv = check_clk_inverted(clk)
+        in_clk, in_clk_inv = check_clk_inverted(in_clk)
         assert_is_signal_or_clocksignal(clk)
         platform     = LiteXContext.platform
         if len(io) == 1:
@@ -461,7 +464,7 @@ class EfinixDDRResyncTristateImpl(LiteXModule):
             "out_reg"        : "DDIO_RESYNC",
             "out_clk_pin"    : clk,
             "oe_reg"         : "REG",
-            "in_clk_inv"     : out_clk_inv,
+            "in_clk_inv"     : in_clk_inv,
             "out_clk_inv"    : out_clk_inv,
             "drive_strength" : io_prop_dict.get("DRIVE_STRENGTH", "4")
         }
@@ -473,13 +476,14 @@ class EfinixDDRResyncTristateImpl(LiteXModule):
 class EfinixDDRResyncTristate(DDRTristate):
     @staticmethod
     def lower(dr):
-        return EfinixDDRResyncTristateImpl(dr.io, dr.o1, dr.o2, dr.oe1, dr.oe2, dr.i1, dr.i2, dr.clk)
+        return EfinixDDRResyncTristateImpl(dr.io, dr.o1, dr.o2, dr.oe1, dr.oe2, dr.i1, dr.i2, dr.clk, dr.in_clk)
 
 # Efinix SDRTristate -------------------------------------------------------------------------------
 
 class EfinixSDRTristateImpl(LiteXModule):
-    def __init__(self, io, o, oe, i, clk):
+    def __init__(self, io, o, oe, i, clk, in_clk):
         clk, out_clk_inv = check_clk_inverted(clk)
+        in_clk, in_clk_inv = check_clk_inverted(in_clk)
         assert_is_signal_or_clocksignal(clk)
         platform     = LiteXContext.platform
         if len(io) == 1:
@@ -512,12 +516,12 @@ class EfinixSDRTristateImpl(LiteXModule):
             "properties"     : io_prop,
             "size"           : len(io),
             "in_reg"         : "REG",
-            "in_clk_pin"     : clk,
+            "in_clk_pin"     : in_clk,
             "out_reg"        : "REG",
             "out_clk_pin"    : clk,
             "const_output"   : const_output,
             "oe_reg"         : "REG",
-            "in_clk_inv"     : out_clk_inv,
+            "in_clk_inv"     : in_clk_inv,
             "out_clk_inv"    : out_clk_inv,
             "drive_strength" : io_prop_dict.get("DRIVE_STRENGTH", "4")
         }
@@ -530,7 +534,7 @@ class EfinixSDRTristateImpl(LiteXModule):
 class EfinixSDRTristate(LiteXModule):
     @staticmethod
     def lower(dr):
-        return EfinixSDRTristateImpl(dr.io, dr.o, dr.oe, dr.i, dr.clk)
+        return EfinixSDRTristateImpl(dr.io, dr.o, dr.oe, dr.i, dr.clk, dr.in_clk)
 
 # Efinix SDROutput ---------------------------------------------------------------------------------
 

--- a/litex/build/efinix/ifacewriter.py
+++ b/litex/build/efinix/ifacewriter.py
@@ -250,6 +250,8 @@ design.create("{2}", "{3}", "./../gateware", overwrite=True)
             cmd += 'design.create_clockout_gpio("{}")\n'.format(name)
             cmd += 'design.set_property("{}","OUT_CLK_PIN","{}")\n'.format(name, name)
             cmd += 'design.assign_pkg_pin("{}","{}")\n\n'.format(name, block["location"])
+            if "out_clk_inv" in block:
+                cmd += f'design.set_property("{name}","IS_OUTCLK_INVERTED","{block["out_clk_inv"]}")\n'
             if prop:
                 for p, val in prop:
                     cmd += 'design.set_property("{}","{}","{}")\n'.format(name, p, val)

--- a/litex/build/gowin/common.py
+++ b/litex/build/gowin/common.py
@@ -169,7 +169,7 @@ class Gw5ASDRInput:
 # Gw5A SDRTristate ---------------------------------------------------------------------------------
 
 class Gw5ASDRTristateImpl(Module):
-    def __init__(self, io, o, oe, i, clk):
+    def __init__(self, io, o, oe, i, clk, in_clk):
         _o    = Signal().like(o)
         _oe_n = Signal().like(oe)
         _i    = Signal().like(i if i is not None else o)
@@ -178,7 +178,7 @@ class Gw5ASDRTristateImpl(Module):
             SDROutput(~oe, _oe_n, clk),
         ]
         if i is not None:
-            self.specials += SDRInput(i, _i, clk)
+            self.specials += SDRInput(i, _i, in_clk)
         for j in range(len(io)):
             self.specials += Instance("IOBUF",
                     io_IO = io[j],
@@ -191,7 +191,7 @@ class Gw5ASDRTristateImpl(Module):
 class Gw5ASDRTristate:
     @staticmethod
     def lower(dr):
-        return Gw5ASDRTristateImpl(dr.io, dr.o, dr.oe, dr.i, dr.clk)
+        return Gw5ASDRTristateImpl(dr.io, dr.o, dr.oe, dr.i, dr.clk, dr.in_clk)
 
 # Gw5A Special Overrides ---------------------------------------------------------------------------
 

--- a/litex/build/lattice/common.py
+++ b/litex/build/lattice/common.py
@@ -336,7 +336,7 @@ class LatticeNXDDROutput:
 # NX DDR Tristate ----------------------------------------------------------------------------------
 
 class LatticeNXDDRTristateImpl(Module):
-    def __init__(self, io, o1, o2, oe1, oe2, i1, i2, clk):
+    def __init__(self, io, o1, o2, oe1, oe2, i1, i2, clk, in_clk):
         assert oe2 is None
         _o  = Signal().like(o1)
         _oe = Signal().like(oe1)
@@ -344,14 +344,14 @@ class LatticeNXDDRTristateImpl(Module):
         self.specials += DDROutput(o1, o2, _o, clk)
         self.specials += SDROutput(oe1, _oe, clk)
         if _i is not None:
-            self.specials += DDRInput(_i, i1, i2, clk)
+            self.specials += DDRInput(_i, i1, i2, in_clk)
         self.specials += Tristate(io, _o, _oe, _i)
         _oe.attr.add("syn_useioff")
 
 class LatticeNXDDRTristate:
     @staticmethod
     def lower(dr):
-        return LatticeNXDDRTristateImpl(dr.io, dr.o1, dr.o2, dr.oe1, dr.oe2, dr.i1, dr.i2, dr.clk)
+        return LatticeNXDDRTristateImpl(dr.io, dr.o1, dr.o2, dr.oe1, dr.oe2, dr.i1, dr.i2, dr.clk, dr.in_clk)
 
 # NX Special Overrides -----------------------------------------------------------------------------
 
@@ -540,14 +540,14 @@ class LatticeiCE40SDRInput:
 # iCE40 SDR Tristate -------------------------------------------------------------------------------
 
 class LatticeiCE40SDRTristateImpl(Module):
-    def __init__(self, io, o, oe, i, clk):
+    def __init__(self, io, o, oe, i, clk, in_clk):
         if i is None:
             i = Signal().like(o)
         for j in range(len(io)):
             self.specials += Instance("SB_IO",
                 p_PIN_TYPE      = C(0b110100, 6), # PIN_OUTPUT_REGISTERED_ENABLE_REGISTERED + PIN_INPUT_REGISTERED
                 io_PACKAGE_PIN  = io[j],
-                i_INPUT_CLK     = clk,
+                i_INPUT_CLK     = in_clk,
                 i_OUTPUT_CLK    = clk,
                 i_OUTPUT_ENABLE = oe[j],
                 i_D_OUT_0       = o[j] ,
@@ -557,7 +557,7 @@ class LatticeiCE40SDRTristateImpl(Module):
 class LatticeiCE40SDRTristate(Module):
     @staticmethod
     def lower(dr):
-        return LatticeiCE40SDRTristateImpl(dr.io, dr.o, dr.oe, dr.i, dr.clk)
+        return LatticeiCE40SDRTristateImpl(dr.io, dr.o, dr.oe, dr.i, dr.clk, dr.in_clk)
 
 # iCE40 Trellis Special Overrides ------------------------------------------------------------------
 

--- a/litex/build/xilinx/common.py
+++ b/litex/build/xilinx/common.py
@@ -137,14 +137,14 @@ class XilinxDifferentialOutput:
 # Common SDRTristate -------------------------------------------------------------------------------
 
 class XilinxSDRTristateImpl(Module):
-    def __init__(self, io, o, oe, i, clk):
+    def __init__(self, io, o, oe, i, clk, in_clk):
         _o    = Signal().like(o)
         _oe_n = Signal().like(oe)
         _i    = Signal().like(i if i is not None else o)
         self.specials += SDROutput(o, _o, clk)
         self.specials += SDROutput(~oe, _oe_n, clk)
         if i is not None:
-            self.specials += SDRInput(_i, i, clk)
+            self.specials += SDRInput(_i, i, in_clk)
         for j in range(len(io)):
             self.specials += Instance("IOBUF",
                 io_IO = io[j],
@@ -156,19 +156,19 @@ class XilinxSDRTristateImpl(Module):
 class XilinxSDRTristate:
     @staticmethod
     def lower(dr):
-        return XilinxSDRTristateImpl(dr.io, dr.o, dr.oe, dr.i, dr.clk)
+        return XilinxSDRTristateImpl(dr.io, dr.o, dr.oe, dr.i, dr.clk, dr.in_clk)
 
 # Common DDRTristate -------------------------------------------------------------------------------
 
 class XilinxDDRTristateImpl(Module):
-    def __init__(self, io, o1, o2, oe1, oe2, i1, i2, clk, i_async):
+    def __init__(self, io, o1, o2, oe1, oe2, i1, i2, clk, in_clk, i_async):
         _o    = Signal().like(o1)
         _oe_n = Signal().like(oe1)
         _i    = Signal().like(_o)
         self.specials += DDROutput(o1, o2, _o, clk)
         self.specials += DDROutput(~oe1, ~oe2, _oe_n, clk) if oe2 is not None else SDROutput(~oe1, _oe_n, clk)
         if i1 is not None and i2 is not None:
-            self.specials += DDRInput(_i, i1, i2, clk)
+            self.specials += DDRInput(_i, i1, i2, in_clk)
         for j in range(len(io)):
             self.specials += Instance("IOBUF",
                 io_IO = io[j],
@@ -182,7 +182,8 @@ class XilinxDDRTristateImpl(Module):
 class XilinxDDRTristate:
     @staticmethod
     def lower(dr):
-        return XilinxDDRTristateImpl(dr.io, dr.o1, dr.o2, dr.oe1, dr.oe2, dr.i1, dr.i2, dr.clk, dr.i_async)
+        return XilinxDDRTristateImpl(dr.io, dr.o1, dr.o2, dr.oe1, dr.oe2, dr.i1, dr.i2, dr.clk, dr.in_clk, dr.i_async)
+
 
 # Common Special Overrides -------------------------------------------------------------------------
 


### PR DESCRIPTION
efinix:
- allow clk output inverting
- allow clk inverting on registered gpios

all:
- allow a different clock for input on SDR and DDR Tristates