### PR TITLE
flatten ghdl output with yosys to avoid conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,12 @@ jobs:
           sudo python3 litex_setup.py --gcc=openrisc
           sudo python3 litex_setup.py --gcc=powerpc
 
+      # Install OSS CAD Suite (Fixed version to avoid issue with GHDL)
+      - name: Install OSS CAD Suite
+        uses: YosysHQ/setup-oss-cad-suite@v3
+        with:
+          version: '2025-04-17'
+
       # Build / Install GHDL
       - name: Build GHDL
         run: |


### PR DESCRIPTION
fixes https://github.com/enjoy-digital/litex/issues/2107 by feeding the ghdl output to yosys to flatten it to avoid naming conflicts

This is still a kinda dumb way to have more than one VHDL instance but it works...