### PR TITLE
Allow us to specify uart_pads in soc_core

### DIFF
--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -100,6 +100,7 @@ class SoCCore(LiteXSoC):
         uart_name                = "serial",
         uart_baudrate            = 115200,
         uart_fifo_depth          = 16,
+        uart_pads                = None,
         uart_with_dynamic_baudrate = False,
 
         # Timer parameters.
@@ -260,7 +261,7 @@ class SoCCore(LiteXSoC):
 
         # Add UART.
         if with_uart:
-            self.add_uart(name="uart", uart_name=uart_name, baudrate=uart_baudrate, fifo_depth=uart_fifo_depth, with_dynamic_baudrate=uart_with_dynamic_baudrate)
+            self.add_uart(name="uart", uart_name=uart_name, uart_pads=uart_pads, baudrate=uart_baudrate, fifo_depth=uart_fifo_depth, with_dynamic_baudrate=uart_with_dynamic_baudrate)
 
         # Add JTAGBone.
         if with_jtagbone:


### PR DESCRIPTION
Altera Cyclone V chips have a HPS to FPGA uart interface that allows a uart connection directly between the CPU and FPGA without external pins or a uart adapter. This allows me to connect directly to a litex core on me terasic DE10 Nano running linux without having to use a different dongle or different computer. This is very useful to me.

The entire chain in setting up a uart connection has options to specify `uart_pads=` instead of requesting a system resource , including the `LiteXSoC.add_uart` function, but `LitexSocCore` doesn't provide access to this option. This made it difficult for me to pass the signals in to the code I have since they are not exposed externally.

Without that I can't do this to create the interface:

```
self.specials += Instance(
        "cyclonev_hps_interface_peripheral_uart",
        i_ri = 0,
        i_rxd = cyclone_uart_pads.tx,
        o_txd = cyclone_uart_pads.rx,
        o_dsr = 1
         )

```

I would like this change so I can submit another patch to the litex-boards repo which allows users to use the same setup as I am using, where they can connect directly to the softcore from their hard linux operating system on the same SoC, simplifying development.
