### PR TITLE
soc/integration/soc: Fix CSRBridge Bus Width conversion

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1138,13 +1138,14 @@ class SoC(LiteXModule, SoCCoreCompat):
         }[self.bus.standard]
         csr_bridge_name = f"{name}_bridge"
         self.check_if_exists(csr_bridge_name)
+        data_width = self.csr.data_width
         csr_bridge = csr_bridge_cls(
             bus_bridge_cls(
                 address_width = self.bus.address_width,
-                data_width    = self.bus.data_width),
+                data_width    = data_width),
             bus_csr = csr_bus.Interface(
                 address_width = self.csr.address_width,
-                data_width    = self.csr.data_width),
+                data_width    = data_width),
             register = register)
         self.logger.info("CSR Bridge {} {}.".format(
             colorer(name, color="underline"),

--- a/litex/soc/interconnect/axi/axi_lite_to_csr.py
+++ b/litex/soc/interconnect/axi/axi_lite_to_csr.py
@@ -29,6 +29,8 @@ class AXILite2CSR(LiteXModule):
         self.axi_lite = axi_lite
         self.csr      = bus_csr
 
+        assert axi_lite.data_width == bus_csr.data_width
+
         fsm, comb = axi_lite_to_simple(
             axi_lite   = self.axi_lite,
             port_adr   = self.csr.adr,

--- a/litex/soc/interconnect/wishbone.py
+++ b/litex/soc/interconnect/wishbone.py
@@ -588,6 +588,8 @@ class Wishbone2CSR(LiteXModule):
             # If no Wishbone bus provided, create it with default parameters.
             self.wishbone = Interface()
 
+        assert self.wishbone.data_width == self.csr.data_width
+
         # # #
 
         wishbone_adr_shift = {

--- a/test/test_axi_lite.py
+++ b/test/test_axi_lite.py
@@ -258,8 +258,8 @@ class TestAXILite(unittest.TestCase):
 
         class DUT(Module):
             def __init__(self):
-                self.axi_lite = AXILiteInterface()
-                self.csr = csr_bus.Interface()
+                self.axi_lite = AXILiteInterface(data_width=32)
+                self.csr = csr_bus.Interface(data_width=32)
                 self.submodules.axilite2csr = AXILite2CSR(self.axi_lite, self.csr)
                 self.errors = 0
 


### PR DESCRIPTION
Wishbone2CSR and AXILite2CSR bridges are incapable for performing bus width conversion, which means it's Bus slave port must have same width as CSRs.

Use CSR width to create slave bus to allow width adaptar to be inserted by add_slave. Also add relevant assertion.

This fixes `--bus-data-width 64` build.