### PR TITLE
soc/ethernet: enable full_memory_we by default for Quartus toolchain

### DIFF
--- a/litex/build/altera/quartus.py
+++ b/litex/build/altera/quartus.py
@@ -14,6 +14,7 @@ import math
 from shutil import which
 
 from migen.fhdl.structure import _Fragment
+from migen.fhdl.simplify import FullMemoryWE
 
 from litex.build.generic_platform import Pins, IOStandard, Misc
 from litex.build.generic_toolchain import GenericToolchain
@@ -38,6 +39,9 @@ class AlteraQuartusToolchain(GenericToolchain):
         **kwargs):
 
         self._synth_tool = synth_tool
+
+        # Apply FullMemoryWE on Design (Quartus does not infer memories correctly otherwise).
+        FullMemoryWE()(fragment)
 
         return GenericToolchain.build(self, platform, fragment, **kwargs)
 


### PR DESCRIPTION
There is an reported issue with Quartus toolchain, that fails to infer memories with multiple write enable signals.
It is a problem for liteeth module with large buffers (https://github.com/enjoy-digital/liteeth/issues/63) which was fixed and later changed  to configurable `full_memory_we`  option in https://github.com/enjoy-digital/liteeth/pull/72, because of regression on other FPGAs.

However, this option/problem is not documented and not used in existing codebase, and leads to unexpected, difficult to trace problems with high device utilization.
Because of that, I think it would be a good idea to enable this option by default if Quartus toolchain is detected.

The second place where `full_memory_we` option is defined is L2 Cache, where it is enabled by default for all targets.