### PR TITLE
Fix dynamic baudrate UART issue by explicitly naming CSRs. 

### DIFF
--- a/litex/soc/cores/uart.py
+++ b/litex/soc/cores/uart.py
@@ -153,7 +153,7 @@ class RS232PHY(LiteXModule):
     def __init__(self, pads, clk_freq, baudrate=115200, with_dynamic_baudrate=False):
         tuning_word = int((baudrate/clk_freq)*2**32)
         if with_dynamic_baudrate:
-            self._tuning_word  = CSRStorage(32, reset=tuning_word)
+            self._tuning_word  = CSRStorage(32, reset=tuning_word, name="tuning_word")
             tuning_word = self._tuning_word.storage
         self.tx = RS232PHYTX(pads, tuning_word)
         self.rx = RS232PHYRX(pads, tuning_word)
@@ -217,17 +217,17 @@ class UART(LiteXModule, UARTInterface):
             rx_fifo_depth = 16,
             rx_fifo_rx_we = False,
             phy_cd        = "sys"):
-        self._rxtx    = CSR(8) # RX/TX Data.
-        self._txfull  = CSRStatus(description="TX FIFO Full.")
-        self._rxempty = CSRStatus(description="RX FIFO Empty.")
+        self._rxtx    = CSR(8, name="rxtx") # RX/TX Data.
+        self._txfull  = CSRStatus(description="TX FIFO Full.", name="txfull")
+        self._rxempty = CSRStatus(description="RX FIFO Empty.", name="rxempty")
 
         self.ev    = EventManager()
         self.ev.tx = EventSourceLevel()
         self.ev.rx = EventSourceLevel()
         self.ev.finalize()
 
-        self._txempty = CSRStatus(description="TX FIFO Empty.")
-        self._rxfull  = CSRStatus(description="RX FIFO Full.")
+        self._txempty = CSRStatus(description="TX FIFO Empty.", name="txempty")
+        self._rxfull  = CSRStatus(description="RX FIFO Full.", name="rxfull")
 
         # # #
 

--- a/litex/soc/interconnect/csr_eventmanager.py
+++ b/litex/soc/interconnect/csr_eventmanager.py
@@ -182,7 +182,7 @@ class EventManager(Module, AutoCSR):
                 desc = "This register contains the current raw level of the {} event trigger.  Writes to this register have no effect.".format(str(name))
             # Add CSRField
             fields.append(CSRField(name=name, size=1, description=f"Level of the ``{name}`` event"))
-        self.status = CSRStatus(n, description=desc, fields=fields)
+        self.status = CSRStatus(n, description=desc, fields=fields, name="status")
 
         # Pending Register
         fields = []
@@ -195,7 +195,7 @@ class EventManager(Module, AutoCSR):
                 desc = "When a  {} event occurs, the corresponding bit will be set in this register.  To clear the Event, set the corresponding bit in this register.".format(str(name))
             # Add CSRField
             fields.append(CSRField(name=name, size=1, description=get_pending_source_description(source)))
-        self.pending = CSRStatus(n, description=desc, fields=fields, read_only=False)
+        self.pending = CSRStatus(n, description=desc, fields=fields, read_only=False, name="pending")
 
         # Enable Register
         fields = []
@@ -208,7 +208,7 @@ class EventManager(Module, AutoCSR):
                 desc = "This register enables the corresponding {} events.  Write a ``0`` to this register to disable individual events.".format(str(name))
             # Add CSRField
             fields.append(CSRField(name=name, offset=i, description=f"Write a ``1`` to enable the ``{name}`` Event"))
-        self.enable = CSRStorage(n, description=desc, fields=fields)
+        self.enable = CSRStorage(n, description=desc, fields=fields, name="enable")
 
         # Connect Events/Fields
         for i, source in enumerate(sources):


### PR DESCRIPTION
#2394 reported that enabling dynamic baudrate on UART caused transmission failure.

`CSR` objects were instantiated without explicit names, relying on automatic name extraction from variable names. This extraction can be fragile, especially with private attributes (starting with `_`) or in certain contexts (like `EventManager`).
When `LiteXModule` introspection logic changed (as noted in the issue referencing commit `1b5fc97`), this implicit naming likely broke, causing the `tuning_word` CSR (required for dynamic baudrate) or `rxtx` CSR to be mishandled.

I reproduced the `ValueError: Cannot extract CSR name` in a standalone simulation script, confirming the fragility.
The fix involves explicitly passing `name="..."` to `CSR`, `CSRStatus`, and `CSRStorage` in `RS232PHY`, `UART`, and `EventManager`.
This ensures robust CSR generation and fixes the issue.