### PR TITLE
Add Linux support for CVA5, including PLIC and CLINT and major bug fixes

### DIFF
--- a/litex/soc/cores/cpu/cva5/boot-helper.S
+++ b/litex/soc/cores/cpu/cva5/boot-helper.S
@@ -1,4 +1,15 @@
 .section    .text, "ax", @progbits
-.global     boot_helper
+.global boot_helper
+.global smp_lottery_target
+.global smp_lottery_lock
+.global smp_lottery_args
+
 boot_helper:
+	sw x10, smp_lottery_args  , x14
+	sw x11, smp_lottery_args+4, x14
+	sw x12, smp_lottery_args+8, x14
+	sw x13, smp_lottery_target, x14
+	fence w, w
+	li x15, 1
+	sw x15, smp_lottery_lock, x14
 	jr x13

--- a/litex/soc/cores/cpu/cva5/core.py
+++ b/litex/soc/cores/cpu/cva5/core.py
@@ -62,7 +62,7 @@ class CVA5(CPU):
         cpu_group = parser.add_argument_group(title="CPU options")
         cpu_group.add_argument("--cpu-count",                    default=1,            help="Number of CPU(s) in the cluster.", type=int)
         cpu_group.add_argument("--clint-base",                   default="0xf0010000", help="CLINT base address.")
-        cpu_group.add_argument("--plic-base",                    default="0xf0c00000", help="PLIC base address.")
+        cpu_group.add_argument("--plic-base",                    default="0xf8000000", help="PLIC base address.")
         cpu_group.add_argument("--bus-type",                    default="wishbone", help="Bus type can be either wishbone or axi")
         cpu_group.add_argument("--variant",                    default="Linux", help="The CPU type for now it has the linux type")#TODO add other configs
 

--- a/litex/soc/cores/cpu/cva5/core.py
+++ b/litex/soc/cores/cpu/cva5/core.py
@@ -13,8 +13,10 @@ from litex import get_data_mod
 from litex.gen import *
 
 from litex.soc.interconnect import wishbone
+from litex.soc.interconnect import axi
 from litex.soc.interconnect.csr import *
 from litex.soc.cores.cpu import CPU, CPU_GCC_TRIPLE_RISCV32
+from litex.soc.integration.soc import SoCRegion
 
 # Variants -----------------------------------------------------------------------------------------
 
@@ -47,12 +49,24 @@ class CVA5(CPU):
     linker_output_format = "elf32-littleriscv"
     nop                  = "nop"
     io_regions           = {0x80000000: 0x80000000} # origin, length
+    plic_base            = 0xf800_0000
+    clint_base           = 0xf001_0000
 
+    # Memory Mapping.
+    @property
+    def mem_map(self):
+        return {
+            "rom":            0x0000_0000,
+            "sram":           0x0100_0000,
+            "main_ram":       0x4000_0000,
+            "csr":            0xf000_0000,
+        }
+    
     # GCC Flags.
     @property
     def gcc_flags(self):
         flags = GCC_FLAGS[self.variant]
-        flags += "-D__cva5__"
+        flags += "-D__riscv_plic__"
         return flags
 
     def __init__(self, platform, variant="standard"):
@@ -64,74 +78,81 @@ class CVA5(CPU):
         self.periph_buses = [] # Peripheral buses (Connected to main SoC's bus).
         self.memory_buses = [] # Memory buses (Connected directly to LiteDRAM).
 
-        # # #
-
         # CPU Instance.
         self.cpu_params = dict(
-            # Configuration.
-            p_LITEX_VARIANT  = CPU_VARIANTS.index(variant),
+            # Configuration.           
             p_RESET_VEC      = 0,
             p_NON_CACHABLE_L = 0x80000000, # FIXME: Use io_regions.
             p_NON_CACHABLE_H = 0xFFFFFFFF, # FIXME: Use io_regions.
+            p_NUM_CORES      = 4,
+            p_AXI = 1,
 
             # Clk/Rst.
             i_clk = ClockSignal("sys"),
             i_rst = ResetSignal("sys"),
-
-            # Interrupts.
-            i_litex_interrupt = self.interrupt
         )
-        # CPU Wishbone Buses.
-        if variant == "minimal":
-            # Minimal variant has no caches, no multiply or divide support, and no branch predictor.
-            # It also uses separate fetch and load-store wishbone interfaces.
-            self.ibus = ibus = wishbone.Interface(data_width=32, address_width=32, addressing="word")
-            self.dbus = dbus = wishbone.Interface(data_width=32, address_width=32, addressing="word")
-            self.periph_buses.append(ibus)
-            self.periph_buses.append(dbus)
-            self.cpu_params.update(
-                o_ibus_adr   = ibus.adr,
-                o_ibus_dat_w = ibus.dat_w,
-                o_ibus_sel   = ibus.sel,
-                o_ibus_cyc   = ibus.cyc,
-                o_ibus_stb   = ibus.stb,
-                o_ibus_we    = ibus.we,
-                o_ibus_cti   = ibus.cti,
-                o_ibus_bte   = ibus.bte,
-                i_ibus_dat_r = ibus.dat_r,
-                i_ibus_ack   = ibus.ack,
-                i_ibus_err   = ibus.err,
+       
+        # Standard variant includes instruction and data caches, multiply and divide support
+        # along with the branch predictor. It uses a shared wishbone interface.
+        # self.idbus = idbus = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+        # self.periph_buses.append(idbus)
+        self.axi_if = axi_if = axi.AXIInterface(data_width=32, address_width=32, id_width=4)
+        self.periph_buses.append(axi_if)
 
-                o_dbus_adr   = dbus.adr,
-                o_dbus_dat_w = dbus.dat_w,
-                o_dbus_sel   = dbus.sel,
-                o_dbus_cyc   = dbus.cyc,
-                o_dbus_stb   = dbus.stb,
-                o_dbus_we    = dbus.we,
-                o_dbus_cti   = dbus.cti,
-                o_dbus_bte   = dbus.bte,
-                i_dbus_dat_r = dbus.dat_r,
-                i_dbus_ack   = dbus.ack,
-                i_dbus_err   = dbus.err
-            )
-        if variant == "standard":
-            # Standard variant includes instruction and data caches, multiply and divide support
-            # along with the branch predictor. It uses a shared wishbone interface.
-            self.idbus = idbus = wishbone.Interface(data_width=32, address_width=32, addressing="word")
-            self.periph_buses.append(idbus)
-            self.cpu_params.update(
-                o_idbus_adr   = idbus.adr,
-                o_idbus_dat_w = idbus.dat_w,
-                o_idbus_sel   = idbus.sel,
-                o_idbus_cyc   = idbus.cyc,
-                o_idbus_stb   = idbus.stb,
-                o_idbus_we    = idbus.we,
-                o_idbus_cti   = idbus.cti,
-                o_idbus_bte   = idbus.bte,
-                i_idbus_dat_r = idbus.dat_r,
-                i_idbus_ack   = idbus.ack,
-                i_idbus_err   = idbus.err,
-            )
+        self.cpu_params.update(
+            # o_idbus_adr   = idbus.adr,
+            # o_idbus_dat_w = idbus.dat_w,
+            # o_idbus_sel   = idbus.sel,
+            # o_idbus_cyc   = idbus.cyc,
+            # o_idbus_stb   = idbus.stb,
+            # o_idbus_we    = idbus.we,
+            # o_idbus_cti   = idbus.cti,
+            # o_idbus_bte   = idbus.bte,
+            # i_idbus_dat_r = idbus.dat_r,
+            # i_idbus_ack   = idbus.ack,
+            # i_idbus_err   = idbus.err,
+
+            # AXI read address channel
+            i_m_axi_arready  = axi_if.ar.ready,
+            o_m_axi_arvalid  = axi_if.ar.valid,
+            o_m_axi_araddr   = axi_if.ar.addr,
+            o_m_axi_arlen    = axi_if.ar.len,
+            o_m_axi_arsize   = axi_if.ar.size,
+            o_m_axi_arburst  = axi_if.ar.burst,
+            o_m_axi_arcache  = axi_if.ar.cache,
+            o_m_axi_arid     = axi_if.ar.id,
+
+            # AXI read data channel
+            o_m_axi_rready   = axi_if.r.ready,
+            i_m_axi_rvalid   = axi_if.r.valid,
+            i_m_axi_rdata    = axi_if.r.data,
+            i_m_axi_rresp    = axi_if.r.resp,
+            i_m_axi_rlast    = axi_if.r.last,
+            i_m_axi_rid      = axi_if.r.id,
+
+            # AXI write address channel
+            i_m_axi_awready  = axi_if.aw.ready,
+            o_m_axi_awvalid  = axi_if.aw.valid,
+            o_m_axi_awaddr   = axi_if.aw.addr,
+            o_m_axi_awlen    = axi_if.aw.len,
+            o_m_axi_awsize   = axi_if.aw.size,
+            o_m_axi_awburst  = axi_if.aw.burst,
+            o_m_axi_awcache  = axi_if.aw.cache,
+            o_m_axi_awid     = axi_if.aw.id,
+
+            # AXI write data channel
+            i_m_axi_wready   = axi_if.w.ready,
+            o_m_axi_wvalid   = axi_if.w.valid,
+            o_m_axi_wdata    = axi_if.w.data,
+            o_m_axi_wstrb    = axi_if.w.strb,
+            o_m_axi_wlast    = axi_if.w.last,
+
+            # AXI write response channel
+            o_m_axi_bready   = axi_if.b.ready,
+            i_m_axi_bvalid   = axi_if.b.valid,
+            i_m_axi_bresp    = axi_if.b.resp,
+            i_m_axi_bid      = axi_if.b.id,
+        )
         self.add_sources(platform)
 
     def set_reset_address(self, reset_address):
@@ -141,14 +162,128 @@ class CVA5(CPU):
 
     @staticmethod
     def add_sources(platform):
+        platform.add_source("/media/CVA5_PLIC/CLINT/Clint.sv")
         cva5_path = get_data_mod("cpu", "cva5").data_location
         with open(os.path.join(cva5_path, "tools/compile_order"), "r") as f:
             for line in f:
                 if line.strip() != '':
                     platform.add_source(os.path.join(cva5_path, line.strip()))
-        platform.add_source(os.path.join(cva5_path, "examples/litex/l1_to_wishbone.sv"))
         platform.add_source(os.path.join(cva5_path, "examples/litex/litex_wrapper.sv"))
 
     def do_finalize(self):
         assert hasattr(self, "reset_address")
         self.specials += Instance("litex_wrapper", **self.cpu_params)
+
+    def add_soc_components(self, soc):
+        # soc.csr.add("sdram", n=1)
+        soc.csr.add("uart", n=2)
+        soc.csr.add("timer0", n=3)
+        soc.csr.add("supervisor", n=4)
+
+        # Unused signals
+        one_b0_i = Signal(reset=0)
+        thirtytwo_b0_i = Signal(32, reset=0)
+        fourteen_b0_i = Signal(14, reset=0)
+        twentyfour_b0_i = Signal(24, reset=0)
+        one_b0_o = Signal()
+        thirtytwo_b0_o = Signal(32)
+
+        # PLIC
+        seip = Signal(int(self.cpu_params["p_NUM_CORES"]))
+        meip = Signal(int(self.cpu_params["p_NUM_CORES"]))
+        eip = Signal(2*int(self.cpu_params["p_NUM_CORES"]))
+        es = Signal(2, reset=0)
+
+        # self.plicbus = plicbus = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+        self.plicbus = plicbus = axi.AXIInterface(data_width=32, address_width=32, id_width=4)
+        self.specials += Instance("plic_wrapper",
+            p_NUM_SOURCES = 1,
+            p_NUM_TARGETS = 2*int(self.cpu_params["p_NUM_CORES"]),
+            p_PRIORITY_W = 8,
+            p_REG_STAGE = 1,
+            p_AXI = 1,
+            i_clk = ClockSignal("sys"),
+            i_rst = ResetSignal("sys"),
+            # i_wb_cyc = plicbus.cyc,
+            # i_wb_stb = plicbus.stb,
+            # i_wb_we = plicbus.we,
+            # i_wb_adr = plicbus.adr,
+            # i_wb_dat_i = plicbus.dat_w,
+            # o_wb_dat_o = plicbus.dat_r,
+            # o_wb_ack = plicbus.ack,
+            i_irq_srcs = self.interrupt,
+            i_edge_sensitive = es,
+            o_eip = eip,
+            i_s_axi_awvalid = plicbus.aw.valid,
+            i_s_axi_awaddr = plicbus.aw.addr,
+            i_s_axi_wvalid = plicbus.w.valid,
+            i_s_axi_wdata = plicbus.w.data,
+            i_s_axi_bready = plicbus.b.ready,
+            i_s_axi_arvalid = plicbus.ar.valid,
+            i_s_axi_araddr = plicbus.ar.addr,
+            i_s_axi_rready = plicbus.r.ready,
+            o_s_axi_awready = plicbus.aw.ready,
+            o_s_axi_wready = plicbus.w.ready,
+            o_s_axi_bvalid = plicbus.b.valid,
+            o_s_axi_arready = plicbus.ar.ready,
+            o_s_axi_rvalid = plicbus.r.valid,
+            o_s_axi_rdata = plicbus.r.data
+        )
+
+        self.comb += [
+            meip.eq(Cat(*[eip[i*2] for i in range(int(self.cpu_params["p_NUM_CORES"]))])),
+            seip.eq(Cat(*[eip[i*2 + 1] for i in range(int(self.cpu_params["p_NUM_CORES"]))]))
+        ]
+
+        self.cpu_params.update(
+            i_seip = seip,
+            i_meip = meip
+        )
+
+        soc.bus.add_slave("plic", self.plicbus, region=SoCRegion(origin=self.plic_base, size=0x40_0000, cached=False))
+
+        # CLINT
+        mtime = Signal(64)
+        msip = Signal(int(self.cpu_params["p_NUM_CORES"]))
+        mtip = Signal(int(self.cpu_params["p_NUM_CORES"]))
+        
+        # self.clintbus = clintbus = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+        self.clintbus = clintbus = axi.AXIInterface(data_width=32, address_width=32, id_width=4)
+        
+        self.specials += Instance("clint_wrapper",
+            p_NUM_CORES = int(self.cpu_params["p_NUM_CORES"]),
+            p_AXI = 1,
+            i_clk = ClockSignal("sys"),
+            i_rst = ResetSignal("sys"),
+            # i_wb_cyc = clintbus.cyc,
+            # i_wb_stb = clintbus.stb,
+            # i_wb_we = clintbus.we,
+            # i_wb_adr = clintbus.adr,
+            # i_wb_dat_i = clintbus.dat_w,
+            # o_wb_dat_o = clintbus.dat_r,
+            # o_wb_ack = clintbus.ack,
+            o_mtip = mtip,
+            o_msip = msip,
+            o_mtime  = mtime,
+            i_s_axi_awvalid = clintbus.aw.valid,
+            i_s_axi_awaddr = clintbus.aw.addr,
+            i_s_axi_wvalid = clintbus.w.valid,
+            i_s_axi_wdata = clintbus.w.data,
+            i_s_axi_bready = clintbus.b.ready,
+            i_s_axi_arvalid = clintbus.ar.valid,
+            i_s_axi_araddr = clintbus.ar.addr,
+            i_s_axi_rready = clintbus.r.ready,
+            o_s_axi_awready = clintbus.aw.ready,
+            o_s_axi_wready = clintbus.w.ready,
+            o_s_axi_bvalid = clintbus.b.valid,
+            o_s_axi_arready = clintbus.ar.ready,
+            o_s_axi_rvalid = clintbus.r.valid,
+            o_s_axi_rdata = clintbus.r.data
+        )
+        self.cpu_params.update(
+            i_mtime = mtime,
+            i_msip = msip,
+            i_mtip = mtip
+        )
+
+        soc.bus.add_slave("clint", clintbus, region=SoCRegion(origin=self.clint_base, size=0x1_0000, cached=False))

--- a/litex/soc/cores/cpu/cva5/crt0.S
+++ b/litex/soc/cores/cpu/cva5/crt0.S
@@ -2,6 +2,11 @@
 .global isr
 .global _start
 
+.global smp_lottery_target
+.global smp_lottery_lock
+.global smp_lottery_args
+.global smp_slave
+
 _start:
   j crt_init
   nop
@@ -52,11 +57,27 @@ trap_entry:
   mret
   .text
 
-
 crt_init:
   la sp, _fstack
   la a0, trap_entry
   csrw mtvec, a0
+  sw x0, smp_lottery_lock, a1
+
+smp_tyranny:
+  csrr a0, mhartid
+  beqz a0, data_init
+
+smp_slave:
+  lw a0, smp_lottery_lock
+  beqz a0, smp_slave
+  fence r, r
+
+  .word(0x100F) //i$ flush
+  lw x10, smp_lottery_args
+  lw x11, smp_lottery_args+4
+  lw x12, smp_lottery_args+8
+  lw x13, smp_lottery_target
+  jr x13
 
 data_init:
   la a0, _fdata
@@ -81,9 +102,19 @@ bss_loop:
   j bss_loop
 bss_done:
 
-  li a0, 0x880  //880 enable timer + external interrupt  (until mstatus.MIE is set, they will never trigger an interrupt)
-  csrw mie,a0
+  call plic_init // initialize external interrupt controller
+  li t0, 0x800   // external interrupt sources only (using LiteX timer);
+                 // NOTE: must still enable mstatus.MIE!
+  csrw mie,t0
 
   call main
 infinit_loop:
   j infinit_loop
+
+
+
+//Initialized to avoid having them set to zero by BSS clear
+.bss
+  smp_lottery_target: .word 0
+  smp_lottery_args:   .word 0; .word 0; .word 0
+  smp_lottery_lock:   .word 0

--- a/litex/soc/cores/cpu/cva5/irq.h
+++ b/litex/soc/cores/cpu/cva5/irq.h
@@ -20,30 +20,63 @@ extern "C" {
 
 #define PLIC_EXT_IRQ_BASE 1
 
-static inline unsigned int irq_getie(void)
-{
-    return (csrr(mstatus) & CSR_MSTATUS_MIE) != 0;
-}
+#ifndef __riscv_plic__
 
-static inline void irq_setie(unsigned int ie)
-{
-    if(ie) csrs(mstatus,CSR_MSTATUS_MIE); else csrc(mstatus,CSR_MSTATUS_MIE);
-}
+    static inline unsigned int irq_getie(void)
+    {
+        return (csrr(mstatus) & CSR_MSTATUS_MIE) != 0;
+    }
 
-static inline unsigned int irq_getmask(void)
-{
-    return (csrr(mie) >> CSR_IRQ_EXTERNAL_OFFSET);
-}
+    static inline void irq_setie(unsigned int ie)
+    {
+        if(ie) csrs(mstatus,CSR_MSTATUS_MIE); else csrc(mstatus,CSR_MSTATUS_MIE);
+    }
 
-static inline void irq_setmask(unsigned int mask)
-{
-    if (mask) csrs(mie,CSR_IRQ_EXTERNAL_OFFSET); else csrc(mie,CSR_IRQ_EXTERNAL_OFFSET);
-}
+    static inline unsigned int irq_getmask(void)
+    {
+        return (csrr(mie) >> CSR_IRQ_EXTERNAL_OFFSET);
+    }
 
-static inline unsigned int irq_pending(void)
-{
-    return ((csrr(mie) | csrr(mip)) >> CSR_IRQ_EXTERNAL_OFFSET) & 0x1;
-}
+    static inline void irq_setmask(unsigned int mask)
+    {
+        if (mask) csrs(mie,CSR_IRQ_EXTERNAL_OFFSET); else csrc(mie,CSR_IRQ_EXTERNAL_OFFSET);
+    }
+
+    static inline unsigned int irq_pending(void)
+    {
+        return ((csrr(mie) | csrr(mip)) >> CSR_IRQ_EXTERNAL_OFFSET) & 0x1;
+    }
+#else
+
+    static inline unsigned int irq_getie(void)
+    {
+        return (csrr(mstatus) & CSR_MSTATUS_MIE) != 0;
+    }
+
+    static inline void irq_setie(unsigned int ie)
+    {
+        if(ie) csrs(mstatus,CSR_MSTATUS_MIE); else csrc(mstatus,CSR_MSTATUS_MIE);
+    }
+
+    static inline unsigned int irq_getmask(void)
+    {
+        // (csrr(mie) >> CSR_IRQ_EXTERNAL_OFFSET);
+        return *((unsigned int *)PLIC_ENABLED) >> PLIC_EXT_IRQ_BASE;
+    }
+
+    static inline void irq_setmask(unsigned int mask)
+    {
+        // if (mask) csrs(mie,CSR_IRQ_EXTERNAL_OFFSET); else csrc(mie,CSR_IRQ_EXTERNAL_OFFSET);
+        *((unsigned int *)PLIC_ENABLED) = mask << PLIC_EXT_IRQ_BASE;
+    }
+
+    static inline unsigned int irq_pending(void)
+    {
+        // ((csrr(mie) | csrr(mip)) >> CSR_IRQ_EXTERNAL_OFFSET) & 0x1;
+        return *((unsigned int *)PLIC_PENDING) >> PLIC_EXT_IRQ_BASE;
+    }
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/litex/soc/cores/cpu/cva5/irq.h
+++ b/litex/soc/cores/cpu/cva5/irq.h
@@ -9,6 +9,17 @@ extern "C" {
 #include <generated/csr.h>
 #include <generated/soc.h>
 
+// The CVA5 uses a Platform-Level Interrupt Controller (PLIC) which
+// is programmed and queried via a set of MMIO registers.
+
+#define PLIC_BASE    0xf8000000L // Base address and per-pin priority array
+#define PLIC_PENDING 0xf8001000L // Bit field matching currently pending pins
+#define PLIC_ENABLED 0xf8002000L // Bit field corresponding to the current mask
+#define PLIC_THRSHLD 0xf8200000L // Per-pin priority must be >= this to trigger
+#define PLIC_CLAIM   0xf8200004L // Claim & completion register address
+
+#define PLIC_EXT_IRQ_BASE 1
+
 static inline unsigned int irq_getie(void)
 {
     return (csrr(mstatus) & CSR_MSTATUS_MIE) != 0;

--- a/litex_setup.py
+++ b/litex_setup.py
@@ -120,7 +120,7 @@ git_repos = {
     "pythondata-cpu-blackparrot":  GitRepo(url="https://github.com/litex-hub/"),
     "pythondata-cpu-cv32e40p":     GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
     "pythondata-cpu-cv32e41p":     GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
-    "pythondata-cpu-cva5":         GitRepo(url="https://github.com/litex-hub/"),
+    "pythondata-cpu-cva5":         GitRepo(url="https://github.com/mohammadshahidzade"),
     "pythondata-cpu-cva6":         GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
     "pythondata-cpu-ibex":         GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
     "pythondata-cpu-minerva":      GitRepo(url="https://github.com/litex-hub/"),

--- a/litex_setup.py
+++ b/litex_setup.py
@@ -77,7 +77,7 @@ git_repos = {
     # ------------------
     "pythondata-software-picolibc":    GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
     "pythondata-software-compiler_rt": GitRepo(url="https://github.com/litex-hub/"),
-    "litex":                           GitRepo(url="https://github.com/mohammadshahidzade/", tag=True),
+    "litex":                           GitRepo(url="https://github.com/enjoy-digital/", tag=True),
 
     # LiteX Cores Ecosystem.
     # ----------------------
@@ -120,7 +120,7 @@ git_repos = {
     "pythondata-cpu-blackparrot":  GitRepo(url="https://github.com/litex-hub/"),
     "pythondata-cpu-cv32e40p":     GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
     "pythondata-cpu-cv32e41p":     GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
-    "pythondata-cpu-cva5":         GitRepo(url="https://github.com/mohammadshahidzade/"),
+    "pythondata-cpu-cva5":         GitRepo(url="https://github.com/litex-hub/"),
     "pythondata-cpu-cva6":         GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
     "pythondata-cpu-ibex":         GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
     "pythondata-cpu-minerva":      GitRepo(url="https://github.com/litex-hub/"),
@@ -173,7 +173,7 @@ def litex_setup_location_check():
         current_path = os.path.join(current_path, "../")
 
 def litex_setup_auto_update():
-    litex_setup_url = "https://raw.githubusercontent.com/mohammadshahidzade/litex/master/litex_setup.py"
+    litex_setup_url = "https://raw.githubusercontent.com/enjoy-digital/litex/master/litex_setup.py"
     current_sha1 = hashlib.sha1(open(os.path.realpath(__file__)).read().encode("utf-8")).hexdigest()
     print_status("LiteX Setup auto-update...")
     try:

--- a/litex_setup.py
+++ b/litex_setup.py
@@ -120,7 +120,7 @@ git_repos = {
     "pythondata-cpu-blackparrot":  GitRepo(url="https://github.com/litex-hub/"),
     "pythondata-cpu-cv32e40p":     GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
     "pythondata-cpu-cv32e41p":     GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
-    "pythondata-cpu-cva5":         GitRepo(url="https://github.com/mohammadshahidzade"),
+    "pythondata-cpu-cva5":         GitRepo(url="https://github.com/mohammadshahidzade/"),
     "pythondata-cpu-cva6":         GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
     "pythondata-cpu-ibex":         GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
     "pythondata-cpu-minerva":      GitRepo(url="https://github.com/litex-hub/"),

--- a/litex_setup.py
+++ b/litex_setup.py
@@ -77,7 +77,7 @@ git_repos = {
     # ------------------
     "pythondata-software-picolibc":    GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
     "pythondata-software-compiler_rt": GitRepo(url="https://github.com/litex-hub/"),
-    "litex":                           GitRepo(url="https://github.com/enjoy-digital/", tag=True),
+    "litex":                           GitRepo(url="https://github.com/mohammadshahidzade/", tag=True),
 
     # LiteX Cores Ecosystem.
     # ----------------------
@@ -173,7 +173,7 @@ def litex_setup_location_check():
         current_path = os.path.join(current_path, "../")
 
 def litex_setup_auto_update():
-    litex_setup_url = "https://raw.githubusercontent.com/enjoy-digital/litex/master/litex_setup.py"
+    litex_setup_url = "https://raw.githubusercontent.com/mohammadshahidzade/litex/master/litex_setup.py"
     current_sha1 = hashlib.sha1(open(os.path.realpath(__file__)).read().encode("utf-8")).hexdigest()
     print_status("LiteX Setup auto-update...")
     try:


### PR DESCRIPTION
This pull request introduces key changes to enable Linux support on the CVA5 core, including the addition of PLIC and CLINT, which required modifications to isr.c. It also resolves the original interrupt issue and includes initial changes necessary for running an operating system on multicore CVA5.

Key Updates:

- Full support for the 20240411 RISC-V privileged architecture (previously, only a draft spec from ~2017-2019 was supported).
- New separate TLBs for instructions and data.
- Sv32 virtual memory support.
- Significant bug fixes for interrupt and exception handling. This resolves issue #19 (Interrupts can lead to MEPC inconsistent with register state).
- RISC-V atomic extension (AMO) support, resolving issue #21 (State of AMO support).
- Simulation support for the latest Verilator version.
- Multicore support with cache snooping, validated on configurations with 1, 2, and 4 cores.
- Optimized PLIC and CLINT implementation, required for full multicore Linux support.
- Validated on FPGA boards, including VCU118 and Digilent Nexys.
- Performance: Achieves up to 250 MHz on the VCU118 (single-core).
- Software compatibility tested with Linux 5.18.0 and OpenSBI v0.8-2-ga9ce3ad.

These changes are based on [PR #29 from openhwgroup/cva5](https://github.com/openhwgroup/cva5/pull/29). Let me know if any refinements are needed!