### PR TITLE
bios: fix sdram_debug error report

### DIFF
--- a/litex/soc/software/liblitedram/sdram_dbg.c
+++ b/litex/soc/software/liblitedram/sdram_dbg.c
@@ -28,15 +28,15 @@ void error_stats_update(struct error_stats *stats, struct memory_error err) {
 
 void error_stats_print(struct error_stats *stats) {
 	printf("        DQ:");
-	for (int bit = 0; bit < 16; ++bit) {
+	for (int bit = 0; bit < SDRAM_PHY_DATABITS; ++bit) {
 		printf(" %5d", bit);
 	}
 	printf("\n");
-	for (int phase = 0; phase < 8; ++phase) {
-		for (int edge = 0; edge < 2; ++edge) {
+	for (int phase = 0; phase < SDRAM_PHY_PHASES; ++phase) {
+		for (int edge = 0; edge < SDRAM_PHY_XDR; ++edge) {
 			unsigned int beat = 2*phase + edge;
 			printf("  beat[%2d]:", beat);
-			for (int bit = 0; bit < 16; ++bit) {
+			for (int bit = 0; bit < SDRAM_PHY_DATABITS; ++bit) {
 				unsigned int dq_errors = stats->phase[phase].edge[edge].dq[bit];
 				printf(" %5d", dq_errors);
 			}


### PR DESCRIPTION
The error report of `sdram_debug` was hard coded for testing 16-bit DDR RAM, now it's generic as the data collection already was. It reports now one beat line for SDR RAM run at sys_clck and two beat lines when running SDR RAM at sys_clk * 2 (`--sdram-rate 1:2`).

Some hopefully useful context for anyone finding this later via github keyword search:

This bios command was great for understanding that certain colorlight i5 modules come only with half of the SDRAM size accessible (one bank address pin out of two can be unconnected, full story: https://github.com/enjoy-digital/litex/pull/917#issuecomment-3220207378 and https://github.com/wuxx/Colorlight-FPGA-Projects/issues/26#issuecomment-3225063362). 

Since litex uses `ROW_BANK_COL` address mapping, it's not just the upper half of RAM that was missing in my case.

It was also helpful to reduce `MEMTEST_DATA_SIZE`, e.g. `self.add_constant("MEMTEST_DATA_SIZE", 0x40)` in the SoCCore-derived system design. Because with the address mapping that LiteX uses, a bank access error depends highly at which base address the SDRAM is being read/written: large `sdram_debug` error stats per data line may hide the actual issue and can make it seem like general signal integrity/delay errors - which was luckily not happening in my case. `sdram_debug` should eventually get parameters to specify an offset and test range. Or be interruptible by key press like `srdam_bist`. Something for next time...    