### PR TITLE
Fix WS2812 with nled=1

### DIFF
--- a/litex/soc/cores/led.py
+++ b/litex/soc/cores/led.py
@@ -152,7 +152,7 @@ class WS2812(LiteXModule):
 
 
         # Internal Signals.
-        led_count  = Signal(max=nleds)
+        led_count  = Signal(max=max(nleds, 2))
         led_data   = Signal(24)
         xfer_start = Signal()
         xfer_done  = Signal()


### PR DESCRIPTION
To fix the following error:

```text
  File ".../litex/litex/soc/cores/led.py", line 155, in __init__
    led_count  = Signal(max=nleds)
                 ^^^^^^^^^^^^^^^^^
  File ".../migen/migen/fhdl/structure.py", line 375, in __init__
    assert(min < max)
           ^^^^^^^^^
AssertionError
```

The `Signal` type does not accept max=1.