### PR TITLE
cpu: vexiiriscv: introduce AIA support.

### DIFF
--- a/litex/soc/cores/cpu/vexiiriscv/core.py
+++ b/litex/soc/cores/cpu/vexiiriscv/core.py
@@ -61,6 +61,7 @@ class VexiiRiscv(CPU):
     with_dma         = False
     with_axi3        = False
     with_opensbi     = False
+    with_aplic       = False
     jtag_tap         = False
     jtag_instruction = False
     with_cpu_clk     = False
@@ -109,23 +110,33 @@ class VexiiRiscv(CPU):
     # Memory Mapping.
     @property
     def mem_map(self):
-        return {
+        mapping = {
             "rom":      0x0000_0000,
             "sram":     0x1000_0000,
             "main_ram": 0x4000_0000,
             "csr":      0xf000_0000,
             "clint":    0xf001_0000,
-            "plic":     0xf0c0_0000,
         }
+
+        if VexiiRiscv.with_aplic:
+            mapping["aplic_m"] = 0xf0c0_0000
+            mapping["aplic_s"] = 0xf0e0_0000
+        else:
+            mapping["plic"] = 0xf0c0_0000
+
+        return mapping
 
     # GCC Flags.
     @property
     def gcc_flags(self):
         flags =  f" -march={VexiiRiscv.get_arch()} -mabi={VexiiRiscv.get_abi()}"
         flags += f" -D__VexiiRiscv__"
-        flags += f" -D__riscv_plic__"
         if VexiiRiscv.with_rvcbom:
             flags += f" -D__riscv_zicbom__"
+        if VexiiRiscv.with_aplic:
+            flags += f" -D__riscv_aplic__"
+        else:
+            flags += f" -D__riscv_plic__"
         return flags
 
     # Reserved Interrupts.
@@ -155,7 +166,7 @@ class VexiiRiscv(CPU):
         cpu_group.add_argument("--with-axi3",             action="store_true",   help="mbus will be axi3 instead of axi4")
         cpu_group.add_argument("--vexii-video",           action="append",  default=[], help="Add the memory coherent video controller")
         cpu_group.add_argument("--vexii-macsg",           action="append",  default=[], help="Add the memory coherent ethernet mac")
-
+        cpu_group.add_argument("--with-aplic",            action="store_true",   help="Enable APLIC.")
 
 
 
@@ -195,6 +206,7 @@ class VexiiRiscv(CPU):
         VexiiRiscv.jtag_instruction = args.with_jtag_instruction
         VexiiRiscv.with_dma         = args.with_coherent_dma
         VexiiRiscv.with_axi3        = args.with_axi3
+        VexiiRiscv.with_aplic       = args.with_aplic
         VexiiRiscv.update_repo      = args.update_repo
         VexiiRiscv.no_netlist_cache = args.no_netlist_cache
         VexiiRiscv.vexii_args      += " " + args.vexii_args
@@ -405,6 +417,7 @@ class VexiiRiscv(CPU):
         md5_hash.update(str(VexiiRiscv.jtag_instruction).encode('utf-8'))
         md5_hash.update(str(VexiiRiscv.with_dma).encode('utf-8'))
         md5_hash.update(str(VexiiRiscv.with_axi3).encode('utf-8'))
+        md5_hash.update(str(VexiiRiscv.with_aplic).encode('utf-8'))
         md5_hash.update(str(VexiiRiscv.memory_regions).encode('utf-8'))
         md5_hash.update(str(VexiiRiscv.vexii_args).encode('utf-8'))
         md5_hash.update(str(VexiiRiscv.vexii_video).encode('utf-8'))
@@ -448,6 +461,8 @@ class VexiiRiscv(CPU):
             gen_args.append(f"--with-dma")
         if(VexiiRiscv.with_axi3) :
             gen_args.append(f"--with-axi3")
+        if(VexiiRiscv.with_aplic) :
+            gen_args.append(f"--with-aplic")
         for arg in VexiiRiscv.vexii_video:
             gen_args.append(f"--video {arg}")
         for arg in VexiiRiscv.vexii_macsg:
@@ -502,7 +517,12 @@ class VexiiRiscv(CPU):
         soc.add_config("CPU_ISA", VexiiRiscv.get_arch())
         soc.add_config("CPU_MMU", {32 : "sv32", 64 : "sv39"}[VexiiRiscv.xlen])
 
-        soc.bus.add_region("plic",  SoCRegion(origin=soc.mem_map.get("plic"),  size=0x40_0000, cached=False,  linker=True))
+        if VexiiRiscv.with_aplic:
+            soc.bus.add_region("aplic_m",  SoCRegion(origin=soc.mem_map.get("aplic_m"),  size=0x20_0000, cached=False,  linker=True))
+            soc.bus.add_region("aplic_s",  SoCRegion(origin=soc.mem_map.get("aplic_s"),  size=0x20_0000, cached=False,  linker=True))
+        else:
+            soc.bus.add_region("plic",  SoCRegion(origin=soc.mem_map.get("plic"),  size=0x40_0000, cached=False,  linker=True))
+
         soc.bus.add_region("clint", SoCRegion(origin=soc.mem_map.get("clint"), size= 0x1_0000, cached=False,  linker=True))
 
         if VexiiRiscv.jtag_tap:

--- a/litex/soc/cores/cpu/vexiiriscv/core.py
+++ b/litex/soc/cores/cpu/vexiiriscv/core.py
@@ -65,6 +65,7 @@ class VexiiRiscv(CPU):
     jtag_tap         = False
     jtag_instruction = False
     with_cpu_clk     = False
+    imsic_interrupts = 0
     vexii_video      = []
     vexii_macsg      = []
     vexii_args       = ""
@@ -124,6 +125,10 @@ class VexiiRiscv(CPU):
         else:
             mapping["plic"] = 0xf0c0_0000
 
+        if VexiiRiscv.imsic_interrupts > 0:
+            mapping["imsic_m"] = 0xf100_0000
+            mapping["imsic_s"] = 0xf120_0000
+
         return mapping
 
     # GCC Flags.
@@ -167,6 +172,7 @@ class VexiiRiscv(CPU):
         cpu_group.add_argument("--vexii-video",           action="append",  default=[], help="Add the memory coherent video controller")
         cpu_group.add_argument("--vexii-macsg",           action="append",  default=[], help="Add the memory coherent ethernet mac")
         cpu_group.add_argument("--with-aplic",            action="store_true",   help="Enable APLIC.")
+        cpu_group.add_argument("--imsic-interrupts",      default=0, type=int,   help="VexiiRiscv IMSIC interrupts, default is 0 (disabled)")
 
 
 
@@ -207,6 +213,7 @@ class VexiiRiscv(CPU):
         VexiiRiscv.with_dma         = args.with_coherent_dma
         VexiiRiscv.with_axi3        = args.with_axi3
         VexiiRiscv.with_aplic       = args.with_aplic
+        VexiiRiscv.imsic_interrupts = args.imsic_interrupts
         VexiiRiscv.update_repo      = args.update_repo
         VexiiRiscv.no_netlist_cache = args.no_netlist_cache
         VexiiRiscv.vexii_args      += " " + args.vexii_args
@@ -418,6 +425,7 @@ class VexiiRiscv(CPU):
         md5_hash.update(str(VexiiRiscv.with_dma).encode('utf-8'))
         md5_hash.update(str(VexiiRiscv.with_axi3).encode('utf-8'))
         md5_hash.update(str(VexiiRiscv.with_aplic).encode('utf-8'))
+        md5_hash.update(str(VexiiRiscv.imsic_interrupts).encode('utf-8'))
         md5_hash.update(str(VexiiRiscv.memory_regions).encode('utf-8'))
         md5_hash.update(str(VexiiRiscv.vexii_args).encode('utf-8'))
         md5_hash.update(str(VexiiRiscv.vexii_video).encode('utf-8'))
@@ -463,6 +471,8 @@ class VexiiRiscv(CPU):
             gen_args.append(f"--with-axi3")
         if(VexiiRiscv.with_aplic) :
             gen_args.append(f"--with-aplic")
+        if(VexiiRiscv.imsic_interrupts > 0) :
+            gen_args.append(f"--imsic-interrupt-number={VexiiRiscv.imsic_interrupts}")
         for arg in VexiiRiscv.vexii_video:
             gen_args.append(f"--video {arg}")
         for arg in VexiiRiscv.vexii_macsg:
@@ -522,6 +532,10 @@ class VexiiRiscv(CPU):
             soc.bus.add_region("aplic_s",  SoCRegion(origin=soc.mem_map.get("aplic_s"),  size=0x20_0000, cached=False,  linker=True))
         else:
             soc.bus.add_region("plic",  SoCRegion(origin=soc.mem_map.get("plic"),  size=0x40_0000, cached=False,  linker=True))
+
+        if VexiiRiscv.imsic_interrupts > 0:
+            soc.bus.add_region("imsic_m",  SoCRegion(origin=soc.mem_map.get("imsic_m"),  size=0x20_0000, cached=False,  linker=True))
+            soc.bus.add_region("imsic_s",  SoCRegion(origin=soc.mem_map.get("imsic_s"),  size=0x20_0000, cached=False,  linker=True))
 
         soc.bus.add_region("clint", SoCRegion(origin=soc.mem_map.get("clint"), size= 0x1_0000, cached=False,  linker=True))
 

--- a/litex/soc/cores/cpu/vexiiriscv/core.py
+++ b/litex/soc/cores/cpu/vexiiriscv/core.py
@@ -57,6 +57,7 @@ class VexiiRiscv(CPU):
     with_rvd         = False
     with_rva         = False
     with_rvcbom      = False
+    with_supervisor  = False
     with_dma         = False
     with_axi3        = False
     with_opensbi     = False
@@ -93,7 +94,11 @@ class VexiiRiscv(CPU):
         if VexiiRiscv.with_rvc:
             arch += "c"
         if VexiiRiscv.with_rvcbom:
-            arch += "zicbom"
+            arch += "_zicbom"
+        arch += "_smaia"
+        if VexiiRiscv.with_supervisor:
+            arch += "_ssaia"
+
         # arch += "zicntr"
         # arch += "zicsr"
         # arch += "zifencei"
@@ -173,6 +178,7 @@ class VexiiRiscv(CPU):
 
         if args.cpu_variant in ["linux", "debian"]:
             VexiiRiscv.with_opensbi = True
+            VexiiRiscv.with_supervisor = True
             VexiiRiscv.vexii_args += " --with-rva --with-supervisor"
             VexiiRiscv.vexii_args += " --fetch-l1-ways=4 --fetch-l1-mem-data-width-min=64"
             VexiiRiscv.vexii_args += " --lsu-l1-ways=4 --lsu-l1-mem-data-width-min=64"
@@ -404,6 +410,7 @@ class VexiiRiscv(CPU):
         md5_hash.update(str(VexiiRiscv.vexii_video).encode('utf-8'))
         md5_hash.update(str(VexiiRiscv.vexii_macsg).encode('utf-8'))
         md5_hash.update(str(VexiiRiscv.with_opensbi).encode('utf-8'))
+        md5_hash.update(str(VexiiRiscv.with_supervisor).encode('utf-8'))
 
         # md5_hash.update(str(VexiiRiscv.internal_bus_width).encode('utf-8'))
 

--- a/litex/soc/cores/cpu/vexiiriscv/crt0.S
+++ b/litex/soc/cores/cpu/vexiiriscv/crt0.S
@@ -78,7 +78,7 @@ crt_init:
   la sp, _fstack
   la a0, trap_entry
   csrw mtvec, a0
-  
+
 enable_fpu:
   li x1, MSTATUS_FS_INITIAL
   csrs mstatus, x1
@@ -124,7 +124,11 @@ bss_loop:
   j bss_loop
 bss_done:
 
-  call plic_init // initialize external interrupt controller
+  #if defined(__riscv_plic__)
+    call plic_init // initialize external interrupt controller
+  #else
+    call aplic_init // initialize external advanced i nterrupt controller
+  #endif
   li t0, 0x800   // external interrupt sources only (using LiteX timer);
                  // NOTE: must still enable mstatus.MIE!
   csrw mie,t0
@@ -138,4 +142,3 @@ infinit_loop:
   smp_lottery_target: .word 0
   smp_lottery_args:   .word 0; .word 0; .word 0
   smp_lottery_lock:   .word 0
-

--- a/litex/soc/cores/cpu/vexiiriscv/irq.h
+++ b/litex/soc/cores/cpu/vexiiriscv/irq.h
@@ -12,11 +12,42 @@ extern "C" {
 // VexiiRiscv uses a Platform-Level Interrupt Controller (PLIC) which
 // is programmed and queried via a set of MMIO registerss
 
+// PLIC
 #define PLIC_BASE    0xf0c00000L // Base address and per-pin priority array
 #define PLIC_PENDING 0xf0c01000L // Bit field matching currently pending pins
 #define PLIC_ENABLED 0xf0c02000L // Bit field corresponding to the current mask
 #define PLIC_THRSHLD 0xf0e00000L // Per-pin priority must be >= this to trigger
 #define PLIC_CLAIM   0xf0e00004L // Claim & completion register address
+
+// APLIC
+#define APLIC_BASE 0xf0c00000L
+
+#define domaincfgOffset     0x0000L
+#define sourcecfgOffset     0x0004L
+#define mmsiaddrcfgOffset   0x1BC0L
+#define mmsiaddrcfghOffset  0x1BC4L
+#define smsiaddrcfgOffset   0x1BC8L
+#define smsiaddrcfghOffset  0x1BCCL
+#define setipOffset         0x1C00L
+#define setipnumOffset      0x1CDCL
+#define in_clripOffset      0x1D00L
+#define clripnumOffset      0x1DDCL
+#define setieOffset         0x1E00L
+#define setienumOffset      0x1EDCL
+#define clrieOffset         0x1F00L
+#define clrienumOffset      0x1FDCL
+#define setipnum_leOffset   0x2000L
+#define setipnum_beOffset   0x2004L
+#define genmsiOffset        0x3000L
+#define targetOffset        0x3004L
+
+#define idcOffset           0x4000L
+#define idcGroupSize        0x20L
+#define ideliveryOffset     0x00L
+#define iforceOffset        0x04L
+#define ithresholdOffset    0x08L
+#define topiOffset          0x18L
+#define claimiOffset        0x1cL
 
 #define PLIC_EXT_IRQ_BASE 0
 
@@ -29,6 +60,8 @@ static inline void irq_setie(unsigned int ie)
 {
 	if(ie) csrs(mstatus,CSR_MSTATUS_MIE); else csrc(mstatus,CSR_MSTATUS_MIE);
 }
+
+#if defined(__riscv_plic__)
 
 static inline unsigned int irq_getmask(void)
 {
@@ -44,6 +77,38 @@ static inline unsigned int irq_pending(void)
 {
 	return *((unsigned int *)PLIC_PENDING) >> PLIC_EXT_IRQ_BASE;
 }
+
+#elif defined(__riscv_aplic__)
+
+static inline unsigned int irq_getmask(void)
+{
+	return *((unsigned int *)(APLIC_BASE + setieOffset));
+}
+
+static inline void irq_setmask(unsigned int mask)
+{
+	*((unsigned int *)(APLIC_BASE + setieOffset)) = mask;
+}
+
+static inline unsigned int irq_pending(void)
+{
+	return *((unsigned int *)(APLIC_BASE + setipOffset));
+}
+
+static inline void init_aplic(void)
+{
+	*((unsigned int *)(APLIC_BASE + domaincfgOffset)) = 0x80000000L;
+
+	for (int i = 0; i < 31; i++) {
+		*((unsigned int *)(APLIC_BASE + sourcecfgOffset) + i) = 0x6; // edge1
+		*((unsigned int *)(APLIC_BASE + targetOffset) + i) = 0x0;
+	}
+	*((unsigned int *)(APLIC_BASE + idcOffset + ideliveryOffset)) = 0x1;
+	*((unsigned int *)(APLIC_BASE + idcOffset + ithresholdOffset)) = 0x0;
+	*((unsigned int *)(APLIC_BASE + setipOffset)) = 0x0;
+}
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/litex/soc/software/libbase/isr.c
+++ b/litex/soc/software/libbase/isr.c
@@ -92,6 +92,54 @@ void isr(void)
     }
 }
 
+#elif defined(__riscv_aplic__)
+
+void aplic_init(void)
+{
+    int i;
+
+    init_aplic();
+    /* Set priorities for the first 8 external interrupts to 1. */
+    for (i = 0; i < 8; i++) {
+	*((unsigned int *)(APLIC_BASE + targetOffset) + i) = 0x1;
+    }
+
+    /* Enable the first 8 external interrupts. */
+    *((unsigned int *)(APLIC_BASE + setieOffset)) = 0x1fe;
+
+    *((unsigned int *)(APLIC_BASE + domaincfgOffset)) = 0x80000100;
+
+    /* Set priority threshold to 0 (any priority > 0 triggers an interrupt). */
+}
+
+/* Interrupt Service Routine. */
+void isr(void)
+{
+    unsigned int claim;
+
+    /* Claim and handle pending interrupts. */
+    while ((claim = *((unsigned int *)(APLIC_BASE + idcOffset + claimiOffset)))) {
+        unsigned int irq = claim >> 16 & ((1 << 10) - 1);
+        if (irq < CONFIG_CPU_INTERRUPTS && irq_table[irq].isr) {
+            irq_table[irq].isr();
+        } else {
+            /* Unhandled interrupt source, print diagnostic information. */
+            printf("## PLIC: Unhandled claim: %d\n", claim);
+            printf("# plic_enabled:    %08x\n", irq_getmask());
+            printf("# plic_pending:    %08x\n", irq_pending());
+            printf("# mepc:    %016lx\n", csrr(mepc));
+            printf("# mcause:  %016lx\n", csrr(mcause));
+            printf("# mtval:   %016lx\n", csrr(mtval));
+            printf("# mie:     %016lx\n", csrr(mie));
+            printf("# mip:     %016lx\n", csrr(mip));
+            printf("###########################\n\n");
+        }
+        /* Acknowledge the interrupt. */
+        // *((unsigned int *)PLIC_CLAIM) = claim;
+    }
+}
+
+
 /************************************************/
 /* ISR Handling for CV32E40P and CV32E41P CPUs. */
 /************************************************/
@@ -281,4 +329,3 @@ void isr(void) {};
 #endif
 
 #endif
-


### PR DESCRIPTION
Introduce AIA support for vexiiriscv. Require SpinalHDL/SpinalHDL#1811 and  SpinalHDL/VexiiRiscv#84

This PR includes two parts:

### `litex_json2dts_linux`
1. Generate cpu isa extension based on the ISA string. This supports multiple letters extension.
2. Add APlic and IMSIC device support and generate `interrupts` and `interrupt-parent` based on the controller type.

### ``vexiiriscv``
1. add `Smaia` and `Ssaia` extension to the ISA string
2. adapt the change of PR

## Resource usage: 
This is build on XCKU5P, with uart and sdcart enabled. The IMSIC enables 64 interrupts.

```
1 core
PLIC:          19580 CLB LUTs
APLIC:         20311 CLB LUTs
APLIC + IMSIC: 23901 CLB LUTs

4 cores
PLIC:          54112 CLB LUTs
APLIC:         55528 CLB LUTs
APLIC + IMSIC: 62244 CLB LUTs
```