### PR TITLE
litex/build/efinix/platform.py: get_pin_name method: always adds idx to the signal name -> avoid some inversion between my_sig and my_sig_1

### DIFF
--- a/litex/build/efinix/platform.py
+++ b/litex/build/efinix/platform.py
@@ -144,18 +144,16 @@ class EfinixPlatform(GenericPlatform):
             return None
         assert len(sig) == 1
         idx = 0
-        slc = False
         while isinstance(sig, _Slice) and hasattr(sig, "value"):
             idx = sig.start
             sig = sig.value
-            slc = hasattr(sig, "nbits") and sig.nbits > 1
         sc = self.constraint_manager.get_sig_constraints()
         for s, pins, others, resource in sc:
             if s == sig:
                 name = resource[0] + (f"{resource[1]}" if resource[1] is not None else "")
                 if resource[2]:
                     name = name + "_" + resource[2]
-                name = name + (f"{idx}" if slc else "")
+                name = name + f"{idx}"
                 return name
         return None
 


### PR DESCRIPTION
*Efinix* FPGAs, unlike others FPGAs, has a specifics way to adds `specials`. It's not an `Instance` and are located out-of-code, requiring the use of *ifacewriter* to adds these.

This specificity has for side effect to create additionals signals, at entity level, with the same name. The result is to have both `my_sig` and `my_sig_1`.

It appear in some case an inversion between these two signals:
- the real signal is correctly added to the `iface.py` with all required informations
- the duplicated signal (with `_1`) is also added but without any informations
- the real signal is left unconnected in the verilog file
- the duplicated signal (with `_1`) is used in the verilog file
- `ifacewriter` fails with `INFO: Design check issue : id:3 name:my_sig_1 type:gpio sev:SeverityType.error rule:gpio_rule_resource msg:Resource name is empty.`

This issue was observed with the use of `SDRInput` specials where more than 2 instance of the same Module are added in the gateware. It's not clear if the issue is related to an error in *build/efinix* or some magic with, for instance, a dict and its internal organisation.

The Workaround is to always adds the index at `build/efinix/platform.py:get_pin_name` to have 2 signals with 2 different names.