### PR TITLE
tools/litex_term: fix CPU overload during serial binary upload

### DIFF
--- a/litex/tools/litex_term.py
+++ b/litex/tools/litex_term.py
@@ -486,13 +486,17 @@ class LiteXTerm:
         start           = time.time()
         remaining       = length
         outstanding     = 0
+        last_progress_update = 0.0
         while remaining:
-            # Show progress
-            sys.stdout.write("|{}>{}| {}%\r".format(
-                "=" * (20*position//length),
-                " " * (20-20*position//length),
-                100*position//length))
-            sys.stdout.flush()
+            # Show progress (throttled to 10 Hz to avoid overloading terminal/X11)
+            now = time.time()
+            if now - last_progress_update >= 0.1:
+                sys.stdout.write("|{}>{}| {}%\r".format(
+                    "=" * (20*position//length),
+                    " " * (20-20*position//length),
+                    100*position//length))
+                sys.stdout.flush()
+                last_progress_update = now
 
             # Send frame if max outstanding not reached.
             if outstanding <= self.outstanding:
@@ -515,12 +519,16 @@ class LiteXTerm:
                 # Inter-frame delay.
                 time.sleep(self.delay)
 
-            # Read response if available.
-            while self.port.in_waiting:
-                ack = self.receive_upload_response()
-                if ack:
-                    outstanding -= 1
-                    break
+            # Read response if available, else yield CPU briefly.
+            if self.port.in_waiting:
+                while self.port.in_waiting:
+                    ack = self.receive_upload_response()
+                    if ack:
+                        outstanding -= 1
+                        break
+            elif outstanding > self.outstanding:
+                # yield 1/10th of frame transmission time to avoids busy-wait (minimum is 0.1ms)
+                time.sleep(max(0.0001, (self.length * 10) / self.port.baudrate / 10))
 
         # Get remaining responses.
         for _ in range(outstanding):


### PR DESCRIPTION
When uploading a big binary (~265 kB) with `litex_term --safe --kernel`, i have excessive CPU usage. Because:

* X11/xterm saturation: the progress bar was refreshed on every frame transmission,
* Python busy-wait: without yield, the loop iterates millions of times per frame cycle

This patch adds :
* progress bar throttling
* a short sleep period proportional to the communication rate to avoid busy loop

Now the CPU usage doesn't exceed 1%, and the transfer rate is exactly the same (tested at 115200 bps).

Before:
```
--============== Boot ==================--
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
[LITEX-TERM] Received firmware download request from the device.
[LITEX-TERM] Uploading /mnt/SSD2T/ZEPHYR/zephyr-project/MeProjects/dhcpv4_client/build/zephyr/zephyr.bin to 0x40000000 (247732 bytes)...
[LITEX-TERM] Upload complete (5.9KB/s).
[LITEX-TERM] Booting the device.
[LITEX-TERM] Done.
Executing booted program at 0x40000000

--============= Liftoff! ===============--
```

After:
```
--============== Boot ==================--
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
[LITEX-TERM] Received firmware download request from the device.
[LITEX-TERM] Uploading /mnt/SSD2T/ZEPHYR/zephyr-project/MeProjects/dhcpv4_client/build/zephyr/zephyr.bin to 0x40000000 (247732 bytes)...
[LITEX-TERM] Upload complete (5.9KB/s).
[LITEX-TERM] Booting the device.
[LITEX-TERM] Done.
Executing booted program at 0x40000000

--============= Liftoff! ===============--
```

No change, except that the fan no longer needs to speed up :)