### PR TITLE
cores: cpu: vexiiriscv: use gcc macro for riscv extensions

### DIFF
--- a/litex/soc/cores/cpu/vexiiriscv/core.py
+++ b/litex/soc/cores/cpu/vexiiriscv/core.py
@@ -127,8 +127,6 @@ class VexiiRiscv(CPU):
     def gcc_flags(self):
         flags =  f" -march={VexiiRiscv.get_gcc_arch()} -mabi={VexiiRiscv.get_abi()}"
         flags += f" -D__VexiiRiscv__"
-        if VexiiRiscv.with_rvcbom:
-            flags += f" -D__riscv_zicbom__"
         if VexiiRiscv.soc_args.with_aplic:
             flags += f" -D__riscv_aplic__"
         else:

--- a/litex/soc/cores/cpu/vexiiriscv/system.h
+++ b/litex/soc/cores/cpu/vexiiriscv/system.h
@@ -33,7 +33,7 @@ __attribute__((unused)) static void flush_cpu_dcache(void)
 {
 }
 
-#ifdef __riscv_zicbom__
+#ifdef __riscv_zicbom
 
 static inline void clean_cpu_dcache_range(void *start_addr, size_t size)
 {
@@ -56,7 +56,7 @@ static inline void invd_cpu_dcache_range(void *start_addr, size_t size)
 
 #define HAS_INVD_CPU_DCACHE_RANGE 1
 
-#endif /* __riscv_zicbom__ */
+#endif /* __riscv_zicbom */
 
 void flush_l2_cache(void);
 


### PR DESCRIPTION
gcc already adds defines for each enabled riscv extension via `riscv_*`. Use that for the zicbom extension.