### PR TITLE
build/nextpnr_wrapper.py: directly handles himbaechel architecture

### DIFF
--- a/litex/build/gowin/apicula.py
+++ b/litex/build/gowin/apicula.py
@@ -66,9 +66,6 @@ class GowinApiculaToolchain(YosysNextPNRToolchain):
 
         YosysNextPNRToolchain.finalize(self)
 
-        # family is gowin but NextPNRWrapper needs to call 'nextpnr-himbaechel' not 'nextpnr-gowin'
-        self._nextpnr.name = "nextpnr-himbaechel"
-
     def build(self, platform, fragment, **kwargs):
         self.platform = platform
 

--- a/litex/build/nextpnr_wrapper.py
+++ b/litex/build/nextpnr_wrapper.py
@@ -4,6 +4,8 @@
 # Copyright (c) 2022 Gwenhael Goavec-Merou <gwenhael.goavec-merou@trabucayre.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
+from shutil import which
+
 from litex.build import tools
 
 # NextPNR Wrapper ----------------------------------------------------------------------------------
@@ -45,7 +47,6 @@ class NextPNRWrapper():
         kwargs: dict
             alternate options key/value
         """
-        self.name           = f"nextpnr-{family}"
         self._target        = family
         self._build_name    = build_name
         self._in_format     = in_format
@@ -61,6 +62,17 @@ class NextPNRWrapper():
             else:
                 if value != "":
                     self._pnr_opts += f"--{key} {value} "
+
+        # Gowin toolchain differs from others: it is supported by himbaechel architecture
+        if family in ["gowin"]:
+            self.name = "nextpnr-himbaechel"
+            # For Himbächel architecture:
+            # one binary may be build supporting all uarch or
+            # when HIMBAECHEL_SPLIT is set a dedicated binary is built per uarch
+            if which(f"{self.name}-{family}") is not None:
+                self.name = f"{self.name}-{family}"
+        else:
+            self.name = f"nextpnr-{family}"
 
     @property
     def pnr_opts(self):


### PR DESCRIPTION
Recent `nextPNR`'s evolutions have introduces *himbaechel* architecture. This one supports FPGAs like **gowin**, **gatemate**, **xilinx**, ...
For *apicula* toolchain current solution is to force nextPNR name in `finalize` method.

But since `nextpnr-gowin` is now deprecated it make more sense to moves this logic in `nextpnr_wrapper.py`: `apicula.py` know informations about gowin devices, `nextpnr_wrapper.py` know for gowin architecture the executable is called `nextpnr-himbaechel`.

A second `nextPNR` evolution is the introduction of `HIMBAECHEL_SPLIT` option:
- when unset, or set to OFF, all selected `uarch` are included into a single executable
- when set each `uarch` is supported by a specific executable (`nextpnr-himbaechel-XXX`) where XXX is the `uarch` name

This PR:
- adapts the code to move naming translation at `nextpnr_wrapper.py` level
- adds a test to select nextPNR executable name (`nextpnr-himbaechel` or `nextpnr-himbaechel-uarch`).