### PR TITLE
Serialboot recovery improvements.

### DIFF
--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -100,6 +100,7 @@ void romboot(void)
 
 #define ACK_TIMEOUT_DELAY CONFIG_CLOCK_FREQUENCY/4
 #define CMD_TIMEOUT_DELAY CONFIG_CLOCK_FREQUENCY/4
+#define CMD_RECOVERY_DELAY CONFIG_CLOCK_FREQUENCY/64
 
 static void timer0_load(unsigned int value) {
 	timer0_en_write(0);
@@ -140,6 +141,18 @@ static int check_ack(void)
 		timer0_update_value_write(1);
 	}
 	return ACK_TIMEOUT;
+}
+
+static void serialboot_flush_input(void)
+{
+	timer0_load(CMD_RECOVERY_DELAY);
+	while(timer0_value_read()) {
+		if(uart_read_nonblock()) {
+			uart_read();
+			timer0_load(CMD_RECOVERY_DELAY);
+		}
+		timer0_update_value_write(1);
+	}
 }
 
 static uint32_t get_uint32(unsigned char* data)
@@ -228,6 +241,7 @@ int serialboot(void)
 		/* Check Timeout */
 		if (timeout) {
 			/* Acknowledge the Timeout and continue with a new frame */
+			serialboot_flush_input();
 			uart_write(SFL_ACK_ERROR);
 			if(serialboot_fail(&failures))
 				return 1;

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -100,7 +100,6 @@ void romboot(void)
 
 #define ACK_TIMEOUT_DELAY CONFIG_CLOCK_FREQUENCY/4
 #define CMD_TIMEOUT_DELAY CONFIG_CLOCK_FREQUENCY/4
-#define CMD_RECOVERY_DELAY CONFIG_CLOCK_FREQUENCY/64
 
 static void timer0_load(unsigned int value) {
 	timer0_en_write(0);
@@ -141,18 +140,6 @@ static int check_ack(void)
 		timer0_update_value_write(1);
 	}
 	return ACK_TIMEOUT;
-}
-
-static void serialboot_flush_input(void)
-{
-	timer0_load(CMD_RECOVERY_DELAY);
-	while(timer0_value_read()) {
-		if(uart_read_nonblock()) {
-			uart_read();
-			timer0_load(CMD_RECOVERY_DELAY);
-		}
-		timer0_update_value_write(1);
-	}
 }
 
 static uint32_t get_uint32(unsigned char* data)
@@ -241,7 +228,6 @@ int serialboot(void)
 		/* Check Timeout */
 		if (timeout) {
 			/* Acknowledge the Timeout and continue with a new frame */
-			serialboot_flush_input();
 			uart_write(SFL_ACK_ERROR);
 			if(serialboot_fail(&failures))
 				return 1;

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -152,6 +152,16 @@ static uint32_t get_uint32(unsigned char* data)
 
 #define MAX_FAILURES 256
 
+static int serialboot_fail(int *failures)
+{
+	(*failures)++;
+	if(*failures >= MAX_FAILURES) {
+		printf("Too many consecutive errors, aborting\n");
+		return 1;
+	}
+	return 0;
+}
+
 /* Returns 1 if other boot methods should be tried */
 int serialboot(void)
 {
@@ -191,21 +201,24 @@ int serialboot(void)
 		/* Get one Frame */
 		i = 0;
 		timeout = 1;
-		while((i == 0) || timer0_value_read()) {
+		timer0_load(CMD_TIMEOUT_DELAY);
+		while(timer0_value_read()) {
 			if (uart_read_nonblock()) {
+				unsigned char data;
+				data = uart_read();
 				if (i == 0) {
 					timer0_load(CMD_TIMEOUT_DELAY);
-					frame.payload_length = uart_read();
+					frame.payload_length = data;
 				}
-				if (i == 1) frame.crc[0] = uart_read();
-				if (i == 2) frame.crc[1] = uart_read();
-				if (i == 3) frame.cmd    = uart_read();
+				if (i == 1) frame.crc[0] = data;
+				if (i == 2) frame.crc[1] = data;
+				if (i == 3) frame.cmd    = data;
 				if (i >= 4) {
-					frame.payload[i-4] = uart_read();
-					if (i == (frame.payload_length + 4 - 1)) {
-						timeout = 0;
-						break;
-					}
+					frame.payload[i-4] = data;
+				}
+				if (i == (frame.payload_length + 4 - 1)) {
+					timeout = 0;
+					break;
 				}
 				i++;
 			}
@@ -216,6 +229,8 @@ int serialboot(void)
 		if (timeout) {
 			/* Acknowledge the Timeout and continue with a new frame */
 			uart_write(SFL_ACK_ERROR);
+			if(serialboot_fail(&failures))
+				return 1;
 			continue;
 		}
 
@@ -227,11 +242,8 @@ int serialboot(void)
 			uart_write(SFL_ACK_CRCERROR);
 
 			/* Increment failures and exit when max is reached */
-			failures++;
-			if(failures == MAX_FAILURES) {
-				printf("Too many consecutive errors, aborting");
+			if(serialboot_fail(&failures))
 				return 1;
-			}
 			continue;
 		}
 
@@ -249,6 +261,13 @@ int serialboot(void)
 			case SFL_CMD_LOAD: {
 				char *load_addr;
 
+				if(frame.payload_length < 4) {
+					uart_write(SFL_ACK_ERROR);
+					if(serialboot_fail(&failures))
+						return 1;
+					break;
+				}
+
 				/* Reset failures */
 				failures = 0;
 
@@ -264,6 +283,13 @@ int serialboot(void)
 			case SFL_CMD_JUMP: {
 				uint32_t jump_addr;
 
+				if(frame.payload_length < 4) {
+					uart_write(SFL_ACK_ERROR);
+					if(serialboot_fail(&failures))
+						return 1;
+					break;
+				}
+
 				/* Reset failures */
 				failures = 0;
 
@@ -274,17 +300,12 @@ int serialboot(void)
 				break;
 			}
 			default:
-				/* Increment failures */
-				failures++;
-
 				/* Acknowledge the UNKNOWN cmd */
 				uart_write(SFL_ACK_UNKNOWN);
 
 				/* Increment failures and exit when max is reached */
-				if(failures == MAX_FAILURES) {
-					printf("Too many consecutive errors, aborting");
+				if(serialboot_fail(&failures))
 					return 1;
-				}
 
 				break;
 		}

--- a/litex/tools/litex_term.py
+++ b/litex/tools/litex_term.py
@@ -258,6 +258,10 @@ sfl_ack_unknown  = b"U"
 sfl_ack_error    = b"E"
 
 
+class SFLUploadError(Exception):
+    pass
+
+
 class SFLFrame:
     def __init__(self):
         self.cmd = bytes()
@@ -349,7 +353,7 @@ class LiteXTerm:
         self.safe        = safe
         self.delay       = 0
         self.length      = 64
-        self.outstanding = 0 if safe else 128
+        self.outstanding = 1 if safe else 128
 
     def open(self, port, baudrate):
         if hasattr(self, "port"):
@@ -374,30 +378,59 @@ class LiteXTerm:
         else:
             self.sigint_time_last = sigint_time_current
 
-    def send_frame(self, frame):
-        retry = 1
-        while retry:
+    def read_sfl_reply(self, timeout=1.0):
+        if not hasattr(self.port, "timeout"):
+            reply = self.port.read()
+            if reply == b"":
+                raise SFLUploadError("timed out waiting for device reply")
+            return reply
+
+        previous_timeout = self.port.timeout
+        self.port.timeout = timeout
+        try:
+            reply = self.port.read()
+        finally:
+            self.port.timeout = previous_timeout
+
+        if reply == b"":
+            raise SFLUploadError("timed out waiting for device reply")
+        return reply
+
+    def drain(self):
+        while self.port.in_waiting:
+            self.port.read(self.port.in_waiting)
+
+    def send_frame(self, frame, timeout=1.0, retries=16):
+        for _ in range(retries):
             self.port.write(frame.encode())
             # Get the reply from the device
-            reply = self.port.read()
+            try:
+                reply = self.read_sfl_reply(timeout=timeout)
+            except SFLUploadError as e:
+                print(f"[LITEX-TERM] {e}, aborting.")
+                return 0
             if reply == sfl_ack_success:
-                retry = 0
+                return 1
             elif reply == sfl_ack_crcerror:
-                retry = 1
+                continue
             else:
                 print("[LITEX-TERM] Got unknown reply '{}' from the device, aborting.".format(reply))
                 return 0
-        return 1
+        print("[LITEX-TERM] Too many CRC errors from the device, aborting.")
+        return 0
 
     def receive_upload_response(self):
-        reply = self.port.read()
+        reply = self.read_sfl_reply()
         if reply == sfl_ack_success:
             return True
         elif reply == sfl_ack_crcerror:
-            print("[LITEX-TERM] Upload to device failed due to data corruption (CRC error)")
+            raise SFLUploadError("upload failed due to data corruption (CRC error)")
+        elif reply == sfl_ack_error:
+            raise SFLUploadError("device reported a serial frame error")
+        elif reply == sfl_ack_unknown:
+            raise SFLUploadError("device reported an unknown serial command")
         else:
-            print(f"[LITEX-TERM] Got unexpected response from device '{reply}'")
-        sys.exit(1)
+            raise SFLUploadError(f"got unexpected response from device '{reply}'")
 
     def upload_calibration(self, address):
 
@@ -425,19 +458,35 @@ class LiteXTerm:
                 frame.payload += frame_data
                 frame = frame.encode()
 
+                # Drain stale replies from previous attempts.
+                self.drain()
+
                 # Send N consecutive frames.
                 for i in range(nframes):
                     self.port.write(frame)
                     time.sleep(delay)
 
-                # Wait and get acks.
+                # Wait and get all expected ACKs.
                 working = True
-                time.sleep(0.2)
-                while self.port.in_waiting:
-                    ack = self.port.read()
-                    #print(ack)
-                    if ack in [sfl_ack_error, sfl_ack_crcerror]:
+                ack_count = 0
+                baudrate = getattr(self.port, "baudrate", 115200) or 115200
+                frame_time = (len(frame) * 10) / baudrate
+                deadline = time.time() + max(0.5, frame_time * nframes * 4)
+                while ack_count < nframes and time.time() < deadline:
+                    try:
+                        ack = self.read_sfl_reply(timeout=max(0, deadline - time.time()))
+                    except SFLUploadError:
+                        break
+                    ack_count += 1
+                    if ack != sfl_ack_success:
                         working = False
+
+                if ack_count != nframes:
+                    working = False
+
+                if not working:
+                    time.sleep(0.35)
+                    self.drain()
 
                 if working:
                     # Save working delay/length and exit.
@@ -461,92 +510,115 @@ class LiteXTerm:
             print("failed, switching to --safe mode.")
             self.delay       = 0
             self.length      = 64
-            self.outstanding = 0
+            self.outstanding = 1
 
     def upload(self, filename, address):
-        f = open(filename, "rb")
-        f.seek(0, 2)
-        length = f.tell()
-        f.seek(0, 0)
+        with open(filename, "rb") as f:
+            f.seek(0, 2)
+            length = f.tell()
+            f.seek(0, 0)
 
-        print(f"[LITEX-TERM] Uploading {filename} to 0x{address:08x} ({length} bytes)...")
+            print(f"[LITEX-TERM] Uploading {filename} to 0x{address:08x} ({length} bytes)...")
 
-        # Upload calibration
-        if not self.safe:
-            self.upload_calibration(address)
-            # Force safe mode settings when calibration fails.
-            if self.delay is None:
-                self.delay       = 0
-                self.length      = 64
-                self.outstanding = 0
+            # Upload calibration
+            if not self.safe:
+                self.upload_calibration(address)
+                # Force safe mode settings when calibration fails.
+                if self.delay is None:
+                    self.delay       = 0
+                    self.length      = 64
+                    self.outstanding = 1
 
-        # Prepare parameters
-        current_address = address
-        position        = 0
-        start           = time.time()
-        remaining       = length
-        outstanding     = 0
-        last_progress_update = 0.0
-        while remaining:
-            # Show progress (throttled to 10 Hz to avoid overloading terminal/X11)
-            now = time.time()
-            if now - last_progress_update >= 0.1:
-                sys.stdout.write("|{}>{}| {}%\r".format(
-                    "=" * (20*position//length),
-                    " " * (20-20*position//length),
-                    100*position//length))
-                sys.stdout.flush()
-                last_progress_update = now
+            # Prepare parameters
+            current_address = address
+            position        = 0
+            start           = time.time()
+            remaining       = length
+            outstanding     = 0
+            last_progress_update = 0.0
+            while remaining:
+                # Show progress (throttled to 10 Hz to avoid overloading terminal/X11)
+                now = time.time()
+                if now - last_progress_update >= 0.1:
+                    sys.stdout.write("|{}>{}| {}%\r".format(
+                        "=" * (20*position//length),
+                        " " * (20-20*position//length),
+                        100*position//length))
+                    sys.stdout.flush()
+                    last_progress_update = now
 
-            # Send frame if max outstanding not reached.
-            if outstanding <= self.outstanding:
-                # Prepare frame.
-                frame      = SFLFrame()
-                frame.cmd  = sfl_cmd_load
-                frame_data = f.read(min(remaining, self.length-4))
-                frame.payload = current_address.to_bytes(4, "big")
-                frame.payload += frame_data
+                # Send frame if max outstanding not reached.
+                if outstanding < self.outstanding:
+                    # Prepare frame.
+                    frame      = SFLFrame()
+                    frame.cmd  = sfl_cmd_load
+                    frame_data = f.read(min(remaining, self.length-4))
+                    frame.payload = current_address.to_bytes(4, "big")
+                    frame.payload += frame_data
 
-                # Encode frame and send it.
-                self.port.write(frame.encode())
+                    # Encode frame and send it.
+                    self.port.write(frame.encode())
 
-                # Update parameters
-                current_address += len(frame_data)
-                position        += len(frame_data)
-                remaining       -= len(frame_data)
-                outstanding     += 1
+                    # Update parameters
+                    current_address += len(frame_data)
+                    position        += len(frame_data)
+                    remaining       -= len(frame_data)
+                    outstanding     += 1
 
-                # Inter-frame delay.
-                time.sleep(self.delay)
+                    # Inter-frame delay.
+                    time.sleep(self.delay)
 
-            # Read response if available, else yield CPU briefly.
-            if self.port.in_waiting:
-                while self.port.in_waiting:
-                    ack = self.receive_upload_response()
-                    if ack:
-                        outstanding -= 1
-                        break
-            elif outstanding > self.outstanding:
-                # yield 1/10th of frame transmission time to avoids busy-wait (minimum is 0.1ms)
-                time.sleep(max(0.0001, (self.length * 10) / self.port.baudrate / 10))
+                # Read response if available, else yield CPU briefly.
+                if self.port.in_waiting:
+                    while self.port.in_waiting:
+                        ack = self.receive_upload_response()
+                        if ack:
+                            outstanding -= 1
+                            break
+                elif outstanding >= self.outstanding:
+                    # yield 1/10th of frame transmission time to avoids busy-wait (minimum is 0.1ms)
+                    baudrate = getattr(self.port, "baudrate", 115200) or 115200
+                    time.sleep(max(0.0001, (self.length * 10) / baudrate / 10))
 
-        # Get remaining responses.
-        for _ in range(outstanding):
-            self.receive_upload_response()
+            # Get remaining responses.
+            for _ in range(outstanding):
+                self.receive_upload_response()
 
-        # Compute speed.
-        end     = time.time()
-        elapsed = end - start
-        print("[LITEX-TERM] Upload complete ({0:.1f}KB/s).".format(length/(elapsed*1024)))
-        f.close()
-        return length
+            # Compute speed.
+            end     = time.time()
+            elapsed = end - start
+            print("[LITEX-TERM] Upload complete ({0:.1f}KB/s).".format(length/(elapsed*1024)))
+            return length
 
     def boot(self):
         print("[LITEX-TERM] Booting the device.")
         frame = SFLFrame()
         frame.cmd = sfl_cmd_jump
         frame.payload = int(self.boot_address, 16).to_bytes(4, "big")
-        self.send_frame(frame)
+        if not self.send_frame(frame):
+            raise SFLUploadError("could not send boot command")
+
+    def abort_serialboot(self):
+        print("[LITEX-TERM] Aborting serial boot.")
+        time.sleep(0.35)
+        self.drain()
+
+        frame = SFLFrame()
+        frame.cmd = sfl_cmd_abort
+        self.port.write(frame.encode())
+
+        try:
+            reply = self.read_sfl_reply(timeout=1.0)
+        except SFLUploadError as e:
+            print(f"[LITEX-TERM] Serial boot abort failed: {e}.")
+            return False
+
+        if reply == sfl_ack_success:
+            print("[LITEX-TERM] Serial boot aborted.")
+            return True
+
+        print(f"[LITEX-TERM] Serial boot abort got unexpected response '{reply}'.")
+        return False
 
     def detect_prompt(self, data):
         if len(data):
@@ -570,10 +642,14 @@ class LiteXTerm:
         print("[LITEX-TERM] Received firmware download request from the device.")
         if(len(self.mem_regions)):
             self.port.write(sfl_magic_ack)
-        for filename, base in self.mem_regions.items():
-            self.upload(filename, int(base, 16))
-        self.boot()
-        print("[LITEX-TERM] Done.")
+        try:
+            for filename, base in self.mem_regions.items():
+                self.upload(filename, int(base, 16))
+            self.boot()
+            print("[LITEX-TERM] Done.")
+        except SFLUploadError as e:
+            print(f"\n[LITEX-TERM] Serial boot failed: {e}.")
+            self.abort_serialboot()
 
     def reader(self):
         try:

--- a/litex/tools/litex_term.py
+++ b/litex/tools/litex_term.py
@@ -361,6 +361,7 @@ class LiteXTerm:
         self.delay       = 0
         self.length      = sfl_safe_data_length if safe else sfl_data_length
         self.outstanding = 1 if safe else sfl_default_outstanding
+        self.calibrated_upload_profiles = []
 
     def open(self, port, baudrate):
         if hasattr(self, "port"):
@@ -375,7 +376,10 @@ class LiteXTerm:
 
     def sigint(self, sig, frame):
         if hasattr(self, "port"):
-            self.port.write(b"\x03")
+            try:
+                self.write_sfl_data(b"\x03", timeout=0.1)
+            except SFLUploadError:
+                pass
         sigint_time_current = time.time()
         # Exit term if 2 CTRL-C pressed in less than 0.5s or if the writer is not alive anymore.
         if not self.writer_alive or (sigint_time_current - self.sigint_time_last < 0.5):
@@ -403,15 +407,32 @@ class LiteXTerm:
             raise SFLUploadError("timed out waiting for device reply")
         return reply
 
+    def write_sfl_data(self, data, timeout=1.0):
+        if not hasattr(self.port, "write_timeout"):
+            return self.port.write(data)
+
+        previous_timeout = self.port.write_timeout
+        self.port.write_timeout = timeout
+        try:
+            written = self.port.write(data)
+        except serial.SerialTimeoutException as e:
+            raise SFLUploadError("timed out writing device frame") from e
+        finally:
+            self.port.write_timeout = previous_timeout
+
+        if written is not None and written != len(data):
+            raise SFLUploadError(f"short write to device ({written}/{len(data)} bytes)")
+        return written
+
     def drain(self):
         while self.port.in_waiting:
             self.port.read(self.port.in_waiting)
 
     def send_frame(self, frame, timeout=1.0, retries=16):
+        encoded_frame = frame.encode()
         for _ in range(retries):
-            self.port.write(frame.encode())
-            # Get the reply from the device
             try:
+                self.write_sfl_data(encoded_frame, timeout=timeout)
                 reply = self.read_sfl_reply(timeout=timeout)
             except SFLUploadError as e:
                 print(f"[LITEX-TERM] {e}, aborting.")
@@ -459,6 +480,40 @@ class LiteXTerm:
         time.sleep(max(0.35, self.frame_time(data_length) * max(1, outstanding) + 0.35))
         self.drain()
 
+    def probe_upload_profile(self, address, data_length, outstanding, nframes=None):
+        data_length  = max(1, min(data_length, sfl_data_length))
+        outstanding  = max(1, outstanding)
+        nframes      = max(nframes or 0, outstanding, 1)
+        frame        = self.make_load_frame(address, bytes(data_length))
+        encoded_frame = frame.encode()
+        pending      = 0
+        sent         = 0
+        write_timeout = max(1.0, self.frame_time(data_length) + 0.5)
+        ack_timeout   = max(1.0, self.frame_time(data_length) * (outstanding + 1) + 0.5)
+
+        self.drain()
+        try:
+            while sent < nframes or pending:
+                while sent < nframes and pending < outstanding:
+                    self.write_sfl_data(encoded_frame, timeout=write_timeout)
+                    sent    += 1
+                    pending += 1
+                    time.sleep(self.delay)
+
+                if pending:
+                    self.receive_upload_response(timeout=ack_timeout)
+                    pending -= 1
+        except SFLUploadError:
+            self.settle_upload(data_length=data_length, outstanding=outstanding)
+            return False
+
+        return True
+
+    def recover_upload_link(self, address, data_length=None):
+        data_length = min(sfl_safe_data_length, data_length or sfl_safe_data_length)
+        self.settle_upload(data_length=data_length, outstanding=1)
+        return self.probe_upload_profile(address, data_length, 1, nframes=1)
+
     def upload_calibration(self, address, image_length=None):
 
         print("[LITEX-TERM] Upload calibration... ", end="")
@@ -471,37 +526,62 @@ class LiteXTerm:
             print("skipped.")
             return True
 
-        nframes = 4
-        length_range = []
-        for length in [sfl_data_length, 128, sfl_safe_data_length]:
+        best_length      = min(sfl_safe_data_length, max_probe_length)
+        best_outstanding = 1
+        best_score       = best_length * best_outstanding
+        tested_lengths   = []
+        successful_profiles = [(best_length, best_outstanding)]
+        calibration_alive = True
+
+        if not self.probe_upload_profile(address, best_length, best_outstanding, nframes=4):
+            print("failed, switching to --safe mode.")
+            self.delay       = 0
+            self.length      = best_length
+            self.outstanding = 1
+            self.calibrated_upload_profiles = [(best_length, 1)]
+            return False
+
+        for length in [best_length, 128, sfl_data_length]:
+            if not calibration_alive:
+                break
             length = min(length, max_probe_length)
-            if length > 0 and length not in length_range:
-                length_range.append(length)
+            if length <= 0 or length in tested_lengths:
+                continue
+            tested_lengths.append(length)
 
-        for length in length_range:
-            frame = self.make_load_frame(address, bytes(length))
-            self.drain()
+            if length != best_length:
+                if not self.probe_upload_profile(address, length, 1, nframes=4):
+                    self.recover_upload_link(address, best_length)
+                    break
+                successful_profiles.append((length, 1))
+                score = length
+                if score > best_score:
+                    best_length      = length
+                    best_outstanding = 1
+                    best_score       = score
 
-            working = True
-            for _ in range(nframes):
-                if not self.send_frame(frame, timeout=max(1.0, self.frame_time(length) + 0.5), retries=2):
-                    working = False
+            for outstanding in [2, 4, sfl_default_outstanding]:
+                if not self.probe_upload_profile(address, length, outstanding, nframes=outstanding * 2):
+                    calibration_alive = self.recover_upload_link(address, best_length)
                     break
 
-            if working:
-                self.delay       = 0
-                self.length      = length
-                self.outstanding = min(self.outstanding, sfl_default_outstanding)
-                print(f"(inter-frame: {self.delay*1e6:5.2f}us, length: {self.length}, window: {self.outstanding})")
-                return True
+                successful_profiles.append((length, outstanding))
+                score = length * outstanding
+                if score > best_score:
+                    best_length      = length
+                    best_outstanding = outstanding
+                    best_score       = score
 
-            self.settle_upload(data_length=length, outstanding=1)
-
-        print("failed, switching to --safe mode.")
         self.delay       = 0
-        self.length      = min(sfl_safe_data_length, max(1, max_probe_length))
-        self.outstanding = 1
-        return False
+        self.length      = best_length
+        self.outstanding = best_outstanding
+        self.calibrated_upload_profiles = sorted(
+            set(successful_profiles),
+            key=lambda profile: (profile[0] * profile[1], profile[0], profile[1]),
+            reverse=True,
+        )
+        print(f"(inter-frame: {self.delay*1e6:5.2f}us, length: {self.length}, window: {self.outstanding})")
+        return True
 
     def upload(self, filename, address):
         length = os.path.getsize(filename)
@@ -544,17 +624,24 @@ class LiteXTerm:
             return [(self.length, 1)]
 
         profiles = []
-        for data_length, outstanding in [
-            (self.length, self.outstanding),
-            (self.length, min(4, self.outstanding)),
-            (self.length, 1),
-            (min(sfl_safe_data_length, self.length), 1),
-        ]:
+        for data_length, outstanding in getattr(self, "calibrated_upload_profiles", []):
             data_length = max(1, min(data_length, sfl_data_length))
             outstanding = max(1, outstanding)
             profile = (data_length, outstanding)
             if profile not in profiles:
                 profiles.append(profile)
+
+        if not profiles:
+            outstanding = max(1, self.outstanding)
+            while outstanding > 1:
+                profiles.append((max(1, min(self.length, sfl_data_length)), outstanding))
+                outstanding = max(1, outstanding // 2)
+            profiles.append((max(1, min(self.length, sfl_data_length)), 1))
+
+        safe_profile = (min(sfl_safe_data_length, max(1, self.length)), 1)
+        if safe_profile not in profiles:
+            profiles.append(safe_profile)
+
         return profiles
 
     def upload_once(self, filename, address, length, data_length, max_outstanding):
@@ -586,7 +673,8 @@ class LiteXTerm:
                     encoded_frame = frame.encode()
 
                     # Encode frame and send it.
-                    self.port.write(encoded_frame)
+                    write_timeout = max(1.0, self.frame_time(data_length) + 0.5)
+                    self.write_sfl_data(encoded_frame, timeout=write_timeout)
 
                     # Update parameters
                     current_address += len(frame_data)
@@ -611,7 +699,8 @@ class LiteXTerm:
                         outstanding[0]["retries"] < 16
                     ):
                         outstanding[0]["retries"] += 1
-                        self.port.write(outstanding[0]["frame"])
+                        write_timeout = max(1.0, self.frame_time(data_length) + 0.5)
+                        self.write_sfl_data(outstanding[0]["frame"], timeout=write_timeout)
                         current_window = 1
                         window_successes = 0
                         continue
@@ -646,9 +735,9 @@ class LiteXTerm:
 
         frame = SFLFrame()
         frame.cmd = sfl_cmd_abort
-        self.port.write(frame.encode())
 
         try:
+            self.write_sfl_data(frame.encode(), timeout=1.0)
             reply = self.read_sfl_reply(timeout=1.0)
         except SFLUploadError as e:
             print(f"[LITEX-TERM] Serial boot abort failed: {e}.")

--- a/litex/tools/litex_term.py
+++ b/litex/tools/litex_term.py
@@ -18,6 +18,7 @@ import threading
 import argparse
 import json
 import socket
+from collections import deque
 
 # Console ------------------------------------------------------------------------------------------
 
@@ -245,6 +246,10 @@ sfl_magic_req = b"sL5DdSMmkekro\n"
 sfl_magic_ack = b"z6IHG7cYDID6o\n"
 
 sfl_payload_length  = 255
+sfl_address_length  = 4
+sfl_data_length     = sfl_payload_length - sfl_address_length
+sfl_safe_data_length = 64
+sfl_default_outstanding = 8
 
 # General commands
 sfl_cmd_abort       = b"\x00"
@@ -259,7 +264,9 @@ sfl_ack_error    = b"E"
 
 
 class SFLUploadError(Exception):
-    pass
+    def __init__(self, message, reply=None):
+        super().__init__(message)
+        self.reply = reply
 
 
 class SFLFrame:
@@ -352,8 +359,8 @@ class LiteXTerm:
 
         self.safe        = safe
         self.delay       = 0
-        self.length      = 64
-        self.outstanding = 1 if safe else 128
+        self.length      = sfl_safe_data_length if safe else sfl_data_length
+        self.outstanding = 1 if safe else sfl_default_outstanding
 
     def open(self, port, baudrate):
         if hasattr(self, "port"):
@@ -419,127 +426,151 @@ class LiteXTerm:
         print("[LITEX-TERM] Too many CRC errors from the device, aborting.")
         return 0
 
-    def receive_upload_response(self):
-        reply = self.read_sfl_reply()
+    def receive_upload_response(self, timeout=1.0):
+        reply = self.read_sfl_reply(timeout=timeout)
         if reply == sfl_ack_success:
             return True
         elif reply == sfl_ack_crcerror:
-            raise SFLUploadError("upload failed due to data corruption (CRC error)")
+            raise SFLUploadError("upload failed due to data corruption (CRC error)", reply=reply)
         elif reply == sfl_ack_error:
-            raise SFLUploadError("device reported a serial frame error")
+            raise SFLUploadError("device reported a serial frame error", reply=reply)
         elif reply == sfl_ack_unknown:
-            raise SFLUploadError("device reported an unknown serial command")
+            raise SFLUploadError("device reported an unknown serial command", reply=reply)
         else:
             raise SFLUploadError(f"got unexpected response from device '{reply}'")
 
-    def upload_calibration(self, address):
+    def baudrate(self):
+        return getattr(self.port, "baudrate", 115200) or 115200
+
+    def frame_time(self, data_length=None):
+        data_length = self.length if data_length is None else data_length
+        frame_length = 1 + 2 + 1 + sfl_address_length + data_length
+        return (frame_length * 10) / self.baudrate()
+
+    def make_load_frame(self, address, data):
+        frame = SFLFrame()
+        frame.cmd = sfl_cmd_load
+        frame.payload = address.to_bytes(4, "big") + data
+        return frame
+
+    def settle_upload(self, data_length=None, outstanding=None):
+        data_length = self.length if data_length is None else data_length
+        outstanding = self.outstanding if outstanding is None else outstanding
+        time.sleep(max(0.35, self.frame_time(data_length) * max(1, outstanding) + 0.35))
+        self.drain()
+
+    def upload_calibration(self, address, image_length=None):
 
         print("[LITEX-TERM] Upload calibration... ", end="")
         sys.stdout.flush()
 
-        # Calibration parameters.
-        min_delay    = 1e-5
-        max_delay    = 1e-3
-        nframes      = 16
-        length_range = [64]
+        max_probe_length = sfl_data_length
+        if image_length is not None:
+            max_probe_length = min(max_probe_length, image_length)
+        if max_probe_length <= 0:
+            print("skipped.")
+            return True
 
-        # Run calibration with increasing delay and decreasing length.
-        delay = min_delay
-        working_delay  = None
-        working_length = None
-        while delay <= max_delay:
-            for length in length_range:
-                #p0rint(f"delay {delay}, length {length}")
-                # Prepare frame.
-                frame         = SFLFrame()
-                frame.cmd     = sfl_cmd_load
-                frame_data    = bytearray(min(length, sfl_payload_length-4))
-                frame.payload = address.to_bytes(4, "big")
-                frame.payload += frame_data
-                frame = frame.encode()
+        nframes = 4
+        length_range = []
+        for length in [sfl_data_length, 128, sfl_safe_data_length]:
+            length = min(length, max_probe_length)
+            if length > 0 and length not in length_range:
+                length_range.append(length)
 
-                # Drain stale replies from previous attempts.
-                self.drain()
+        for length in length_range:
+            frame = self.make_load_frame(address, bytes(length))
+            self.drain()
 
-                # Send N consecutive frames.
-                for i in range(nframes):
-                    self.port.write(frame)
-                    time.sleep(delay)
-
-                # Wait and get all expected ACKs.
-                working = True
-                ack_count = 0
-                baudrate = getattr(self.port, "baudrate", 115200) or 115200
-                frame_time = (len(frame) * 10) / baudrate
-                deadline = time.time() + max(0.5, frame_time * nframes * 4)
-                while ack_count < nframes and time.time() < deadline:
-                    try:
-                        ack = self.read_sfl_reply(timeout=max(0, deadline - time.time()))
-                    except SFLUploadError:
-                        break
-                    ack_count += 1
-                    if ack != sfl_ack_success:
-                        working = False
-
-                if ack_count != nframes:
+            working = True
+            for _ in range(nframes):
+                if not self.send_frame(frame, timeout=max(1.0, self.frame_time(length) + 0.5), retries=2):
                     working = False
-
-                if not working:
-                    time.sleep(0.35)
-                    self.drain()
-
-                if working:
-                    # Save working delay/length and exit.
-                    working_delay  = delay
-                    working_length = min(length, sfl_payload_length - 4)
                     break
 
-            # Exit if working delay found.
-            if (working_delay is not None):
-                break
+            if working:
+                self.delay       = 0
+                self.length      = length
+                self.outstanding = min(self.outstanding, sfl_default_outstanding)
+                print(f"(inter-frame: {self.delay*1e6:5.2f}us, length: {self.length}, window: {self.outstanding})")
+                return True
 
-            # Else increase delay.
-            delay = delay*2
+            self.settle_upload(data_length=length, outstanding=1)
 
-        # Set parameters.
-        if (working_delay is not None):
-            print(f"(inter-frame: {working_delay*1e6:5.2f}us, length: {working_length})")
-            self.delay  = working_delay
-            self.length = working_length
-        else:
-            print("failed, switching to --safe mode.")
-            self.delay       = 0
-            self.length      = 64
-            self.outstanding = 1
+        print("failed, switching to --safe mode.")
+        self.delay       = 0
+        self.length      = min(sfl_safe_data_length, max(1, max_probe_length))
+        self.outstanding = 1
+        return False
 
     def upload(self, filename, address):
+        length = os.path.getsize(filename)
+
+        print(f"[LITEX-TERM] Uploading {filename} to 0x{address:08x} ({length} bytes)...")
+
+        # Upload calibration
+        if not self.safe:
+            self.upload_calibration(address, length)
+
+        profiles = self.upload_profiles()
+        last_error = None
+        for n, (data_length, outstanding) in enumerate(profiles):
+            try:
+                uploaded = self.upload_once(filename, address, length, data_length, outstanding)
+                self.length = data_length
+                self.outstanding = outstanding
+                if not self.safe and data_length <= sfl_safe_data_length and outstanding == 1:
+                    self.safe = True
+                return uploaded
+            except SFLUploadError as e:
+                last_error = e
+                if n == len(profiles) - 1:
+                    break
+                print(
+                    f"\n[LITEX-TERM] Upload failed with length {data_length}, "
+                    f"window {outstanding}: {e}."
+                )
+                self.settle_upload(data_length=data_length, outstanding=outstanding)
+                next_length, next_outstanding = profiles[n + 1]
+                print(
+                    f"[LITEX-TERM] Retrying with length {next_length}, "
+                    f"window {next_outstanding}."
+                )
+
+        raise last_error
+
+    def upload_profiles(self):
+        if self.safe:
+            return [(self.length, 1)]
+
+        profiles = []
+        for data_length, outstanding in [
+            (self.length, self.outstanding),
+            (self.length, min(4, self.outstanding)),
+            (self.length, 1),
+            (min(sfl_safe_data_length, self.length), 1),
+        ]:
+            data_length = max(1, min(data_length, sfl_data_length))
+            outstanding = max(1, outstanding)
+            profile = (data_length, outstanding)
+            if profile not in profiles:
+                profiles.append(profile)
+        return profiles
+
+    def upload_once(self, filename, address, length, data_length, max_outstanding):
         with open(filename, "rb") as f:
-            f.seek(0, 2)
-            length = f.tell()
-            f.seek(0, 0)
-
-            print(f"[LITEX-TERM] Uploading {filename} to 0x{address:08x} ({length} bytes)...")
-
-            # Upload calibration
-            if not self.safe:
-                self.upload_calibration(address)
-                # Force safe mode settings when calibration fails.
-                if self.delay is None:
-                    self.delay       = 0
-                    self.length      = 64
-                    self.outstanding = 1
-
-            # Prepare parameters
             current_address = address
             position        = 0
             start           = time.time()
             remaining       = length
-            outstanding     = 0
+            outstanding     = deque()
+            current_window  = 1
+            window_successes = 0
             last_progress_update = 0.0
-            while remaining:
+            while remaining or outstanding:
                 # Show progress (throttled to 10 Hz to avoid overloading terminal/X11)
                 now = time.time()
-                if now - last_progress_update >= 0.1:
+                if length and now - last_progress_update >= 0.1:
                     sys.stdout.write("|{}>{}| {}%\r".format(
                         "=" * (20*position//length),
                         " " * (20-20*position//length),
@@ -548,41 +579,51 @@ class LiteXTerm:
                     last_progress_update = now
 
                 # Send frame if max outstanding not reached.
-                if outstanding < self.outstanding:
+                while remaining and len(outstanding) < current_window:
                     # Prepare frame.
-                    frame      = SFLFrame()
-                    frame.cmd  = sfl_cmd_load
-                    frame_data = f.read(min(remaining, self.length-4))
-                    frame.payload = current_address.to_bytes(4, "big")
-                    frame.payload += frame_data
+                    frame_data = f.read(min(remaining, data_length))
+                    frame = self.make_load_frame(current_address, frame_data)
+                    encoded_frame = frame.encode()
 
                     # Encode frame and send it.
-                    self.port.write(frame.encode())
+                    self.port.write(encoded_frame)
 
                     # Update parameters
                     current_address += len(frame_data)
                     position        += len(frame_data)
                     remaining       -= len(frame_data)
-                    outstanding     += 1
+                    outstanding.append({"frame": encoded_frame, "retries": 0})
 
                     # Inter-frame delay.
                     time.sleep(self.delay)
 
-                # Read response if available, else yield CPU briefly.
-                if self.port.in_waiting:
-                    while self.port.in_waiting:
-                        ack = self.receive_upload_response()
-                        if ack:
-                            outstanding -= 1
-                            break
-                elif outstanding >= self.outstanding:
-                    # yield 1/10th of frame transmission time to avoids busy-wait (minimum is 0.1ms)
-                    baudrate = getattr(self.port, "baudrate", 115200) or 115200
-                    time.sleep(max(0.0001, (self.length * 10) / baudrate / 10))
+                if not outstanding:
+                    continue
 
-            # Get remaining responses.
-            for _ in range(outstanding):
-                self.receive_upload_response()
+                try:
+                    ack = self.receive_upload_response(
+                        timeout=max(1.0, self.frame_time(data_length) * (len(outstanding) + 1) + 0.5)
+                    )
+                except SFLUploadError as e:
+                    if (
+                        e.reply == sfl_ack_crcerror and
+                        len(outstanding) == 1 and
+                        outstanding[0]["retries"] < 16
+                    ):
+                        outstanding[0]["retries"] += 1
+                        self.port.write(outstanding[0]["frame"])
+                        current_window = 1
+                        window_successes = 0
+                        continue
+                    raise
+
+                if ack:
+                    outstanding.popleft()
+                    if current_window < max_outstanding:
+                        window_successes += 1
+                        if window_successes >= current_window:
+                            current_window += 1
+                            window_successes = 0
 
             # Compute speed.
             end     = time.time()

--- a/litex/tools/litex_term.py
+++ b/litex/tools/litex_term.py
@@ -361,7 +361,6 @@ class LiteXTerm:
         self.delay       = 0
         self.length      = sfl_safe_data_length if safe else sfl_data_length
         self.outstanding = 1 if safe else sfl_default_outstanding
-        self.calibrated_upload_profiles = []
 
     def open(self, port, baudrate):
         if hasattr(self, "port"):
@@ -480,40 +479,6 @@ class LiteXTerm:
         time.sleep(max(0.35, self.frame_time(data_length) * max(1, outstanding) + 0.35))
         self.drain()
 
-    def probe_upload_profile(self, address, data_length, outstanding, nframes=None):
-        data_length  = max(1, min(data_length, sfl_data_length))
-        outstanding  = max(1, outstanding)
-        nframes      = max(nframes or 0, outstanding, 1)
-        frame        = self.make_load_frame(address, bytes(data_length))
-        encoded_frame = frame.encode()
-        pending      = 0
-        sent         = 0
-        write_timeout = max(1.0, self.frame_time(data_length) + 0.5)
-        ack_timeout   = max(1.0, self.frame_time(data_length) * (outstanding + 1) + 0.5)
-
-        self.drain()
-        try:
-            while sent < nframes or pending:
-                while sent < nframes and pending < outstanding:
-                    self.write_sfl_data(encoded_frame, timeout=write_timeout)
-                    sent    += 1
-                    pending += 1
-                    time.sleep(self.delay)
-
-                if pending:
-                    self.receive_upload_response(timeout=ack_timeout)
-                    pending -= 1
-        except SFLUploadError:
-            self.settle_upload(data_length=data_length, outstanding=outstanding)
-            return False
-
-        return True
-
-    def recover_upload_link(self, address, data_length=None):
-        data_length = min(sfl_safe_data_length, data_length or sfl_safe_data_length)
-        self.settle_upload(data_length=data_length, outstanding=1)
-        return self.probe_upload_profile(address, data_length, 1, nframes=1)
-
     def upload_calibration(self, address, image_length=None):
 
         print("[LITEX-TERM] Upload calibration... ", end="")
@@ -526,62 +491,31 @@ class LiteXTerm:
             print("skipped.")
             return True
 
-        best_length      = min(sfl_safe_data_length, max_probe_length)
-        best_outstanding = 1
-        best_score       = best_length * best_outstanding
-        tested_lengths   = []
-        successful_profiles = [(best_length, best_outstanding)]
-        calibration_alive = True
+        nframes = 4
+        working_length = min(sfl_safe_data_length, max_probe_length)
+        frame = self.make_load_frame(address, bytes(working_length))
+        self.drain()
 
-        if not self.probe_upload_profile(address, best_length, best_outstanding, nframes=4):
-            print("failed, switching to --safe mode.")
-            self.delay       = 0
-            self.length      = best_length
-            self.outstanding = 1
-            self.calibrated_upload_profiles = [(best_length, 1)]
-            return False
-
-        for length in [best_length, 128, sfl_data_length]:
-            if not calibration_alive:
+        working = True
+        for _ in range(nframes):
+            timeout = max(1.0, self.frame_time(working_length) + 0.5)
+            if not self.send_frame(frame, timeout=timeout, retries=2):
+                working = False
                 break
-            length = min(length, max_probe_length)
-            if length <= 0 or length in tested_lengths:
-                continue
-            tested_lengths.append(length)
 
-            if length != best_length:
-                if not self.probe_upload_profile(address, length, 1, nframes=4):
-                    self.recover_upload_link(address, best_length)
-                    break
-                successful_profiles.append((length, 1))
-                score = length
-                if score > best_score:
-                    best_length      = length
-                    best_outstanding = 1
-                    best_score       = score
+        if working:
+            self.delay       = 0
+            self.length      = working_length
+            self.outstanding = 1
+            print(f"(inter-frame: {self.delay*1e6:5.2f}us, length: {self.length}, window: {self.outstanding})")
+            return True
 
-            for outstanding in [2, 4, sfl_default_outstanding]:
-                if not self.probe_upload_profile(address, length, outstanding, nframes=outstanding * 2):
-                    calibration_alive = self.recover_upload_link(address, best_length)
-                    break
-
-                successful_profiles.append((length, outstanding))
-                score = length * outstanding
-                if score > best_score:
-                    best_length      = length
-                    best_outstanding = outstanding
-                    best_score       = score
-
+        self.settle_upload(data_length=working_length, outstanding=1)
+        print("failed, switching to --safe mode.")
         self.delay       = 0
-        self.length      = best_length
-        self.outstanding = best_outstanding
-        self.calibrated_upload_profiles = sorted(
-            set(successful_profiles),
-            key=lambda profile: (profile[0] * profile[1], profile[0], profile[1]),
-            reverse=True,
-        )
-        print(f"(inter-frame: {self.delay*1e6:5.2f}us, length: {self.length}, window: {self.outstanding})")
-        return True
+        self.length      = min(sfl_safe_data_length, max(1, max_probe_length))
+        self.outstanding = 1
+        return False
 
     def upload(self, filename, address):
         length = os.path.getsize(filename)
@@ -624,24 +558,17 @@ class LiteXTerm:
             return [(self.length, 1)]
 
         profiles = []
-        for data_length, outstanding in getattr(self, "calibrated_upload_profiles", []):
+        for data_length, outstanding in [
+            (self.length, self.outstanding),
+            (self.length, min(4, self.outstanding)),
+            (self.length, 1),
+            (min(sfl_safe_data_length, self.length), 1),
+        ]:
             data_length = max(1, min(data_length, sfl_data_length))
             outstanding = max(1, outstanding)
             profile = (data_length, outstanding)
             if profile not in profiles:
                 profiles.append(profile)
-
-        if not profiles:
-            outstanding = max(1, self.outstanding)
-            while outstanding > 1:
-                profiles.append((max(1, min(self.length, sfl_data_length)), outstanding))
-                outstanding = max(1, outstanding // 2)
-            profiles.append((max(1, min(self.length, sfl_data_length)), 1))
-
-        safe_profile = (min(sfl_safe_data_length, max(1, self.length)), 1)
-        if safe_profile not in profiles:
-            profiles.append(safe_profile)
-
         return profiles
 
     def upload_once(self, filename, address, length, data_length, max_outstanding):

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -10,6 +10,7 @@ import os
 import socket
 import sys
 import tempfile
+import threading
 import time
 import itertools
 import pytest
@@ -19,6 +20,7 @@ from litex.tools.litex_term import (
     sfl_ack_error,
     sfl_ack_success,
     sfl_cmd_abort,
+    sfl_cmd_load,
     sfl_magic_ack,
     sfl_magic_req,
 )
@@ -140,6 +142,65 @@ def test_serialboot_abort_recovers(tmp_path):
         except (OSError, pexpect.EOF, pexpect.TIMEOUT, TimeoutError):
             is_success = False
             print(f"*** Serialboot abort recovery failure: {cmd}")
+            log_file.seek(0)
+            print(log_file.read())
+        finally:
+            if sock is not None:
+                sock.close()
+            p.terminate(force=True)
+
+    assert is_success
+
+def test_serialboot_bad_probe_recovers_to_load(tmp_path):
+    port = _get_free_tcp_port()
+    cmd = (
+        "litex_sim --cpu-type=vexriscv --cpu-variant=standard "
+        f"--uart-tcp --uart-tcp-port={port} "
+        "--integrated-main-ram-size=65536 "
+        f"--output-dir={tmp_path} --opt-level=O0 --jobs {_sim_jobs()} --non-interactive"
+    )
+    litex_prompt = b"litex"
+    load = SFLFrame()
+    load.cmd = sfl_cmd_load
+    load.payload = (0x40000000).to_bytes(4, "big") + bytes(64)
+    abort = SFLFrame()
+    abort.cmd = sfl_cmd_abort
+    sock = None
+    is_success = True
+
+    def send_bad_probe(sock):
+        deadline = time.time() + 0.5
+        while time.time() < deadline:
+            sock.sendall(b"\xff")
+            time.sleep(0.005)
+
+    with tempfile.TemporaryFile(mode="w+", prefix="litex_test") as log_file:
+        log_file.writelines(f"Command: {cmd}\n")
+        log_file.flush()
+        p = pexpect.spawn(cmd, timeout=None, encoding=sys.getdefaultencoding(), logfile=log_file)
+        try:
+            p.expect(f"Found port {port}", timeout=1200)
+            sock = _connect_tcp_uart(port)
+
+            _recv_until(sock, litex_prompt, timeout=20)
+            sock.sendall(b"serialboot\n")
+            _recv_until(sock, sfl_magic_req, timeout=10)
+
+            sock.sendall(sfl_magic_ack)
+            sender = threading.Thread(target=send_bad_probe, args=(sock,))
+            sender.start()
+            sender.join(timeout=2)
+            _recv_until(sock, sfl_ack_error, timeout=10)
+
+            sock.sendall(load.encode())
+            _recv_until(sock, sfl_ack_success, timeout=10)
+
+            sock.sendall(abort.encode())
+            _recv_until(sock, sfl_ack_success, timeout=10)
+            _recv_until(sock, litex_prompt, timeout=10)
+        except (OSError, pexpect.EOF, pexpect.TIMEOUT, TimeoutError):
+            is_success = False
+            print(f"*** Serialboot bad-probe recovery failure: {cmd}")
             log_file.seek(0)
             print(log_file.read())
         finally:

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -10,7 +10,6 @@ import os
 import socket
 import sys
 import tempfile
-import threading
 import time
 import itertools
 import pytest
@@ -20,7 +19,6 @@ from litex.tools.litex_term import (
     sfl_ack_error,
     sfl_ack_success,
     sfl_cmd_abort,
-    sfl_cmd_load,
     sfl_magic_ack,
     sfl_magic_req,
 )
@@ -142,65 +140,6 @@ def test_serialboot_abort_recovers(tmp_path):
         except (OSError, pexpect.EOF, pexpect.TIMEOUT, TimeoutError):
             is_success = False
             print(f"*** Serialboot abort recovery failure: {cmd}")
-            log_file.seek(0)
-            print(log_file.read())
-        finally:
-            if sock is not None:
-                sock.close()
-            p.terminate(force=True)
-
-    assert is_success
-
-def test_serialboot_bad_probe_recovers_to_load(tmp_path):
-    port = _get_free_tcp_port()
-    cmd = (
-        "litex_sim --cpu-type=vexriscv --cpu-variant=standard "
-        f"--uart-tcp --uart-tcp-port={port} "
-        "--integrated-main-ram-size=65536 "
-        f"--output-dir={tmp_path} --opt-level=O0 --jobs {_sim_jobs()} --non-interactive"
-    )
-    litex_prompt = b"litex"
-    load = SFLFrame()
-    load.cmd = sfl_cmd_load
-    load.payload = (0x40000000).to_bytes(4, "big") + bytes(64)
-    abort = SFLFrame()
-    abort.cmd = sfl_cmd_abort
-    sock = None
-    is_success = True
-
-    def send_bad_probe(sock):
-        deadline = time.time() + 0.5
-        while time.time() < deadline:
-            sock.sendall(b"\xff")
-            time.sleep(0.005)
-
-    with tempfile.TemporaryFile(mode="w+", prefix="litex_test") as log_file:
-        log_file.writelines(f"Command: {cmd}\n")
-        log_file.flush()
-        p = pexpect.spawn(cmd, timeout=None, encoding=sys.getdefaultencoding(), logfile=log_file)
-        try:
-            p.expect(f"Found port {port}", timeout=1200)
-            sock = _connect_tcp_uart(port)
-
-            _recv_until(sock, litex_prompt, timeout=20)
-            sock.sendall(b"serialboot\n")
-            _recv_until(sock, sfl_magic_req, timeout=10)
-
-            sock.sendall(sfl_magic_ack)
-            sender = threading.Thread(target=send_bad_probe, args=(sock,))
-            sender.start()
-            sender.join(timeout=2)
-            _recv_until(sock, sfl_ack_error, timeout=10)
-
-            sock.sendall(load.encode())
-            _recv_until(sock, sfl_ack_success, timeout=10)
-
-            sock.sendall(abort.encode())
-            _recv_until(sock, sfl_ack_success, timeout=10)
-            _recv_until(sock, litex_prompt, timeout=10)
-        except (OSError, pexpect.EOF, pexpect.TIMEOUT, TimeoutError):
-            is_success = False
-            print(f"*** Serialboot bad-probe recovery failure: {cmd}")
             log_file.seek(0)
             print(log_file.read())
         finally:

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -7,16 +7,69 @@
 
 import pexpect
 import os
+import socket
 import sys
 import tempfile
+import time
 import itertools
 import pytest
+
+from litex.tools.litex_term import (
+    SFLFrame,
+    sfl_ack_error,
+    sfl_ack_success,
+    sfl_cmd_abort,
+    sfl_magic_ack,
+    sfl_magic_req,
+)
 
 def _sim_jobs():
     # When pytest-xdist is running several tests in parallel, divide the
     # available cores between workers to avoid oversubscribing the build.
     workers = int(os.environ.get("PYTEST_XDIST_WORKER_COUNT", "1") or "1")
     return max(1, (os.cpu_count() or 1) // max(1, workers))
+
+def _get_free_tcp_port():
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    except OSError as e:
+        pytest.skip(f"local TCP sockets are unavailable: {e}")
+
+    try:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+    except OSError as e:
+        pytest.skip(f"local TCP bind is unavailable: {e}")
+    finally:
+        sock.close()
+
+def _connect_tcp_uart(port, timeout=10):
+    deadline = time.time() + timeout
+    last_error = None
+    while time.time() < deadline:
+        try:
+            sock = socket.create_connection(("127.0.0.1", port), timeout=1)
+            sock.settimeout(0.1)
+            return sock
+        except OSError as e:
+            last_error = e
+            time.sleep(0.1)
+    raise TimeoutError(f"could not connect to litex_sim UART on port {port}: {last_error}")
+
+def _recv_until(sock, needle, timeout=10):
+    deadline = time.time() + timeout
+    data = b""
+    while time.time() < deadline:
+        try:
+            chunk = sock.recv(1)
+            if not chunk:
+                break
+            data += chunk
+            if needle in data:
+                return data
+        except socket.timeout:
+            pass
+    raise TimeoutError(f"did not receive {needle!r}; last data: {data[-200:]!r}")
 
 def boot_test(cpu_type="vexriscv", cpu_variant="standard", args="", output_dir=None):
     output_arg = f' --output-dir={output_dir}' if output_dir else ''
@@ -50,6 +103,51 @@ def boot_test(cpu_type="vexriscv", cpu_variant="standard", args="", output_dir=N
             print(f'*** Boot Success: {cmd}')
 
     return is_success
+
+def test_serialboot_abort_recovers(tmp_path):
+    port = _get_free_tcp_port()
+    cmd = (
+        "litex_sim --cpu-type=vexriscv --cpu-variant=standard "
+        f"--uart-tcp --uart-tcp-port={port} "
+        "--integrated-main-ram-size=65536 "
+        f"--output-dir={tmp_path} --opt-level=O0 --jobs {_sim_jobs()} --non-interactive"
+    )
+    litex_prompt = b"litex"
+    abort = SFLFrame()
+    abort.cmd = sfl_cmd_abort
+    sock = None
+    is_success = True
+
+    with tempfile.TemporaryFile(mode="w+", prefix="litex_test") as log_file:
+        log_file.writelines(f"Command: {cmd}\n")
+        log_file.flush()
+        p = pexpect.spawn(cmd, timeout=None, encoding=sys.getdefaultencoding(), logfile=log_file)
+        try:
+            p.expect(f"Found port {port}", timeout=1200)
+            sock = _connect_tcp_uart(port)
+
+            _recv_until(sock, litex_prompt, timeout=20)
+            sock.sendall(b"serialboot\n")
+            _recv_until(sock, sfl_magic_req, timeout=10)
+
+            sock.sendall(sfl_magic_ack)
+            sock.sendall(b"\x10")
+            _recv_until(sock, sfl_ack_error, timeout=10)
+
+            sock.sendall(abort.encode())
+            _recv_until(sock, sfl_ack_success, timeout=10)
+            _recv_until(sock, litex_prompt, timeout=10)
+        except (OSError, pexpect.EOF, pexpect.TIMEOUT, TimeoutError):
+            is_success = False
+            print(f"*** Serialboot abort recovery failure: {cmd}")
+            log_file.seek(0)
+            print(log_file.read())
+        finally:
+            if sock is not None:
+                sock.close()
+            p.terminate(force=True)
+
+    assert is_success
 
 TESTED_CPUS = [
     #"cv32e40p",     # (riscv   / softcore)

--- a/test/test_litex_term.py
+++ b/test/test_litex_term.py
@@ -16,7 +16,6 @@ from litex.tools.litex_term import (
     sfl_ack_success,
     sfl_cmd_abort,
     sfl_cmd_load,
-    sfl_data_length,
     sfl_magic_ack,
 )
 
@@ -176,13 +175,13 @@ class TestLiteXTermSFL(unittest.TestCase):
         self.assertEqual(term.outstanding, 1)
 
     def test_upload_calibration_uses_safe_stop_and_wait(self):
-        port = FakePort(write_replies=[sfl_ack_success] * 4 + [sfl_ack_error, sfl_ack_success, sfl_ack_success])
+        port = FakePort(write_replies=[sfl_ack_success] * 12)
         term = make_term(port)
         term.safe = False
         term.outstanding = 8
 
         with mock.patch.object(litex_term.time, "sleep"), redirect_stdout(io.StringIO()):
-            term.upload_calibration(0x40000000, image_length=64)
+            term.upload_calibration(0x40000000)
 
         frame = SFLFrame()
         frame.cmd = sfl_cmd_load
@@ -191,21 +190,7 @@ class TestLiteXTermSFL(unittest.TestCase):
         self.assertEqual(term.delay, 0)
         self.assertEqual(term.length, 64)
         self.assertEqual(term.outstanding, 1)
-        self.assertEqual(port.written, frame.encode() * 7)
-
-    def test_upload_calibration_uses_fastest_working_profile(self):
-        port = FakePort(write_replies=[sfl_ack_success] * 96)
-        term = make_term(port)
-        term.safe = False
-        term.outstanding = 8
-
-        with mock.patch.object(litex_term.time, "sleep"), redirect_stdout(io.StringIO()):
-            term.upload_calibration(0x40000000)
-
-        self.assertEqual(term.delay, 0)
-        self.assertEqual(term.length, sfl_data_length)
-        self.assertEqual(term.outstanding, 8)
-        self.assertEqual(term.upload_profiles()[0], (sfl_data_length, 8))
+        self.assertEqual(port.written, frame.encode() * 4)
 
     def test_upload_retries_crc_error_in_stop_and_wait_mode(self):
         port = FakePort(read_data=sfl_ack_crcerror + sfl_ack_success)

--- a/test/test_litex_term.py
+++ b/test/test_litex_term.py
@@ -15,6 +15,7 @@ from litex.tools.litex_term import (
     sfl_ack_error,
     sfl_ack_success,
     sfl_cmd_abort,
+    sfl_cmd_load,
     sfl_magic_ack,
 )
 
@@ -128,7 +129,7 @@ class TestLiteXTermSFL(unittest.TestCase):
         self.assertTrue(port.written)
 
     def test_upload_calibration_requires_all_acks(self):
-        port = FakePort(read_data=sfl_ack_success * 15)
+        port = FakePort(read_data=sfl_ack_success * 3)
         term = make_term(port)
         term.safe = False
         term.outstanding = 128
@@ -139,6 +140,48 @@ class TestLiteXTermSFL(unittest.TestCase):
         self.assertEqual(term.delay, 0)
         self.assertEqual(term.length, 64)
         self.assertEqual(term.outstanding, 1)
+
+    def test_upload_retries_crc_error_in_stop_and_wait_mode(self):
+        port = FakePort(read_data=sfl_ack_crcerror + sfl_ack_success)
+        term = make_term(port)
+
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"LiteX")
+            filename = f.name
+        try:
+            with redirect_stdout(io.StringIO()):
+                term.upload(filename, 0x40000000)
+        finally:
+            os.unlink(filename)
+
+        frame = SFLFrame()
+        frame.cmd = sfl_cmd_load
+        frame.payload = (0x40000000).to_bytes(4, "big") + b"LiteX"
+        self.assertEqual(port.written, frame.encode() * 2)
+
+    def test_upload_retries_with_smaller_window_after_optimized_error(self):
+        port = FakePort(
+            read_data=sfl_ack_success + sfl_ack_error,
+            write_replies=[b"", b"", sfl_ack_success, sfl_ack_success],
+        )
+        term = make_term(port)
+        term.safe = False
+        term.length = 4
+        term.outstanding = 2
+
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"LiteXSoC")
+            filename = f.name
+        try:
+            output = io.StringIO()
+            with mock.patch.object(term, "upload_calibration", return_value=True), \
+                 mock.patch.object(litex_term.time, "sleep"), \
+                 redirect_stdout(output):
+                term.upload(filename, 0x40000000)
+        finally:
+            os.unlink(filename)
+
+        self.assertIn("Retrying with length 4, window 1", output.getvalue())
 
 
 if __name__ == "__main__":

--- a/test/test_litex_term.py
+++ b/test/test_litex_term.py
@@ -16,6 +16,7 @@ from litex.tools.litex_term import (
     sfl_ack_success,
     sfl_cmd_abort,
     sfl_cmd_load,
+    sfl_data_length,
     sfl_magic_ack,
 )
 
@@ -26,6 +27,7 @@ class FakePort:
         self._write_replies = list(write_replies or [])
         self.written = bytearray()
         self.timeout = None
+        self.write_timeout = None
         self.baudrate = baudrate
 
     @property
@@ -96,6 +98,38 @@ class TestLiteXTermSFL(unittest.TestCase):
         frame.cmd = sfl_cmd_abort
         self.assertEqual(port.written, frame.encode())
 
+    def test_send_frame_times_out_blocked_write(self):
+        class TimeoutWritePort(FakePort):
+            def write(self, data):
+                raise litex_term.serial.SerialTimeoutException("blocked")
+
+        port = TimeoutWritePort()
+        term = make_term(port)
+        frame = SFLFrame()
+        frame.cmd = sfl_cmd_abort
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            self.assertEqual(term.send_frame(frame, timeout=0.01), 0)
+
+        self.assertIn("timed out writing device frame", output.getvalue())
+        self.assertIsNone(port.write_timeout)
+
+    def test_sigint_uses_bounded_write(self):
+        class TimeoutWritePort(FakePort):
+            def write(self, data):
+                raise litex_term.serial.SerialTimeoutException("blocked")
+
+        port = TimeoutWritePort()
+        term = make_term(port)
+        term.writer_alive = True
+        term.sigint_time_last = 0
+
+        term.sigint(None, None)
+
+        self.assertIsNone(port.write_timeout)
+        self.assertGreater(term.sigint_time_last, 0)
+
     def test_answer_magic_aborts_on_upload_error(self):
         port = FakePort()
         term = make_term(port)
@@ -140,6 +174,38 @@ class TestLiteXTermSFL(unittest.TestCase):
         self.assertEqual(term.delay, 0)
         self.assertEqual(term.length, 64)
         self.assertEqual(term.outstanding, 1)
+
+    def test_upload_calibration_uses_safe_stop_and_wait(self):
+        port = FakePort(write_replies=[sfl_ack_success] * 4 + [sfl_ack_error, sfl_ack_success, sfl_ack_success])
+        term = make_term(port)
+        term.safe = False
+        term.outstanding = 8
+
+        with mock.patch.object(litex_term.time, "sleep"), redirect_stdout(io.StringIO()):
+            term.upload_calibration(0x40000000, image_length=64)
+
+        frame = SFLFrame()
+        frame.cmd = sfl_cmd_load
+        frame.payload = (0x40000000).to_bytes(4, "big") + bytes(64)
+
+        self.assertEqual(term.delay, 0)
+        self.assertEqual(term.length, 64)
+        self.assertEqual(term.outstanding, 1)
+        self.assertEqual(port.written, frame.encode() * 7)
+
+    def test_upload_calibration_uses_fastest_working_profile(self):
+        port = FakePort(write_replies=[sfl_ack_success] * 96)
+        term = make_term(port)
+        term.safe = False
+        term.outstanding = 8
+
+        with mock.patch.object(litex_term.time, "sleep"), redirect_stdout(io.StringIO()):
+            term.upload_calibration(0x40000000)
+
+        self.assertEqual(term.delay, 0)
+        self.assertEqual(term.length, sfl_data_length)
+        self.assertEqual(term.outstanding, 8)
+        self.assertEqual(term.upload_profiles()[0], (sfl_data_length, 8))
 
     def test_upload_retries_crc_error_in_stop_and_wait_mode(self):
         port = FakePort(read_data=sfl_ack_crcerror + sfl_ack_success)

--- a/test/test_litex_term.py
+++ b/test/test_litex_term.py
@@ -1,0 +1,145 @@
+import io
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+from litex.tools import litex_term
+from litex.tools.litex_term import (
+    LiteXTerm,
+    SFLFrame,
+    SFLUploadError,
+    crc16,
+    sfl_ack_crcerror,
+    sfl_ack_error,
+    sfl_ack_success,
+    sfl_cmd_abort,
+    sfl_magic_ack,
+)
+
+
+class FakePort:
+    def __init__(self, read_data=b"", write_replies=None, baudrate=115200):
+        self._read_data = bytearray(read_data)
+        self._write_replies = list(write_replies or [])
+        self.written = bytearray()
+        self.timeout = None
+        self.baudrate = baudrate
+
+    @property
+    def in_waiting(self):
+        return len(self._read_data)
+
+    def read(self, size=1):
+        if not self._read_data:
+            return b""
+        data = self._read_data[:size]
+        del self._read_data[:size]
+        return bytes(data)
+
+    def write(self, data):
+        self.written += data
+        if self._write_replies:
+            self._read_data += self._write_replies.pop(0)
+        return len(data)
+
+
+def make_term(port):
+    term = LiteXTerm.__new__(LiteXTerm)
+    term.port = port
+    term.safe = True
+    term.delay = 0
+    term.length = 64
+    term.outstanding = 1
+    return term
+
+
+class TestSFLFrame(unittest.TestCase):
+    def test_zero_length_abort_frame(self):
+        frame = SFLFrame()
+        frame.cmd = sfl_cmd_abort
+
+        encoded = frame.encode()
+
+        self.assertEqual(encoded[0], 0)
+        self.assertEqual(encoded[1:3], crc16(sfl_cmd_abort).to_bytes(2, "big"))
+        self.assertEqual(encoded[3:4], sfl_cmd_abort)
+        self.assertEqual(len(encoded), 4)
+
+    def test_send_frame_retries_after_crc_error(self):
+        port = FakePort(read_data=sfl_ack_crcerror + sfl_ack_success)
+        term = make_term(port)
+        frame = SFLFrame()
+        frame.cmd = sfl_cmd_abort
+
+        self.assertEqual(term.send_frame(frame), 1)
+        self.assertEqual(port.written, frame.encode() * 2)
+
+
+class TestLiteXTermSFL(unittest.TestCase):
+    def test_receive_upload_response_raises_on_device_error(self):
+        term = make_term(FakePort(read_data=sfl_ack_error))
+
+        with self.assertRaisesRegex(SFLUploadError, "serial frame error"):
+            term.receive_upload_response()
+
+    def test_abort_serialboot_drains_stale_data_and_sends_abort(self):
+        port = FakePort(read_data=b"E", write_replies=[sfl_ack_success])
+        term = make_term(port)
+
+        with mock.patch.object(litex_term.time, "sleep"), redirect_stdout(io.StringIO()):
+            self.assertTrue(term.abort_serialboot())
+
+        frame = SFLFrame()
+        frame.cmd = sfl_cmd_abort
+        self.assertEqual(port.written, frame.encode())
+
+    def test_answer_magic_aborts_on_upload_error(self):
+        port = FakePort()
+        term = make_term(port)
+        term.mem_regions = {"image.bin": "0x40000000"}
+        term.upload = mock.Mock(side_effect=SFLUploadError("boom"))
+        term.boot = mock.Mock()
+        term.abort_serialboot = mock.Mock(return_value=True)
+
+        with redirect_stdout(io.StringIO()):
+            term.answer_magic()
+
+        self.assertEqual(port.written, sfl_magic_ack)
+        term.upload.assert_called_once_with("image.bin", 0x40000000)
+        term.boot.assert_not_called()
+        term.abort_serialboot.assert_called_once()
+
+    def test_upload_raises_on_device_error_ack(self):
+        port = FakePort(read_data=sfl_ack_error)
+        term = make_term(port)
+
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"LiteX")
+            filename = f.name
+        try:
+            with redirect_stdout(io.StringIO()):
+                with self.assertRaisesRegex(SFLUploadError, "serial frame error"):
+                    term.upload(filename, 0x40000000)
+        finally:
+            os.unlink(filename)
+
+        self.assertTrue(port.written)
+
+    def test_upload_calibration_requires_all_acks(self):
+        port = FakePort(read_data=sfl_ack_success * 15)
+        term = make_term(port)
+        term.safe = False
+        term.outstanding = 128
+
+        with mock.patch.object(litex_term.time, "sleep"), redirect_stdout(io.StringIO()):
+            term.upload_calibration(0x40000000)
+
+        self.assertEqual(term.delay, 0)
+        self.assertEqual(term.length, 64)
+        self.assertEqual(term.outstanding, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  This improves LiteX serialboot robustness while keeping the existing SFL wire protocol compatible.

  ## Changes

  - Make BIOS serialboot recover from malformed, partial, or timed-out frames.
  - Add support for zero-length `SFL_CMD_ABORT` so the host can return the BIOS to the prompt after a failed upload.
  - Avoid getting stuck in repeated `E` error responses after a failed serialboot attempt.
  - Improve `litex_term` error handling so upload failures are recoverable instead of terminating the tool path abruptly.
  - Replace the fixed optimized upload burst with adaptive pacing:
    - probe usable frame length,
    - start with stop-and-wait,
    - ramp to a bounded outstanding window,
    - retry with safer profiles after recoverable upload errors.
  - Keep `--safe` as an explicit conservative override, but reduce the need for manual tuning.
  - Add unit tests for `litex_term` recovery, CRC retry, calibration, and adaptive fallback.
  - Add a `litex_sim` integration test covering serialboot abort recovery.

  ## Tested

  ```text
  python3 -m py_compile litex/tools/litex_term.py test/test_litex_term.py
  python3 -m unittest test.test_litex_term
  python3 -m pytest test/test_integration.py::test_serialboot_abort_recovers -q