### PR TITLE
build/altera/quartus: define SYNTHESIS macro globally

### DIFF
--- a/litex/build/altera/quartus.py
+++ b/litex/build/altera/quartus.py
@@ -182,6 +182,9 @@ class AlteraQuartusToolchain(GenericToolchain):
         # Set timing constraints
         qsf.append("set_global_assignment -name SDC_FILE {}.sdc".format(self._build_name))
 
+        # Define SYNTHESIS macro
+        qsf.append('set_global_assignment -name VERILOG_MACRO "SYNTHESIS=1"')
+
         # Add additional commands
         qsf += self.additional_qsf_commands
 

--- a/litex/soc/cores/cpu/vexriscv_smp/core.py
+++ b/litex/soc/cores/cpu/vexriscv_smp/core.py
@@ -445,10 +445,6 @@ class VexRiscvSMP(CPU):
         from litex.build.altera import AlteraPlatform
         if isinstance(platform, AlteraPlatform):
             ram_filename = "Ram_1w_1rs_Intel.v"
-            # define SYNTHESIS verilog name to avoid issues with unsupported
-            # functions
-            platform.toolchain.additional_qsf_commands.append(
-                'set_global_assignment -name VERILOG_MACRO "SYNTHESIS=1"')
         # On Efinix platforms, use specific implementation.
         from litex.build.efinix import EfinixPlatform
         if isinstance(platform, EfinixPlatform):


### PR DESCRIPTION
Fixes: 195cc915ed ("cores/cpu/vexriscv_smp: define SYNTHESIS in Quartus")

enabling "SYNTHESIS" should be done across all builds (rather than specifically per CPU model or individual designs) :)