### PR TITLE
cores: uart: switch to EventSourceLevel irq

### DIFF
--- a/litex/soc/cores/uart.py
+++ b/litex/soc/cores/uart.py
@@ -222,8 +222,8 @@ class UART(LiteXModule, UARTInterface):
         self._rxempty = CSRStatus(description="RX FIFO Empty.")
 
         self.ev    = EventManager()
-        self.ev.tx = EventSourceProcess(edge="rising")
-        self.ev.rx = EventSourceProcess(edge="rising")
+        self.ev.tx = EventSourceLevel()
+        self.ev.rx = EventSourceLevel()
         self.ev.finalize()
 
         self._txempty = CSRStatus(description="TX FIFO Empty.")

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1540,7 +1540,7 @@ class LiteXSoC(SoC):
         self.add_config(name, identifier)
 
     # Add UART -------------------------------------------------------------------------------------
-    def add_uart(self, name="uart", uart_name="serial", uart_pads=None, baudrate=115200, fifo_depth=16, with_dynamic_baudrate=False):
+    def add_uart(self, name="uart", uart_name="serial", uart_pads=None, baudrate=115200, fifo_depth=16, with_dynamic_baudrate=False, rx_fifo_rx_we=False):
         # Imports.
         from litex.soc.cores.uart import UART, UARTCrossover
 
@@ -1565,6 +1565,7 @@ class LiteXSoC(SoC):
         uart_kwargs    = {
             "tx_fifo_depth": fifo_depth,
             "rx_fifo_depth": fifo_depth,
+            "rx_fifo_rx_we": rx_fifo_rx_we,
         }
         if (uart_pads is None) and (uart_name not in supported_uarts):
             self.logger.error("{} UART {}, supported are: \n{}.".format(
@@ -1625,6 +1626,9 @@ class LiteXSoC(SoC):
             self.add_module(name=f"{name}_phy", module=uart_phy)
         if uart is not None:
             self.add_module(name=name, module=uart)
+
+        if rx_fifo_rx_we:
+            self.add_config(f"{name}_RX_FIFO_RX_WE", 1)
 
         # IRQ.
         if self.irq.enabled:

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -102,6 +102,7 @@ class SoCCore(LiteXSoC):
         uart_fifo_depth          = 16,
         uart_pads                = None,
         uart_with_dynamic_baudrate = False,
+        uart_rx_fifo_rx_we       = False,
 
         # Timer parameters.
         with_timer               = True,
@@ -261,7 +262,7 @@ class SoCCore(LiteXSoC):
 
         # Add UART.
         if with_uart:
-            self.add_uart(name="uart", uart_name=uart_name, uart_pads=uart_pads, baudrate=uart_baudrate, fifo_depth=uart_fifo_depth, with_dynamic_baudrate=uart_with_dynamic_baudrate)
+            self.add_uart(name="uart", uart_name=uart_name, uart_pads=uart_pads, baudrate=uart_baudrate, fifo_depth=uart_fifo_depth, with_dynamic_baudrate=uart_with_dynamic_baudrate, rx_fifo_rx_we=uart_rx_fifo_rx_we)
 
         # Add JTAGBone.
         if with_jtagbone:


### PR DESCRIPTION
switch to EventSourceLevel irq, this way we don't have to
reset pending.

Should still be compatible with the existing drivers in
linux and zephyr.