### PR TITLE
Fix warning in verilator source that prevents compilation with GCC 15

### DIFF
--- a/litex/build/sim/core/veril.cpp
+++ b/litex/build/sim/core/veril.cpp
@@ -126,7 +126,7 @@ extern "C" int litex_sim_got_finish()
 {
   int finished;
   tfp->flush();
-  if(finished = Verilated::gotFinish()) {
+  if((finished = Verilated::gotFinish())) {
     tfp->close();
   }
   return Verilated::gotFinish();


### PR DESCRIPTION
This gets promoted to an error and breaks the build