### PR TITLE
Update migen version to work with python3.13

### DIFF
--- a/litex_setup.py
+++ b/litex_setup.py
@@ -70,7 +70,7 @@ class GitRepo:
 git_repos = {
     # HDL.
     # ----
-    "migen":    GitRepo(url="https://github.com/m-labs/", clone="recursive", sha1=0xccaee68e14d3636e1d8fb2e0864dd89b1b1f7384),
+    "migen":    GitRepo(url="https://github.com/m-labs/", clone="recursive", sha1=0x4c2ae8dfeea37f235b52acb8166f12acaaae4f7c),
 
     # LiteX SoC builder.
     # ------------------


### PR DESCRIPTION
Updates to the following migen commit, which incudes support for the bytecodes in python 3.13 https://github.com/m-labs/migen/commit/4c2ae8dfeea37f235b52acb8166f12acaaae4f7c

The [changes to the current commit](https://github.com/m-labs/migen/compare/ccaee68e14d3636e1d8fb2e0864dd89b1b1f7384..4c2ae8dfeea37f235b52acb8166f12acaaae4f7c) don't look to egregious and in my (admittedly limited) testing no issues occured.

Fixes https://github.com/enjoy-digital/litex/issues/2152