### PR TITLE
soc/cores/clock/gowin_gw5a.py: GW5AT uses PLLA

### DIFF
--- a/litex/soc/cores/clock/gowin_gw5a.py
+++ b/litex/soc/cores/clock/gowin_gw5a.py
@@ -234,7 +234,7 @@ class GW5APLL(LiteXModule):
             o_CLKFBOUT = Open()
         )
 
-        if self.device.startswith('GW5A-'): # GW5A-25, uses PLLA
+        if self.device.startswith('GW5A-') or self.device.startswith("GW5AT-"): # GW5A(T), uses PLLA
             instance_name = 'PLLA'
             self.params.update(
                 i_MDCLK  = 0,


### PR DESCRIPTION
As for *GW5A-*, *GW5AT* uses PLLA. Without this fix synthesis fails because no PLL is found.