### PR TITLE
cores/cpu/ibex: Align with latest RTL

### DIFF
--- a/litex/soc/cores/cpu/ibex/core.py
+++ b/litex/soc/cores/cpu/ibex/core.py
@@ -141,7 +141,8 @@ class Ibex(CPU):
 
         self.cpu_params = dict(
             # Configuration.
-            p_RegFile        = 1, # RegFileFPGA
+            # Verilator is not happy with using number for enum parameters.
+            # p_RegFile        = 1, # RegFileFPGA
             i_test_en_i      = 0,
             i_hart_id_i      = 0,
 
@@ -181,7 +182,8 @@ class Ibex(CPU):
             # Control/Status.
             i_fetch_enable_i = 1,
             o_alert_minor_o  = Open(),
-            o_alert_major_o  = Open(),
+            o_alert_major_internal_o  = Open(),
+            o_alert_major_bus_o = Open(),
             o_core_sleep_o   = Open()
         )
 
@@ -198,34 +200,62 @@ class Ibex(CPU):
         platform.add_verilog_include_path(os.path.join(ibexdir,
             "vendor", "lowrisc_ip", "ip", "prim", "rtl")
         )
+        platform.add_verilog_include_path(os.path.join(ibexdir,
+            "dv", "uvm", "core_ibex", "common", "prim")
+        )
         platform.add_source(os.path.join(ibexdir, "syn", "rtl", "prim_clock_gating.v"))
         platform.add_sources(os.path.join(ibexdir, "vendor", "lowrisc_ip", "ip", "prim", "rtl"),
-            "prim_alert_pkg.sv",
-            "prim_assert.sv",
+            "prim_util_pkg.sv",
+            "prim_count_pkg.sv",
+            "prim_count.sv",
+            "prim_cipher_pkg.sv",
+            "prim_lfsr.sv",
+            "prim_secded_pkg.sv",
+            "prim_secded_22_16_dec.sv",
+            "prim_secded_22_16_enc.sv",
+            "prim_secded_28_22_dec.sv",
+            "prim_secded_28_22_enc.sv",
+            "prim_secded_39_32_dec.sv",
+            "prim_secded_39_32_enc.sv",
+            "prim_secded_64_57_dec.sv",
+            "prim_secded_64_57_enc.sv",
+            "prim_secded_72_64_dec.sv",
+            "prim_secded_72_64_enc.sv",
+            "prim_secded_hamming_22_16_dec.sv",
+            "prim_secded_hamming_22_16_enc.sv",
+            "prim_secded_hamming_39_32_dec.sv",
+            "prim_secded_hamming_39_32_enc.sv",
+            "prim_secded_hamming_72_64_dec.sv",
+            "prim_secded_hamming_72_64_enc.sv",
+            "prim_secded_inv_28_22_dec.sv",
+            "prim_secded_inv_28_22_enc.sv",
+            "prim_secded_inv_39_32_dec.sv",
+            "prim_secded_inv_39_32_enc.sv",
+            "prim_secded_inv_72_64_dec.sv",
+            "prim_secded_inv_72_64_enc.sv",
+            "prim_prince.sv",
+            "prim_subst_perm.sv",
+            "prim_onehot_check.sv",
+            "prim_onehot_enc.sv",
+            "prim_onehot_mux.sv",
+            "prim_mubi_pkg.sv",
             "prim_ram_1p_pkg.sv",
+            "prim_ram_1p_adv.sv",
+            "prim_ram_1p_scr.sv"
         )
-        platform.add_sources(os.path.join(ibexdir, "rtl"),
-            "ibex_pkg.sv",
-            "ibex_alu.sv",
-            "ibex_compressed_decoder.sv",
-            "ibex_controller.sv",
-            "ibex_counter.sv",
-            "ibex_cs_registers.sv",
-            "ibex_csr.sv",
-            "ibex_decoder.sv",
-            "ibex_ex_block.sv",
-            "ibex_id_stage.sv",
-            "ibex_if_stage.sv",
-            "ibex_load_store_unit.sv",
-            "ibex_multdiv_slow.sv",
-            "ibex_multdiv_fast.sv",
-            "ibex_prefetch_buffer.sv",
-            "ibex_fetch_fifo.sv",
-            "ibex_register_file_fpga.sv",
-            "ibex_wb_stage.sv",
-            "ibex_core.sv",
-            "ibex_top.sv"
+
+        platform.add_sources(os.path.join(ibexdir, "vendor", "lowrisc_ip", "ip", "prim_generic", "rtl"),
+            "prim_generic_ram_1p.sv",
+            "prim_generic_buf.sv"
         )
+
+        rtl_base = os.path.join(ibexdir, "rtl")
+        with open(os.path.join(rtl_base, "ibex_core.f")) as f:
+            for line in f:
+                # Skip comments and empty lines
+                if line.startswith("//") or not line.strip():
+                    continue
+                platform.add_source(os.path.join(rtl_base, line.strip()))
 
     def set_reset_address(self, reset_address):
         self.reset_address = reset_address

--- a/litex/soc/cores/cpu/ibex/crt0.S
+++ b/litex/soc/cores/cpu/ibex/crt0.S
@@ -91,6 +91,8 @@ trap_entry:
 crt_init:
   la sp, _fstack
   la t0, vector_table
+  /* Enable vectored interrupt handling */
+  ori t0, t0, 0x1
   csrw mtvec, t0
 
 data_init:

--- a/litex/soc/cores/cpu/ibex/system.h
+++ b/litex/soc/cores/cpu/ibex/system.h
@@ -7,7 +7,13 @@
 extern "C" {
 #endif
 
-__attribute__((unused)) static void flush_cpu_icache(void){}; /* No instruction cache */
+__attribute__((unused)) static void flush_cpu_icache(void)
+{
+  asm volatile(
+    "fence.i\n"
+  );
+}
+
 __attribute__((unused)) static void flush_cpu_dcache(void){}; /* No instruction cache */
 void flush_l2_cache(void);
 

--- a/litex_setup.py
+++ b/litex_setup.py
@@ -120,7 +120,7 @@ git_repos = {
     "pythondata-cpu-cv32e41p":     GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
     "pythondata-cpu-cva5":         GitRepo(url="https://github.com/litex-hub/"),
     "pythondata-cpu-cva6":         GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
-    "pythondata-cpu-ibex":         GitRepo(url="https://github.com/litex-hub/", clone="recursive", sha1=0xd3d53df),
+    "pythondata-cpu-ibex":         GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
     "pythondata-cpu-minerva":      GitRepo(url="https://github.com/litex-hub/"),
     "pythondata-cpu-naxriscv":     GitRepo(url="https://github.com/litex-hub/", branch="smp"),
     "pythondata-cpu-picorv32":     GitRepo(url="https://github.com/litex-hub/"),


### PR DESCRIPTION
Fix up file path and workaround verilator limitation on parameter type.

Also fix crt0 and system.h to reflect RTL changes.