### PR TITLE
Revert "Change SIM_DEVICE from ULTRASCALE to ULTRASCALE_PLUS"

### DIFF
--- a/litex/soc/cores/clock/xilinx_usp.py
+++ b/litex/soc/cores/clock/xilinx_usp.py
@@ -211,7 +211,7 @@ class USPIDELAYCTRL(LiteXModule):
         ]
         self.specials += [
             Instance("IDELAYCTRL",
-                p_SIM_DEVICE = "ULTRASCALE_PLUS",
+                p_SIM_DEVICE = "ULTRASCALE",
                 i_REFCLK     = cd_ref.clk,
                 i_RST        = ic_reset,
                 o_RDY        = ic_ready),


### PR DESCRIPTION
This reverts commit a4658cfd9beb2f2b05d505f30f49bf1afe32cbbe.

The following error will produce when build with XCKU5P:

```
ERROR: [DRC ADEF-911] SIM_DEVICE_arch_mismatch: When the netlist was initialized, the value of SIM_DEVICE on cell IDELAYCTRL was not specified and therefore was set to 'ULTRASCALE' to match the current FPGA architecture. For functional simulation to match hardware behavior, the value of SIM_DEVICE should be set in the source netlist.
ERROR: [DRC ADEF-911] SIM_DEVICE_arch_mismatch: When the netlist was initialized, the value of SIM_DEVICE on cell IDELAYCTRL_REPLICATED_0 was not specified and therefore was set to 'ULTRASCALE' to match the current FPGA architecture. For functional simulation to match hardware behavior, the value of SIM_DEVICE should be set in the source netlist.
ERROR: [DRC ADEF-911] SIM_DEVICE_arch_mismatch: When the netlist was initialized, the value of SIM_DEVICE on cell IDELAYCTRL_REPLICATED_0_10 was not specified and therefore was set to 'ULTRASCALE' to match the current FPGA architecture. For functional simulation to match hardware behavior, the value of SIM_DEVICE should be set in the source netlist.
ERROR: [DRC ADEF-911] SIM_DEVICE_arch_mismatch: When the netlist was initialized, the value of SIM_DEVICE on cell IDELAYCTRL_REPLICATED_0_11 was not specified and therefore was set to 'ULTRASCALE' to match the current FPGA architecture. For functional simulation to match hardware behavior, the value of SIM_DEVICE should be set in the source netlist.
ERROR: [DRC ADEF-911] SIM_DEVICE_arch_mismatch: When the netlist was initialized, the value of SIM_DEVICE on cell IDELAYCTRL_REPLICATED_0_12 was not specified and therefore was set to 'ULTRASCALE' to match the current FPGA architecture. For functional simulation to match hardware behavior, the value of SIM_DEVICE should be set in the source netlist.
ERROR: [DRC ADEF-911] SIM_DEVICE_arch_mismatch: When the netlist was initialized, the value of SIM_DEVICE on cell IDELAYCTRL_REPLICATED_0_13 was not specified and therefore was set to 'ULTRASCALE' to match the current FPGA architecture. For functional simulation to match hardware behavior, the value of SIM_DEVICE should be set in the source netlist.
ERROR: [DRC ADEF-911] SIM_DEVICE_arch_mismatch: When the netlist was initialized, the value of SIM_DEVICE on cell IDELAYCTRL_REPLICATED_0_14 was not specified and therefore was set to 'ULTRASCALE' to match the current FPGA architecture. For functional simulation to match hardware behavior, the value of SIM_DEVICE should be set in the source netlist.
ERROR: [DRC ADEF-911] SIM_DEVICE_arch_mismatch: When the netlist was initialized, the value of SIM_DEVICE on cell IDELAYCTRL_REPLICATED_0_15 was not specified and therefore was set to 'ULTRASCALE' to match the current FPGA architecture. For functional simulation to match hardware behavior, the value of SIM_DEVICE should be set in the source netlist.
ERROR: [DRC ADEF-911] SIM_DEVICE_arch_mismatch: When the netlist was initialized, the value of SIM_DEVICE on cell IDELAYCTRL_REPLICATED_0_2 was not specified and therefore was set to 'ULTRASCALE' to match the current FPGA architecture. For functional simulation to match hardware behavior, the value of SIM_DEVICE should be set in the source netlist.
ERROR: [DRC ADEF-911] SIM_DEVICE_arch_mismatch: When the netlist was initialized, the value of SIM_DEVICE on cell IDELAYCTRL_REPLICATED_0_3 was not specified and therefore was set to 'ULTRASCALE' to match the current FPGA architecture. For functional simulation to match hardware behavior, the value of SIM_DEVICE should be set in the source netlist.
ERROR: [DRC ADEF-911] SIM_DEVICE_arch_mismatch: When the netlist was initialized, the value of SIM_DEVICE on cell IDELAYCTRL_REPLICATED_0_4 was not specified and therefore was set to 'ULTRASCALE' to match the current FPGA architecture. For functional simulation to match hardware behavior, the value of SIM_DEVICE should be set in the source netlist.
ERROR: [DRC ADEF-911] SIM_DEVICE_arch_mismatch: When the netlist was initialized, the value of SIM_DEVICE on cell IDELAYCTRL_REPLICATED_0_5 was not specified and therefore was set to 'ULTRASCALE' to match the current FPGA architecture. For functional simulation to match hardware behavior, the value of SIM_DEVICE should be set in the source netlist.
ERROR: [DRC ADEF-911] SIM_DEVICE_arch_mismatch: When the netlist was initialized, the value of SIM_DEVICE on cell IDELAYCTRL_REPLICATED_0_6 was not specified and therefore was set to 'ULTRASCALE' to match the current FPGA architecture. For functional simulation to match hardware behavior, the value of SIM_DEVICE should be set in the source netlist.
ERROR: [DRC ADEF-911] SIM_DEVICE_arch_mismatch: When the netlist was initialized, the value of SIM_DEVICE on cell IDELAYCTRL_REPLICATED_0_7 was not specified and therefore was set to 'ULTRASCALE' to match the current FPGA architecture. For functional simulation to match hardware behavior, the value of SIM_DEVICE should be set in the source netlist.
ERROR: [DRC ADEF-911] SIM_DEVICE_arch_mismatch: When the netlist was initialized, the value of SIM_DEVICE on cell IDELAYCTRL_REPLICATED_0_8 was not specified and therefore was set to 'ULTRASCALE' to match the current FPGA architecture. For functional simulation to match hardware behavior, the value of SIM_DEVICE should be set in the source netlist.
ERROR: [DRC ADEF-911] SIM_DEVICE_arch_mismatch: When the netlist was initialized, the value of SIM_DEVICE on cell IDELAYCTRL_REPLICATED_0_9 was not specified and therefore was set to 'ULTRASCALE' to match the current FPGA architecture. For functional simulation to match hardware behavior, the value of SIM_DEVICE should be set in the source netlist.
```

I found a Q&A related to this problem
https://adaptivesupport.amd.com/s/question/0D52E00006iHicLSAS/idelay-odelay-idelaycntrl-critical-warning-netlist-29345-the-value-of-simdevice-on-instance-?language=en_US