### PR TITLE
Fix add_controller() call

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -507,7 +507,7 @@ class SoCBusHandler(LiteXModule):
             colorer("added", color="green")))
 
     def add_controller(self, name=None, controller=None):
-        self.add_master(self, name=name, master=controller)
+        self.add_master(name=name, master=controller)
 
     def add_slave(self, name=None, slave=None, region=None):
         no_name   = name   is None


### PR DESCRIPTION
The `add_controller` alias for `add_master` incorrectly includes self in the method call, which causes a runtime error complaining if a user runs `self.bus.add_controller(name="x", controller=controller)`It just needs a simple fix to work correctly.