### PR TITLE
build/altera/common: implements a dedicated Agilex5SDRInputImpl instead of using Agilex5DDRInputImpl

### DIFF
--- a/litex/build/altera/common.py
+++ b/litex/build/altera/common.py
@@ -12,6 +12,8 @@ from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex.build.io import *
 
+from litex.gen import *
+
 # Common JTAG --------------------------------------------------------------------------------------
 
 altera_reserved_jtag_pads = [
@@ -329,10 +331,24 @@ class Agilex5SDROutput:
 
 # Agilex5 SDRInput ---------------------------------------------------------------------------------
 
+class Agilex5SDRInputImpl(LiteXModule):
+    n = 0 # FIXME
+    def __init__(self, i, o, clk):
+        # Create a local ClockDomain with a unique name.
+        self.cd_sdrinput = ClockDomain(f"sdrinput{self.n}")
+        self.comb += self.cd_sdrinput.clk.eq(clk)
+
+        # Get Clk as sync.
+        sync = getattr(self.sync, self.cd_sdrinput.name)
+        sync += o.eq(i)
+
+        # Update class attribute.
+        Agilex5SDRInputImpl.n += 1
+
 class Agilex5SDRInput:
     @staticmethod
     def lower(dr):
-        return Agilex5DDRInputImpl(dr.i, dr.o, Signal(len(dr.o)), dr.clk)
+        return Agilex5SDRInputImpl(dr.i, dr.o, dr.clk)
 
 # Agilex5 SDRTristate ------------------------------------------------------------------------------
 


### PR DESCRIPTION
When an `SDRInput` is used with an Agilex5, build fails at fitter step with the cryptic / hard to analyse message:
```bash
Error (23098): One or more blocks are configured incorrectly and will not have the desired functionality. --BCM instance name: hvio_0_0
Error (12274): A critical error occurred while the periphery placement was committed to the atom netlist. The atom netlist is now invalid and the Fitter must be restarted.
```

After some investigations reason of this failure is the use of `tennm_ph2_ddio_in` primitive with `regouthi` left floating.

*Platform designer* code produces for an GPIO in SDR input shows a simple sync register is used.

This PR implements a code similar to the official one.

Tested with a *LAN8720A* RMII Pmod connected to an **AXE5000** board.