### PR TITLE
Agilex support update

### DIFF
--- a/litex/build/altera/common.py
+++ b/litex/build/altera/common.py
@@ -263,6 +263,50 @@ class Agilex5SDRTristate(Module):
     def lower(dr):
         return Agilex5SDRTristateImpl(dr.io, dr.o, dr.oe, dr.i, dr.clk)
 
+# Agilex5 Tristate ---------------------------------------------------------------------------------
+
+class Agilex5TristateImpl(Module):
+    def __init__(self, io, o, oe, i):
+        nbits, _ = value_bits_sign(io)
+        for bit in range(nbits):
+            if i is not None:
+                self.specials += Instance("tennm_ph2_io_ibuf",
+                    p_buffer_usage    = "REGULAR",
+                    p_bus_hold        = "BUS_HOLD_OFF",
+                    p_equalization    = "EQUALIZATION_OFF",
+                    p_io_standard     = "IO_STANDARD_IOSTD_OFF",
+                    p_rzq_id          = "RZQ_ID_RZQ0",
+                    p_schmitt_trigger = "SCHMITT_TRIGGER_OFF",
+                    p_termination     = "TERMINATION_RT_OFF",
+                    p_toggle_speed    = "TOGGLE_SPEED_SLOW",
+                    p_usage_mode      = "USAGE_MODE_GPIO",
+                    p_vref            = "VREF_OFF",
+                    p_weak_pull_down  = "WEAK_PULL_DOWN_OFF",
+                    p_weak_pull_up    = "WEAK_PULL_UP_OFF",
+                    io_i              = io[bit] if nbits > 1 else io, # FIXME: its an input but io is needed to have correct dir at top module
+                    o_o               = i[bit]  if nbits > 1 else i,
+                )
+            self.specials += Instance("tennm_ph2_io_obuf",
+                p_buffer_usage            = "REGULAR",
+                p_dynamic_pull_up_enabled = "FALSE",
+                p_equalization            = "EQUALIZATION_OFF",
+                p_io_standard             = "IO_STANDARD_IOSTD_OFF",
+                p_open_drain              = "OPEN_DRAIN_OFF",
+                p_rzq_id                  = "RZQ_ID_RZQ0",
+                p_slew_rate               = "SLEW_RATE_SLOW",
+                p_termination             = "TERMINATION_SERIES_OFF",
+                p_toggle_speed            = "TOGGLE_SPEED_SLOW",
+                p_usage_mode              = "USAGE_MODE_GPIO",
+                i_i                       = o[bit]   if nbits > 1 else o,
+                i_oe                      = oe[bit] if len(oe) == nbits > 1 else oe,
+                io_o                      = io[bit]  if nbits > 1 else io, # FIXME: its an output but io is needed to have correct dir at top module
+            )
+
+class Agilex5Tristate:
+    @staticmethod
+    def lower(dr):
+        return Agilex5TristateImpl(dr.target, dr.o, dr.oe, dr.i)
+
 # Agilex5 Special Overrides ------------------------------------------------------------------------
 
 agilex5_special_overrides = {
@@ -274,4 +318,5 @@ agilex5_special_overrides = {
     SDROutput:              Agilex5SDROutput,
     SDRInput:               Agilex5SDRInput,
     SDRTristate:            Agilex5SDRTristate,
+    Tristate:               Agilex5Tristate,
 }

--- a/litex/build/altera/common.py
+++ b/litex/build/altera/common.py
@@ -226,16 +226,36 @@ class Agilex5SDRTristateImpl(Module):
         for j in range(len(io)):
             if _i is not None:
                 self.specials += Instance("tennm_ph2_io_ibuf",
-                        p_bus_hold = "BUS_HOLD_OFF",
-                        io_i       = io[j], # FIXME: its an input but io is needed to have correct dir at top module
-                        o_o        = _i[j],
+                    p_buffer_usage    = "REGULAR",
+                    p_bus_hold        = "BUS_HOLD_OFF",
+                    p_equalization    = "EQUALIZATION_OFF",
+                    p_io_standard     = "IO_STANDARD_IOSTD_OFF",
+                    p_rzq_id          = "RZQ_ID_RZQ0",
+                    p_schmitt_trigger = "SCHMITT_TRIGGER_OFF",
+                    p_termination     = "TERMINATION_RT_OFF",
+                    p_toggle_speed    = "TOGGLE_SPEED_SLOW",
+                    p_usage_mode      = "USAGE_MODE_GPIO",
+                    p_vref            = "VREF_OFF",
+                    p_weak_pull_down  = "WEAK_PULL_DOWN_OFF",
+                    p_weak_pull_up    = "WEAK_PULL_UP_OFF",
+                    io_i              = io[j], # FIXME: its an input but io is needed to have correct dir at top module
+                    o_o               = _i[j],
                 )
 
             self.specials += Instance("tennm_ph2_io_obuf",
-                p_open_drain = "OPEN_DRAIN_OFF",
-                i_i          = _o[j],
-                i_oe         = _oe[j],
-                io_o         = io[j], # FIXME: its an output but io is needed to have correct dir at top module
+                p_buffer_usage            = "REGULAR",
+                p_dynamic_pull_up_enabled = "FALSE",
+                p_equalization            = "EQUALIZATION_OFF",
+                p_io_standard             = "IO_STANDARD_IOSTD_OFF",
+                p_open_drain              = "OPEN_DRAIN_OFF",
+                p_rzq_id                  = "RZQ_ID_RZQ0",
+                p_slew_rate               = "SLEW_RATE_SLOW",
+                p_termination             = "TERMINATION_SERIES_OFF",
+                p_toggle_speed            = "TOGGLE_SPEED_SLOW",
+                p_usage_mode              = "USAGE_MODE_GPIO",
+                i_i                       = _o[j],
+                i_oe                      = _oe[j],
+                io_o                      = io[j], # FIXME: its an output but io is needed to have correct dir at top module
             )
 
 class Agilex5SDRTristate(Module):

--- a/litex/build/altera/common.py
+++ b/litex/build/altera/common.py
@@ -149,24 +149,6 @@ altera_special_overrides = {
     SDRInput:               AlteraSDRInput,
 }
 
-# Agilex5 AsyncResetSynchronizer -------------------------------------------------------------------
-
-class Agilex5AsyncResetSynchronizerImpl(Module):
-    def __init__(self, cd, async_reset):
-        self.specials += Instance("altera_std_synchronizer_nocut", name=f"ars_cd_{cd.name}_ff0",
-            p_depth     = 3,
-            p_rst_value = 0,
-            i_clk       = cd.clk,
-            i_reset_n   = Constant(1, 1),
-            i_din       = async_reset,
-            o_dout      = cd.rst,
-        )
-
-class Agilex5AsyncResetSynchronizer:
-    @staticmethod
-    def lower(dr):
-        return Agilex5AsyncResetSynchronizerImpl(dr.cd, dr.async_reset)
-
 # Agilex5 DDROutput --------------------------------------------------------------------------------
 
 class Agilex5DDROutputImpl(Module):
@@ -264,7 +246,7 @@ class Agilex5SDRTristate(Module):
 # Agilex5 Special Overrides ------------------------------------------------------------------------
 
 agilex5_special_overrides = {
-    AsyncResetSynchronizer: Agilex5AsyncResetSynchronizer,
+    AsyncResetSynchronizer: AlteraAsyncResetSynchronizer,
     DifferentialInput:      AlteraDifferentialInput,
     DifferentialOutput:     AlteraDifferentialOutput,
     DDROutput:              Agilex5DDROutput,


### PR DESCRIPTION
This PR aims to update agilex5 support with recent quartus pro version (25.1.1)
- First commit: removes `Agilex5AsyncResetSynchronizerImpl` to uses default implementation. `altera_std_synchronizer_nocut` is only available with `Platform designer` and corresponding code is more or less similar to uses of `DFF`
- Second commit updates `Agilex5SDRTristateImpl`. With new quartus version `tennm_ph2_io_ibuf` and `tennm_ph2_io_obuf` must have all parameters explicitly provided to avoid build failure
- Third commit adds `Agilex5TristateImpl` required when HyperRAM core is used. The code is quite similar to `Agilex5SDRTristateImpl`
- Last commit adds argument to select between `quartus_cpf` and `quartus_pfg`. Last one is required to convert sof to rbf for Agilex target (svf can't be produces at all).

Tested with Arrow AXE5000 board