### PR TITLE
liblitespi: add 4k erase function

### DIFF
--- a/litex/soc/software/liblitespi/spiflash.c
+++ b/litex/soc/software/liblitespi/spiflash.c
@@ -238,6 +238,15 @@ void spiflash_erase_range(uint32_t addr, uint32_t len)
 	}
 }
 
+void spiflash_erase_4k_sector(uint32_t addr)
+{
+	w_buf[0] = 0x20;
+	w_buf[1] = addr>>16;
+	w_buf[2] = addr>>8;
+	w_buf[3] = addr>>0;
+	transfer_cmd(w_buf, r_buf, 4);
+}
+
 int spiflash_write_stream(uint32_t addr, uint8_t *stream, uint32_t len)
 {
 	int res = 0;

--- a/litex/soc/software/liblitespi/spiflash.h
+++ b/litex/soc/software/liblitespi/spiflash.h
@@ -14,6 +14,7 @@ void spiflash_memspeed(void);
 void spiflash_init(void);
 int spiflash_write_stream(uint32_t addr, uint8_t *stream, uint32_t len);
 void spiflash_erase_range(uint32_t addr, uint32_t len);
+void spiflash_erase_4k_sector(uint32_t addr);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Currently, only range erase is supported. In some cases, it might be necessary, to erase blocks with a finer granularity than 64k. With this function, erasing individual 4k blocks is possible.