### PR TITLE
build: common: TristateImpl: support longer oe

### DIFF
--- a/litex/build/efinix/common.py
+++ b/litex/build/efinix/common.py
@@ -163,7 +163,7 @@ class EfinixTristateImpl(LiteXModule):
             io_data_i = platform.add_iface_io(io_name + "_OUT", len(io))
             self.comb += io_data_i.eq(o)
         io_data_e    = platform.add_iface_io(io_name + "_OE", len(io))
-        self.comb += io_data_e.eq(oe)
+        self.comb += io_data_e.eq(oe if len(oe) == len(io) else Replicate(oe, len(io)))
         if i is not None:
             io_data_o  = platform.add_iface_io(io_name + "_IN", len(io))
             self.comb += i.eq(io_data_o)

--- a/litex/build/gowin/common.py
+++ b/litex/build/gowin/common.py
@@ -120,7 +120,7 @@ class Gw5ATristateImpl(Module):
                 io_IO = io[bit] if nbits > 1 else io,
                 o_O   = i[bit]  if nbits > 1 else i,
                 i_I   = o[bit]  if nbits > 1 else o,
-                i_OEN = ~oe,
+                i_OEN = ~oe[bit] if len(oe) == nbits > 1 else ~oe,
             )
 
 class Gw5ATristate:

--- a/litex/build/lattice/common.py
+++ b/litex/build/lattice/common.py
@@ -151,7 +151,7 @@ class LatticeECP5TristateImpl(Module):
                 io_B  = io[bit] if nbits > 1 else io,
                 i_I   = o[bit]  if nbits > 1 else o,
                 o_O   = i[bit]  if nbits > 1 else i,
-                i_T   = ~oe
+                i_T   = ~oe[bit] if len(oe) == nbits > 1 else ~oe
             )
 
 class LatticeECP5Tristate(Module):
@@ -183,7 +183,7 @@ class LatticeECP5TrellisTristateImpl(Module):
                 i_B   = io[bit] if nbits > 1 else io,
                 i_I   = o[bit]  if nbits > 1 else o,
                 o_O   = i[bit]  if nbits > 1 else i,
-                i_T   = ~oe
+                i_T   = ~oe[bit] if len(oe) == nbits > 1 else ~oe
             )
 
 class LatticeECP5TrellisTristate(Module):
@@ -400,7 +400,7 @@ class LatticeiCE40TristateImpl(Module):
             self.specials += Instance("SB_IO",
                 p_PIN_TYPE      = C(0b101001, 6), # PIN_OUTPUT_TRISTATE + PIN_INPUT
                 io_PACKAGE_PIN  = io[bit] if nbits > 1 else io,
-                i_OUTPUT_ENABLE = oe,
+                i_OUTPUT_ENABLE = oe[bit] if len(oe) == nbits > 1 else oe,
                 i_D_OUT_0       = o[bit]  if nbits > 1 else o,
                 o_D_IN_0        = i[bit]  if nbits > 1 else i,
             )


### PR DESCRIPTION
support setting a different oe for every line in
the Tristates.

this is also needed for the multibit io, where oe has the same lenght
as the io., because some platforms use the generic implementation
of the SDR/DDRTristate, that uses a Tristate internally.