### PR TITLE
Zynq7000 ethernet support

### DIFF
--- a/litex/soc/cores/cpu/zynq7000/core.py
+++ b/litex/soc/cores/cpu/zynq7000/core.py
@@ -142,32 +142,6 @@ class Zynq7000(CPU):
         )
         self.specials += AsyncResetSynchronizer(self.cd_ps7, ~ps7_rst_n)
 
-        # Enet0 mdio -------------------------------------------------------------------------------
-        ps7_enet0_mdio_pads = platform.request("ps7_enet0_mdio", loose=True, reserve=self.reserve_pads)
-        if ps7_enet0_mdio_pads is not None:
-            self.cpu_params.update(
-                o_ENET0_MDIO_MDC = ps7_enet0_mdio_pads.mdc,
-                i_ENET0_MDIO_I   = ps7_enet0_mdio_pads.i,
-                o_ENET0_MDIO_O   = ps7_enet0_mdio_pads.o,
-                o_ENET0_MDIO_T   = ps7_enet0_mdio_pads.t
-            )
-
-        # Enet0 ------------------------------------------------------------------------------------
-        ps7_enet0_pads = platform.request("ps7_enet0", loose=True, reserve=self.reserve_pads)
-        if ps7_enet0_pads is not None:
-            self.cpu_params.update(
-                    o_ENET0_GMII_TX_EN  = ps7_enet0_pads.tx_en,
-                    o_ENET0_GMII_TX_ER  = ps7_enet0_pads.tx_er,
-                    o_ENET0_GMII_TXD    = ps7_enet0_pads.txd,
-                    i_ENET0_GMII_COL    = ps7_enet0_pads.col,
-                    i_ENET0_GMII_CRS    = ps7_enet0_pads.crs,
-                    i_ENET0_GMII_RX_CLK = ps7_enet0_pads.rx_clk,
-                    i_ENET0_GMII_RX_DV  = ps7_enet0_pads.rx_dv,
-                    i_ENET0_GMII_RX_ER  = ps7_enet0_pads.rx_er,
-                    i_ENET0_GMII_TX_CLK = ps7_enet0_pads.tx_clk,
-                    i_ENET0_GMII_RXD    = ps7_enet0_pads.rxd
-                )
-
         # SDIO0 ------------------------------------------------------------------------------------
         ps7_sdio0_pads = platform.request("ps7_sdio0", loose=True, reserve=self.reserve_pads)
         if ps7_sdio0_pads is not None:


### PR DESCRIPTION
_Zynq7000_ has 2 _GEM_ (ethernet controler) connected to _PS_: these controlers may be used with _PS_ IOs (`MMIO`) or via _PL_ (`EMIO`).
- In `MMIO` mode: `TCL` must be updated with sequence to enable/configure the controler. Since `ENETx/MDIOx` are not exposed at _Zynq_ wrapper level, this update is enough
- In `EMIO` mode: `TCL` must also be updated but IOs must be physically connected to Zynq pads.

In _EMIO_ the interface exposed at PL side is only _GMII_. To connect an `RGMII` phy a converter (`gmii_to_rgmii`) must be added to the gateware and configured

The second commit removes primitive update since _ENET_ interface and _MDIO_ interface are not exposed in `MMIO` and also this piece of code is hardcoded and ENET0. In fact tcl sequence at platform level is enough to configures the Zynq and `ps_init_gpl` files used in bare-metal or by u-boot.