### PR TITLE
tools/litex_json2dts_linux: add clint to dts if the memory map exists

### DIFF
--- a/litex/tools/litex_json2dts_linux.py
+++ b/litex/tools/litex_json2dts_linux.py
@@ -360,7 +360,7 @@ def generate_dts(d, initrd_start=None, initrd_size=None, initrd=None, root_devic
 
     # Interrupt Controller -------------------------------------------------------------------------
 
-    if (cpu_family == "riscv") and (cpu_name in ["rocket",  "vexiiriscv"]):
+    if (cpu_family == "riscv") and "clint" in d["memories"]:
         # FIXME  : L4 definitiion?
         # CHECKME: interrupts-extended.
         dts += """


### PR DESCRIPTION
The existence of the CLINT module is detected by looking at the entries in the memory map instead of looking at the cpu type used. All risc-v types that adds an entry in the memory map should also have in the device tree.