### PR TITLE
readline_simple.c: add set_idle_hook()

### DIFF
--- a/litex/soc/software/bios/readline_simple.c
+++ b/litex/soc/software/bios/readline_simple.c
@@ -8,7 +8,16 @@
 #include <string.h>
 #include <ctype.h>
 
+#include <libbase/uart.h>
+
 #include "readline.h"
+
+static void (*idle_hook_ptr)(void) = NULL;
+
+void set_idle_hook(void (*fptr)(void))
+{
+	idle_hook_ptr = fptr;
+}
 
 int readline(char *s, int size)
 {
@@ -19,6 +28,12 @@ int readline(char *s, int size)
 	c[1] = 0;
 	ptr = 0;
 	while(1) {
+		if (idle_hook_ptr != NULL) {
+			while (!uart_read_nonblock()) {
+				idle_hook_ptr();
+			}
+		}
+
 		c[0] = getchar();
 		if (c[0] == skip)
 			continue;


### PR DESCRIPTION
fixes #978

tested with

```
litex_sim --with-ethernet --bios-console lite
```

An alternative solution would be to add an empty `void set_idle_hook(void (*fptr)(void)) {}` declaration to readline_simple.c.

This would make the bios compile when `BIOS_CONSOLE_LITE` is set, but leave the ping feature in a slightly broken state: It would only respond when `udp_service()` is actively called, like when waiting for net-boot for example.