### PR TITLE
Import get_sdram_phy_settings from litedram.phy.model

### DIFF
--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -29,6 +29,8 @@ from litex.soc.cores.gpio    import GPIOTristate
 from litex.soc.cores.cpu     import CPUS
 from litex.soc.cores.video   import VideoGenericPHY
 
+from litedram.phy.model import get_sdram_phy_settings
+
 from liteeth.common             import *
 from liteeth.phy.gmii           import LiteEthPHYGMII
 from liteeth.phy.xgmii          import LiteEthPHYXGMII


### PR DESCRIPTION
Fixed the following import error that occurred when running `litedram_gen example.yml --sim`: `ImportError: cannot import name 'get_sdram_phy_settings' from 'litex.tools.litex_sim'`