### PR TITLE
Fix gcc march parameter for minerva and sentinel cores

### DIFF
--- a/litex/soc/cores/cpu/minerva/core.py
+++ b/litex/soc/cores/cpu/minerva/core.py
@@ -40,7 +40,7 @@ class Minerva(CPU):
     # GCC Flags.
     @property
     def gcc_flags(self):
-        flags =  "-march=rv32im "
+        flags =  "-march=rv32i2p0_m "
         flags += "-mabi=ilp32 "
         flags += "-D__minerva__ "
         return flags

--- a/litex/soc/cores/cpu/sentinel/core.py
+++ b/litex/soc/cores/cpu/sentinel/core.py
@@ -47,7 +47,7 @@ class Sentinel(CPU):
     # GCC Flags.
     @property
     def gcc_flags(self):
-        flags =  "-march=rv32i "
+        flags =  "-march=rv32i2p0 "
         flags += "-mabi=ilp32 "
         flags += "-D__sentinel__ "
         return flags


### PR DESCRIPTION
This one fixes GCC flags parameter to be inline with those used on the other CPU cores.