### PR TITLE
Zynq7000 sdio

### DIFF
--- a/litex/soc/cores/cpu/zynq7000/core.py
+++ b/litex/soc/cores/cpu/zynq7000/core.py
@@ -143,33 +143,6 @@ class Zynq7000(CPU):
         )
         self.specials += AsyncResetSynchronizer(self.cd_ps7, ~ps7_rst_n)
 
-        # SDIO0 ------------------------------------------------------------------------------------
-        ps7_sdio0_pads = platform.request("ps7_sdio0", loose=True, reserve=self.reserve_pads)
-        if ps7_sdio0_pads is not None:
-            self.cpu_params.update(
-                o_SDIO0_CLK     = ps7_sdio0_pads.clk,
-                i_SDIO0_CLK_FB  = ps7_sdio0_pads.clk_fb,
-                o_SDIO0_CMD_O   = ps7_sdio0_pads.cmd_o,
-                i_SDIO0_CMD_I   = ps7_sdio0_pads.cmd_i,
-                o_SDIO0_CMD_T   = ps7_sdio0_pads.cmd_t,
-                o_SDIO0_DATA_O  = ps7_sdio0_pads.data_o,
-                i_SDIO0_DATA_I  = ps7_sdio0_pads.data_i,
-                o_SDIO0_DATA_T  = ps7_sdio0_pads.data_t,
-                o_SDIO0_LED     = ps7_sdio0_pads.led,
-                o_SDIO0_BUSPOW  = ps7_sdio0_pads.buspow,
-                o_SDIO0_BUSVOLT = ps7_sdio0_pads.busvolt,
-            )
-
-        # SDIO0_CD ---------------------------------------------------------------------------------
-        ps7_sdio0_cd_pads = platform.request("ps7_sdio0_cd", loose=True, reserve=self.reserve_pads)
-        if ps7_sdio0_cd_pads is not None:
-            self.cpu_params.update(i_SDIO0_CDN = ps7_sdio0_cd_pads.cdn)
-
-        # SDIO0_WP ---------------------------------------------------------------------------------
-        ps7_sdio0_wp_pads = platform.request("ps7_sdio0_wp", loose=True, reserve=self.reserve_pads)
-        if ps7_sdio0_wp_pads is not None:
-            self.cpu_params.update(i_SDIO0_WP = ps7_sdio0_wp_pads.wp)
-
         # GP0 as Bus master ------------------------------------------------------------------------
         self.pbus = self.add_axi_gp_master()
         self.periph_buses.append(self.pbus)


### PR DESCRIPTION
The *zynq7000* contains 2 SDIO controlers. These may be used in *MIO mode* (PS side) or in *EMIO mode* (via PL IOs).
- In *MIO mode* no IOs are exposed to the logic, and `card detect` and `write protect` may be enabled/disabled and used via *MIO* or *EMIO*
- in *EMIO mode* a single signals set of IOs are exposed in logic. `card_detect` and `write protect` are not configurables and always present in IOs set
- in both mode: `power control` may be enabled/disabled but must be always connected to PS MIO.

The second commit removes in CTOR the SDIO part unused and not working (in *MIO mode* signals are not accessibles by the logic).

Tested with an `digilent_arty_z7` and a digilent micro SD PMOD.

This solution address issue #2361