### PR TITLE
backwards compatibility with python3.7

### DIFF
--- a/litex/soc/cores/clock/xilinx_usp.py
+++ b/litex/soc/cores/clock/xilinx_usp.py
@@ -143,7 +143,8 @@ class USPMMCM(XilinxClocking):
 
                     dividers = list(clkdiv_range(*self.clkout_divide_range))
                     # Add specific range dividers if they exist
-                    if specific_div_range := getattr(self, f"clkout{n}_divide_range", None):
+                    specific_div_range = getattr(self, f"clkout{n}_divide_range", None)
+                    if specific_div_range:
                         dividers.extend(clkdiv_range(*specific_div_range))
 
                     # For clkout0, CLKOUT[0]_DIVIDE_F also has range 2.0 to 128.0 with step 0.125

--- a/litex/tools/litex_json2dts_linux.py
+++ b/litex/tools/litex_json2dts_linux.py
@@ -100,7 +100,7 @@ def generate_dts(d, initrd_start=None, initrd_size=None, initrd=None, root_devic
     # Clocks ---------------------------------------------------------------------------------------
 
     for c in [c for c in d["constants"].keys() if c.endswith("config_clock_frequency")]:
-        name = c.removesuffix("config_clock_frequency") + "sys_clk"
+        name = c[:len(c) - len("config_clock_frequency")] + "sys_clk"
         dts += """
         {name}: clock-{freq} {{
             compatible = "fixed-clock";


### PR DESCRIPTION
https://github.com/enjoy-digital/litex/pull/2117 broke my linux-on-litex-vexriscv build as the f4pga conda environment still uses python3.7 and the new (python3.8) [assignment expression](https://docs.python.org/3/whatsnew/3.8.html#assignment-expressions)  got used in `if specific_div_range := getattr(self, f"clkout{n}_divide_range", None):`.

For the sake of backwards compatibility, and not unnecessarily breaking the build for other people, this PR gets rid of the assignment expression.

Edit: Same issue with building versa_ecp5 in linux-on-litex-vexriscv as the nextpnr-ecp5 install (`conda install litex-hub::yosys litex-hub::nextpnr-ecp5`) requires python>=3.7,<3.8 but some script is using the python3.9's str removesuffix method.