### PR TITLE
interconnect:axi_full: Initialize AXIInterfaces with correct id_width

### DIFF
--- a/litex/soc/interconnect/axi/axi_full.py
+++ b/litex/soc/interconnect/axi/axi_full.py
@@ -641,7 +641,8 @@ class AXIInterconnectShared(LiteXModule):
     def __init__(self, masters, slaves, register=False, timeout_cycles=1e6):
         data_width = get_check_parameters(ports=masters + [s for _, s in slaves])
         adr_width = max([m.address_width for m in masters])
-        shared = AXIInterface(data_width=data_width, address_width=adr_width)
+        id_width = max([m.id_width for m in masters])
+        shared = AXIInterface(data_width=data_width, address_width=adr_width, id_width=id_width)
         self.arbiter = AXIArbiter(masters, shared)
         self.decoder = AXIDecoder(shared, slaves)
         if timeout_cycles is not None:
@@ -655,8 +656,9 @@ class AXICrossbar(LiteXModule):
     def __init__(self, masters, slaves, register=False, timeout_cycles=1e6):
         data_width = get_check_parameters(ports=masters + [s for _, s in slaves])
         adr_width = max([m.address_width for m in masters])
+        id_width = max([m.id_width for m in masters])
         matches, busses = zip(*slaves)
-        access_m_s = [[AXIInterface(data_width=data_width, address_width=adr_width) for j in slaves] for i in masters]  # a[master][slave]
+        access_m_s = [[AXIInterface(data_width=data_width, address_width=adr_width, id_width=id_width) for j in slaves] for i in masters]  # a[master][slave]
         access_s_m = list(zip(*access_m_s))  # a[slave][master]
         # Decode each master into its access row.
         for slaves, master in zip(access_m_s, masters):


### PR DESCRIPTION
In the AXIInterconnectShared and AXICrossbar classes AXIInterfaces are always initialized with id_width = 1, which causes id errors.

Fixed by initializing them with the biggest id_width of all master Interfaces (like data_width and address_width).