### PR TITLE
json2dts_zephyr: update interrupt name to use the correct identifier

### DIFF
--- a/litex/tools/litex_json2dts_zephyr.py
+++ b/litex/tools/litex_json2dts_zephyr.py
@@ -237,7 +237,7 @@ def spiflash_handler(name, parm, csr):
         csr['constants'][name + '_phy_frequency']))
 
     try:
-        dtsi += dts_intr(name + '_core', csr)
+        dtsi += dts_intr(name, csr)
     except KeyError as e:
         print('  dtsi key', e, 'not found, no interrupt override')
 


### PR DESCRIPTION
remove `_core`suffix.