### PR TITLE
Add GenericTAP and enable JTAGBone access via jtagremote in litex_sim

### DIFF
--- a/litex/soc/cores/jtag.py
+++ b/litex/soc/cores/jtag.py
@@ -393,6 +393,136 @@ class ECP5JTAG(LiteXModule):
             tck = new_tck
         self.comb += self.tck.eq(tck)
 
+class GenericTAP(LiteXModule):
+    """Minimal TAP implementation for simulation or soft-TAP use.
+
+    Features:
+    - Configurable IR length (default 4).
+    - Implements IDCODE, BYPASS and one USER instruction.
+    - IDCODE is provided as a 32-bit value.
+    - TMS/TDI sampled on rising TCK, TDO updated on falling TCK
+      (via inverted 'jtag_inv' clock domain).
+    - Intended to work with OpenOCD remote_bitbang and daisy-chained TAPs.
+
+    Not implemented (so not fully compliant):
+    - Boundary scan register and mandatory EXTEST / SAMPLE / PRELOAD instructions.
+    - TRST* pin and detailed Run-Test/Idle timing behavior.
+    - Multiple USER instructions
+    """
+
+    def __init__(self, pads,
+                 idcode      = 0x1C0DE001, # mfr=0, part=0xC0DE, version=1
+                 ir_length   = 4,
+                 user_ir_val = 0b0010):
+        assert (idcode & 0x1) == 0x1, "IDCODE LSB (bit 0) must be 1 (according to spec)"
+        self.reset   = Signal()
+        self.capture = Signal()
+        self.shift   = Signal()
+        self.update  = Signal()
+        self.tck = Signal()
+        self.tms = Signal()
+        self.tdi = Signal()
+        self.tdo = Signal()
+
+        self.comb += [
+            self.tck.eq(pads.tck),
+            self.tms.eq(pads.tms),
+            self.tdi.eq(pads.tdi),
+        ]
+
+        # TDO that goes out to the JTAG chain
+        tdo_pre  = Signal() # before registering (comb)
+        tdo_reg  = Signal()
+        self.comb += pads.tdo.eq(tdo_reg)
+
+        # TAP state machine runs in "jtag" clock domain (posedge TCK)
+        self.submodules.tap = tap = ClockDomainsRenamer("jtag")(JTAGTAPFSM(self.tms))
+
+        # Inverted clock domain to register TDO on falling TCK
+        self.cd_jtag_inv = ClockDomain("jtag_inv")
+        self.comb += [
+            ClockSignal("jtag_inv").eq(~ClockSignal("jtag")),
+            ResetSignal("jtag_inv").eq(ResetSignal("jtag")),
+        ]
+        self.sync.jtag_inv += tdo_reg.eq(tdo_pre)
+
+        # Instruction register (IR) path
+        ir_shift   = Signal(ir_length, reset=0b0001)  # IR shift register
+        ir_latched = Signal(ir_length, reset=0b0001)  # current instruction (IDCODE after reset)
+        self.sync.jtag += [
+            If(tap.TEST_LOGIC_RESET,
+                # After reset, default to IDCODE instruction
+                ir_latched.eq(1),
+            ).Elif(tap.CAPTURE_IR,
+                # IR capture pattern: LSBs must be 01
+                ir_shift.eq(1),
+            ).Elif(tap.SHIFT_IR,
+                # Shift right: bit 0 -> TDO, new TDI enters MSB
+                ir_shift.eq(Cat(ir_shift[1:], self.tdi)),
+            ).Elif(tap.UPDATE_IR,
+                ir_latched.eq(ir_shift),
+            )
+        ]
+
+        # Data register (DR) path: BYPASS, IDCODE, USER
+        instr_bypass = (1 << ir_length) - 1   # all ones
+        instr_idcode = 0b0001
+        bypass_bit   = Signal(reset=0)        # 1-bit BYPASS register
+        idcode_shift = Signal(32, reset=idcode)
+
+        self.sync.jtag += [
+            # Capture-DR: load DRs based on current instruction
+            If(tap.CAPTURE_DR,
+                If(ir_latched == instr_bypass,
+                    # BYPASS must capture 0 in Capture-DR
+                    bypass_bit.eq(0),
+                ).Elif(ir_latched == instr_idcode,
+                    idcode_shift.eq(idcode),
+                )
+            ),
+            # Shift-DR: shift BYPASS/IDCODE if selected
+            If(tap.SHIFT_DR,
+                If(ir_latched == instr_bypass,
+                    bypass_bit.eq(self.tdi),
+                ).Elif(ir_latched == instr_idcode,
+                    idcode_shift.eq(Cat(idcode_shift[1:], self.tdi)),
+                )
+            )
+        ]
+
+        # USER instruction: Interface to JTAGPHY
+        user_selected = Signal()
+        self.comb += user_selected.eq(ir_latched == user_ir_val)
+        self.comb += [
+            self.reset.eq(tap.TEST_LOGIC_RESET),
+            self.capture.eq(tap.CAPTURE_DR & user_selected),
+            self.shift.eq(tap.SHIFT_DR   & user_selected),
+            self.update.eq(tap.UPDATE_DR & user_selected),
+        ]
+
+        # TDO mux: IR shift, DR (BYPASS/IDCODE/USER), or 0 when idle
+        tdo_comb = Signal()
+        self.comb += [
+            If(tap.SHIFT_IR, # During IR shift, drive IR LSB
+                tdo_comb.eq(ir_shift[0]),
+            ).Elif(tap.SHIFT_DR,
+                If(ir_latched == instr_bypass,
+                    tdo_comb.eq(bypass_bit),
+                ).Elif(ir_latched == instr_idcode,
+                    tdo_comb.eq(idcode_shift[0]),
+                ).Elif(user_selected, # USER data register is driven by JTAGPHY
+                    tdo_comb.eq(self.tdo),
+                ).Else( # Unknown instruction: drive 0 in DR shift
+                    tdo_comb.eq(0),
+                )
+            ).Else( # Outside of shift states, TDO is don't-care
+                tdo_comb.eq(0),
+            ),
+            # This value is then registered on falling TCK in jtag_inv domain
+            tdo_pre.eq(tdo_comb),
+        ]
+
+
 # JTAG PHY -----------------------------------------------------------------------------------------
 
 class JTAGPHY(LiteXModule):
@@ -440,6 +570,8 @@ class JTAGPHY(LiteXModule):
                     primitive = AlteraJTAG.get_primitive(device),
                     pads      = platform.get_reserved_jtag_pads()
                 )
+            elif device == 'SIM':
+                jtag = GenericTAP(pads=platform.request("jtag"))
             else:
                 print(device)
                 raise NotImplementedError

--- a/litex/soc/cores/jtag.py
+++ b/litex/soc/cores/jtag.py
@@ -421,8 +421,8 @@ class JTAGPHY(LiteXModule):
 
 
         # JTAG TAP ---------------------------------------------------------------------------------
+        jtag_tdi_delay = 0
         if jtag is None:
-            jtag_tdi_delay = 0
             # Xilinx.
             if XilinxJTAG.get_primitive(device) is not None:
                 jtag = XilinxJTAG(primitive=XilinxJTAG.get_primitive(device), chain=chain)

--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -575,6 +575,9 @@ def main():
     if args.with_jtagremote:
         sim_config.add_module("jtagremote", "jtag", args={'port': 44853})
 
+    if args.with_jtagbone:
+        sim_config.add_module("jtagremote", "jtag", args={'port': 44853})
+
     # Video.
     if args.with_video_framebuffer or args.with_video_terminal or args.with_video_colorbars:
         sim_config.add_module("video", "vga", args={"render_on_vsync": args.video_vsync})


### PR DESCRIPTION
This PR introduces a minimal, vendor-agnostic JTAG TAP implementation (GenericTAP) that works both in simulation and on regular FPGAs.

**Note**: This is intentionally a minimal TAP (not full IEEE 1149.1 compliance: no boundary scan / EXTEST / SAMPLE / PRELOAD).
**Tested**: It was tested in litex_sim and on a basys3 board

**When to use?** 
- When you need JTAG on non-dedicated FPGA I/O pins
- When you want to debug low-level JTAG signaling in simulation, especially around JTAGBone

### How to test in litex_sim:
create `test.cfg`:
```
interface remote_bitbang
remote_bitbang_host localhost
remote_bitbang_port 44853
set _CHIPNAME auto0
```
run:
```
litex_sim --with-jtagbone
litex_server --jtag-config test.cfg  --jtag
litex_cli --regs
0xf0000000 : 0x00000000 ctrl_reset
0xf0000004 : 0x12345678 ctrl_scratch
0xf0000008 : 0x00000000 ctrl_bus_errors
0xf0001000 : 0x0003d090 timer0_load
0xf0001004 : 0x00000000 timer0_reload
0xf0001008 : 0x00000001 timer0_en
0xf000100c : 0x00000001 timer0_update_value
0xf0001010 : 0x00000000 timer0_value
```
**Be aware it is very slow in the simulator**
Because the chunk size in openocd is way to large for the simulator:
```
diff --git a/litex/build/openocd.py b/litex/build/openocd.py
index 62644da5f..59015b08e 100644
--- a/litex/build/openocd.py
+++ b/litex/build/openocd.py
@@ -153,7 +153,7 @@ proc jtagstream_drain {tap tx chunk_rx max_rx} {
 proc jtagstream_rxtx {tap client is_poll} {
     if {![$client eof]} {
         set tx [$client read 16]
-        set rx [jtagstream_drain $tap $tx 128 4096]
+        set rx [jtagstream_drain $tap $tx 16 64]
         if {[string length $rx]} {
             #echo [string length $rx]
             $client puts -nonewline $rx
```
Because the default jtagremote has:
```
--- a/litex/build/sim/core/modules/jtagremote/jtagremote.c
+++ b/litex/build/sim/core/modules/jtagremote/jtagremote.c
@@ -222,8 +222,8 @@ static int jtagremote_tick(void *sess, uint64_t time_ps)
   }

   s->cntticks++;
-  if(s->cntticks % 10)
-         return RC_OK;
+  //if(s->cntticks % 10)
+       //  return RC_OK;

   if(s->datalen)
```

### Real world (e.g. Basys3):
board target file:
```
from litex.soc.cores import uart
from litex.soc.cores.jtag import JTAGPHY, GenericTAP
name = "test"
self.jtag_tap = GenericTAP(platform.request("jtag"))
jtagbone_phy = JTAGPHY(device=self.platform.device, chain=0x1, platform=self.platform, jtag=self.jtag_tap)
jtagbone = uart.UARTBone(
    phy           = jtagbone_phy,
    clk_freq      = self.sys_clk_freq,
    address_width = self.bus.address_width
)
self.add_module(name=name,          module=jtagbone)
self.bus.add_master(name=name, master=jtagbone.wishbone)
```
openocd output:
```
openocd  --file test.cfg
Open On-Chip Debugger 0.11.0
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
DEPRECATED! use 'adapter speed' not 'adapter_khz'
jtag
Info : Listening on port 6666 for tcl connections
Info : Listening on port 4444 for telnet connections
Info : J-Link ARM Lite V8 compiled Mar 14 2018 16:03:26
Info : Hardware version: 8.00
Info : VTarget = 3.410 V
Info : clock speed 1000 kHz
Warn : There are no enabled taps.  AUTO PROBING MIGHT NOT WORK!!
Info : JTAG tap: auto0.tap tap/device found: 0x1c0de001 (mfg: 0x000 (<invalid>), part: 0xc0de, ver: 0x1)
Warn : AUTO auto0.tap - use "jtag newtap auto0 tap -irlen 4 -expected-id 0x1c0de001"
Warn : gdb services need one or more targets defined
```