### PR TITLE
gatemate: use multipliers with peppercorn toolchain

### DIFF
--- a/litex/build/colognechip/peppercorn.py
+++ b/litex/build/colognechip/peppercorn.py
@@ -20,7 +20,6 @@ class PeppercornToolchain(YosysNextPNRToolchain):
     def __init__(self):
         super().__init__()
         self._synth_opts = "-luttree -nomx8"
-        self._synth_opts += " -nomult" # Temporary: currently no supports for CC_MULT.
 
     # Timing Constraints (.sdc) --------------------------------------------------------------------
 


### PR DESCRIPTION
Since multipliers are now supported in nextpnr, no more need to prevent their usage