### PR TITLE
Vexiirsicv: Replace 'lw' with 'lwu' to avoid unintended sign extension

### DIFF
--- a/litex/soc/cores/cpu/vexiiriscv/crt0.S
+++ b/litex/soc/cores/cpu/vexiiriscv/crt0.S
@@ -17,10 +17,12 @@
 #define STORE sd
 #define LOAD ld
 #define WORD 8
+#define LOADW lwu
 #else
 #define STORE sw
 #define LOAD lw
 #define WORD 4
+#define LOADW lw
 #endif
 
 _start:
@@ -94,10 +96,10 @@ smp_slave:
   fence r, r
 
   .word(0x100F) //i$ flush
-  lw x10, smp_lottery_args
-  lw x11, smp_lottery_args+4
-  lw x12, smp_lottery_args+8
-  lw x13, smp_lottery_target
+  LOADW x10, smp_lottery_args
+  LOADW x11, smp_lottery_args+4
+  LOADW x12, smp_lottery_args+8
+  LOADW x13, smp_lottery_target
   jr x13
 
 


### PR DESCRIPTION
Hi,
When a non–cold-boot CPU jumps to 0x4000_0000, the address is sign-extended to 0x00_4000_0000, which works correctly.
However, if we move the memory base to 0x8000_0000, the address becomes sign-extended to 0x7F_8000_0000, causing the CPU to crash.