### PR TITLE
build/vhd2v_converter: fixed assert when nor params nor instance are provided (#2212)

### DIFF
--- a/litex/build/vhd2v_converter.py
+++ b/litex/build/vhd2v_converter.py
@@ -71,7 +71,10 @@ class VHD2VConverter(Module):
         self._work_package  = work_package
         self._libraries     = list()
 
-        assert (self._params is None) ^ (self._instance is None)
+        # Params and instance can't be provided at the same time.
+        assert not ((self._params is not None) and (self._instance is not None))
+        # When add_instance params or instance must be set.
+        assert not (self._add_instance and ((self._params is None) and (self._instance is None)))
 
         if self._instance is not None and self._top_entity is None:
             self._top_entity = self._instance.name_override
@@ -140,7 +143,7 @@ class VHD2VConverter(Module):
         if self._platform.support_mixed_language and not self._force_convert:
             if self._params:
                 ip_params = self._params
-            else:
+            elif self._instance:
                 ip_params = self._instance.items
             for file in self._sources:
                 self._platform.add_source(file, library=self._work_package)
@@ -182,7 +185,7 @@ class VHD2VConverter(Module):
                         generics.append("-g" + k[2:] + "=" + str(v))
                     else:
                         ip_params[k] = v
-            else:
+            elif self._instance:
                 ip_params = list()
                 for item in self._instance.items:
                     if isinstance(item, Instance.Parameter):


### PR DESCRIPTION
Since commit a6845a7d6369c8be82a64a831acb35884ab6e9cf an instance may be provided at constructor level.
The `assert` has been updated to check if `instance` or `params` are provided using a `XOR`. This is fine to avoid to have both parameters provided at the same time but fails when both are `None`.

This PR:
- fix this failure by changing the `assert`'s test
- adds a second `assert` to check if exactly one of the two parameters are provided when `add_instance` is set to `True`
- modify some `if/else` to uses `_instance` only when not `None`.