### PR TITLE
Fixes #2092: provides support for riscv gcc installation on Alpine Linux.

### DIFF
--- a/litex_setup.py
+++ b/litex_setup.py
@@ -349,6 +349,9 @@ def riscv_gcc_install():
         # Arch.
         elif "arch" in os_release:
             os.system("pacman -S riscv64-linux-gnu-gcc")
+        # Alpine.
+        elif "alpine" in os_release:
+            os.system("apk add gcc-cross-embedded")
         # Ubuntu.
         else:
             os.system("apt install gcc-riscv64-unknown-elf")
@@ -377,6 +380,9 @@ def powerpc_gcc_install():
         # Arch (AUR repository).
         elif "arch" in os_release:
             os.system("yay -S powerpc64le-linux-gnu-gcc")
+        # Alpine.
+        elif "alpine" in os_release:
+            os.system("apk add gcc binutils-ppc64le")
         # Ubuntu.
         else:
             os.system("apt install gcc-powerpc64le-linux-gnu binutils-multiarch")
@@ -400,6 +406,9 @@ def openrisc_gcc_install():
         # Arch.
         elif "arch" in os_release:
             os.system("pacman -S or1k-elf-gcc")
+        # Alpine.
+        elif "alpine" in os_release:
+            os.system("apk add gcc-cross-embedded")
         # Ubuntu.
         else:
             os.system("apt install gcc-or1k-elf")


### PR DESCRIPTION
This PR adds support for installing RISC-V GCC in Alpine Linux environments, which is useful for creating Docker development containers based on Alpine images.

**WARNING**: To test the fix, you must run the command **litex_setup.py** with the _--dev_ option to prevent the script from auto-updating (the checksum is validated against the main branch of the original repository):

`./litex_setup.py --gcc=riscv --dev`