### PR TITLE
Add DR1V90MEG484 device and load_bitstream function support for Anlogic platform

### DIFF
--- a/litex/build/anlogic/anlogic.py
+++ b/litex/build/anlogic/anlogic.py
@@ -17,9 +17,9 @@ from litex.build.generic_platform import *
 from litex.build.generic_toolchain import GenericToolchain
 from litex.build import tools
 
-# TangDinastyToolchain -----------------------------------------------------------------------------
+# TangDynastyToolchain -----------------------------------------------------------------------------
 
-class TangDinastyToolchain(GenericToolchain):
+class TangDynastyToolchain(GenericToolchain):
     attr_translate = {}
 
     def __init__(self):

--- a/litex/build/anlogic/anlogic.py
+++ b/litex/build/anlogic/anlogic.py
@@ -193,6 +193,13 @@ class TangDynastyToolchain(GenericToolchain):
                 msg += "- Add  Tang Dinasty toolchain to your $PATH."
                 raise OSError(msg)
 
+            if self._architecture == "dr1_90":
+                td_version = subprocess.check_output(["td", "-v"],
+                    stderr=subprocess.STDOUT).decode("utf-8")
+                if "5.9" not in td_version:
+                    msg = "dr1_90 architecture is only supported in Tang Dinasty 5.9."
+                    raise OSError(msg)
+
             if subprocess.call(["td", script]) != 0:
                 raise OSError("Error occured during Tang Dinasty's script execution.")
 
@@ -200,6 +207,7 @@ class TangDynastyToolchain(GenericToolchain):
         device = self.platform.device
 
         devices = {
+            "DR1V90MEG484" :[ "dr1_90", "DR1", "DR1V90MEG484" ],
             "EG4S20BG256" :[ "eagle_s20", "EG4", "BG256" ],
         }
 

--- a/litex/build/anlogic/anlogic.py
+++ b/litex/build/anlogic/anlogic.py
@@ -180,6 +180,7 @@ class TangDynastyToolchain(GenericToolchain):
         tcl.append("place")
         tcl.append("route")
         tcl.append(f"bitgen -bit \"{self._build_name}.bit\" -version 0X00 -g ucode:000000000000000000000000")
+        tcl.append("exit")
 
         # Generate .tcl.
         tools.write_to_file("run.tcl", "\n".join(tcl))

--- a/litex/build/anlogic/platform.py
+++ b/litex/build/anlogic/platform.py
@@ -21,7 +21,7 @@ class AnlogicPlatform(GenericPlatform):
     def __init__(self, device, *args, toolchain="td", **kwargs):
         GenericPlatform.__init__(self, device, *args, **kwargs)
         if toolchain == "td":
-            self.toolchain = anlogic.TangDinastyToolchain()
+            self.toolchain = anlogic.TangDynastyToolchain()
         else:
             raise ValueError(f"Unknown toolchain {toolchain}")
 

--- a/litex/build/anlogic/programmer.py
+++ b/litex/build/anlogic/programmer.py
@@ -1,0 +1,31 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2015-2025 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2025 Junhui Liu <junhui.liu@pigmoral.tech>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import subprocess
+from shutil import which
+
+from litex.build.generic_programmer import GenericProgrammer
+
+def _run_td(cmds):
+    if which("td") is None:
+        msg = "Unable to find Tang Dinasty toolchain, please:\n"
+        msg += "- Add Tang Dinasty toolchain to your $PATH."
+        raise OSError(msg)
+
+    with subprocess.Popen("td", stdin=subprocess.PIPE, shell=True) as process:
+        process.stdin.write(cmds.encode("ASCII"))
+        process.communicate()
+
+class TangDynastyProgrammer(GenericProgrammer):
+    def __init__(self):
+        GenericProgrammer.__init__(self)
+
+    def load_bitstream(self, bitstream_file):
+        cmds = """download -bit {bitstream} -mode jtag -spd 7 -sec 64 -cable 0
+exit
+""".format(bitstream=bitstream_file)
+        _run_td(cmds)


### PR DESCRIPTION
This introduces enhancements to the Anlogic platform:

1. Fix typo Dinasty to  Dynasty.
2. Fix Tang Dynasty not exiting problem after running `run.tcl`.
3. Add DR1V90MEG484 device support, which has built-in FPGA with 94464 LUTs and a UX900 RISC-V CPU hardcore from Nuclei System Technology. The dr1_90 architecture is only supported in Tang Dynasty version 5.9.
4. Introduced a new `TangDynastyProgrammer`, supporting `load_bitstream()` function for Anlogic platform. Since I don't have the Sipeed Tang Primer board, it's only tested on the dr1v90 platform.