### PR TITLE
litex/build/xilinx : Add Device Image (pdi) generation support to Vivado builds

### DIFF
--- a/litex/build/xilinx/platform.py
+++ b/litex/build/xilinx/platform.py
@@ -32,7 +32,7 @@ class XilinxPlatform(GenericPlatform):
         "xcau", "xcku", "xcvu", "xczu"
     ]
 
-    def __init__(self, *args, toolchain="ise", **kwargs):
+    def __init__(self, *args, toolchain="ise", device_image_arch=None, **kwargs):
         GenericPlatform.__init__(self, *args, **kwargs)
         self.edifs = set()
         self.ips   = {}
@@ -41,7 +41,7 @@ class XilinxPlatform(GenericPlatform):
             self.toolchain = ise.XilinxISEToolchain()
         elif toolchain == "vivado":
             from litex.build.xilinx import vivado
-            self.toolchain = vivado.XilinxVivadoToolchain()
+            self.toolchain = vivado.XilinxVivadoToolchain(device_image_arch=device_image_arch)
         elif toolchain == "symbiflow" or toolchain == "f4pga":
             from litex.build.xilinx import f4pga
             self.toolchain = f4pga.F4PGAToolchain()
@@ -50,6 +50,8 @@ class XilinxPlatform(GenericPlatform):
             self.toolchain = yosys_nextpnr.XilinxYosysNextpnrToolchain(toolchain)
         else:
             raise ValueError(f"Unknown toolchain {toolchain}")
+        if device_image_arch is not None:
+            self._bitstream_ext["sram"] = ".pdi"
 
     def add_edif(self, filename):
         self.edifs.add((os.path.abspath(filename)))

--- a/litex/build/xilinx/vivado.py
+++ b/litex/build/xilinx/vivado.py
@@ -97,7 +97,7 @@ class XilinxVivadoToolchain(GenericToolchain):
         "no_shreg_extract": None
     }
 
-    def __init__(self):
+    def __init__(self, device_image_arch=None):
         super().__init__()
         self.bitstream_commands         = []
         self.additional_commands        = []
@@ -109,6 +109,7 @@ class XilinxVivadoToolchain(GenericToolchain):
         self.incremental_implementation = False
         self._synth_mode                = "vivado"
         self._enable_xpm                = False
+        self._device_image_arch         = device_image_arch
 
     def finalize(self):
         # Convert clocks and false path to platform commands
@@ -386,6 +387,8 @@ class XilinxVivadoToolchain(GenericToolchain):
             tcl.append(bitstream_command.format(build_name=self._build_name))
         tcl.append("\n# Bitstream generation\n")
         tcl.append(f"write_bitstream -force {self._build_name}.bit ")
+        if self._device_image_arch is not None:
+            tcl.append(f"exec bootgen -arch {self._device_image_arch} -image {self._build_name}.bif -w -o {self._build_name}.pdi")
 
         # Additional commands
         for additional_command in self.additional_commands:


### PR DESCRIPTION
Added for Spartan UltraScale+ (and perhaps future Versal) support

Tested with enclosed files using 2025.1

[test.tar.gz](https://github.com/user-attachments/files/21008683/test.tar.gz)
 