### PR TITLE
feat: add uart_with_dynamic_baudrate to SoCCore

### DIFF
--- a/litex/soc/cores/uart.py
+++ b/litex/soc/cores/uart.py
@@ -202,14 +202,14 @@ def _get_uart_fifo(depth, sink_cd="sys", source_cd="sys"):
     else:
         return stream.SyncFIFO([("data", 8)], depth, buffered=True)
 
-def UARTPHY(pads, clk_freq, baudrate):
+def UARTPHY(pads, clk_freq, baudrate, with_dynamic_baudrate=False):
     # FT245 Asynchronous FIFO mode (baudrate ignored)
     if hasattr(pads, "rd_n") and hasattr(pads, "wr_n"):
         from litex.soc.cores.usb_fifo import FT245PHYAsynchronous
         return FT245PHYAsynchronous(pads, clk_freq)
     # RS232
     else:
-        return  RS232PHY(pads, clk_freq, baudrate)
+        return  RS232PHY(pads, clk_freq, baudrate, with_dynamic_baudrate=with_dynamic_baudrate)
 
 class UART(LiteXModule, UARTInterface):
     def __init__(self, phy=None,

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1511,7 +1511,7 @@ class LiteXSoC(SoC):
         self.add_config(name, identifier)
 
     # Add UART -------------------------------------------------------------------------------------
-    def add_uart(self, name="uart", uart_name="serial", uart_pads=None, baudrate=115200, fifo_depth=16):
+    def add_uart(self, name="uart", uart_name="serial", uart_pads=None, baudrate=115200, fifo_depth=16, with_dynamic_baudrate=False):
         # Imports.
         from litex.soc.cores.uart import UART, UARTCrossover
 
@@ -1550,7 +1550,7 @@ class LiteXSoC(SoC):
 
         # Crossover + UARTBone.
         elif uart_name in ["crossover+uartbone"]:
-            self.add_uartbone(baudrate=baudrate)
+            self.add_uartbone(baudrate=baudrate, with_dynamic_baudrate=with_dynamic_baudrate)
             uart = UARTCrossover(**uart_kwargs)
 
         # JTAG UART.
@@ -1588,7 +1588,7 @@ class LiteXSoC(SoC):
         # Regular UART.
         else:
             from litex.soc.cores.uart import UARTPHY
-            uart_phy  = UARTPHY(uart_pads, clk_freq=self.sys_clk_freq, baudrate=baudrate)
+            uart_phy  = UARTPHY(uart_pads, clk_freq=self.sys_clk_freq, baudrate=baudrate, with_dynamic_baudrate=with_dynamic_baudrate)
             uart      = UART(uart_phy, **uart_kwargs)
 
         # Add PHY/UART.
@@ -1604,7 +1604,7 @@ class LiteXSoC(SoC):
             self.add_constant("UART_POLLING", check_duplicate=False)
 
     # Add UARTbone ---------------------------------------------------------------------------------
-    def add_uartbone(self, name="uartbone", uart_name="serial", clk_freq=None, baudrate=115200, cd="sys"):
+    def add_uartbone(self, name="uartbone", uart_name="serial", clk_freq=None, baudrate=115200, cd="sys", with_dynamic_baudrate=False):
         # Imports.
         from litex.soc.cores import uart
 
@@ -1612,7 +1612,7 @@ class LiteXSoC(SoC):
         if clk_freq is None:
             clk_freq = self.sys_clk_freq
         self.check_if_exists(name)
-        uartbone_phy = uart.UARTPHY(self.platform.request(uart_name), clk_freq, baudrate)
+        uartbone_phy = uart.UARTPHY(self.platform.request(uart_name), clk_freq, baudrate, with_dynamic_baudrate=with_dynamic_baudrate)
         uartbone     = uart.UARTBone(
             phy           = uartbone_phy,
             clk_freq      = clk_freq,

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -100,6 +100,7 @@ class SoCCore(LiteXSoC):
         uart_name                = "serial",
         uart_baudrate            = 115200,
         uart_fifo_depth          = 16,
+        uart_with_dynamic_baudrate = False,
 
         # Timer parameters.
         with_timer               = True,
@@ -255,11 +256,11 @@ class SoCCore(LiteXSoC):
 
         # Add UARTBone.
         if with_uartbone:
-            self.add_uartbone(baudrate=uart_baudrate)
+            self.add_uartbone(baudrate=uart_baudrate, fifo_depth=uart_fifo_depth, with_dynamic_baudrate=with_dynamic_baudrate)
 
         # Add UART.
         if with_uart:
-            self.add_uart(name="uart", uart_name=uart_name, baudrate=uart_baudrate, fifo_depth=uart_fifo_depth)
+            self.add_uart(name="uart", uart_name=uart_name, baudrate=uart_baudrate, fifo_depth=uart_fifo_depth, with_dynamic_baudrate=uart_with_dynamic_baudrate)
 
         # Add JTAGBone.
         if with_jtagbone:


### PR DESCRIPTION
In our application, we would like our default UART to have a configurable baud rate based on other system parameters.  Sample code to drive this:

```c
static uint32_t current_uart_baudrate = 921600;

static struct tuning {
    uint32_t baudrate;
    uint32_t tuning;
} predefined_tunings[] = {
    { 1500000, 85899346 },
    { 921600, 52776558 },
    { 115200, 6597070 }
};

static void update_uart_baudrate(uint32_t desired_baudrate) {
    uint32_t new_tuning = 0;
    for (int i = 0; i < sizeof(predefined_tunings) / sizeof(predefined_tunings[0]); i++) {
        if (predefined_tunings[i].baudrate == desired_baudrate) {
            new_tuning = predefined_tunings[i].tuning;
        }
    }

    if (new_tuning == 0) {
        uint64_t new_baudrate = (uint64_t)desired_baudrate << 32;
        new_tuning = new_baudrate / 75000000l;
    }
    if (new_tuning) {
        uartbone_phy_tuning_word_write(new_tuning);
        current_uart_baudrate = desired_baudrate;
    }
}

static void baud_cmd(char *arg)
{
    int baud = atoi(arg);
    update_uart_baudrate(baud);
    printf("baud rate is now %d\n", baud);
}
DEFINE_COMMAND(baud_cmd, "baud", "set UART baud rate");
```

cc: @jameyhicks
