### PR TITLE
copy picolibc to build folder, as it gets modified while building

### DIFF
--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -189,8 +189,13 @@ class Builder:
         picolibc_directory    = get_data_mod("software", "picolibc").data_location
         compiler_rt_directory = get_data_mod("software", "compiler_rt").data_location
 
+        # copy picolibc to build folder, as it gets modified while building
+        picolibc_directory_build = f"{self.output_dir}/software/src/picolibc"
+        os.makedirs(picolibc_directory_build, exist_ok=True)
+        shutil.copytree(picolibc_directory, picolibc_directory_build, dirs_exist_ok=True, copy_function=shutil.copyfile)
+
         define("SOC_DIRECTORY",         soc_directory)
-        define("PICOLIBC_DIRECTORY",    picolibc_directory)
+        define("PICOLIBC_DIRECTORY",    picolibc_directory_build)
         define("PICOLIBC_FORMAT",       self.bios_format)
         define("COMPILER_RT_DIRECTORY", compiler_rt_directory)
         variables_contents.append("export BUILDINC_DIRECTORY")


### PR DESCRIPTION
this allows sharing or read only access to the python package


I face a build error while I tried to build it in nixos, as the system is there read-only by design.
The build script in `pythondata-software-picolibc` modifies the source code included.
This could also lead to conflicts when building multiple targets at once.

This patch copy the source code to the build folder to have a local copy.


Here is a more or less working example for an cyclone10lp - cyc1000 board with this patch:

https://git.o-g.at/FPGA/cyc1000_tests

A bit hacked together, as I'm still learning / testing.