### PR TITLE
Optimize memspeed test for cores with slow modulo.

### DIFF
--- a/litex/soc/software/libbase/memtest.c
+++ b/litex/soc/software/libbase/memtest.c
@@ -318,11 +318,24 @@ void memspeed(unsigned int *addr, unsigned long size, bool read_only, bool rando
 	start = timer0_value_read();
 
 	int num = size/sz;
+	int ones_cnt = 0;
+
+	for(int check = num; check != 0; check = ((check >> 1) & INT_MAX)) {
+		if(check & 0x1) {
+			ones_cnt += 1;
+		}
+	}
+
+	bool power_of_two = (ones_cnt == 1);
 
 	if (random) {
 		for (i = 0; i < size/sz; i++) {
 			seed_32 = seed_to_data_32(seed_32, i);
-			data = array[seed_32 % num];
+			if(power_of_two) {
+				data = array[seed_32 & (num - 1)];
+			} else {
+				data = array[seed_32 % num];
+			}
 		}
 	} else {
 		ptr = array;


### PR DESCRIPTION
The random memspeed test uses modulo to bounds-check reads. The modulo operator is [rather heavy](https://mastodon.social/@cr1901/114015524022352658) on cores without division, and the time spent calculating it can dwarf the amount of time actually reading from memory.

By default, the memtests seem to use power-of-two sizes. If BIOS LTO is enabled (which is _not_ default), then the compiler should optimize modulo to an AND mask. However, since memtest is by default part of a static lib without LTO, the compiler can't do this optimization. This patch adds a dynamic check for power-of-two size and manually does the optimization if it applies.

After this patch, I've seen LiteX go from reporting a 4KiB/s random access read on QSPI flash to ~150KiB/s!