### PR TITLE
build: io: efinix: DDR: Input: correct timing

### DIFF
--- a/litex/build/altera/common.py
+++ b/litex/build/altera/common.py
@@ -231,29 +231,30 @@ class Agilex5SDRInput:
 
 class Agilex5SDRTristateImpl(Module):
     def __init__(self, io, o, oe, i, clk):
-        _i  = Signal().like(i)
+        _i  = Signal().like(i) if i is not None else None
         _o  = Signal().like(o)
         _oe = Signal().like(oe)
         self.specials += [
             SDRIO(o, _o, clk),
-            SDRIO(oe, _oe, clk),
-            SDRIO(_i, i, clk)
+            SDRIO(oe, _oe, clk)
         ]
-        
+        if _i is not None:
+            self.specials += SDRIO(_i, i, clk)
+
         for j in range(len(io)):
-            self.specials += [
-                Instance("tennm_ph2_io_ibuf",
-                    p_bus_hold = "BUS_HOLD_OFF",
-                    io_i       = io[j], # FIXME: its an input but io is needed to have correct dir at top module
-                    o_o        = _i[j],
-                ),
-                Instance("tennm_ph2_io_obuf",
-                    p_open_drain = "OPEN_DRAIN_OFF",
-                    i_i          = _o[j],
-                    i_oe         = _oe[j],
-                    io_o         = io[j], # FIXME: its an output but io is needed to have correct dir at top module
-                ),
-            ]
+            if _i is not None:
+                self.specials += Instance("tennm_ph2_io_ibuf",
+                        p_bus_hold = "BUS_HOLD_OFF",
+                        io_i       = io[j], # FIXME: its an input but io is needed to have correct dir at top module
+                        o_o        = _i[j],
+                )
+
+            self.specials += Instance("tennm_ph2_io_obuf",
+                p_open_drain = "OPEN_DRAIN_OFF",
+                i_i          = _o[j],
+                i_oe         = _oe[j],
+                io_o         = io[j], # FIXME: its an output but io is needed to have correct dir at top module
+            )
 
 class Agilex5SDRTristate(Module):
     @staticmethod

--- a/litex/build/colognechip/common.py
+++ b/litex/build/colognechip/common.py
@@ -162,12 +162,13 @@ class CologneChipSDRTristateImpl(Module):
     def __init__(self, io, o, oe, i, clk):
         _o    = Signal().like(o)
         _oe_n = Signal().like(oe)
-        _i    = Signal().like(i)
+        _i    = Signal().like(i if i is not None else o)
         self.specials += [
             SDROutput(o, _o, clk),
             SDROutput(~oe, _oe_n, clk),
-            SDRInput(_i, i, clk),
         ]
+        if i is not None:
+            self.specials += SDRInput(i, _i, clk)
         for j in range(len(io)):
             self.specials += Instance("CC_IOBUF",
                     p_FF_OBF = 1,

--- a/litex/build/colognechip/common.py
+++ b/litex/build/colognechip/common.py
@@ -189,6 +189,8 @@ class CologneChipSDRTristate:
 class CologneChipTristateImpl(Module):
     def __init__(self, io, o, oe, i):
         nbits, _ = value_bits_sign(io)
+        if i is None:
+            i = Signal().like(o)
         for bit in range(nbits):
             self.specials += Instance("CC_IOBUF",
                 io_IO = io[bit] if nbits > 1 else io,

--- a/litex/build/efinix/common.py
+++ b/litex/build/efinix/common.py
@@ -178,6 +178,8 @@ class EfinixTristateImpl(LiteXModule):
         if i is not None:
             io_data_o  = platform.add_iface_io(io_name + "_IN", len(io))
             self.comb += i.eq(io_data_o)
+        else:
+            io_prop.append(("IN_PIN", ""))
         block = {
             "type"           : "GPIO",
             "mode"           : "INOUT",

--- a/litex/build/efinix/common.py
+++ b/litex/build/efinix/common.py
@@ -362,10 +362,13 @@ class EfinixSDRTristateImpl(LiteXModule):
             const_output = "NONE"
             io_data_i = platform.add_iface_io(io_name + "_OUT", len(io))
             self.comb += io_data_i.eq(o)                
-        io_data_o    = platform.add_iface_io(io_name + "_IN", len(io))
         io_data_e    = platform.add_iface_io(io_name + "_OE", len(io))
         self.comb += io_data_e.eq(oe)
-        self.comb += i.eq(io_data_o)
+        if i is not None:
+            io_data_o    = platform.add_iface_io(io_name + "_IN", len(io))
+            self.comb += i.eq(io_data_o)
+        else:
+            io_prop.append(("IN_PIN", ""))
         block = {
             "type"           : "GPIO",
             "mode"           : "INOUT",
@@ -383,6 +386,8 @@ class EfinixSDRTristateImpl(LiteXModule):
             "out_clk_inv"    : 0,
             "drive_strength" : io_prop_dict.get("DRIVE_STRENGTH", "4")
         }
+        if i is None:
+            block.pop("in_reg")
         platform.toolchain.ifacewriter.blocks.append(block)
         platform.toolchain.excluded_ios.append(platform.get_pin(io))
 

--- a/litex/build/efinix/common.py
+++ b/litex/build/efinix/common.py
@@ -309,14 +309,20 @@ class EfinixDDRTristateImpl(LiteXModule):
         io_prop_dict = dict(io_prop)
         io_data_i_h  = platform.add_iface_io(io_name + "_OUT_HI", len(io))
         io_data_i_l  = platform.add_iface_io(io_name + "_OUT_LO", len(io))
-        io_data_o_h  = platform.add_iface_io(io_name + "_IN_HI", len(io))
-        io_data_o_l  = platform.add_iface_io(io_name + "_IN_LO", len(io))
         io_data_e    = platform.add_iface_io(io_name + "_OE", len(io))
         self.comb += io_data_i_h.eq(o1)
         self.comb += io_data_i_l.eq(o2)
         self.comb += io_data_e.eq(oe1)
-        self.comb += i1.eq(io_data_o_h)
-        self.comb += i2.eq(io_data_o_l)
+        if i1 is not None:
+            io_data_o_h  = platform.add_iface_io(io_name + "_IN_HI", len(io))
+            self.comb += i1.eq(io_data_o_h)
+        else:
+            io_prop.append(("IN_HI_PIN", ""))
+        if i2 is not None:
+            io_data_o_l  = platform.add_iface_io(io_name + "_IN_LO", len(io))
+            self.comb += i2.eq(io_data_o_l)
+        else:
+            io_prop.append(("IN_LO_PIN", ""))
         block = {
             "type"           : "GPIO",
             "mode"           : "INOUT",
@@ -333,6 +339,8 @@ class EfinixDDRTristateImpl(LiteXModule):
             "out_clk_inv"    : 0,
             "drive_strength" : io_prop_dict.get("DRIVE_STRENGTH", "4")
         }
+        if i1 is None and i2 is None:
+            block.pop("in_reg")
         platform.toolchain.ifacewriter.blocks.append(block)
         platform.toolchain.excluded_ios.append(platform.get_pin(io))
 

--- a/litex/build/gowin/common.py
+++ b/litex/build/gowin/common.py
@@ -115,6 +115,8 @@ gowin_special_overrides = {
 class Gw5ATristateImpl(Module):
     def __init__(self, io, o, oe, i):
         nbits, _ = value_bits_sign(io)
+        if i is None:
+            i = Signal().like(o)
         for bit in range(nbits):
             self.specials += Instance("IOBUF",
                 io_IO = io[bit] if nbits > 1 else io,

--- a/litex/build/gowin/common.py
+++ b/litex/build/gowin/common.py
@@ -172,12 +172,13 @@ class Gw5ASDRTristateImpl(Module):
     def __init__(self, io, o, oe, i, clk):
         _o    = Signal().like(o)
         _oe_n = Signal().like(oe)
-        _i    = Signal().like(i)
+        _i    = Signal().like(i if i is not None else o)
         self.specials += [
             SDROutput(o, _o, clk),
             SDROutput(~oe, _oe_n, clk),
-            SDRInput(_i, i, clk),
         ]
+        if i is not None:
+            self.specials += SDRInput(i, _i, clk)
         for j in range(len(io)):
             self.specials += Instance("IOBUF",
                     io_IO = io[j],

--- a/litex/build/io.py
+++ b/litex/build/io.py
@@ -111,27 +111,32 @@ class InferedSDRTristate(Module):
     def __init__(self, io, o, oe, i, clk):
         _o  = Signal().like(o)
         _oe = Signal().like(oe)
-        _i  = Signal().like(i)
+        _i  = Signal().like(i) if i is not None else None
         self.specials   += SDROutput(o, _o, clk)
-        self.specials   += SDRInput(_i, i, clk)
+        if _i is not None:
+            self.specials   += SDRInput(_i, i, clk)
         self.submodules += InferedSDRIO(oe, _oe, clk)
         self.specials   += Tristate(io, _o, _oe, _i)
 
 class SDRTristate(Special):
-    def __init__(self, io, o, oe, i, clk=None):
+    def __init__(self, io, o, oe, i=None, clk=None):
         Special.__init__(self)
         self.io  = wrap(io)
         self.o   = wrap(o)
         self.oe  = wrap(oe)
-        self.i   = wrap(i)
+        self.i   = wrap(i) if i is not None else None
         self.clk = wrap(clk) if clk is not None else ClockSignal()
-        assert len(self.i) == len(self.o) == len(self.oe)
+        if self.i is not None:
+            assert len(self.i) == len(self.o) == len(self.oe)
+        else:
+            assert len(self.o) == len(self.oe)
 
     def iter_expressions(self):
         yield self, "io" , SPECIAL_INOUT
         yield self, "o"  , SPECIAL_INPUT
         yield self, "oe" , SPECIAL_INPUT
-        yield self, "i"  , SPECIAL_OUTPUT
+        if self.i is not None:
+            yield self, "i"  , SPECIAL_OUTPUT
         yield self, "clk", SPECIAL_INPUT
 
     @staticmethod

--- a/litex/build/lattice/common.py
+++ b/litex/build/lattice/common.py
@@ -540,6 +540,8 @@ class LatticeiCE40SDRInput:
 
 class LatticeiCE40SDRTristateImpl(Module):
     def __init__(self, io, o, oe, i, clk):
+        if i is None:
+            i = Signal().like(o)
         for j in range(len(io)):
             self.specials += Instance("SB_IO",
                 p_PIN_TYPE      = C(0b110100, 6), # PIN_OUTPUT_REGISTERED_ENABLE_REGISTERED + PIN_INPUT_REGISTERED

--- a/litex/build/lattice/common.py
+++ b/litex/build/lattice/common.py
@@ -146,6 +146,8 @@ class LatticeECP5DifferentialOutput:
 class LatticeECP5TristateImpl(Module):
     def __init__(self, io, o, oe, i):
         nbits, sign = value_bits_sign(io)
+        if i is None:
+            i = Signal().like(o)
         for bit in range(nbits):
             self.specials += Instance("BB",
                 io_B  = io[bit] if nbits > 1 else io,
@@ -177,6 +179,8 @@ lattice_ecp5_special_overrides = {
 class LatticeECP5TrellisTristateImpl(Module):
     def __init__(self, io, o, oe, i):
         nbits, sign = value_bits_sign(io)
+        if i is None:
+            i = Signal().like(o)
         for bit in range(nbits):
             self.specials += Instance("TRELLIS_IO",
                 p_DIR = "BIDIR",
@@ -396,6 +400,8 @@ class LatticeiCE40AsyncResetSynchronizer:
 class LatticeiCE40TristateImpl(Module):
     def __init__(self, io, o, oe, i):
         nbits, sign = value_bits_sign(io)
+        if i is None:
+            i = Signal().like(o)
         for bit in range(nbits):
             self.specials += Instance("SB_IO",
                 p_PIN_TYPE      = C(0b101001, 6), # PIN_OUTPUT_TRISTATE + PIN_INPUT

--- a/litex/build/lattice/common.py
+++ b/litex/build/lattice/common.py
@@ -340,10 +340,11 @@ class LatticeNXDDRTristateImpl(Module):
         assert oe2 is None
         _o  = Signal().like(o1)
         _oe = Signal().like(oe1)
-        _i  = Signal().like(i1)
+        _i  = Signal().like(_o) if i1 is not None and i2 is not None else None
         self.specials += DDROutput(o1, o2, _o, clk)
         self.specials += SDROutput(oe1, _oe, clk)
-        self.specials += DDRInput(_i, i1, i2, clk)
+        if _i is not None:
+            self.specials += DDRInput(_i, i1, i2, clk)
         self.specials += Tristate(io, _o, _oe, _i)
         _oe.attr.add("syn_useioff")
 

--- a/litex/build/xilinx/common.py
+++ b/litex/build/xilinx/common.py
@@ -140,10 +140,11 @@ class XilinxSDRTristateImpl(Module):
     def __init__(self, io, o, oe, i, clk):
         _o    = Signal().like(o)
         _oe_n = Signal().like(oe)
-        _i    = Signal().like(i)
+        _i    = Signal().like(i if i is not None else o)
         self.specials += SDROutput(o, _o, clk)
         self.specials += SDROutput(~oe, _oe_n, clk)
-        self.specials += SDRInput(_i, i, clk)
+        if i is not None:
+            self.specials += SDRInput(_i, i, clk)
         for j in range(len(io)):
             self.specials += Instance("IOBUF",
                 io_IO = io[j],

--- a/litex/build/xilinx/common.py
+++ b/litex/build/xilinx/common.py
@@ -164,10 +164,11 @@ class XilinxDDRTristateImpl(Module):
     def __init__(self, io, o1, o2, oe1, oe2, i1, i2, clk, i_async):
         _o    = Signal().like(o1)
         _oe_n = Signal().like(oe1)
-        _i    = Signal().like(i1)
+        _i    = Signal().like(_o)
         self.specials += DDROutput(o1, o2, _o, clk)
         self.specials += DDROutput(~oe1, ~oe2, _oe_n, clk) if oe2 is not None else SDROutput(~oe1, _oe_n, clk)
-        self.specials += DDRInput(_i, i1, i2, clk)
+        if i1 is not None and i2 is not None:
+            self.specials += DDRInput(_i, i1, i2, clk)
         for j in range(len(io)):
             self.specials += Instance("IOBUF",
                 io_IO = io[j],
@@ -175,7 +176,8 @@ class XilinxDDRTristateImpl(Module):
                 i_I   = _o[j],
                 i_T   = _oe_n[j],
             )
-        self.comb += i_async.eq(_i)
+        if i_async is not None:
+            self.comb += i_async.eq(_i)
 
 class XilinxDDRTristate:
     @staticmethod


### PR DESCRIPTION
The input of the DDRInput and the DDRTristate
of the Efinix implementations was not matching,
these of the other implementations. like for the sim in
litex/build/sim/verilog/iddr_verilog.v
This fixes it. For Titanium/Topaz, this can be done by
useing DDIO_RESYNC_PIPE for in_reg, the Trion doesn't
support that, so we have to delay i1 manualy by one cycle.

The old variants with the wrong timing are still there for
those, who need them.

Contains: #2310