### PR TITLE
tools: json2dts_zephyr: fix mdio handler

### DIFF
--- a/litex/tools/litex_json2dts_zephyr.py
+++ b/litex/tools/litex_json2dts_zephyr.py
@@ -150,6 +150,9 @@ def ethphy_mdio_handler(name, parm, csr):
     if len(registers) == 0:
         raise KeyError
 
+    for reg in registers:
+        reg["name"] = "mdio_" + reg["name"]
+
     dtsi = dts_reg(registers)
     dtsi += dts_reg_names(registers)
     return dtsi


### PR DESCRIPTION
zephyr still expects the reg names still be
mdio_w and mdio_r, so add that prefix back
after it been filtered.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>