### PR TITLE
build: efinix: use ifacewriter to set bank voltage

### DIFF
--- a/litex/build/efinix/efinity.py
+++ b/litex/build/efinix/efinity.py
@@ -252,13 +252,14 @@ class EfinityToolchain(GenericToolchain):
         self.resolve_iface_signal_names()
 
         header = self.ifacewriter.header(self._build_name, self.platform.device)
+        iobank = self.ifacewriter.iobank_info(self.platform.iobank_info)
         gen    = self.ifacewriter.generate(self.platform.device)
         #TODO  : move this to ifacewriter
         gpio   = self._build_iface_gpio()
         add    = "\n".join(self.additional_iface_commands)
         footer = self.ifacewriter.footer()
 
-        tools.write_to_file("iface.py", header + gen + gpio + add + footer)
+        tools.write_to_file("iface.py", header + iobank + gen + gpio + add + footer)
 
     # Project configuration (.xml) -----------------------------------------------------------------
 
@@ -325,8 +326,7 @@ class EfinityToolchain(GenericToolchain):
 
         # Some IO blocks don't have Python API so we need to configure them
         # directly in the peri.xml file
-        # We also need to configure the bank voltage here
-        if self.ifacewriter.xml_blocks or self.platform.iobank_info:
+        if self.ifacewriter.xml_blocks:
             self.ifacewriter.generate_xml_blocks()
 
         # Because the Python API is sometimes bugged, we need to tweak the generated xml

--- a/litex/build/efinix/ifacewriter.py
+++ b/litex/build/efinix/ifacewriter.py
@@ -77,9 +77,6 @@ class InterfaceWriter:
                 if block["type"] == "DRAM":
                     self.add_dram_xml(root, block)
 
-        if self.platform.iobank_info:
-            self.add_iobank_info_xml(root, self.platform.iobank_info)
-
         xml_string = et.tostring(root, "utf-8")
         reparsed = expatbuilder.parseString(xml_string, False)
         print_string = reparsed.toprettyxml(indent="    ")
@@ -118,6 +115,13 @@ design.create("{2}", "{3}", "./../gateware", overwrite=True)
 
 """
         return header.format(self.efinity_path, "True", build_name, partnumber)
+
+    def iobank_info(self, iobank_info):
+        cmd = "# ---------- IOBANK INFO ---------\n"
+        for name, iostd in iobank_info:
+            cmd += 'design.set_iobank_voltage("{0}", "{1}")\n'.format(name, iostd[:3])
+        cmd += "# ---------- END IOBANK INFO ---------\n\n"
+        return cmd
 
     def get_block(self, name):
         for b in self.blocks:
@@ -681,12 +685,3 @@ design.create("{2}", "{3}", "./../gateware", overwrite=True)
 design.generate(enable_bitstream=True)
 # Save the configured periphery design
 design.save()"""
-
-
-    def add_iobank_info_xml(self, root, iobank_info):
-        dev = root.find("efxpt:device_info", namespaces)
-        bank_info = dev.find("efxpt:iobank_info", namespaces)
-        for name, iostd in iobank_info:
-            for child in bank_info:
-                    if name == child.get("name"):
-                        child.set("iostd", iostd)


### PR DESCRIPTION
use efinix python api to set bank voltage,
instead of editing the peri.xml file.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>