### PR TITLE
cores/cpu/vexiiriscv: Add PMP support

### DIFF
--- a/litex/soc/cores/cpu/vexiiriscv/core.py
+++ b/litex/soc/cores/cpu/vexiiriscv/core.py
@@ -156,7 +156,7 @@ class VexiiRiscv(CPU):
         vdir = get_data_mod("cpu", "vexiiriscv").data_location
         ndir = os.path.join(vdir, "ext", "VexiiRiscv")
 
-        NaxRiscv.git_setup("VexiiRiscv", ndir, "https://github.com/SpinalHDL/VexiiRiscv.git", "dev", "ca10ab58", args.update_repo)
+        NaxRiscv.git_setup("VexiiRiscv", ndir, "https://github.com/SpinalHDL/VexiiRiscv.git", "dev", "b4269ddc", args.update_repo)
 
         if not args.cpu_variant:
             args.cpu_variant = "standard"


### PR DESCRIPTION
The RISC-V PMP feature can now be enabled via --vexii-args="--pmp-size=8" for instance.

TOR support can be disabled via --pmp-tor-disable to save area / timings