### PR TITLE
Add FTDI serial number option to openfpgaloader

### DIFF
--- a/litex/build/openfpgaloader.py
+++ b/litex/build/openfpgaloader.py
@@ -12,7 +12,7 @@ from litex.build.generic_programmer import GenericProgrammer
 class OpenFPGALoader(GenericProgrammer):
     needs_bitreverse = False
 
-    def __init__(self, board="", cable="", freq=0, fpga_part="", index_chain=None):
+    def __init__(self, board="", cable="", freq=0, fpga_part="", index_chain=None, ftdi_serial=None):
         # openFPGALoader base command.
         self.cmd = ["openFPGALoader"]
 
@@ -35,6 +35,9 @@ class OpenFPGALoader(GenericProgrammer):
         # Specify index in the JTAG chain.
         if index_chain is not None:
             self.cmd += ["--index-chain", str(int(index_chain))]
+
+        if ftdi_serial is not None:
+            self.cmd += ["--ftdi-serial", str(ftdi_serial)]
 
     def load_bitstream(self, bitstream_file):
         # Load base command.


### PR DESCRIPTION
Split PR https://github.com/enjoy-digital/litex/pull/2111 into 3 parts as requested in https://github.com/enjoy-digital/litex/pull/2111#issuecomment-2454519454

Part 2/3: Add FTDI serial number option to openfpgaloader, useful when multiple similar boards are connected for CI/CD