### PR TITLE
More quality of life improvements for Agilex family of devices

### DIFF
--- a/litex/build/altera/quartus.py
+++ b/litex/build/altera/quartus.py
@@ -123,7 +123,8 @@ class AlteraQuartusToolchain(GenericToolchain):
                 sdc.append(tpl.format(name=name, clk=clk_sig, period=str(period)))
 
         # Enable automatical constraint generation for PLLs
-        sdc.append("derive_pll_clocks -use_net_name")
+        if not self.platform.device[:3] in ["A5E", "A3C"]:
+            sdc.append("derive_pll_clocks -use_net_name")
 
         # Any additional clock constraints like "create_generated_clock" etc.
         sdc += self.clock_constraints

--- a/litex/build/altera/quartus.py
+++ b/litex/build/altera/quartus.py
@@ -24,7 +24,8 @@ from litex.build import tools
 
 class AlteraQuartusToolchain(GenericToolchain):
     attr_translate = {
-        "keep": ("keep", 1),
+        "keep":    ("keep", 1),
+        "noprune": ("noprune", 1),
     }
 
     def __init__(self):

--- a/litex/build/altera/quartus.py
+++ b/litex/build/altera/quartus.py
@@ -31,6 +31,7 @@ class AlteraQuartusToolchain(GenericToolchain):
         super().__init__()
         self._synth_tool             = "quartus_map"
         self._conv_tool              = "quartus_cpf"
+        self.clock_constraints       = []
         self.additional_sdc_commands = []
         self.additional_qsf_commands = []
         self.cst                     = []
@@ -123,6 +124,9 @@ class AlteraQuartusToolchain(GenericToolchain):
 
         # Enable automatical constraint generation for PLLs
         sdc.append("derive_pll_clocks -use_net_name")
+
+        # Any additional clock constraints like "create_generated_clock" etc.
+        sdc += self.clock_constraints
 
         # False path constraints
         for from_, to in sorted(self.false_paths, key=lambda x: (x[0].duid, x[1].duid)):

--- a/litex/build/generic_toolchain.py
+++ b/litex/build/generic_toolchain.py
@@ -182,5 +182,5 @@ class GenericToolchain:
                 from_.attr.add("keep")
             if isinstance(to, Signal):
                 to.attr.add("keep")
-        if (to, from_) not in self.false_paths:
+        if (from_, to) not in self.false_paths:
             self.false_paths.add((from_, to))

--- a/litex/soc/cores/clock/intel_agilex.py
+++ b/litex/soc/cores/clock/intel_agilex.py
@@ -41,6 +41,18 @@ class AgilexPLL(IntelClocking):
             self.clkin_name = clkin.cd
         super().register_clkin(clkin, freq)
 
+    def create_clkout(self, cd, freq, phase=0, margin=1e-2, with_reset=True):
+        assert self.nclkouts < self.nclkouts_max
+        clkout = Signal()
+        self.clkouts[self.nclkouts] = (clkout, freq, phase, margin, cd.clk.name_override)
+        if with_reset:
+            self.specials += AsyncResetSynchronizer(cd, ~self.locked)
+        if not hasattr(cd.clk, "keep"):
+            cd.clk.attr.add("keep")
+        self.comb += cd.clk.eq(clkout)
+        create_clkout_log(self.logger, cd.name, freq, margin, self.nclkouts)
+        self.nclkouts += 1
+
     def compute_config(self):
         valid_configs = []
 
@@ -90,7 +102,7 @@ class AgilexPLL(IntelClocking):
                 max_error         = 0.0
 
                 for i in range(len(self.clkouts)):
-                    (_, target_freq, phase, margin) = self.clkouts[i]
+                    (_, target_freq, phase, margin, name) = self.clkouts[i]
                     # Calculate ideal C divider.
                     ideal_c = vco_freq / target_freq
 
@@ -274,7 +286,7 @@ class AgilexPLL(IntelClocking):
 
         ## Add timing constraints
         # First, generate the internal PLL reference clock
-        sdc = self.platform.toolchain.additional_sdc_commands
+        sdc = self.platform.toolchain.clock_constraints
         sdc.append("# ------------------------ #")
         sdc.append("# -                      - #")
         sdc.append("# ---REFERENCE CLOCK(s)--- #")
@@ -311,8 +323,9 @@ class AgilexPLL(IntelClocking):
         sdc.append("# -                       - #")
         sdc.append("# ------------------------- #")
         for i in range(len(self.clkouts)):
-            (_, target_freq, phase, margin) = self.clkouts[i]
-            name   = f"{inst}_outclk{i}"
+            (_, target_freq, phase, margin, name) = self.clkouts[i]
+            if not name:
+                name = f"{inst}_outclk{i}"
             master = nname if ndiv > 1 else refname
             source = ntarget if ndiv > 1 else refname
             target = f"{inst}|out_clk[{i}]"

--- a/litex/soc/cores/clock/intel_agilex.py
+++ b/litex/soc/cores/clock/intel_agilex.py
@@ -38,7 +38,9 @@ class AgilexPLL(IntelClocking):
         if isinstance(clkin, Signal):
             self.clkin_name = clkin.name_override
         elif isinstance(clkin, ClockSignal):
-            self.clkin_name = clkin.cd
+            self.clkin_name = f"{clkin.cd}_clk"
+        else:
+            raise ValueError
         super().register_clkin(clkin, freq)
 
     def create_clkout(self, cd, freq, phase=0, margin=1e-2, with_reset=True):


### PR DESCRIPTION
Added a new object for PLL SDC statements that gets applied earlier in the generated SDC file as a replacement for the "derive_pll_clocks" command which are no longer supported in the Agilex family.

Also some cleanups/fixes related to clock naming in the SDC file and false path statements.