### PR TITLE
Gatemate himbaechel toolchain

### DIFF
--- a/litex/build/colognechip/peppercorn.py
+++ b/litex/build/colognechip/peppercorn.py
@@ -1,0 +1,95 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2025 Gwenhael Goavec-Merou <gwenhael.goavec-merou@trabucayre.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from litex.build.generic_platform import *
+from litex.build.colognechip.colognechip import _build_ccf
+from litex.build import tools
+from litex.build.yosys_nextpnr_toolchain import YosysNextPNRToolchain
+
+# PeppercornToolchain ------------------------------------------------------------------------------
+
+class PeppercornToolchain(YosysNextPNRToolchain):
+    family     = "gatemate"
+    synth_fmt  = "json"
+    pnr_fmt    = "txt"
+    packer_cmd = "gmpack"
+
+    def __init__(self):
+        super().__init__()
+        self._synth_opts = "-luttree -nomx8"
+        self._synth_opts += " -nomult" # Temporary: currently no supports for CC_MULT.
+
+    # Timing Constraints (.sdc) --------------------------------------------------------------------
+
+    def build_timing_constraints(self, vns):
+        max_freq = 0
+        sdc      = []
+
+        # Clock constraints
+        for clk, [period, name] in sorted(self.clocks.items(), key=lambda x: x[0].duid):
+            # Search for the highest frequency.
+            freq = int(1e3 / period)
+            if freq > max_freq:
+                max_freq = freq
+
+            is_port = False
+            for sig, pins, others, resname in self.named_sc:
+                if sig == vns.get_name(clk):
+                    is_port = True
+            clk_sig = self._vns.get_name(clk)
+            if name is None:
+                name = clk_sig
+            if is_port:
+                tpl = "create_clock -name {name} -period {period} [get_ports {{{clk}}}]"
+                sdc.append(tpl.format(name=name, clk=clk_sig, period=str(period)))
+            else:
+                tpl = "create_clock -name {name} -period {period} [get_nets {{{clk}}}]"
+                sdc.append(tpl.format(name=name, clk=clk_sig, period=str(period)))
+
+        # False path constraints
+        for from_, to in sorted(self.false_paths, key=lambda x: (x[0].duid, x[1].duid)):
+            tpl = "set_false_path -from [get_clocks {{{from_}}}] -to [get_clocks {{{to}}}]"
+            sdc.append(tpl.format(from_=vns.get_name(from_), to=vns.get_name(to)))
+
+        # Generate .sdc
+        tools.write_to_file("{}.sdc".format(self._build_name), "\n".join(sdc))
+
+        # FIXME: NextPNRWrapper is constructed at finalize level, too early
+        # to update self._pnr_opts. The solution is to update _nextpnr instance.
+        self._nextpnr._pnr_opts += f" --freq {max_freq}"
+
+    # IO Constraints (.ccf) ------------------------------------------------------------------------
+
+    def build_io_constraints(self):
+        ccf = _build_ccf(self.named_sc, self.named_pc)
+        tools.write_to_file(f"{self._build_name}.ccf", "\n".join(ccf))
+        return (f"{self._build_name}.ccf", "CCF")
+
+    def finalize(self):
+        pnr_opts = "--device {device}" + \
+            " --vopt ccf={top}.ccf --router router2"
+        #pnr_opts += " --sdc {top}.sdc"
+        self._pnr_opts += pnr_opts.format(
+            device     = self.platform.device,
+            top        = self._build_name,
+        )
+
+        self._packer_opts += "{top}.txt {top}.bit".format(
+            top = self._build_name
+        )
+
+        YosysNextPNRToolchain.finalize(self)
+
+    def build(self, platform, fragment, **kwargs):
+        self.platform = platform
+
+        return YosysNextPNRToolchain.build(self, platform, fragment, **kwargs)
+
+def peppercorn_args(parser):
+    pass
+
+def peppercorn_argdict(args):
+    return {}

--- a/litex/build/colognechip/platform.py
+++ b/litex/build/colognechip/platform.py
@@ -7,7 +7,7 @@
 import os
 
 from litex.build.generic_platform import GenericPlatform
-from litex.build.colognechip import common, colognechip
+from litex.build.colognechip import common, colognechip, peppercorn
 
 # CologneChipPlatform ------------------------------------------------------------------------------
 
@@ -15,12 +15,18 @@ class CologneChipPlatform(GenericPlatform):
     _bitstream_ext = "_00.cfg.bit"
     _jtag_support  = False
 
-    _supported_toolchains = ["colognechip"]
+    _supported_toolchains = ["colognechip", "peppercorn"]
 
     def __init__(self, device, *args, toolchain="colognechip", devicename=None, **kwargs):
         GenericPlatform.__init__(self, device, *args, **kwargs)
 
-        self.toolchain = colognechip.CologneChipToolchain()
+        if toolchain == "colognechip":
+            self.toolchain = colognechip.CologneChipToolchain()
+        elif toolchain == "peppercorn":
+            self._bitstream_ext = ".bit"
+            self.toolchain = peppercorn.PeppercornToolchain()
+        else:
+            raise ValueError(f"Unknown toolchain {toolchain}")
 
     def get_verilog(self, *args, special_overrides=dict(), **kwargs):
         so = dict(common.colognechip_special_overrides)
@@ -51,7 +57,10 @@ class CologneChipPlatform(GenericPlatform):
         parser: argparse.ArgumentParser
             parser to be filled
         """
-        colognechip.colognechip_args(parser)
+        if toolchain == "colognechip":
+            colognechip.colognechip_args(parser)
+        else:
+            peppercorn.peppercorn_args(parser)
 
     @classmethod
     def get_argdict(cls, toolchain, args):
@@ -67,4 +76,7 @@ class CologneChipPlatform(GenericPlatform):
         ======
         a dict of key/value for each args or an empty dict
         """
-        return colognechip.colognechip_argdict(args)
+        if toolchain == "colognechip":
+            return colognechip.colognechip_argdict(args)
+        else:
+            return peppercorn.peppercorn_argdict(args)

--- a/litex/build/nextpnr_wrapper.py
+++ b/litex/build/nextpnr_wrapper.py
@@ -64,7 +64,7 @@ class NextPNRWrapper():
                     self._pnr_opts += f"--{key} {value} "
 
         # Gowin toolchain differs from others: it is supported by himbaechel architecture
-        if family in ["gowin"]:
+        if family in ["gowin", "gatemate"]:
             self.name = "nextpnr-himbaechel"
             # For Himbächel architecture:
             # one binary may be build supporting all uarch or
@@ -98,12 +98,14 @@ class NextPNRWrapper():
         cmd = "{pnr_name} --{in_fmt} {build_name}.{in_fmt}"
         if self._constr_format != "":
             cmd += " --{constr_fmt} {build_name}.{constr_fmt}"
-        cmd += " --{out_fmt} {build_name}.{out_ext} {pnr_opts}"
+        cmd += " --{out_fmt}{build_name}.{out_ext} {pnr_opts}"
         base_cmd = cmd.format(
             pnr_name   = self.name,
             build_name = self._build_name,
             in_fmt     = self._in_format,
-            out_fmt    = "textcfg" if self._out_format == "config" else self._out_format,
+            out_fmt    = {
+                "config" : "textcfg ",
+                "txt"    : "vopt out="}.get(self._out_format, self._out_format + " "),
             out_ext    = self._out_format,
             constr_fmt = self._constr_format,
             pnr_opts   = self._pnr_opts


### PR DESCRIPTION
A new opensource toolchain is available for CologneChip GateMate FPGAs. This one is based on Yosys/nextPNR and Project Peppercorn.
This PR adds support to this alternate toolchain.

Note: nextPNR and peppercorn is under development and consequently GateMate FPGAs are not fully supported (`no-mult` option is passed to Yosys, because `CC_MULT` aren't supported.

Tested with both CologneChip GateMate eval board and Olimex GateMate EVB