### PR TITLE
build: common: make sure Signal lenght is right

### DIFF
--- a/litex/build/altera/common.py
+++ b/litex/build/altera/common.py
@@ -135,7 +135,7 @@ class AlteraSDROutput:
 class AlteraSDRInput:
     @staticmethod
     def lower(dr):
-        return AlteraDDRInputImpl(dr.i, dr.o, Signal(), dr.clk)
+        return AlteraDDRInputImpl(dr.i, dr.o, Signal(len(dr.o)), dr.clk)
 
 # Special Overrides --------------------------------------------------------------------------------
 
@@ -225,7 +225,7 @@ class Agilex5SDROutput:
 class Agilex5SDRInput:
     @staticmethod
     def lower(dr):
-        return Agilex5DDRInputImpl(dr.i, dr.o, Signal(), dr.clk)
+        return Agilex5DDRInputImpl(dr.i, dr.o, Signal(len(dr.o)), dr.clk)
 
 # Agilex5 SDRTristate ------------------------------------------------------------------------------
 

--- a/litex/build/lattice/common.py
+++ b/litex/build/lattice/common.py
@@ -528,7 +528,7 @@ class LatticeiCE40SDROutput:
 class LatticeiCE40SDRInput:
     @staticmethod
     def lower(dr):
-        return LatticeiCE40DDRInputImpl(dr.i, dr.o, Signal(), dr.clk)
+        return LatticeiCE40DDRInputImpl(dr.i, dr.o, Signal(len(dr.o)), dr.clk)
 
 # iCE40 SDR Tristate -------------------------------------------------------------------------------
 

--- a/litex/build/xilinx/common.py
+++ b/litex/build/xilinx/common.py
@@ -255,7 +255,7 @@ class XilinxSDROutputS6:
 class XilinxSDRInputS6:
     @staticmethod
     def lower(dr):
-        return XilinxDDRInputImplS6(dr.i, dr.o, Signal(), dr.clk)
+        return XilinxDDRInputImplS6(dr.i, dr.o, Signal(len(dr.o)), dr.clk)
 
 # Spartan6 Special Overrides -----------------------------------------------------------------------
 
@@ -323,7 +323,7 @@ class XilinxSDROutputS7:
 class XilinxSDRInputS7:
     @staticmethod
     def lower(dr):
-        return XilinxDDRInputImplS7(dr.i, dr.o, Signal(), dr.clk)
+        return XilinxDDRInputImplS7(dr.i, dr.o, Signal(len(dr.o)), dr.clk)
 
 # 7-Series Special Overrides -----------------------------------------------------------------------
 


### PR DESCRIPTION
make sure the the lenght of the o2 Signal is
the same lenght of o1, when a DDRImput implementation is used
for a SDRInput. This is needed for multibit io.

This was forgotten in https://github.com/enjoy-digital/litex/pull/2105

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>