### PR TITLE
stream: make use of reverse parameter for changing byte endianness

### DIFF
--- a/litex/soc/interconnect/stream.py
+++ b/litex/soc/interconnect/stream.py
@@ -472,7 +472,12 @@ class _IdentityConverter(LiteXModule):
         # # #
 
         self.comb += [
-            sink.connect(source),
+            # evaluate reverse for conversion of byte endianness
+            source.data.eq({True : reverse_bytes(sink.data), False: sink.data}[reverse]),
+            source.valid.eq(sink.valid),
+            source.first.eq(sink.first),
+            source.last.eq(sink.last),
+            sink.ready.eq(source.ready),
             source.valid_token_count.eq(1)
         ]
 

--- a/litex/soc/interconnect/stream.py
+++ b/litex/soc/interconnect/stream.py
@@ -465,20 +465,26 @@ class _DownConverter(LiteXModule):
 
 class _IdentityConverter(LiteXModule):
     def __init__(self, nbits_from, nbits_to, ratio, reverse):
+        # nbits_from = nbits_to, ratio = 1
         self.sink   = sink   = Endpoint([("data", nbits_from)])
         self.source = source = Endpoint([("data", nbits_to), ("valid_token_count", 1)])
         self.latency = 0
 
         # # #
 
+        if reverse:
+            # reverse order/endianness of bytes
+            if nbits_from % 8:
+                raise ValueError("When reversing ratio=1 streams, data width must be a multiple of 8 bits")
+            self.comb += source.data.eq(reverse_bytes(sink.data)),
+        else:
+            self.comb += source.data.eq(sink.data)
         self.comb += [
-            # evaluate reverse for conversion of byte endianness
-            source.data.eq({True : reverse_bytes(sink.data), False: sink.data}[reverse]),
-            source.valid.eq(sink.valid),
-            source.first.eq(sink.first),
-            source.last.eq(sink.last),
-            sink.ready.eq(source.ready),
-            source.valid_token_count.eq(1)
+                source.valid.eq(sink.valid),
+                source.first.eq(sink.first),
+                source.last.eq(sink.last),
+                sink.ready.eq(source.ready),
+                source.valid_token_count.eq(1)
         ]
 
 


### PR DESCRIPTION
When `stream.Convert()` operates on equal data widths (`nbits_from = nbits_to`) the `reverse` parameter wasn't used so far in` _IdentityConverter()`. Only in case of up/down conversion, e.g. from 8 to 32 bit width and vice versa, `reverse` could be used to swap byte endianness.

With this PR, `Convert(...,reverse=True)` can be used to reverse *byte order of equally-sized* LiteX streams. I have not seen an alternative LiteX stream module that could do this. This is handy for dealing with UDP streams as the etherbone/UDP core of LiteEth converts Ethernet payloads to little endian already on reception and independently of downstream processing in a CPU core  (see https://github.com/enjoy-digital/liteeth/pull/82).

There should be a built-in LiteX feature to convert a streams' byte order like this commit. Please let me know if there is a more canonical way that I've missed.