### PR TITLE
Make litex bios respond to ping requests

### DIFF
--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -384,7 +384,7 @@ void set_local_ip(const char * ip_address)
 {
 	if (parse_ip(ip_address, local_ip) == 0) {
 		udp_set_ip(IPTOINT(local_ip[0], local_ip[1], local_ip[2], local_ip[3]));
-		printf("Local IP: %d.%d.%d.%d", local_ip[0], local_ip[1], local_ip[2], local_ip[3]);
+		net_init();
 	}
 }
 
@@ -446,6 +446,7 @@ void set_mac_addr(const char * mac_address)
 	if (parse_mac_addr(mac_address) == 0) {
 		udp_set_mac(macadr);
 		printf("MAC address : %x:%x:%x:%x:%x:%x", macadr[0], macadr[1], macadr[2], macadr[3], macadr[4], macadr[5]);
+		net_init();
 	}
 }
 
@@ -539,9 +540,8 @@ static void netboot_from_bin(const char * filename, unsigned int ip, unsigned sh
 #endif
 
 void net_init(void) {
-  printf("Local IP: %d.%d.%d.%d\n", local_ip[0], local_ip[1], local_ip[2], local_ip[3]);
-  printf("Remote IP: %d.%d.%d.%d\n", remote_ip[0], remote_ip[1], remote_ip[2], remote_ip[3]);
-  udp_start(macadr, IPTOINT(local_ip[0], local_ip[1], local_ip[2], local_ip[3]));
+	printf("Local IP: %d.%d.%d.%d\n", local_ip[0], local_ip[1], local_ip[2], local_ip[3]);
+	udp_start(macadr, IPTOINT(local_ip[0], local_ip[1], local_ip[2], local_ip[3]));
 }
 
 void netboot(int nb_params, char **params)
@@ -554,8 +554,9 @@ void netboot(int nb_params, char **params)
 
 	printf("Booting from network...\n");
 
-  net_init();
+	net_init();
 	ip = IPTOINT(remote_ip[0], remote_ip[1], remote_ip[2], remote_ip[3]);
+	printf("Remote IP: %d.%d.%d.%d\n", remote_ip[0], remote_ip[1], remote_ip[2], remote_ip[3]);
 
 	if (filename) {
 		printf("Booting from %s (JSON)...\n", filename);

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -538,6 +538,12 @@ static void netboot_from_bin(const char * filename, unsigned int ip, unsigned sh
 }
 #endif
 
+void net_init(void) {
+  printf("Local IP: %d.%d.%d.%d\n", local_ip[0], local_ip[1], local_ip[2], local_ip[3]);
+  printf("Remote IP: %d.%d.%d.%d\n", remote_ip[0], remote_ip[1], remote_ip[2], remote_ip[3]);
+  udp_start(macadr, IPTOINT(local_ip[0], local_ip[1], local_ip[2], local_ip[3]));
+}
+
 void netboot(int nb_params, char **params)
 {
 	unsigned int ip;
@@ -548,11 +554,8 @@ void netboot(int nb_params, char **params)
 
 	printf("Booting from network...\n");
 
-	printf("Local IP: %d.%d.%d.%d\n", local_ip[0], local_ip[1], local_ip[2], local_ip[3]);
-	printf("Remote IP: %d.%d.%d.%d\n", remote_ip[0], remote_ip[1], remote_ip[2], remote_ip[3]);
-
+  net_init();
 	ip = IPTOINT(remote_ip[0], remote_ip[1], remote_ip[2], remote_ip[3]);
-	udp_start(macadr, IPTOINT(local_ip[0], local_ip[1], local_ip[2], local_ip[3]));
 
 	if (filename) {
 		printf("Booting from %s (JSON)...\n", filename);

--- a/litex/soc/software/bios/boot.h
+++ b/litex/soc/software/bios/boot.h
@@ -13,4 +13,5 @@ void romboot(void);
 void sdcardboot(void);
 void sataboot(void);
 
+void net_init(void);
 #endif /* __BOOT_H */

--- a/litex/soc/software/bios/boot.h
+++ b/litex/soc/software/bios/boot.h
@@ -1,9 +1,13 @@
 #ifndef __BOOT_H
 #define __BOOT_H
 
+// Set local, remote IP and MAC-address
 void set_local_ip(const char * ip_address);
 void set_remote_ip(const char * ip_address);
 void set_mac_addr(const char * mac_address);
+
+// Apply local IP and MAC-address to UDP driver
+void net_init(void);
 
 void __attribute__((noreturn)) boot(unsigned long r1, unsigned long r2, unsigned long r3, unsigned long addr);
 int serialboot(void);
@@ -12,6 +16,4 @@ void flashboot(void);
 void romboot(void);
 void sdcardboot(void);
 void sataboot(void);
-
-void net_init(void);
 #endif /* __BOOT_H */

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -185,6 +185,8 @@ __attribute__((__used__)) int main(int i, char **c)
     printf("--========== \e[1mInitialization\e[0m ============--\n");
 #ifdef CSR_ETHMAC_BASE
 	eth_init();
+	net_init();
+	set_idle_hook(udp_service);
 #endif
 
 	/* Initialize and test SPIRAM */

--- a/litex/soc/software/bios/readline.h
+++ b/litex/soc/software/bios/readline.h
@@ -77,7 +77,9 @@ struct esc_cmds {
 	}					\
 }
 
+// set a function which is called repeatedly as long as there are no new characters to process
 void set_idle_hook(void (*fptr)(void));
+
 int readline(char *buf, int len);
 void hist_init(void);
 

--- a/litex/soc/software/bios/readline.h
+++ b/litex/soc/software/bios/readline.h
@@ -77,6 +77,7 @@ struct esc_cmds {
 	}					\
 }
 
+void set_idle_hook(void (*fptr)(void));
 int readline(char *buf, int len);
 void hist_init(void);
 


### PR DESCRIPTION
A useful feature to check if the ethernet connection is working.

It can be tested in the emulator with:

```bash
litex_sim --with-ethernet

# in another terminal
ping 192.168.1.50
```
This replaces the previous pull request #978 which is a bit out of date.