### PR TITLE
Fix gowin.py WSL issue

### DIFF
--- a/litex/build/gowin/gowin.py
+++ b/litex/build/gowin/gowin.py
@@ -171,10 +171,7 @@ class GowinToolchain(GenericToolchain):
         # Some python distros for windows (e.g, oss-cad-suite)
         # which does not have 'os.uname' support, we should check 'sys.platform' firstly.
         gw_sh = "gw_sh"
-        if sys.platform.find("linux") >= 0:
-            if os.uname().release.find("WSL") > 0:
-                # gw_sh += ".exe"
-                print("#WSL-fixed")
+        
         if which(gw_sh) is None:
             msg = "Unable to find Gowin toolchain, please:\n"
             msg += "- Add Gowin toolchain to your $PATH."


### PR DESCRIPTION
I’ve been working with LiteX on the Tang Nano 9K FPGA. Everything was going fine until I ran into a frustrating issue on WSL: the Gowin toolchain was installed, but LiteX couldn’t detect it, and the build failed with an error saying it couldn’t find the toolchain.

After digging into `litex/build/gowin/gowin.py`, I noticed that the script assumed that on WSL the `gw_sh` executable would have a `.exe` suffix. That’s not the case, so the toolchain was never found. Commenting out the `.exe` addition fixed the problem, and now everything builds correctly.

It was a small change, but it saved a lot of time and frustration. This was a good reminder that even well-maintained tools can have small assumptions that don’t hold in every environment.