### PR TITLE
fix serie 7 mmcm fractional divide range

### DIFF
--- a/litex/soc/cores/clock/xilinx_s7.py
+++ b/litex/soc/cores/clock/xilinx_s7.py
@@ -78,7 +78,7 @@ class S7MMCM(XilinxClocking):
             -3: (600e6, 1600e6),
         }[speedgrade]
         
-        self.clkout0_divide_range = (1, (128 + 1/8), 1/8) # Fractional Divide available on CLKOUT0
+        self.clkout0_divide_range = (2, (128 + 1/8), 1/8) # Fractional Divide available on CLKOUT0
         self.clkfbout_mult_frange = (2,  64+1/8, 1/8) # Fractional multiply
 
         if not fractional:


### PR DESCRIPTION
This commit fixes the parameter range for CLKOUT0_DIVIDE_F on 7 series MMCMs. As I understand it (and tested), the allowed values are 1 and all values in `[2*8:128*8[ / 8`, so 1.5 and such are forbidden and result in this error :
```
[Drc 23-20] Rule violation (AVAL-45) MMCM_Clkdiv - Incompatible programming for clknetwork/inst/mmcm_adv_inst. CLKOUT0_DIVIDE_F is out of range. Valid range is 1, 2 to 128 for fractional counters.
```

I also checked that this modification does not keep litex from choosing 1 as a divider, since integer dividers in `XilinxClocking.clkout_divide_range` are tried first.

I think this edge case was not detected yet because previously dividers were tried in decreasing order, and this error had been luckly avoided. I am sorry that my [last pull request ](https://github.com/enjoy-digital/litex/pull/2391)might have broken stuff, and hope this one doesn't !!!

Thank you,