### PR TITLE
Fix NaxRISCV Bare Metal Demo and small fix for demo.py make routine

### DIFF
--- a/litex/soc/cores/cpu/naxriscv/crt0.S
+++ b/litex/soc/cores/cpu/naxriscv/crt0.S
@@ -124,8 +124,7 @@ bss_loop:
 bss_done:
 
   call plic_init // initialize external interrupt controller
-  li t0, 0x800   // external interrupt sources only (using LiteX timer);
-                 // NOTE: must still enable mstatus.MIE!
+  li t0, 0x808   // external interrupt sources (using LiteX timer) and enable mstatus.MIE.
   csrw mie,t0
 
   call main

--- a/litex/soc/software/demo/demo.py
+++ b/litex/soc/software/demo/demo.py
@@ -31,7 +31,7 @@ def main():
 
     # Compile demo
     build_path = args.build_path if os.path.isabs(args.build_path) else os.path.join("..", args.build_path)
-    os.system(f"export BUILD_DIR={build_path} && {'export WITH_CXX=1 &&' if args.with_cxx else ''} cd demo && make")
+    os.system(f"export BUILD_DIR={build_path} && {'export WITH_CXX=1 &&' if args.with_cxx else ''} cd demo && make clean && make") # Clean demo before make to handle case when switching to a different CPU.
 
     # Copy demo.bin
     os.system("cp demo/demo.bin ./")


### PR DESCRIPTION
Two small contributions:
* Added two small fixes to the NaxRISCV bare metal demo (which was not working due to lack of interrupts in #2169) 
* A small QoL fix in the demo.py routine which needed to be cleaned before running `make`.