### PR TITLE
litex/build/lattice/diamond, platform: allows users to add custom sdc files

### DIFF
--- a/litex/build/lattice/diamond.py
+++ b/litex/build/lattice/diamond.py
@@ -121,6 +121,10 @@ class LatticeDiamondToolchain(GenericToolchain):
         for filename in self.platform.ips:
             tcl.append("prj_src add \"{}\" -work {}".format(tcl_path(filename), library))
 
+        # Add SDCs
+        for filename in self.platform.sdcs:
+            tcl.append("prj_src add \"{}\" -format SDC".format(tcl_path(filename)))
+
         # Add Strategy
         for filename, strategy_name in self.platform.strategy:
             tcl.append("prj_strgy import -name {} -file {}".format(strategy_name, tcl_path(filename)))

--- a/litex/build/lattice/platform.py
+++ b/litex/build/lattice/platform.py
@@ -24,6 +24,7 @@ class LatticePlatform(GenericPlatform):
     def __init__(self, *args, toolchain="diamond", **kwargs):
         GenericPlatform.__init__(self, *args, **kwargs)
         self.ips      = set()
+        self.sdcs     = set()
         self.strategy = set()
         if toolchain == "diamond":
             self.toolchain = diamond.LatticeDiamondToolchain()
@@ -41,6 +42,9 @@ class LatticePlatform(GenericPlatform):
 
     def add_ip(self, filename):
         self.ips.add((os.path.abspath(filename)))
+
+    def add_sdc(self, filename):
+        self.sdcs.add((os.path.abspath(filename)))
 
     def add_strategy(self, filename, strategy_name):
         self.strategy.add((os.path.abspath(filename), strategy_name))


### PR DESCRIPTION
With the current diamond support all timings constraints are written into .lpf
This mean it's no possible to assign constraints to internal OSC or PLL outputs.

As a Workaround this PR allows users to provides one or more sdc files to integrate to the project.

Future work is to integrate sdc generation as done for radiant.