### PR TITLE
soc/integration/builder,export: added new cores section in json to store dict core instance name <-> class name

### DIFF
--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -277,6 +277,7 @@ class Builder:
         # JSON Export.
         if self.csr_json is not None:
             csr_json_contents = export.get_csr_json(
+                soc         = self.soc,
                 csr_regions = self.soc.csr_regions,
                 constants   = self.soc.constants,
                 mem_regions = self.soc.mem_regions)
@@ -285,6 +286,7 @@ class Builder:
         # CSV Export.
         if self.csr_csv is not None:
             csr_csv_contents = export.get_csr_csv(
+                soc         = self.soc,
                 csr_regions = self.soc.csr_regions,
                 constants   = self.soc.constants,
                 mem_regions = self.soc.mem_regions)


### PR DESCRIPTION
`litex_json2dts_linux.py` uses instance name to create devicetree nodes but more globally this approach is a bit limited.

For *zynq7000* or *zynqMP* it is sometime useful to create via a python script a complete devicetree or a devicetree overlay with arbitrary number of the same cores or some combo between cores not supported by `litex_json2dts_linux.py` or names different than expected.

This PR adds a new entry in the exported json with a dict of instance name <-> class name.
This allows to simplify devicetree generation: if the a class type is known and supported it's possible to create associated node without any predicates.

An example of uses is [here](https://gist.github.com/trabucayre/16371f9871664027c93c89397958a40c)