### PR TITLE
build/microsemi: Reworks Plaform and Toolchain to accept devices other than PolarFire

### DIFF
--- a/litex/build/microsemi/platform.py
+++ b/litex/build/microsemi/platform.py
@@ -13,12 +13,12 @@ class MicrosemiPlatform(GenericPlatform):
     _bitstream_ext = ".bit"
     _jtag_support  = False
 
-    _supported_toolchains = ["libero_soc_polarfire"]
+    _supported_toolchains = ["libero_soc"]
 
-    def __init__(self, *args, toolchain="libero_soc_polarfire", **kwargs):
+    def __init__(self, *args, toolchain="libero_soc", **kwargs):
         GenericPlatform.__init__(self, *args, **kwargs)
-        if toolchain == "libero_soc_polarfire":
-            self.toolchain = libero_soc.MicrosemiLiberoSoCPolarfireToolchain()
+        if toolchain == "libero_soc":
+            self.toolchain = libero_soc.MicrosemiLiberoSoCToolchain()
         else:
             raise ValueError(f"Unknown toolchain {toolchain}")
 


### PR DESCRIPTION
Currently, *Microsemi*/*Microchip* toolchain can only be used for _PolarFire_ devices.

This PR updates the code to be less dependant:
- the Toolchain is renamed to remove _PolarFire_ aspect
- `finalize` method is added to parse `device` as soon as possible, knowing device family is mandatory for most of the subsequent operations
- `pdc` methods are also reworked: depending to the family, options and keywords may differs
- `part_range`, `speed` extract is also improved by analyzing package
- `tcl` operations are modified
  -  to specify `family`, `package`, `part_range`, `speed` and `voltage` when the project is created
  - `export_prog_job` is also modified, some options are only compatibles with _PolarFire_.