### PR TITLE
bios: Move json_token_to_string function outside of #ifdef CSR_ETHMAC_BASE

### DIFF
--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -315,6 +315,20 @@ int serialboot(void)
 
 #endif
 
+static int json_token_to_string(char *dst, size_t dst_size, const char *json, jsmntok_t *token)
+{
+	int len;
+
+	if ((token->start < 0) || (token->end < token->start))
+		return 0;
+	len = token->end - token->start;
+	if (len >= (int)dst_size)
+		return 0;
+	memcpy(dst, json + token->start, len);
+	dst[len] = 0;
+	return 1;
+}
+
 /*-----------------------------------------------------------------------*/
 /* Ethernet Boot                                                         */
 /*-----------------------------------------------------------------------*/
@@ -472,20 +486,6 @@ void set_mac_addr(const char * mac_address)
 }
 
 #endif
-
-static int json_token_to_string(char *dst, size_t dst_size, const char *json, jsmntok_t *token)
-{
-	int len;
-
-	if ((token->start < 0) || (token->end < token->start))
-		return 0;
-	len = token->end - token->start;
-	if (len >= (int)dst_size)
-		return 0;
-	memcpy(dst, json + token->start, len);
-	dst[len] = 0;
-	return 1;
-}
 
 static void netboot_from_json(const char * filename, unsigned int ip, unsigned short tftp_port)
 {


### PR DESCRIPTION
Hello, thank you for developing this awesome project!

I found that commit 97f23539ffec5882f60edbc1f2c120946c60e990 introduced a new function `json_token_to_string`. However, it is declared inside `#ifdef CSR_ETHMAC_BASE` despite this function being used outside of it too, so the code didn't compile when I tried it with my Sipeed Tang Primer 20K dev board:

```
python -m litex_boards.targets.sipeed_tang_primer_20k --build --with-sdcard
...
/home/trickybestia/projects/litex/litex/litex/soc/software/bios/boot.c: In function 'sdcardboot_from_json':
/home/trickybestia/projects/litex/litex/litex/soc/software/bios/boot.c:816:30: error: implicit declaration of function 'json_token_to_string' [-Wimplicit-function-declaration]
  816 |                         if (!json_token_to_string(json_name, sizeof(json_name), json_buffer, &t[i]))
      |                              ^~~~~~~~~~~~~~~~~~~~
make: *** [/home/trickybestia/projects/litex/litex/litex/soc/software/bios/Makefile:92: boot.o] Error 1
make: *** Waiting for unfinished jobs....
make: Leaving directory '/home/trickybestia/build/sipeed_tang_primer_20k/software/bios'
...
```
I could make this compile using `--with-ethernet` options like this:
```
python -m litex_boards.targets.sipeed_tang_primer_20k --build --with-sdcard --with-ethernet
```

I moved `json_token_to_string` function upper in the file, outside of `#ifdef CSR_ETHMAC_BASE`, so the code can be compiled without `--with-ethernet` option 🙂