### PR TITLE
build/openocd: allow jtag_uart to work on Catapult v3 boards

### DIFF
--- a/litex/build/openocd.py
+++ b/litex/build/openocd.py
@@ -55,6 +55,9 @@ class OpenOCD(GenericProgrammer):
         # Intel Max10.
         elif "10m50" in cfg_str:
             chain = 0xc
+        # Intel Arria10.
+        elif "10ax" in cfg_str:
+            chain = 0xc
         # Xilinx ZynqMP.
         elif "zynqmp" in cfg_str:
             chain = {


### PR DESCRIPTION
Catapult v3 boards come with an Arria 10 FPGA, which can work with the same IR value with MAX10.

Add recognition for "10ax" now to allow jtag_uart on Microsoft Catapult v3.

Tested with https://github.com/litex-hub/litex-boards/pull/714 .