### PR TITLE
build/altera/quartus.py: don't call FullMemoryWE when target is based on max10 FPGA

### DIFF
--- a/litex/build/altera/quartus.py
+++ b/litex/build/altera/quartus.py
@@ -40,8 +40,9 @@ class AlteraQuartusToolchain(GenericToolchain):
 
         self._synth_tool = synth_tool
 
-        # Apply FullMemoryWE on Design (Quartus does not infer memories correctly otherwise).
-        FullMemoryWE()(fragment)
+        if not platform.device.startswith("10M"):
+            # Apply FullMemoryWE on Design (Quartus does not infer memories correctly otherwise).
+            FullMemoryWE()(fragment)
 
         return GenericToolchain.build(self, platform, fragment, **kwargs)
 


### PR DESCRIPTION
With `FullMemoryWE()(fragment)` call the build fails with:
```script
Error (14703): Invalid internal configuration mode for design with memory initialization
```

This failure may be related to the use of  *dual_boot* IP core or because project is configured with `INTERNAL_FLASH_UPDATE_MODE "DUAL IMAGES"`. But In as first time simpliest way is to disable this call for max10 targets