### PR TITLE
build/efinix/platform.py: get_pins_name: avoids to create a new signal with a name already existing

### DIFF
--- a/litex/build/efinix/platform.py
+++ b/litex/build/efinix/platform.py
@@ -166,6 +166,7 @@ class EfinixPlatform(GenericPlatform):
                 name = resource[0] + (f"{resource[1]}" if resource[1] is not None else "")
                 if resource[2]:
                     name = name + "_" + resource[2]
+                name = name + "_gen" # Avoids to define a new signal with the same name
                 return name
         return None
 


### PR DESCRIPTION
As mentioned in  #2180 the uses of ifacewriter and out-of-verilog primitives has for effect to creates new signals.
#2180 has fixed issues with 1 bit signals but when a multi bit signal is used directly a new signal with the same name is created.

This PR adds code to appends new name with a extension to avoid conflicts.