### PR TITLE
build/amaranth2v_converter.py: amaranth wrapper

### DIFF
--- a/litex/build/amaranth2v_converter.py
+++ b/litex/build/amaranth2v_converter.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import os
+import re
 
 import amaranth
 from amaranth.hdl import _ast, _ir
@@ -23,22 +24,26 @@ class Amaranth2VConverter(LiteXModule):
     instantiates it as a Migen/LiteX `Instance`. It allows Amaranth-based
     designs to be integrated into LiteX-based SoCs.
 
-    Main responsibilities:
+    The converter allows Amaranth-based IP to be integrated into
+    LiteX-based SoCs without modifying either design flow.
+
+    Main responsibilities
+    ---------------------
     - Manage clock domains for the wrapped Amaranth module
     - Convert the Amaranth design to Verilog
-    - Map LiteX/Migen signals to Amaranth ports
+    - Resolve and map LiteX/Migen signals to Amaranth signals
     - Emit Verilog to the build directory and register it as a source
 
-    The conversion is performed during LiteX finalization, ensuring that
-    the generated Verilog reflects the fully elaborated Amaranth design.
+    Signal connections are declared using string keys in `core_params`
+    and resolved recursively at finalization time.
     """
 
     def __init__(self, platform,
         name          = "amaranth2v_converter",
         module        = None,
-        conn_list     = None,
+        core_params   = None,
         clock_domains = None,
-        output_dir    = None
+        output_dir    = None,
         ):
         """
         Parameters
@@ -48,49 +53,56 @@ class Amaranth2VConverter(LiteXModule):
             registration).
 
         name : str
-            Name of the generated Verilog module and instance.
+            Name of the generated Verilog module and instantiated Instance.
 
         module : amaranth.Module or None
-            Optional Amaranth submodule to add to the internal wrapper module.
+            Optional Amaranth module to be added as a submodule of the
+            internal wrapper module.
 
-        conn_list : list of (Signal, Signal)
-            List of (Amaranth signal, Migen signal) connections used to
-            wire the generated instance.
+        core_params : dict[str, migen.Signal]
+            Mapping between string-encoded port names and LiteX/Migen signals.
 
-            Unlike `Instance` or `VHD2VConverter`, a dictionary mapping
-            Verilog port names to LiteX/Migen `Signal`s is not used here.
-            Instead, this list contains pairs of `Amaranth.Signal` and
-            `Migen.Signal`.
+            Format: <dir>_<path>
 
-            This difference is required because Verilog port names are
-            not always fully known before the Amaranth-to-Verilog
-            conversion step.
+            Where:
+                <dir>  ::= i | o | io
+                <path> ::= name { "_" name }*
 
-        clock_domains : list of str
-            List of clock domain names to create in the Amaranth module.
+            Form may be:
+            - i_rx_data to connect migen Signal to wrapper module.rx.data
+            - o__bus_pullup_o where _bus is an internal object (Record for example)
+              with a pullup sub Record containing only a sub sub Record o
+            - Clock And Reset signals must be <dir>_cdname_[clk|rst]
+
+        clock_domains : list[str] or None
+            List of clock domain names to create in the Amaranth wrapper.
             The 'sync' domain is always added if missing.
 
         output_dir : str or None
             Optional override for the Verilog output directory.
         """
-        self.platform   = platform
-        self.name       = name
-        self.output_dir = output_dir
+        self.platform    = platform
+        self.name        = name
+        self.output_dir  = output_dir
 
         # Internal Amaranth wrapper module
         self.m           = amaranth.Module()
 
-        # List of LiteX <-> Amaranth signal connections
-        self.conn_list   = {True: conn_list, False: list()}[conn_list is not None]
+        # List of LiteX <-> Amaranth signal connections (direction, amaranth_signal, migen_signal)
+        self.conn_list   = []
 
-        # List of clock domains
+        # Core parameters
+        self.core_params = {True: core_params, False: dict()}[core_params is not None]
+
+        # Clock domains
         clock_domains    = {True: clock_domains, False: list()}[clock_domains is not None]
 
-        # Add provided Amaranth module as a submodule
+        # Add provided Amaranth module as submodules
         if module is not None:
             self.m.submodules += module
+            self._module = module
 
-        # Manage Amaranth ClockDomain creation.
+        # Ensure sync domain exists
         if "sync" not in clock_domains:
             clock_domains.append("sync")
 
@@ -124,10 +136,11 @@ class Amaranth2VConverter(LiteXModule):
         """
         connections = {}
 
-        for n, m in self.conn_list:
+        for d, n, m in self.conn_list:
             name, direction = self.amaranth_name_map[n]
-            s = f'{direction}_{name}'
+            s = f"{direction}_{name}"
 
+            assert d == direction, f'Mismatch direction for signal {name}: expected {d} seen {direction}.'
             assert s not in connections, f'Signal {s} connected multiple times.'
 
             connections[s] = m
@@ -149,7 +162,7 @@ class Amaranth2VConverter(LiteXModule):
           port names and directions (`self.amaranth_name_map`)
         - Resolves clock and reset signals for all declared clock domains
         """
-        ports = [n for n, _ in self.conn_list]
+        ports = [n for _, n, _ in self.conn_list]
 
         fragment = _ir.Fragment.get(self.m, None).prepare(
             ports     = ports,
@@ -161,7 +174,7 @@ class Amaranth2VConverter(LiteXModule):
 
         # Map Amaranth signals to Verilog port names and directions
         self.amaranth_name_map = _ast.SignalDict(
-            (sig, (name, 'o' if name in netlist.top.ports_o else 'i'))
+            (sig, (name, "o" if name in netlist.top.ports_o else "i"))
             for name, sig, _ in fragment.ports
         )
 
@@ -174,11 +187,108 @@ class Amaranth2VConverter(LiteXModule):
 
         return v
 
+    def _iter_signals(self, obj, rem_lst):
+        """
+        Recursively resolve a signal by progressively grouping path elements.
+
+        This method performs a depth-first search and backtracks over
+        all possible underscore groupings.
+
+        Parameters
+        ----------
+        obj : object
+            Current object being inspected.
+
+        name : str or None
+            Unused legacy parameter (kept for compatibility).
+
+        rem_lst : list[str]
+            Remaining path components.
+
+        Returns
+        -------
+        amaranth.Signal or None
+        """
+        if obj is None:
+            return None
+        # it's a Signal -> it's the solution
+        if type(obj) is amaranth.Signal:
+            return obj
+
+        sig = None
+
+        for i in range(1, len(rem_lst) + 1):
+            # Extract name from remaining list
+            name = "_".join(rem_lst[:i])
+
+            if type(obj) is amaranth.Record:
+                subobj = getattr(obj, "fields", None)
+                if subobj is not None:
+                    subobj = subobj.get(name, None)
+            else:
+                subobj = getattr(obj, name, None)
+            # Search for the next level.
+            sig = self._iter_signals(subobj, rem_lst[i:])
+            # found -> stop
+            if sig is not None:
+                break
+
+        return sig
+
+    def connect_wrapper(self):
+        """
+        Resolve and register all LiteX ↔ Amaranth signal connections.
+
+        Resolution order:
+        1. Wrapper module
+        2. Provided submodule (recursive)
+        3. Clock domain signals (cdname_clk / cdname_rst)
+
+        Raises
+        ------
+        ValueError
+            If a signal cannot be resolved.
+        """
+        for kw, v in self.core_params.items():
+            # Direction prefix.
+            # Extract direction and signals hierarchy.
+            parts = re.findall(r'(?:^|_)(_[a-z]+|[a-z]+)', kw)
+            if len(parts) == 0:
+                raise ValueError(f"Cannot parse port name {kw}")
+
+            d     = parts[0]
+            parts = parts[1:]
+
+            if d not in ("i", "o", "io"):
+                raise ValueError(f"Invalid port '{kw}': must start with i_, o_ or io_")
+
+            # Wrapper-level resolution.
+            am_sig = getattr(self.m, parts[0], None)
+
+            # Recursive submodule resolution
+            if am_sig is None and hasattr(self, "_module"):
+                am_sig = self._iter_signals(self._module, parts)
+
+            # Wrapper clock domain (cdname_clk or cdname_rst).
+            if am_sig is None and len(parts) >= 2:
+                # join kw with last word
+                cd_name = "_".join(parts[:-1])
+                candr   = parts[-1]
+                cd      = self.m._domains.get(cd_name, None)
+                if cd is not None:
+                    am_sig = getattr(cd, candr, None)
+
+            if am_sig is None:
+                raise ValueError(f"Cannot resolve '{kw}' on Amaranth module.")
+
+            self.conn_list.append((d, am_sig, v))
+
     def do_finalize(self):
         """
         Finalize the module during the LiteX build process.
 
         This method:
+        - Resolves all signal connections
         - Generates and writes Verilog code produced by Amaranth
         - Registers the Verilog file as a platform source
         - Instantiates the generated module
@@ -188,9 +298,10 @@ class Amaranth2VConverter(LiteXModule):
         src_dir = os.path.join(output_dir, self.name)
         v_file  = os.path.join(src_dir, f"{self.name}.v")
 
-        # Create output directory if needed
-        if not os.path.exists(src_dir):
-            os.mkdir(src_dir)
+        os.makedirs(src_dir, exist_ok=True)
+
+        # Resolve connections
+        self.connect_wrapper()
 
         # Generate and write Verilog
         with open(v_file, "w") as f:


### PR DESCRIPTION
It may be useful to integrate cores written in **amaranth-lang** into LiteX gateware.

This has already been demonstrated in 
[litecompute_sdr_poc](https://github.com/enjoy-digital/litecompute_sdr_poc) using simple modules. However, the approach used there is not generic enough. In particular, when the inferred core requires one or more clock domains, this approach no longer works and requires writing an additional Amaranth `Module` to create the missing pieces.

The `Amaranth2VConverter` is based on the orbtrace wrapper. The goal is to provide a more generic way to bridge **Amaranth** and **LiteX/Migen**, following a model similar to `Instance` and `VHD2VConverter`.

## Main features:

- At constructor time an **Amaranth** module is created to handle both clock domains and module provided by the user/caller
- It takes a list of `(Amaranth Signal, Migen Signal)` pairs instead of a classic dictionary mapping signal names to Migen signals.
- A list of clock domains can be provided either at construction time or later.
- It writes out the Verilog generated by Amaranth.
- It creates a LiteX `Instance` to integrate the generated Verilog into the LiteX gateware.

## Example usage

```python
[...]

# Luna/USBSerialDevice ---------------------------------------------------------------------
self.usb = usb = luna.full_devices.USBSerialDevice(bus=ulpi, idVendor=0x1209, idProduct=0x0001)
[...]

# Connections ------------------------------------------------------------------------------
self.conn_list += [
    [...]
    # Source.
    # -------
    (usb.rx.valid,   source.valid),
    (usb.rx.ready,   source.ready),
    (usb.rx.last,    source.last),
    (usb.rx.first,   source.first),
    (usb.rx.payload, source.data),
]
[...]

# Amaranth Converter -----------------------------------------------------------------------
self.converter = Amaranth2VConverter(self.platform,
    name          = "usb_cdc_acm",
    module        = self.usb,
    conn_list     = self.conn_list,
    clock_domains = self.cd_list,
    output_dir    = None,
)
```