### PR TITLE
bios: isr: remove warning

### DIFF
--- a/litex/soc/software/libbase/isr.c
+++ b/litex/soc/software/libbase/isr.c
@@ -50,6 +50,8 @@ int irq_detach(unsigned int irq)
 /***********************************************************/
 #if defined(__riscv_plic__)
 
+void plic_init(void);
+
 /* PLIC initialization. */
 void plic_init(void)
 {


### PR DESCRIPTION
remove warning for
"no previous prototype for 'plic_init' [-Wmissing-prototypes]" when building bios