### PR TITLE
integration/builder: Add bios selftest option

### DIFF
--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -88,6 +88,7 @@ class Builder:
         bios_lto         = False,
         bios_format      = "integer",
         bios_console     = "full",
+        bios_selftest    = "full",
 
         # Documentation.
         generate_doc     = False):
@@ -118,6 +119,7 @@ class Builder:
         self.bios_lto     = bios_lto
         self.bios_format  = bios_format
         self.bios_console = bios_console
+        self.bios_selftest= bios_selftest
 
         # Documentation.
         self.generate_doc = generate_doc
@@ -202,7 +204,8 @@ class Builder:
         define("LTO", f"{self.bios_lto:d}")
         assert self.bios_console in ["full", "no-history", "no-autocomplete", "lite", "disable"]
         define(f"BIOS_CONSOLE_{self.bios_console.upper()}", "1")
-
+        assert self.bios_selftest in ["full", "crc", "ram","disable"]
+        define("CONFIG_BIOS_SELFTEST", self.bios_selftest)
         return "\n".join(variables_contents)
 
     def _generate_includes(self, with_bios=True):
@@ -459,6 +462,7 @@ def builder_args(parser):
     bios_group.add_argument("--bios-lto",     action="store_true", help="Enable BIOS LTO (Link Time Optimization) compilation.")
     bios_group.add_argument("--bios-format",  default="integer",   help="Select BIOS printf format.",  choices=["integer", "float", "double"])
     bios_group.add_argument("--bios-console", default="full"  ,    help="Select BIOS console config.", choices=["full", "no-history", "no-autocomplete", "lite", "disable"])
+    bios_group.add_argument("--bios-selftest", default="full",     help="Enable BIOS boot tests. 'crc' enables ROM CRC verification. 'ram' runs RAM memtest and memspeed.", choices=["full", "crc", "ram","disable"])
 
 def builder_argdict(args):
     return {
@@ -478,4 +482,5 @@ def builder_argdict(args):
         "bios_lto"         : args.bios_lto,
         "bios_format"      : args.bios_format,
         "bios_console"     : args.bios_console,
+        "bios_selftest"    : args.bios_selftest
     }

--- a/litex/soc/software/bios/Makefile
+++ b/litex/soc/software/bios/Makefile
@@ -43,6 +43,19 @@ else
 OBJECTS += readline.o
 endif
 
+ifeq ($(CONFIG_BIOS_SELFTEST),full)
+# intentionally empty (nothing turned off)
+else ifeq ($(CONFIG_BIOS_SELFTEST),crc)
+CFLAGS += -DCONFIG_MAIN_RAM_INIT
+else ifeq ($(CONFIG_BIOS_SELFTEST),ram)
+CFLAGS += -DCONFIG_BIOS_NO_CRC
+else ifeq ($(CONFIG_BIOS_SELFTEST),disable)
+CFLAGS += -DCONFIG_MAIN_RAM_INIT
+CFLAGS += -DCONFIG_BIOS_NO_CRC
+else
+$(error unknown CONFIG_BIOS_SELFTEST value)
+endif
+
 ifeq ($(CPU), zynq7000)
 LSCRIPT = linker-zynq.ld
 else ifeq ($(CPU), zynqmp)


### PR DESCRIPTION
This PR adds a `--bios-selftest {full,ram,crc,disable}` option to the builder.
It should be mainly helpful when using `litex_term`, to save simulation time.

This is also intended as a step toward improving: https://github.com/enjoy-digital/litex/issues/1312.

@enjoy-digital
Happy New Year! As I often mention, I really like this project. I wanted to share a few thoughts/ideas (and I'd be happy to work on PRs for any of them if you think they make sense).
Before that: what’s your policy regarding changing already established CLI parameters? (I’m thinking about API/usage breakage.)
I guess, you say don't change anything that is established and I can fully understand that. Then you don't have to read those ideas ^^.
All ideas below are about argument parsing / CLI UX and a bit about the bios defines.

Idea 1: Group related flags into a single “choice” option
There are several places where multiple flags are really variants of one dimension, and could be grouped into a single option to reduce the total number of parameters without reducing the design space.
Example:
```
  --no-compile
          Disable Software and Gateware compilation. (default: False)
  --no-compile-software
          Disable Software compilation only. (default: False)
  --no-compile-gateware
          Disable Gateware compilation only. (default: False)
```
This is a typical “one thing with multiple modes” situation (similar to already established `--bios-console`). It could become something like:
`--compile {all, gateware, software, nothing}`
Benefits:
- Groups all mutually exclusive variants in one place
- Avoids redundant/conflicting combinations like `--no-compile --no-compile-software` together
- Makes --help easier to read
Other candidates:
- `--with-video-terminal`, `--with-video-framebuffer` `--with-video-colorbars`
--> maybe --with-video {terminal, framebuffer, colorbars} or similar.
Right now litex_sim errors if you specify multiple at once, which suggests they're mutually exclusive anyway (In my option that depends on the board but for litex_sim this is the current situation).
- Tracing options: `--trace {vcd,fst,off}`
-> Currently the trace situation is a bit confusing for newcomers:
- the GTKWave savefile is created depending on `--trace` although there is a option `--gtkwave-savefile`
- one has to implicitly know that `--trace` means “enable tracing + generate VCD + generate GTKWave savefile”
- `--trace-fst` enables tracing but disables VCD generation (which is fine but not obvious)
- `--gtkwave-savefile` doesn't seem to be used at all. What is the policy here? Would you prefer removing it, or is it considered legacy and should be kept stable? PR's allowed :) ?


Idea 2: Prefer consistently "positive" (or consistently "negative") modes for choice options
Right now there's a mix of styles:
`--bios-format` uses additional/positive logic (e.g interger vs float meaning "integer + float", etc)
`--bios-console` uses "negative logic" (e.g. full = everything on, no-history = everything on except history, etc)
For this PR I went with a positive style:
`--bios-selftest` -> crc = means "enable CRC selftest", etc

Personally I find consistently positive options easier to reason about in code and in `--help`, and it avoids double-negations such as:
- `!defined(BIOS_CONSOLE_NO_HISTORY)`
- `#ifndef CONFIG_BIOS_NO_PROMPT`


Idea 3: Rename `CONFIG_BIOS_NO_PROMPT` to something clearer
Would one of `CONFIG_BIOS_NO_{SPLASH|BOOTSCREEN|BANNER}` be clearer than the current `CONFIG_BIOS_NO_PROMPT`?
"Prompt" sounds like user interaction (shell prompt), while the feature is more like a banner/splash/bootscreen.
And `--bios-console` is about user interaction.

Idea 4: (All might be crazy, but this one might be too crazy :D) Consider a QEMU-like CLI style
This is more of a long-term style thought, but wouldn't a QEMU-style argument format be a better fit for LiteX?
Example shape:
`--{enable|with}-component watchdog,with=32,reset-delay=2`
Potential benefits:
- Better grouping of related sub-options
- Makes it obvious that specifying `--watchdog-width` without `--with-watchdog` is pointless
- Saves some verbosity for component parameters, since the repeated prefix can be omitted once you're "inside" the component

I think it could be nice to support `,param=value` and `,+feature` (I would vote agains `-feature` because it would then again create redundancy). Potentially, this could also support `,preset` (without +-=) to enable a predefined set of parameters/features.

On the Python side, this might also encourage grouping related options into structured objects (dicts / dataclasses), which could be passed around as a single entity instead of threading many loosely-related parameters through multiple __init__ calls.

This style would especially help options with multiple dimensions, like `--with-console`, which currently combines on/off plus feature selection.
Also, it's not immediately obvious that lite is effectively "the same base implementation as full, but with features disabled". Someone might assume it's a different implementation.

For example, something along these lines could be clearer:
`--console {off, on[,full][,+history][+autocomplete]}`
I haven’t fully thought this through, and it's not fully QEMU-compliant. I'm just mentioning it because the overall style might fit the project well.

If you think any part of this is worth pursuing, I can draft a PR. I'm happy to help where usefull.

