### PR TITLE
json2dts: Fix for sdcard rename

### DIFF
--- a/litex/tools/litex_json2dts_linux.py
+++ b/litex/tools/litex_json2dts_linux.py
@@ -326,7 +326,7 @@ def generate_dts(d, initrd_start=None, initrd_size=None, initrd=None, root_devic
 """
 
     # Voltage Regulator for LiteSDCard (if applicable) --------------------------------------------
-    if "sdcard_core" in d["csr_bases"]:
+    if "sdcard" in d["csr_bases"]:
         dts += """
         vreg_mmc: vreg_mmc {{
             compatible = "regulator-fixed";


### PR DESCRIPTION
Otherwise this wasn't generating `vreg_mmc` and there would be an error about the reference to it not being found.