### PR TITLE
Fixed for eliminating picolibc in package writing

### DIFF
--- a/litex/soc/software/libc/Makefile
+++ b/litex/soc/software/libc/Makefile
@@ -39,11 +39,13 @@ cross.txt:
 	@echo "$$CROSSFILE" > $@
 
 __libc.a: cross.txt
+	cp -a $(PICOLIBC_DIRECTORY) $(BUILDINC_DIRECTORY)/../picolibc_src
+
 	if [ -d "$(LIBC_DIRECTORY)/$(CPUFAMILY)" ]; then \
-		cp $(LIBC_DIRECTORY)/$(CPUFAMILY)/* $(PICOLIBC_DIRECTORY)/newlib/libc/machine/$(CPUFAMILY)/ ;\
+		cp $(LIBC_DIRECTORY)/$(CPUFAMILY)/* $(BUILDINC_DIRECTORY)/../picolibc_src/newlib/libc/machine/$(CPUFAMILY)/ ;\
 	fi
 
-	meson $(PICOLIBC_DIRECTORY) \
+	meson $(BUILDINC_DIRECTORY)/../picolibc_src \
 		-Dmultilib=false \
 		-Dpicocrt=false \
 		-Datomic-ungetc=false \


### PR DESCRIPTION
While trying to make a reproducible LiteX build using Nix I found that `libc` `Makefile` copies CPU family files to `$PICOLIBC_DIRECTORY/newlib/libc/machine/$(CPUFAMILY)/`. This directory is a package directory and should not be altered during build (what was the cause of build failure due to insufficient permissions in my case).

This PR suggests a walk around that copies all contents of `$PICOLIBC_DIRECTORY` to `picolibc_src` in current build directory and copies `libc` CPU family files there.