### PR TITLE
.github/workflows/ci.yml: integrates oss-cad-suite and remove GHDL Build/Install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,15 +43,9 @@ jobs:
           sudo python3 litex_setup.py --gcc=openrisc
           sudo python3 litex_setup.py --gcc=powerpc
 
-      # Build / Install GHDL
-      - name: Build GHDL
-        run: |
-          sudo apt-get install gnat llvm
-          git clone https://github.com/ghdl/ghdl.git
-          cd ghdl
-          ./configure --with-llvm-config
-          make
-          sudo make install
+      # Install OSS CAD Suite
+      - name: Install OSS CAD Suite
+        uses: YosysHQ/setup-oss-cad-suite@v3
 
       # Build / Install Verilator
       - name: Build Verilator


### PR DESCRIPTION
_oss-cad-suite_ provides a complete tool set including `yosys` and `GHDL`. It also provides an action to simplify integration in _CI_.
This approach:
- avoids to build `GHDL` all the time: `GHDL` shipped with _oss-cad-suite_ is daily built with master branch (similar to the current approach in `LiteX` CI). This allows to reducing CI delays (around 4m/10% for my fork's CI)
- by using `yosys` (based on master branch too) from this package fixes #2213 because `yosys` is by default required and ubuntu's version is too old and fails. This also avoid a big overhead due to `yosys` compile time.