### PR TITLE
Tests/test_integration: Fix log output on failure + Add vexiiriscv to unit tests

### DIFF
--- a/litex/soc/cores/cpu/vexiiriscv/core.py
+++ b/litex/soc/cores/cpu/vexiiriscv/core.py
@@ -156,7 +156,7 @@ class VexiiRiscv(CPU):
         vdir = get_data_mod("cpu", "vexiiriscv").data_location
         ndir = os.path.join(vdir, "ext", "VexiiRiscv")
 
-        NaxRiscv.git_setup("VexiiRiscv", ndir, "https://github.com/SpinalHDL/VexiiRiscv.git", "dev", "3282ca22", args.update_repo)
+        NaxRiscv.git_setup("VexiiRiscv", ndir, "https://github.com/SpinalHDL/VexiiRiscv.git", "dev", "0d32e85", args.update_repo)
 
         if not args.cpu_variant:
             args.cpu_variant = "standard"

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -50,6 +50,7 @@ class TestIntegration(unittest.TestCase):
             "marocchino",   # (or1k    / softcore)
             "naxriscv",     # (riscv   / softcore)
             "serv",         # (riscv   / softcore)
+            "vexiiriscv",   # (riscv   / softcore)
             "vexriscv",     # (riscv   / softcore)
             "vexriscv_smp", # (riscv   / softcore)
             #"microwatt",    # (ppc64   / softcore)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -17,7 +17,7 @@ class TestIntegration(unittest.TestCase):
         litex_prompt = [r'\033\[[0-9;]+mlitex\033\[[0-9;]+m>']
         is_success = True
 
-        with tempfile.TemporaryFile(mode='w', prefix="litex_test") as log_file:
+        with tempfile.TemporaryFile(mode='w+', prefix="litex_test") as log_file:
             log_file.writelines(f"Command: {cmd}")
             log_file.flush()
 


### PR DESCRIPTION
This PR adds vexiiriscv to the test_integration unit test.

While working on this, I noticed the following issues:
- The log output was broken when a CPU failed to boot. This was due to incorrect file mode settings when opening the log file.
- The previously recommended commit for vexiiriscv fails to compile (at least with default settings) due to the following error:
> Error:  Note: the super classes of <$anon: spinal.lib.bus.amba4.axi.sim.Axi4WriteOnlyMonitor> contain the following, non final members named onWriteStart:
> Error:  def onWriteStart(address: BigInt,id: Int,size: Int,len: Int,burst: Int,cache: Int): Unit
> Error:          override def onWriteStart(address: BigInt, id: Int, size: Int, len: Int, burst: Int): Unit = {
- To fix this, I updated the recommended commit to the latest dev version that successfully compiles and passes the test.

@Dolu1990  Is there a more suitable commit you would recommend instead?