### PR TITLE
Optimize Build, Enhance Clock Control, and add FTDI serial number option to openfpgaloader

### DIFF
--- a/litex/build/openfpgaloader.py
+++ b/litex/build/openfpgaloader.py
@@ -12,7 +12,7 @@ from litex.build.generic_programmer import GenericProgrammer
 class OpenFPGALoader(GenericProgrammer):
     needs_bitreverse = False
 
-    def __init__(self, board="", cable="", freq=0, fpga_part="", index_chain=None):
+    def __init__(self, board="", cable="", freq=0, fpga_part="", index_chain=None, ftdi_serial=None):
         # openFPGALoader base command.
         self.cmd = ["openFPGALoader"]
 
@@ -35,6 +35,9 @@ class OpenFPGALoader(GenericProgrammer):
         # Specify index in the JTAG chain.
         if index_chain is not None:
             self.cmd += ["--index-chain", str(int(index_chain))]
+            
+        if ftdi_serial is not None:
+            self.cmd += ["--ftdi-serial", str(ftdi_serial)]
 
     def load_bitstream(self, bitstream_file):
         # Load base command.

--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -316,8 +316,9 @@ class Builder:
             _create_dir(os.path.join(self.software_dir, name))
 
     def _generate_rom_software(self, compile_bios=True):
+        cpu_count = os.cpu_count()
         # Compile all software packages.
-         for name, src_dir in self.software_packages:
+        for name, src_dir in self.software_packages:
 
             # Skip BIOS compilation when disabled.
             if name == "bios" and not compile_bios:
@@ -326,7 +327,7 @@ class Builder:
             dst_dir  = os.path.join(self.software_dir, name)
             makefile = os.path.join(src_dir, "Makefile")
             if self.compile_software:
-                subprocess.check_call(["make", "-C", dst_dir, "-f", makefile])
+                subprocess.check_call(["make", f"-j{cpu_count}", "-C", dst_dir, "-f", makefile])
 
     def _initialize_rom_software(self):
         # Get BIOS data from compiled BIOS binary.

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "packaging",
         "pyserial",
         "requests",
+        "numpy",
     ],
     extras_require                = {
         "develop": [


### PR DESCRIPTION
# Minor Improvements

## Changes

- Enhance build performance by utilizing all available CPU cores in the builder.
- Switch to using `MMCME4_ADV` in `USPMMCM` to enable finer-grained clock output control.
- Add FTDI serial number option to `openfpgaloader`, useful when multiple similar boards are connected for CI/CD

## Testing

Tested with:
- ECPIX5
- ButterStick
- Xem8320


---

Thank you for reviewing this PR!