### PR TITLE
colognechip: remove forcing ram_style=distributed

### DIFF
--- a/litex/build/colognechip/colognechip.py
+++ b/litex/build/colognechip/colognechip.py
@@ -62,7 +62,11 @@ class CologneChipToolchain(GenericToolchain):
     def __init__(self):
         super().__init__()
         self._yosys      = None
-        self._yosys_cmds = []
+        # CologneChip does not have distributed RAM
+        self._yosys_cmds = [
+            "hierarchy -top {build_name}",
+            "setattr -unset ram_style a:ram_style=distributed",
+        ]
         self._synth_opts = "-nomx8 "
 
     def finalize(self):

--- a/litex/build/colognechip/peppercorn.py
+++ b/litex/build/colognechip/peppercorn.py
@@ -85,6 +85,11 @@ class PeppercornToolchain(YosysNextPNRToolchain):
 
     def build(self, platform, fragment, **kwargs):
         self.platform = platform
+        # CologneChip does not have distributed RAM
+        self._yosys_cmds = [
+            "hierarchy -top {build_name}",
+            "setattr -unset ram_style a:ram_style=distributed",
+        ]
 
         return YosysNextPNRToolchain.build(self, platform, fragment, **kwargs)
 


### PR DESCRIPTION
This change lets yosys `memory_libmap` choose proper memory on it's own when `"distributed"` is asked for. This makes CPUs like `vexriscv_smp` to be synthesized.