### PR TITLE
build/xilinx/platform: added xilinx_us_special_overrides for xczu devices

### DIFF
--- a/litex/build/xilinx/platform.py
+++ b/litex/build/xilinx/platform.py
@@ -84,6 +84,8 @@ class XilinxPlatform(GenericPlatform):
             so.update(common.xilinx_us_special_overrides)
         if self.device[:4] == "xcau":
             so.update(common.xilinx_us_special_overrides)
+        if self.device[:4] == "xczu":
+            so.update(common.xilinx_us_special_overrides)
         so.update(special_overrides)
         return GenericPlatform.get_verilog(self, *args,
             special_overrides = so,


### PR DESCRIPTION
specials_overrides are present and used by most of the Ultrascale devices but not for ZynqMP Ultrascale.
this PR adds required lines to enable this support. 