### PR TITLE
Burst Size Width Consistency in AXI3 and AXI4

### DIFF
--- a/litex/soc/interconnect/axi/axi_full.py
+++ b/litex/soc/interconnect/axi/axi_full.py
@@ -25,14 +25,13 @@ from litex.soc.interconnect.axi.axi_stream import AXIStreamInterface
 
 def ax_description(address_width, version="axi4"):
     len_width  = {"axi3":4, "axi4":8}[version]
-    size_width = {"axi3":4, "axi4":3}[version]
     lock_width = {"axi3":2, "axi4":1}[version]
     # * present for interconnect with others cores but not used by LiteX.
     return [
         ("addr",   address_width),   # Address Width.
         ("burst",  2),               # Burst type.
         ("len",    len_width),       # Number of data (-1) transfers (up to 16 (AXI3) or 256 (AXI4)).
-        ("size",   size_width),      # Number of bytes (-1) of each data transfer (up to 1024-bit).
+        ("size",   3),               # Number of bytes (-1) of each data transfer (up to 1024-bit).
         ("lock",   lock_width),      # *
         ("prot",   3),               # *
         ("cache",  4),               # *


### PR DESCRIPTION
According to the [AMBA AXI and ACE Protocol Specification](https://developer.arm.com/-/media/Arm%20Developer%20Community/PDF/IHI0022H_amba_axi_protocol_spec.pdf) (page 49), the burst size width is fixed at 3 and remains unchanged between AXI3 and AXI4.

![image](https://github.com/user-attachments/assets/61c99a80-33d8-402b-95fe-cc6047a77f83)