### PR TITLE
Fixes: Fix not close trace file when the sim is finished

### DIFF
--- a/litex/build/sim/core/veril.cpp
+++ b/litex/build/sim/core/veril.cpp
@@ -78,7 +78,11 @@ extern "C" void litex_sim_tracer_dump()
 
 extern "C" int litex_sim_got_finish()
 {
+  int finished;
   tfp->flush();
+  if(finished = Verilated::gotFinish()) {
+    tfp->close();
+  }
   return Verilated::gotFinish();
 }
 


### PR DESCRIPTION
## Description
During my testing of LiteX simulations using Verilator, I discovered that when the BIOS executes the `finish` command to properly terminate the simulation, the FST files were not being closed correctly. This resulted in `sim.fst` and `sim.fst.hier` not being merged properly.

## Changes
- Fixed the logic to ensure FST files are correctly closed when the `finish` command is executed.

## Testing
- Verified that after executing the `finish` command, the FST files close correctly and the waveform files merge as expected.

## Additional Information
Thank you to the authors for designing such an excellent project with LiteX! I hope this fix can be accepted upstream.
