### PR TITLE
Expose 'check_duplicate' argument in 'add_ip_address_constants' and 'add_mac_address_constants'

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -41,17 +41,17 @@ def build_time(with_time=True):
     fmt = "%Y-%m-%d %H:%M:%S" if with_time else "%Y-%m-%d"
     return datetime.datetime.fromtimestamp(time.time()).strftime(fmt)
 
-def add_ip_address_constants(soc, name, ip_address):
+def add_ip_address_constants(soc, name, ip_address, check_duplicate=True):
     _ip_address = ip_address.split(".")
     assert len(_ip_address) == 4
     for n in range(4):
         assert int(_ip_address[n]) < 256
-        soc.add_constant(f"{name}{n+1}", int(_ip_address[n]))
+        soc.add_constant(f"{name}{n+1}", int(_ip_address[n]), check_duplicate=check_duplicate)
 
-def add_mac_address_constants(soc, name, mac_address):
+def add_mac_address_constants(soc, name, mac_address, check_duplicate=True):
     assert mac_address < 2**48
     for n in range(6):
-        soc.add_constant(f"{name}{n+1}", (mac_address >> ((5 - n) * 8)) & 0xff)
+        soc.add_constant(f"{name}{n+1}", (mac_address >> ((5 - n) * 8)) & 0xff, check_duplicate=check_duplicate)
 
 # SoCError -----------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Makes it easier/more readable to override existing IP/MAC address constants, for example, you could do:
```python
add_ip_address_constants(self, "REMOTEIP", remote_ip, check_duplicate=False)
```
instead of ([source](https://github.com/litex-hub/linux-on-litex-vexriscv/blob/55c2f4aa1cf96924f6e64e6896755dce08aa7f7f/soc_linux.py#L60-L72)):
```python
try: # FIXME: Improve.
    self.constants.pop("REMOTEIP1")
    self.constants.pop("REMOTEIP2")
    self.constants.pop("REMOTEIP3")
    self.constants.pop("REMOTEIP4")
except:
    pass
self.add_constant("REMOTEIP1", int(remote_ip[0]))
self.add_constant("REMOTEIP2", int(remote_ip[1]))
self.add_constant("REMOTEIP3", int(remote_ip[2]))
self.add_constant("REMOTEIP4", int(remote_ip[3]))
```