### PR TITLE
soc/cores/cpu: Add Coreblocks RISC-V cpu

### DIFF
--- a/litex/soc/cores/cpu/coreblocks/__init__.py
+++ b/litex/soc/cores/cpu/coreblocks/__init__.py
@@ -1,0 +1,1 @@
+from litex.soc.cores.cpu.coreblocks.core import Coreblocks

--- a/litex/soc/cores/cpu/coreblocks/boot-helper.S
+++ b/litex/soc/cores/cpu/coreblocks/boot-helper.S
@@ -1,0 +1,4 @@
+	.section .text, "ax", @progbits
+	.global boot_helper
+boot_helper:
+	jr x13

--- a/litex/soc/cores/cpu/coreblocks/core.py
+++ b/litex/soc/cores/cpu/coreblocks/core.py
@@ -1,0 +1,146 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2023-2025 Piotr Wegrzyn (Coreforge Foundation) <piotro@piotro.eu>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import subprocess
+
+from migen import *
+
+from litex import get_data_mod
+from litex.soc.cores.cpu import CPU, CPU_GCC_TRIPLE_RISCV32
+from litex.soc.interconnect import wishbone
+
+# Variants -----------------------------------------------------------------------------------------
+
+CPU_VARIANTS = {
+    "standard": "basic",
+    "full":     "full",
+}
+
+# GCC Flags ----------------------------------------------------------------------------------------
+
+GCC_FLAGS = {
+    "standard":         "-march=rv32i2p0_m                                    -mabi=ilp32 ",
+    "full":             "-march=rv32i2p0_mac_zba_zbb_zbc_zbs                  -mabi=ilp32 ",
+}
+
+# Coreblocks ----------------------------------------------------------------------------------------
+
+class Coreblocks(CPU):
+    category             = "softcore"
+    family               = "riscv"
+    name                 = "coreblocks"
+    human_name           = "Coreblocks"
+    variants             = CPU_VARIANTS
+    data_width           = 32
+    endianness           = "little"
+    gcc_triple           = CPU_GCC_TRIPLE_RISCV32
+    linker_output_format = "elf32-littleriscv"
+    nop                  = "nop"
+    io_regions           = {0xe000_0000: 0x2000_0000} # Origin, Length.
+
+    # GCC Flags.
+    @property
+    def gcc_flags(self):
+        flags =  GCC_FLAGS[self.variant]
+        flags += "-D__coreblocks__ "
+        return flags
+
+    def __init__(self, platform, variant="standard"):
+        self.platform     = platform
+        self.variant      = variant
+        self.human_name   = f"Coreblocks-{CPU_VARIANTS[variant]}"
+        self.reset        = Signal()
+        self.interrupt    = Signal(16) # hart-local 16 platform interrupts - ids 16+n
+
+        self.ibus         = ibus = wishbone.Interface()
+        self.dbus         = dbus = wishbone.Interface()
+        self.periph_buses = [self.ibus, self.dbus] # Peripheral buses (Connected to main SoC's bus).
+        self.memory_buses = []                     # Memory buses (Connected directly to LiteDRAM).
+
+        # # #
+
+        self.interrupts_full = Signal(32)
+        # Shift interrupts to platform range
+        self.comb += self.interrupts_full.eq(self.interrupt << 16)
+
+        self.cpu_params = dict(
+            # Clk / Rst.
+            i_clk = ClockSignal("sys"),
+            i_rst = ResetSignal("sys") | self.reset,
+
+            ## IRQ.
+            i_interrupts = self.interrupts_full,
+
+            # Ibus.
+            o_wb_instr__stb   = ibus.stb,
+            o_wb_instr__cyc   = ibus.cyc,
+            o_wb_instr__we    = ibus.we,
+            o_wb_instr__adr   = ibus.adr,
+            o_wb_instr__dat_w = ibus.dat_w,
+            o_wb_instr__sel   = ibus.sel,
+            i_wb_instr__ack   = ibus.ack,
+            i_wb_instr__err   = ibus.err,
+            i_wb_instr__dat_r = ibus.dat_r,
+
+            # Dbus.
+            o_wb_data__stb   = dbus.stb,
+            o_wb_data__cyc   = dbus.cyc,
+            o_wb_data__we    = dbus.we,
+            o_wb_data__adr   = dbus.adr,
+            o_wb_data__dat_w = dbus.dat_w,
+            o_wb_data__sel   = dbus.sel,
+            i_wb_data__ack   = dbus.ack,
+            i_wb_data__err   = dbus.err,
+            i_wb_data__dat_r = dbus.dat_r,
+        )
+
+    # Memory Mapping.
+    @property
+    def mem_map(self):
+        # Default Memory Map.
+        # In Coreblocks MMIO region is set to 0xe000_0000 - 0xffff_fffff by default configuration.
+        # It can be changed with coreblocks `CoreConfiguration` dataclass.
+        # Remaps `csr` to that region. Other segements can be arbitraily overwritten.
+        return {
+            "rom":      0x0000_0000,
+            "sram":     0x0100_0000,
+            "main_ram": 0x4000_0000,
+            "csr":      0xe000_0000,
+        }
+
+
+    def set_reset_address(self, reset_address):
+        self.reset_address = reset_address
+
+    @staticmethod
+    def elaborate(variant, reset_address, verilog_filename):
+        cli_params = []
+        cli_params.append("--output={}".format(verilog_filename))
+        cli_params.append("--config={}".format(CPU_VARIANTS[variant]))
+        cli_params.append("--reset-pc=0x{:x}".format(reset_address))
+
+        data_mod = get_data_mod("cpu", "coreblocks")
+        sdir = data_mod.data_location
+
+        command = ["python3", os.path.join(sdir, "scripts", "gen_verilog.py")] if data_mod.RUN_NATIVE else ["pipx", "run", f"--python=3.{data_mod.PYTHON3_VERSION}", "--fetch-missing-python", os.path.join(sdir, "..", "gen_verilog_wrapper.py")]
+        command += cli_params
+
+        print(command)
+        if subprocess.call(command):
+            raise OSError("Unable to elaborate Coreblocks CPU, please check your coreblocks, Amaranth/Yosys, and requirements install")
+
+    def do_finalize(self):
+        assert hasattr(self, "reset_address")
+
+        verilog_filename = os.path.join(self.platform.output_dir, "gateware", "core.v")
+        self.elaborate(
+            variant          = self.variant,
+            reset_address    = self.reset_address,
+            verilog_filename = verilog_filename)
+
+        self.platform.add_source(verilog_filename)
+        self.specials += Instance("top", **self.cpu_params)

--- a/litex/soc/cores/cpu/coreblocks/crt0.S
+++ b/litex/soc/cores/cpu/coreblocks/crt0.S
@@ -1,0 +1,71 @@
+	.global _start
+_start:
+	j reset_vector
+
+reset_vector:
+	la sp, _fstack
+	la t0, trap_vector
+	csrw mtvec, t0
+
+	// initialize .data
+	la t0, _fdata
+	la t1, _edata
+	la t2, _fdata_rom
+1:	beq t0, t1, 2f
+	lw t3, 0(t2)
+	sw t3, 0(t0)
+	addi t0, t0, 4
+	addi t2, t2, 4
+	j 1b
+2:
+
+	// initialize .bss
+	la t0, _fbss
+	la t1, _ebss
+1:	beq t0, t1, 3f
+	sw zero, 0(t0)
+	addi t0, t0, 4
+	j 1b
+3:
+
+	call main
+
+1:	j 1b
+
+trap_vector:
+	addi sp, sp, -16*4
+	sw ra,  0*4(sp)
+	sw t0,  1*4(sp)
+	sw t1,  2*4(sp)
+	sw t2,  3*4(sp)
+	sw a0,  4*4(sp)
+	sw a1,  5*4(sp)
+	sw a2,  6*4(sp)
+	sw a3,  7*4(sp)
+	sw a4,  8*4(sp)
+	sw a5,  9*4(sp)
+	sw a6, 10*4(sp)
+	sw a7, 11*4(sp)
+	sw t3, 12*4(sp)
+	sw t4, 13*4(sp)
+	sw t5, 14*4(sp)
+	sw t6, 15*4(sp)
+	call isr
+	lw ra,  0*4(sp)
+	lw t0,  1*4(sp)
+	lw t1,  2*4(sp)
+	lw t2,  3*4(sp)
+	lw a0,  4*4(sp)
+	lw a1,  5*4(sp)
+	lw a2,  6*4(sp)
+	lw a3,  7*4(sp)
+	lw a4,  8*4(sp)
+	lw a5,  9*4(sp)
+	lw a6, 10*4(sp)
+	lw a7, 11*4(sp)
+	lw t3, 12*4(sp)
+	lw t4, 13*4(sp)
+	lw t5, 14*4(sp)
+	lw t6, 15*4(sp)
+	addi sp, sp, 16*4
+	mret

--- a/litex/soc/cores/cpu/coreblocks/csr-defs.h
+++ b/litex/soc/cores/cpu/coreblocks/csr-defs.h
@@ -1,0 +1,15 @@
+#ifndef CSR_DEFS__H
+#define CSR_DEFS__H
+
+#define CSR_MSTATUS_MIE 0x8
+
+// mie
+#define CSR_IRQ_MASK 0x304
+
+// mip
+#define CSR_IRQ_PENDING 0x344
+
+// first platform irq - enables offset in internal software
+#define FIRQ_OFFSET     16
+
+#endif	/* CSR_DEFS__H */

--- a/litex/soc/cores/cpu/coreblocks/irq.h
+++ b/litex/soc/cores/cpu/coreblocks/irq.h
@@ -1,0 +1,47 @@
+#ifndef __IRQ_H
+#define __IRQ_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <system.h>
+#include <generated/csr.h>
+#include <generated/soc.h>
+
+#include "csr-defs.h"
+
+static inline unsigned int irq_getie(void)
+{
+	return (csrr(mstatus) & CSR_MSTATUS_MIE) != 0;
+}
+
+static inline void irq_setie(unsigned int ie)
+{
+	if(ie) csrs(mstatus,CSR_MSTATUS_MIE); else csrc(mstatus,CSR_MSTATUS_MIE);
+}
+
+static inline unsigned int irq_getmask(void)
+{
+	unsigned int mask;
+	asm volatile ("csrr %0, %1" : "=r"(mask) : "i"(CSR_IRQ_MASK));
+	return (mask>>FIRQ_OFFSET);
+}
+
+static inline void irq_setmask(unsigned int mask)
+{
+	asm volatile ("csrw %0, %1" :: "i"(CSR_IRQ_MASK), "r"(mask<<FIRQ_OFFSET));
+}
+
+static inline unsigned int irq_pending(void)
+{
+	unsigned int pending;
+	asm volatile ("csrr %0, %1" : "=r"(pending) : "i"(CSR_IRQ_PENDING));
+	return (pending >> FIRQ_OFFSET);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __IRQ_H */

--- a/litex/soc/cores/cpu/coreblocks/system.h
+++ b/litex/soc/cores/cpu/coreblocks/system.h
@@ -1,0 +1,46 @@
+#ifndef __SYSTEM_H
+#define __SYSTEM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+__attribute__((unused)) static void flush_cpu_icache(void) {
+    asm volatile ("fence.i");
+};
+
+__attribute__((unused)) static void flush_cpu_dcache(void){}; // currently no dcache
+
+void flush_l2_cache(void);
+void busy_wait(unsigned int ms);
+void busy_wait_us(unsigned int us);
+
+#include <csr-defs.h>
+
+#define csrr(reg) ({ unsigned long __tmp; \
+  asm volatile ("csrr %0, " #reg : "=r"(__tmp)); \
+  __tmp; })
+
+#define csrw(reg, val) ({ \
+  if (__builtin_constant_p(val) && (unsigned long)(val) < 32) \
+	asm volatile ("csrw " #reg ", %0" :: "i"(val)); \
+  else \
+	asm volatile ("csrw " #reg ", %0" :: "r"(val)); })
+
+#define csrs(reg, bit) ({ \
+  if (__builtin_constant_p(bit) && (unsigned long)(bit) < 32) \
+	asm volatile ("csrrs x0, " #reg ", %0" :: "i"(bit)); \
+  else \
+	asm volatile ("csrrs x0, " #reg ", %0" :: "r"(bit)); })
+
+#define csrc(reg, bit) ({ \
+  if (__builtin_constant_p(bit) && (unsigned long)(bit) < 32) \
+	asm volatile ("csrrc x0, " #reg ", %0" :: "i"(bit)); \
+  else \
+	asm volatile ("csrrc x0, " #reg ", %0" :: "r"(bit)); })
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __SYSTEM_H */

--- a/litex_setup.py
+++ b/litex_setup.py
@@ -118,6 +118,7 @@ git_repos = {
 
     # RISC-V CPU(s).
     "pythondata-cpu-blackparrot":  GitRepo(url="https://github.com/litex-hub/"),
+    "pythondata-cpu-coreblocks":   GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
     "pythondata-cpu-cv32e40p":     GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
     "pythondata-cpu-cv32e41p":     GitRepo(url="https://github.com/litex-hub/", clone="recursive"),
     "pythondata-cpu-cva5":         GitRepo(url="https://github.com/litex-hub/"),
@@ -143,6 +144,7 @@ minimal_repos = ["migen", "litex"]
 # Standard: Migen + LiteX + Cores + Software + Popular CPUs (LM32, Mor1kx, SERV, VexRiscv).
 standard_repos = list(git_repos.keys())
 standard_repos.remove("pythondata-cpu-blackparrot")
+standard_repos.remove("pythondata-cpu-coreblocks")
 standard_repos.remove("pythondata-cpu-cv32e40p")
 standard_repos.remove("pythondata-cpu-cv32e41p")
 standard_repos.remove("pythondata-cpu-cva5")
@@ -495,4 +497,4 @@ def main():
 
 if __name__ == "__main__":
     main()
-    
+

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -43,6 +43,7 @@ class TestIntegration(unittest.TestCase):
 
     def test_cpu(self):
         tested_cpus = [
+            "coreblocks",   # (riscv   / softcore)
             #"cv32e40p",     # (riscv   / softcore)
             "femtorv",      # (riscv   / softcore)
             "firev",        # (riscv   / softcore)


### PR DESCRIPTION
Hi,
This PR adds [Coreblocks](https://github.com/kuznia-rdzeni/coreblocks/) cpu core support.
Coreblocks is an experimental RISC-V Out-of-Order core generator written in Amaranth.

Core elaboration requires python 3.11, but it is solved similar to recent Sentinel core by PEP-723 script. Wrapper script is placed in `pythondata-cpu-coreblocks` instead, because of dynamically changing dependencies. `pipx` is the only dependency installed by default in pythondata package and it is used to run the wrapper.

Coreblocks with LiteX runs Zephyr [zephyr-on-litex-coreblocks](https://github.com/kuznia-rdzeni/zephyr-on-litex-coreblocks) and (currently) no-mmu Linux [linux-on-litex-coreblocks](https://github.com/kuznia-rdzeni/linux-on-litex-coreblocks) !
I added the core to the CI and simulation boot tests pass. 