### PR TITLE
cpu/ibex: Fix #2258

### DIFF
--- a/litex/soc/cores/cpu/ibex/core.py
+++ b/litex/soc/cores/cpu/ibex/core.py
@@ -256,7 +256,13 @@ class Ibex(CPU):
                 if line.startswith("//") or not line.strip():
                     continue
                 platform.add_source(os.path.join(rtl_base, line.strip()))
-
+        # Add additional ibex files that are missing in ibex_core.f:
+        platform.add_sources(rtl_base,
+            "ibex_wb_stage.sv",
+            "ibex_csr.sv",
+            "ibex_top.sv"
+            )
+        platform.add_source(os.path.join(ibexdir, "dv", "uvm", "core_ibex", "common", "prim", "prim_buf.sv"))
     def set_reset_address(self, reset_address):
         self.reset_address = reset_address
         self.cpu_params.update(i_boot_addr_i=Signal(32, reset=reset_address))

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -55,6 +55,7 @@ class TestIntegration(unittest.TestCase):
             "vexriscv_smp", # (riscv   / softcore)
             #"microwatt",    # (ppc64   / softcore)
             "neorv32",      # (riscv   / softcore)
+            "ibex",         # (riscv   / softcore)
         ]
         untested_cpus = [
             "blackparrot",  # (riscv   / softcore) -> Broken install?
@@ -65,7 +66,6 @@ class TestIntegration(unittest.TestCase):
             "cva6",         # (riscv   / softcore) -> Needs to be tested.
             "eos_s3",       # (arm     / hardcore) -> Hardcore.
             "gowin_emcu",   # (arm     / hardcore) -> Hardcore.
-            "ibex",         # (riscv   / softcore) -> Broken since 2022.11.12.
             "lm32",         # (lm32    / softcore) -> Requires LM32 toolchain.
             "minerva",      # (riscv   / softcore) -> Broken install? (Amaranth?)
             "mor1kx",       # (or1k    / softcore) -> Verilator compilation issue.


### PR DESCRIPTION
This PR fixes #2258.

Vivado require files that define modules to be explicitly added to the project.
I also re-enabled the boot test for ibex CPU.