### PR TITLE
CI: force GHDL version (fix build failure with neorv32)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           sudo apt-get install gnat llvm
           git clone https://github.com/ghdl/ghdl.git
           cd ghdl
+          git checkout 1fc1bccd1a7c256c531bdd6dc8f9641f90eb8ea0
           ./configure --with-llvm-config
           make
           sudo make install


### PR DESCRIPTION
Since https://github.com/ghdl/ghdl/commit/a4d334fb72abb78bf25f9d1eb3a2f25eadf61a97 the CI fails to build due to errors with `litex_sim` and verilator.

This PR force GHDL to the previous commit as a temporary workaround.