### PR TITLE
soc: interconnect: add logic to set a offset to bus slaves

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -2125,8 +2125,7 @@ class LiteXSoC(SoC):
         spiflash_core = LiteSPI(spiflash_phy, mmap_endianness=self.cpu.endianness, **kwargs)
         self.add_module(name=f"{name}_core", module=spiflash_core)
         spiflash_region = SoCRegion(origin=self.mem_map.get(name, None), size=module.total_size)
-        self.bus.add_slave(name=name, slave=spiflash_core.bus, region=spiflash_region)
-        self.comb += spiflash_core.mmap.offset.eq(self.bus.regions.get(name, None).origin)
+        self.bus.add_slave(name=name, slave=spiflash_core.bus, region=spiflash_region, offset_base=True)
 
         # Constants.
         self.add_constant(f"{name}_PHY_FREQUENCY",     clk_freq)
@@ -2173,8 +2172,7 @@ class LiteXSoC(SoC):
         
         # Create Wishbone Slave.
         wb_spiram = wishbone.Interface(data_width=32, address_width=32, addressing="word")
-        self.bus.add_slave(name=name, slave=wb_spiram, region=spiram_region)
-        self.comb += spiram_core.mmap.offset.eq(self.bus.regions.get(name, None).origin)
+        self.bus.add_slave(name=name, slave=wb_spiram, region=spiram_region, offset_base=True)
         
         # L2 Cache
         if l2_cache_size != 0:

--- a/litex/soc/interconnect/axi/axi_full.py
+++ b/litex/soc/interconnect/axi/axi_full.py
@@ -155,6 +155,17 @@ class AXIRemapper(LiteXModule):
         self.comb += slave.aw.addr.eq(origin | master.aw.addr & mask)
         self.comb += slave.ar.addr.eq(origin | master.ar.addr & mask)
 
+# AXI Offset ---------------------------------------------------------------------------------------
+
+class AXIOffset(LiteXModule):
+    """Removes offset from AXI addresses."""
+    def __init__(self, master, slave, offset=0x00000000):
+
+        # Address Mask and Shift.
+        self.comb += master.connect(slave)
+        self.comb += slave.aw.addr.eq(master.aw.addr - offset)
+        self.comb += slave.ar.addr.eq(master.ar.addr - offset)
+
 # AXI Bursts to Beats ------------------------------------------------------------------------------
 
 class AXIBurst2Beat(LiteXModule):

--- a/litex/soc/interconnect/axi/axi_lite.py
+++ b/litex/soc/interconnect/axi/axi_lite.py
@@ -147,6 +147,17 @@ class AXILiteRemapper(LiteXModule):
         self.comb += slave.aw.addr.eq(origin | master.aw.addr & mask)
         self.comb += slave.ar.addr.eq(origin | master.ar.addr & mask)
 
+# AXI-Lite Offset ----------------------------------------------------------------------------------
+
+class AXILiteOffset(LiteXModule):
+    """Removes offset from AXI Lite addresses."""
+    def __init__(self, master, slave, offset=0x00000000):
+
+        # Address Mask and Shift.
+        self.comb += master.connect(slave)
+        self.comb += slave.aw.addr.eq(master.aw.addr - offset)
+        self.comb += slave.ar.addr.eq(master.ar.addr - offset)
+
 # AXI-Lite to Simple Bus ---------------------------------------------------------------------------
 
 def axi_lite_to_simple(axi_lite, port_adr, port_dat_r, port_dat_w=None, port_re=None, port_we=None):

--- a/litex/soc/interconnect/wishbone.py
+++ b/litex/soc/interconnect/wishbone.py
@@ -182,6 +182,26 @@ class Remapper(Module):
                 If(active, slave.adr.eq(dst_adr >> adr_shift))
             ]
 
+# Wishbone Offset --------------------------------------------------------------------------------
+
+class Offset(Module):
+    """Removes offset from Wishbone addresses."""
+    def __init__(self, master, slave, offset=0x00000000):
+        # Parameters.
+        # -----------
+        assert master.addressing == slave.addressing
+
+        # Master to Slave.
+        # ----------------
+        self.comb += master.connect(slave)
+
+        # Origin Remapping.
+        # -----------------
+        if master.addressing == "word":
+            offset    >>= int(log2(len(master.dat_w)//8))
+        # Apply Address Origin/Mask Remapping.
+        self.comb += slave.adr.eq(master.adr - offset)
+
 # Wishbone Timeout ---------------------------------------------------------------------------------
 
 class Timeout(LiteXModule):


### PR DESCRIPTION
add logic to set a offset to bus slaves.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>