### PR TITLE
Added fujprog in Lattice progammer for ULX3S

### DIFF
--- a/litex/build/lattice/programmer.py
+++ b/litex/build/lattice/programmer.py
@@ -159,6 +159,15 @@ class UJProg(GenericProgrammer):
     def load_bitstream(self, bitstream_file):
         self.call(["ujprog", bitstream_file])
 
+# fujprog -------------------------------------------------------------------------------------------
+
+class fujprog(GenericProgrammer):
+    needs_bitreverse = False
+
+    def load_bitstream(self, bitstream_file):
+        self.call(["fujprog", bitstream_file])
+
+
 # EcpDapProgrammer ---------------------------------------------------------------------------------
 
 class EcpDapProgrammer(GenericProgrammer):


### PR DESCRIPTION
While trying to program the ULX3S 85F variant board I got an error when trying to use `ujprog`.

I came across[ this issue](https://github.com/emard/ulx3s-bin/issues/7) where it says that using `ujprog` is outdated and that `fujprog` should be used instead. So I added the fujprog command in the lattice `programmer.py` file. 
Now the ULX3S board programs nicely with the `--load` command.