### PR TITLE
Implement cache flush using fence.i for CVA6

### DIFF
--- a/litex/soc/cores/cpu/cva6/system.h
+++ b/litex/soc/cores/cpu/cva6/system.h
@@ -5,8 +5,9 @@
 extern "C" {
 #endif
 
-__attribute__((unused)) static void flush_cpu_icache(void){}  /* FIXME: do something useful here! */
-__attribute__((unused)) static void flush_cpu_dcache(void){}; /* FIXME: do something useful here! */
+/* CVA6's fence.i flushes both D-Cache and I-Cache */
+__attribute__((unused)) static void flush_cpu_icache(void){ asm volatile("fence.i"); }
+__attribute__((unused)) static void flush_cpu_dcache(void){ asm volatile("fence.i"); }
 void flush_l2_cache(void);
 
 void busy_wait(unsigned int ms);


### PR DESCRIPTION
Replaced empty flush_cpu_icache and flush_cpu_dcache functions with implementations that use the 'fence.i' instruction, which flushes both instruction and data caches on CVA6. This addresses previous FIXME comments and ensures proper cache flushing.

Fixing #2121 