### PR TITLE
Use CP1252-compatible chars for hierarchy on Windows.

### DIFF
--- a/litex/gen/fhdl/hierarchy.py
+++ b/litex/gen/fhdl/hierarchy.py
@@ -4,6 +4,8 @@
 # This file is Copyright (c) 2022 Florent Kermarrec <florent@enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
+import sys
+
 from migen import *
 
 from litex.gen import *
@@ -11,8 +13,8 @@ from litex.gen import *
 # LiteX Hierarchy Explorer -------------------------------------------------------------------------
 
 class LiteXHierarchyExplorer:
-    tree_ident      = "│    "
-    tree_entry      = "└─── "
+    tree_ident      = "|    " if sys.platform == "win32" else "│    "
+    tree_entry      = "|___ " if sys.platform == "win32" else "└─── "
 
     def __init__(self, top, depth=None, with_colors=True):
         self.top         = top


### PR DESCRIPTION
On Windows, this fixes a good ol' `UnicodeEncodeError: 'charmap' codec can't encode characters in position... character maps to <undefined>` error.

Btw, do you still check IRC/Matrix :P? Don't worry, I think I have tentatively one more PR to make and that's it for a while.