### PR TITLE
soc/cores: Update io_regions of gowin_emcu

### DIFF
--- a/litex/soc/cores/cpu/gowin_emcu/core.py
+++ b/litex/soc/cores/cpu/gowin_emcu/core.py
@@ -29,8 +29,15 @@ class GowinEMCU(CPU):
     nop                  = "nop"
     io_regions           = {
         # Origin, Length.
-        0x4000_0000 : 0x2000_0000,
-        0xa000_0000 : 0x6000_0000,
+        #
+        # This is part of the APB master, only exposed on the APBTARGEXP2 pins
+        #
+        # NOTE: I guess that it's only 0x4000_2000 - 0x4000_3000, based on Table 3-2 IPUG517 + 4 integrated peripherals
+        #
+        # 0x4000_0000 : 0x0000_1000,
+
+        # This is only 64 kB deep, based on Figure 3-11 in IPUG517 + testing
+        0xa000_0000 : 0x0001_0000,
     }
 
     # Memory Mapping.


### PR DESCRIPTION
The gowin emcu only exposes very small slices of the address space. 

I've tested this with litescope, any address above 0xa000_1FFC isn't exposed anymore on the AHB master. The APB master also seems to be quite constrained, but I haven't verified it. It also doesn't matter, as it isn't even hooked up (so not accessible in general by user logic in the current code).

This is the document I'm referring to in the comments: https://cdn.gowinsemi.com.cn/IPUG517E.pdf

This also implies that the memory-mapped hyperram in the target file *can't* work: https://github.com/litex-hub/litex-boards/blob/master/litex_boards/targets/sipeed_tang_nano_4k.py#L114

@enjoy-digital Is there any way to use the hyperram core without it needing to be memory mapped in the CPU?