### PR TITLE
efinix: gpio: use constant output option

### DIFF
--- a/litex/build/efinix/ifacewriter.py
+++ b/litex/build/efinix/ifacewriter.py
@@ -169,37 +169,8 @@ design.create("{2}", "{3}", "./../gateware", overwrite=True)
                 for i, pad in enumerate(block["location"]):
                     cmd += f'design.assign_pkg_pin("{name}[{i}]","{pad}")\n'
 
-            if "out_reg" in block:
-                cmd += f'design.set_property("{name}","OUT_REG","{block["out_reg"]}")\n'
-                cmd += f'design.set_property("{name}","OUT_CLK_PIN","{block["out_clk_pin"]}")\n'
-                if "out_delay" in block:
-                    cmd += f'design.set_property("{name}","OUTDELAY","{block["out_delay"]}")\n'
-
-            if "out_clk_inv" in block:
-                cmd += f'design.set_property("{name}","IS_OUTCLK_INVERTED","{block["out_clk_inv"]}")\n'
-
-            if "in_reg" in block:
-                cmd += f'design.set_property("{name}","IN_REG","{block["in_reg"]}")\n'
-                cmd += f'design.set_property("{name}","IN_CLK_PIN","{block["in_clk_pin"]}")\n'
-                if "in_delay" in block:
-                    cmd += f'design.set_property("{name}","INDELAY","{block["in_delay"]}")\n'
-
-            if "in_clk_inv" in block:
-                cmd += f'design.set_property("{name}","IS_INCLK_INVERTED","{block["in_clk_inv"]}")\n'
-
             if "oe_reg" in block:
                 cmd += f'design.set_property("{name}","OE_REG","{block["oe_reg"]}")\n'
-
-            if "drive_strength" in block:
-                cmd += 'design.set_property("{}","DRIVE_STRENGTH","{}")\n'.format(name, block["drive_strength"])
-            if "slewrate" in block:
-                cmd += 'design.set_property("{}","SLEWRATE","{}")\n'.format(name, block["slewrate"])
-
-            if prop:
-                for p, val in prop:
-                    cmd += 'design.set_property("{}","{}","{}")\n'.format(name, p, val)
-            cmd += "\n"
-            return cmd
 
         if mode == "INPUT":
             if len(block["location"]) == 1:
@@ -209,6 +180,8 @@ design.create("{2}", "{3}", "./../gateware", overwrite=True)
                 cmd += f'design.create_input_gpio("{name}",{block["size"]-1},0)\n'
                 for i, pad in enumerate(block["location"]):
                     cmd += f'design.assign_pkg_pin("{name}[{i}]","{pad}")\n'
+        
+        if mode == "INPUT" or mode == "INOUT":
             if "in_reg" in block:
                 in_clk_pin = block["in_clk_pin"]
                 if isinstance(in_clk_pin, ClockSignal):
@@ -225,11 +198,6 @@ design.create("{2}", "{3}", "./../gateware", overwrite=True)
                     cmd += f'design.set_property("{name}","INDELAY","{block["in_delay"]}")\n'
             if "in_clk_inv" in block:
                 cmd += f'design.set_property("{name}","IS_INCLK_INVERTED","{block["in_clk_inv"]}")\n'
-            if prop:
-                for p, val in prop:
-                    cmd += 'design.set_property("{}","{}","{}")\n'.format(name, p, val)
-            cmd += "\n"
-            return cmd
 
         if mode == "OUTPUT":
             if len(block["location"]) == 1:
@@ -240,6 +208,7 @@ design.create("{2}", "{3}", "./../gateware", overwrite=True)
                 for i, pad in enumerate(block["location"]):
                     cmd += 'design.assign_pkg_pin("{}[{}]","{}")\n'.format(name, i, pad)
 
+        if mode == "OUTPUT" or mode == "INOUT":
             if "out_reg" in block:
                 cmd += 'design.set_property("{}","OUT_REG","{}")\n'.format(name, block["out_reg"])
                 cmd += 'design.set_property("{}","OUT_CLK_PIN","{}")\n'.format(name, block["out_clk_pin"])
@@ -254,6 +223,7 @@ design.create("{2}", "{3}", "./../gateware", overwrite=True)
             if "slewrate" in block:
                 cmd += 'design.set_property("{}","SLEWRATE","{}")\n'.format(name, block["slewrate"])
 
+        if mode == "INOUT" or mode == "INPUT" or mode == "OUTPUT":
             if prop:
                 for p, val in prop:
                     cmd += 'design.set_property("{}","{}","{}")\n'.format(name, p, val)

--- a/litex/build/efinix/ifacewriter.py
+++ b/litex/build/efinix/ifacewriter.py
@@ -204,7 +204,7 @@ design.create("{2}", "{3}", "./../gateware", overwrite=True)
                 cmd += 'design.create_output_gpio("{}")\n'.format(name)
                 cmd += 'design.assign_pkg_pin("{}","{}")\n'.format(name, block["location"][0])
             else:
-                cmd += 'design.create_input_gpio("{}",{},0)\n'.format(name, block["size"]-1)
+                cmd += 'design.create_output_gpio("{}",{},0)\n'.format(name, block["size"]-1)
                 for i, pad in enumerate(block["location"]):
                     cmd += 'design.assign_pkg_pin("{}[{}]","{}")\n'.format(name, i, pad)
 

--- a/litex/build/efinix/ifacewriter.py
+++ b/litex/build/efinix/ifacewriter.py
@@ -222,6 +222,12 @@ design.create("{2}", "{3}", "./../gateware", overwrite=True)
                 cmd += 'design.set_property("{}","DRIVE_STRENGTH","{}")\n'.format(name, block["drive_strength"])
             if "slewrate" in block:
                 cmd += 'design.set_property("{}","SLEWRATE","{}")\n'.format(name, block["slewrate"])
+            if "const_output" in block:
+                if not isinstance(block["const_output"], list):
+                    cmd += f'design.set_property("{name}","CONST_OUTPUT","{block["const_output"]}")\n'
+                else:
+                    for i, val in enumerate(block["const_output"]):
+                        cmd += f'design.set_property("{name}[{i}]","CONST_OUTPUT","{val}")\n'
 
         if mode == "INOUT" or mode == "INPUT" or mode == "OUTPUT":
             if prop:

--- a/litex/build/io.py
+++ b/litex/build/io.py
@@ -120,13 +120,13 @@ class InferedSDRTristate(Module):
 
 class SDRTristate(Special):
     def __init__(self, io, o, oe, i, clk=None):
-        assert len(i) == len(o) == len(oe)
         Special.__init__(self)
         self.io  = wrap(io)
         self.o   = wrap(o)
         self.oe  = wrap(oe)
         self.i   = wrap(i)
         self.clk = wrap(clk) if clk is not None else ClockSignal()
+        assert len(self.i) == len(self.o) == len(self.oe)
 
     def iter_expressions(self):
         yield self, "io" , SPECIAL_INOUT


### PR DESCRIPTION
use constant output option, when the output is a `Constant`

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>