### PR TITLE
Use Python's raw string in regex pattern.

### DIFF
--- a/litex/soc/cores/cpu/cv32e40p/core.py
+++ b/litex/soc/cores/cpu/cv32e40p/core.py
@@ -65,9 +65,9 @@ def add_manifest_sources(platform, manifest):
     basedir = get_data_mod("cpu", "cv32e40p").data_location
     with open(os.path.join(basedir, manifest), 'r') as f:
         for l in f:
-            res = re.search('\$\{DESIGN_RTL_DIR\}/(.+)', l)
+            res = re.search(r'\$\{DESIGN_RTL_DIR\}/(.+)', l)
             if res and not re.match('//', l):
-                if re.match('\+incdir\+', l):
+                if re.match(r'\+incdir\+', l):
                     platform.add_verilog_include_path(os.path.join(basedir, 'rtl', res.group(1)))
                 else:
                     platform.add_source(os.path.join(basedir, 'rtl', res.group(1)))

--- a/litex/soc/cores/cpu/cv32e41p/core.py
+++ b/litex/soc/cores/cpu/cv32e41p/core.py
@@ -64,9 +64,9 @@ def add_manifest_sources(platform, manifest):
     basedir = get_data_mod("cpu", "cv32e41p").data_location
     with open(os.path.join(basedir, manifest), 'r') as f:
         for l in f:
-            res = re.search('\$\{DESIGN_RTL_DIR\}/(.+)', l)
+            res = re.search(r'\$\{DESIGN_RTL_DIR\}/(.+)', l)
             if res and not re.match('//', l):
-                if re.match('\+incdir\+', l):
+                if re.match(r'\+incdir\+', l):
                     platform.add_verilog_include_path(os.path.join(basedir, 'rtl', res.group(1)))
                 else:
                     platform.add_source(os.path.join(basedir, 'rtl', res.group(1)))

--- a/litex/soc/cores/cpu/cva6/core.py
+++ b/litex/soc/cores/cpu/cva6/core.py
@@ -44,13 +44,13 @@ def add_manifest_sources(platform, manifest):
     lx_core_dir = os.path.abspath(os.path.dirname(__file__))
     with open(os.path.join(manifest), 'r') as f:
         for l in f:
-            res = re.search('\$\{(CVA6_REPO_DIR|LX_CVA6_CORE_DIR)\}/(.+)', l)
+            res = re.search(r'\$\{(CVA6_REPO_DIR|LX_CVA6_CORE_DIR)\}/(.+)', l)
             if res and not re.match('//', l):
                 if res.group(1) == "LX_CVA6_CORE_DIR":
                     basedir = lx_core_dir
                 else:
                     basedir = cva6_dir
-                if re.match('\+incdir\+', l):
+                if re.match(r'\+incdir\+', l):
                     platform.add_verilog_include_path(os.path.join(basedir, res.group(2)))
                 else:
                     filename = res.group(2)

--- a/litex/soc/cores/cpu/openc906/core.py
+++ b/litex/soc/cores/cpu/openc906/core.py
@@ -62,9 +62,9 @@ def add_manifest_sources(platform, manifest):
     basedir = os.path.join(openc906_dir, "C906_RTL_FACTORY")
     with open(os.path.join(basedir, manifest), 'r') as f:
         for l in f:
-            res = re.search('\$\{CODE_BASE_PATH\}/(.+)', l)
+            res = re.search(r'\$\{CODE_BASE_PATH\}/(.+)', l)
             if res and not re.match('//', l):
-                if re.match('\+incdir\+', l):
+                if re.match(r'\+incdir\+', l):
                     platform.add_verilog_include_path(os.path.join(basedir, res.group(1)))
                 else:
                     platform.add_source(os.path.join(basedir, res.group(1)))

--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -98,7 +98,7 @@ def get_cpu_mak(cpu, compile_software):
         for i, l in enumerate(os.popen(selected_triple + "-ar -V")):
             # Version is last float reported in first line.
             if i == 0:
-                version = float(re.findall("\d+\.\d+", l)[-1])
+                version = float(re.findall(r"\d+\.\d+", l)[-1])
         return version
 
     def apply_riscv_zicsr_march_workaround(flags):


### PR DESCRIPTION
Otherwise, there will warnings like:

```
./litex/soc/cores/cpu/cv32e40p/core.py:68: SyntaxWarning: invalid escape sequence '\$'
  res = re.search('\$\{DESIGN_RTL_DIR\}/(.+)', l)
```