### PR TITLE
Fix efinix hyperram

### DIFF
--- a/litex/build/efinix/common.py
+++ b/litex/build/efinix/common.py
@@ -147,6 +147,12 @@ class EfinixClkOutput(LiteXModule):
 class EfinixTristateImpl(LiteXModule):
     def __init__(self, io, o, oe, i=None):
         platform = LiteXContext.platform
+
+        # FIXME: TSTriple is not supported and only used by EfinixHyperRAM to connect HyperRAM core
+        # HYPERRAM block
+        from migen.fhdl.specials import TSTriple
+        if isinstance(io, TSTriple):
+            return
         if len(io) == 1:
             io_name = platform.get_pin_name(io)
             io_pad  = platform.get_pin_location(io)

--- a/litex/soc/cores/ram/efinix_hyperram.py
+++ b/litex/soc/cores/ram/efinix_hyperram.py
@@ -24,7 +24,7 @@ from litex.soc.cores.hyperbus import HyperRAM
 class EfinixHyperRAM(HyperRAM):
     """ HyperRAM wrapper for efinix F100 (internal)
     """
-    def __init__(self, platform, latency=6, clock_domain="sys", sys_clk_freq=None):
+    def __init__(self, platform, latency=6, latency_mode="fixed", clock_domain="sys", sys_clk_freq=None, with_bursting=True, with_csr=True):
 
         # # #
 
@@ -135,4 +135,13 @@ class EfinixHyperRAM(HyperRAM):
         platform.toolchain.excluded_ios.append(_io_pads.csn)
         platform.toolchain.excluded_ios.append(_io_pads.rstn)
 
-        HyperRAM.__init__(self, _hp_pads, latency, sys_clk_freq)
+        HyperRAM.__init__(self,
+            pads          = _hp_pads,
+            latency       = latency,
+            latency_mode  = latency_mode,
+            sys_clk_freq  = sys_clk_freq,
+            clk_ratio     = "4:1",
+            with_bursting = with_bursting,
+            with_csr      = with_csr,
+            dq_i_cd       = None,
+        )


### PR DESCRIPTION
This PR:
- updates `HyperRAM` module call with missing parameters
- Fix `EfinixTristateImpl`: this class fails when signal is `TSTriple`
- updates PLL uses according to current usage

Note: This PR fix build, but has not being tested since it requires a board based on ti60f100