### PR TITLE
build: efinix: efinity: hide excluded ios

### DIFF
--- a/litex/build/efinix/efinity.py
+++ b/litex/build/efinix/efinity.py
@@ -52,7 +52,10 @@ def _add_custom_params(parent, params):
 # Efinity Toolchain --------------------------------------------------------------------------------
 
 class EfinityToolchain(GenericToolchain):
-    attr_translate = {}
+    attr_translate = {
+        "keep":             ("syn_keep", "true"),
+        "no_retiming":      ("async_reg", "true"),
+    }
 
     def __init__(self, efinity_path):
         super().__init__()

--- a/litex/build/efinix/platform.py
+++ b/litex/build/efinix/platform.py
@@ -155,7 +155,8 @@ class EfinixPlatform(GenericPlatform):
                 name = resource[0] + (f"{resource[1]}" if resource[1] is not None else "")
                 if resource[2]:
                     name = name + "_" + resource[2]
-                name = name + f"{idx}"
+                if hasattr(sig, "nbits") and sig.nbits > 1:
+                    name = name + f"{idx}"
                 return name
         return None
 
@@ -168,7 +169,6 @@ class EfinixPlatform(GenericPlatform):
                 name = resource[0] + (f"{resource[1]}" if resource[1] is not None else "")
                 if resource[2]:
                     name = name + "_" + resource[2]
-                name = name + "_gen" # Avoids to define a new signal with the same name
                 return name
         return None
 
@@ -194,14 +194,15 @@ class EfinixPlatform(GenericPlatform):
 
     def add_iface_io(self, name, size=1):
         self.add_extension([(name, 0, Pins(size))])
-        self.toolchain.excluded_ios.append(name)
-        return self.request(name)
+        tmp = self.request(name)
+        tmp.attr.add(("syn_peri_port", 0))
+        return tmp
 
     def add_iface_ios(self, io):
         self.add_extension(io)
         tmp = self.request(io[0][0])
         for s in tmp.flatten():
-            self.toolchain.excluded_ios.append(s)
+            s.attr.add(("syn_peri_port", 0))
         return tmp
 
     def get_pll_resource(self, name):

--- a/litex/build/generic_platform.py
+++ b/litex/build/generic_platform.py
@@ -203,6 +203,7 @@ class ConstraintManager:
     def __init__(self, io, connectors):
         self.available         = list(io)
         self.matched           = []
+        self.hide              = []
         self.platform_commands = []
         self.connector_manager = ConnectorManager(connectors)
 
@@ -294,6 +295,8 @@ class ConstraintManager:
             else:
                 r.update(obj.flatten())
 
+        r.difference_update(self.hide)
+
         return r
 
     def get_sig_constraints(self):
@@ -325,7 +328,7 @@ class ConstraintManager:
                 pins = self.connector_manager.resolve_identifiers(pins)
                 r.append((obj, pins, others, (name, number, None)))
 
-        return r
+        return [x for x in r if x[0] not in self.hide]
 
     def get_platform_commands(self):
         return self.platform_commands


### PR DESCRIPTION
hide excluded ios, so they are not part of
the top modules ios, so that we don't get a
warning by the efinity that they are unused.

excluded ios are added, when a SDR or DDR Input, Output or Tristate is used.