### PR TITLE
bios: add broadcast support to libliteeth/udp

### DIFF
--- a/litex/soc/software/libliteeth/udp.h
+++ b/litex/soc/software/libliteeth/udp.h
@@ -5,6 +5,8 @@
 extern "C" {
 #endif
 
+#include <generated/soc.h>
+
 #define ETHMAC_EV_SRAM_WRITER	0x1
 #define ETHMAC_EV_SRAM_READER	0x1
 
@@ -15,12 +17,17 @@ extern "C" {
 typedef void (*udp_callback)(uint32_t src_ip, uint16_t src_port, uint16_t dst_port, void *data, uint32_t length);
 
 void udp_set_ip(uint32_t ip);
+uint32_t udp_get_ip(void);
 void udp_set_mac(const uint8_t *macaddr);
 void udp_start(const uint8_t *macaddr, uint32_t ip);
 int udp_arp_resolve(uint32_t ip);
 void *udp_get_tx_buffer(void);
 int udp_send(uint16_t src_port, uint16_t dst_port, uint32_t length);
 void udp_set_callback(udp_callback callback);
+#ifdef ETH_UDP_BROADCAST
+void udp_set_broadcast_callback(udp_callback callback);
+void udp_set_broadcast(void);
+#endif /* ETH_UDP_BROADCAST */
 void udp_service(void);
 
 void eth_init(void);


### PR DESCRIPTION
This adds support for UDP broadcasts and a helper function to get the
currently set IP. These changes are required for BOOTP support.

now protected with a ifdef, so if its nat activated its not compiled in