### PR TITLE
Fix TFTP PUT: Properly Handle OACK for Option Negotiation

### DIFF
--- a/litex/soc/software/libliteeth/tftp.c
+++ b/litex/soc/software/libliteeth/tftp.c
@@ -109,9 +109,11 @@ static void rx_callback(uint32_t src_ip, uint16_t src_port,
 		return;
 	}
 	if (opcode == TFTP_OACK) { /* Option Acknowledgement */
+		data_port = src_port;
 		packet_data = udp_get_tx_buffer();
 		length = format_ack(packet_data, 0);
 		udp_send(PORT_IN, src_port, length);
+		last_ack = 0;
 		return;
 	}
 	if(block < 1) return;


### PR DESCRIPTION
## Brief

This change fixes an issue in the TFTP client where the OACK (Option Acknowledgment) from the server was not fully handled during a file upload (tftp_put). When the server sends an OACK in response to a WRQ with options (like a non-standard block size), the client only sent an ACK(0) without updating its state (e.g., last_ack and data_port). This prevented the client from proceeding with sending data blocks, resulting in a 0-byte file on the server. The fix ensures that upon receiving an OACK, the client sets last_ack to 0 and captures the server's data port, allowing the data transfer to continue as expected.