### PR TITLE
Fixed ROM size and endianness

### DIFF
--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -166,7 +166,7 @@ class SoCCore(LiteXSoC):
         hard_cpus_list = ["zynq7000", "zynqmp", "eos_s3"]
         integrated_rom_disabled = (cpu_type is None) or (cpu_type in hard_cpus_list)
         # Check if a ROM binary file was provided and that it is not empty.
-        integrated_rom_region = get_mem_regions(integrated_rom_init) if isinstance(integrated_rom_init, str) else None
+        integrated_rom_region = get_mem_regions(integrated_rom_init, offset=0) if isinstance(integrated_rom_init, str) else None
         integrated_rom_region_valid = integrated_rom_region and get_mem_region_size(integrated_rom_region)
         # Check if ROM exists.
         integrated_rom_exists = (integrated_rom_region_valid or integrated_rom_size) and not integrated_rom_disabled

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -161,6 +161,16 @@ class SoCCore(LiteXSoC):
         self.cpu_type     = cpu_type
         self.cpu_variant  = cpu_variant
 
+        # ROM
+        # Check if CPU can support ROM.
+        hard_cpus_list = ["zynq7000", "zynqmp", "eos_s3"]
+        integrated_rom_disabled = (cpu_type is None) or (cpu_type in hard_cpus_list)
+        # Check if a ROM binary file was provided and that it is not empty.
+        integrated_rom_region = get_mem_regions(integrated_rom_init) if isinstance(integrated_rom_init, str) else None
+        integrated_rom_region_valid = integrated_rom_region and get_mem_region_size(integrated_rom_region)
+        # Check if ROM exists.
+        integrated_rom_exists = (integrated_rom_region_valid or integrated_rom_size) and not integrated_rom_disabled
+
         # SRAM.
         self.integrated_sram_size = integrated_sram_size
 
@@ -204,7 +214,7 @@ class SoCCore(LiteXSoC):
         self.add_cpu(
             name          = str(cpu_type),
             variant       = "standard" if cpu_variant is None else cpu_variant,
-            reset_address = None if integrated_rom_size else cpu_reset_address,
+            reset_address = None if integrated_rom_exists else cpu_reset_address,
             cfu           = cpu_cfu)
 
         # Add User's interrupts.
@@ -212,24 +222,22 @@ class SoCCore(LiteXSoC):
             for name, loc in self.interrupt_map.items():
                 self.irq.add(name, loc)
 
-        # ROM.
+        # Disable ROM when no CPU/hard-CPU.
+        if integrated_rom_disabled:
+            integrated_rom_init = []
+            integrated_rom_size = 0
         # Initialize ROM from binary file when provided.
-        if isinstance(integrated_rom_init, str):
-            integrated_rom_init = get_mem_data(integrated_rom_init,
+        elif integrated_rom_region_valid:
+            integrated_rom_init = get_mem_data(integrated_rom_region,
                 endianness = self.cpu.endianness,
                 data_width = bus_data_width
             )
             integrated_rom_size = (bus_data_width // 8) * len(integrated_rom_init)
-
-        # Disable ROM when no CPU/hard-CPU.
-        if cpu_type in [None, "zynq7000", "zynqmp", "eos_s3"]:
-            integrated_rom_init = []
-            integrated_rom_size = 0
         self.integrated_rom_size        = integrated_rom_size
         self.integrated_rom_initialized = integrated_rom_init != []
 
         # Add integrated ROM.
-        if integrated_rom_size:
+        if integrated_rom_exists:
             self.add_rom("rom",
                 origin   = self.cpu.reset_address,
                 size     = integrated_rom_size,

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -168,7 +168,7 @@ class SoCCore(LiteXSoC):
                 endianness = "little", # FIXME: Depends on CPU.
                 data_width = bus_data_width
             )
-            integrated_rom_size = 4*len(integrated_rom_init)
+            integrated_rom_size = (bus_data_width // 8) * len(integrated_rom_init)
 
         # Disable ROM when no CPU/hard-CPU.
         if cpu_type in [None, "zynq7000", "zynqmp", "eos_s3"]:

--- a/litex/soc/integration/soc_core.py
+++ b/litex/soc/integration/soc_core.py
@@ -161,22 +161,6 @@ class SoCCore(LiteXSoC):
         self.cpu_type     = cpu_type
         self.cpu_variant  = cpu_variant
 
-        # ROM.
-        # Initialize ROM from binary file when provided.
-        if isinstance(integrated_rom_init, str):
-            integrated_rom_init = get_mem_data(integrated_rom_init,
-                endianness = "little", # FIXME: Depends on CPU.
-                data_width = bus_data_width
-            )
-            integrated_rom_size = (bus_data_width // 8) * len(integrated_rom_init)
-
-        # Disable ROM when no CPU/hard-CPU.
-        if cpu_type in [None, "zynq7000", "zynqmp", "eos_s3"]:
-            integrated_rom_init = []
-            integrated_rom_size = 0
-        self.integrated_rom_size        = integrated_rom_size
-        self.integrated_rom_initialized = integrated_rom_init != []
-
         # SRAM.
         self.integrated_sram_size = integrated_sram_size
 
@@ -227,6 +211,22 @@ class SoCCore(LiteXSoC):
         if self.irq.enabled:
             for name, loc in self.interrupt_map.items():
                 self.irq.add(name, loc)
+
+        # ROM.
+        # Initialize ROM from binary file when provided.
+        if isinstance(integrated_rom_init, str):
+            integrated_rom_init = get_mem_data(integrated_rom_init,
+                endianness = self.cpu.endianness,
+                data_width = bus_data_width
+            )
+            integrated_rom_size = (bus_data_width // 8) * len(integrated_rom_init)
+
+        # Disable ROM when no CPU/hard-CPU.
+        if cpu_type in [None, "zynq7000", "zynqmp", "eos_s3"]:
+            integrated_rom_init = []
+            integrated_rom_size = 0
+        self.integrated_rom_size        = integrated_rom_size
+        self.integrated_rom_initialized = integrated_rom_init != []
 
         # Add integrated ROM.
         if integrated_rom_size:


### PR DESCRIPTION
This is my first time opening a PR in an open-source project, so sorry in advance if I am doing something wrong.

This PR first fixes the issue in #2337, which is simply a one line change in the `SoCCore` initializer code:

https://github.com/enjoy-digital/litex/blob/ffb100c23d00a01d76a430783869a228d1f94340/litex/soc/integration/soc_core.py#L164-L171

where we change that last line to:

``` python
integrated_rom_size = (bus_data_width // 8) * len(integrated_rom_init)
```
and that's it!

&nbsp;

**But... since we are here,** we can also solve the `FIXME` shown by delaying the `integrated_rom_init` and `integrated_rom_size` assignments until after we add the CPU to the SoC, so we can reference its endianness easily. Something like:

``` python
self.add_cpu(
    name          = str(cpu_type),
    variant       = "standard" if cpu_variant is None else cpu_variant,
    reset_address = None if integrated_rom_size else cpu_reset_address,
    cfu           = cpu_cfu)

...

if integrated_rom_region_valid:
    integrated_rom_init = get_mem_data(integrated_rom_init,
        endianness = self.cpu.endianness, # fixed
        data_width = bus_data_width
    )
    integrated_rom_size = (bus_data_width // 8) * len(integrated_rom_init)
```


Evidently, the problem is that the `add_cpu()` function call is using `integrated_rom_size` to set the reset address. To deal with that, instead of using it directly, we create a flag _before_ calculating `integrated_rom_size`, but that serves the same purpose in the context of the `add_cpu()` function; that is, identifying if ROM exists.

Looking at the original `SoCCore` initializer code, ROM exists only if:

1.  we provide a binary file that is not empty (`get_mem_data()` will check for that), as shown in the first snippet;

2. **or** we provide a non-zero value for `integrated_rom_size` directly on the `SoCCore` initializer:
https://github.com/enjoy-digital/litex/blob/ffb100c23d00a01d76a430783869a228d1f94340/litex/soc/integration/soc_core.py#L54-L75

3.  **and** we are using a CPU that is not hard:
https://github.com/enjoy-digital/litex/blob/ffb100c23d00a01d76a430783869a228d1f94340/litex/soc/integration/soc_core.py#L173-L176

We can then encode these checks into our new `integrated_rom_exists` flag:

``` python
# ROM
# Check if CPU can support ROM.
hard_cpus_list = ["zynq7000", "zynqmp", "eos_s3"]
integrated_rom_disabled = (cpu_type is None) or (cpu_type in hard_cpus_list)
# Check if a ROM binary file was provided and that it is not empty.
integrated_rom_region = get_mem_regions(integrated_rom_init, offset=0) if isinstance(integrated_rom_init, str) else None
integrated_rom_region_valid = integrated_rom_region and get_mem_region_size(integrated_rom_region)
# Check if ROM exists.
integrated_rom_exists = (integrated_rom_region_valid or integrated_rom_size) and not integrated_rom_disabled
```

And then finally we change the line in `add_cpu()` to:
``` python
reset_address = None if integrated_rom_exists else cpu_reset_address,
```

This PR makes these changes, along with the creation of the `get_mem_region_size()` function used above, which is really just a block from `get_mem_data()` put into a separate function, so that we can assert that ROM size is non-zero before computing `integrated_rom_init` from the binary file path.

I was able to correctly build and simulate an SoC (from the [repo where I demoed the original issue](https://github.com/franos-cm/litex-rom-bug-demo)) after making these changes to my Litex fork.

Hope this helps! I honestly don't know how opening and closing PRs work for this (or, for that matter, any other open-source) project, so tell me if I need to do anything else :blush: