### PR TITLE
dma: add optional Wishbone burst tagging to DMA reader/writer

### DIFF
--- a/litex/soc/cores/dma.py
+++ b/litex/soc/cores/dma.py
@@ -20,6 +20,36 @@ from litex.soc.interconnect import wishbone
 def format_bytes(s, endianness):
     return {"big": s, "little": reverse_bytes(s)}[endianness]
 
+def add_wishbone_burst_cti(module, bus, last, with_burst):
+    """Optionally add Wishbone CTI/BTE burst tagging.
+
+    This is disabled by default to preserve the legacy Wishbone classic behavior.
+    When enabled, the DMA emits incrementing-burst CTI values and uses linear BTE.
+    """
+    if not with_burst:
+        return
+
+    if not hasattr(bus, "cti"):
+        raise ValueError("Wishbone burst support requires a bus with CTI.")
+    if not hasattr(bus, "bte"):
+        raise ValueError("Wishbone burst support requires a bus with BTE.")
+
+    cti_burst_none         = getattr(wishbone, "CTI_BURST_NONE",         0b000)
+    cti_burst_incrementing = getattr(wishbone, "CTI_BURST_INCREMENTING", 0b010)
+    cti_burst_end          = getattr(wishbone, "CTI_BURST_END",          0b111)
+
+    module.comb += [
+        bus.cti.eq(cti_burst_none),
+        bus.bte.eq(0b00), # Linear burst.
+        If(bus.cyc,
+            If(last,
+                bus.cti.eq(cti_burst_end)
+            ).Else(
+                bus.cti.eq(cti_burst_incrementing)
+            )
+        )
+    ]
+
 # WishboneDMAReader --------------------------------------------------------------------------------
 
 class WishboneDMAReader(LiteXModule):
@@ -40,7 +70,7 @@ class WishboneDMAReader(LiteXModule):
     source : Record("data")
         Source for MMAP word results from reading.
     """
-    def __init__(self, bus, endianness="little", fifo_depth=16, with_csr=False):
+    def __init__(self, bus, endianness="little", fifo_depth=16, with_csr=False, with_burst=False):
         if not isinstance(bus, wishbone.Interface):
             raise TypeError("DMAReader requires a Wishbone bus.")
         if "r" not in bus.mode:
@@ -71,6 +101,14 @@ class WishboneDMAReader(LiteXModule):
 
         # FIFO -> Output.
         self.comb += fifo.source.connect(source)
+
+        # Optional Wishbone burst support.
+        add_wishbone_burst_cti(
+            module     = self,
+            bus        = bus,
+            last       = sink.last,
+            with_burst = with_burst,
+        )
 
         # CSRs.
         if with_csr:
@@ -156,7 +194,7 @@ class WishboneDMAWriter(LiteXModule):
     sink : Record("address", "data")
         Sink for MMAP addresses/datas to be written.
     """
-    def __init__(self, bus, endianness="little", with_csr=False):
+    def __init__(self, bus, endianness="little", with_csr=False, with_burst=False):
         if not isinstance(bus, wishbone.Interface):
             raise TypeError("DMAWriter requires a Wishbone bus.")
         if "w" not in bus.mode:
@@ -177,6 +215,14 @@ class WishboneDMAWriter(LiteXModule):
             bus.dat_w.eq(format_bytes(sink.data, endianness)),
             sink.ready.eq(bus.ack),
         ]
+
+        # Optional Wishbone burst support.
+        add_wishbone_burst_cti(
+            module     = self,
+            bus        = bus,
+            last       = sink.last,
+            with_burst = with_burst,
+        )
 
         # CSRs.
         if with_csr:


### PR DESCRIPTION
## Summary

This PR adds optional Wishbone burst tagging support to `WishboneDMAReader` and `WishboneDMAWriter`.

A new `with_burst` parameter is introduced for both DMA modules. When enabled, the modules drive the Wishbone `cti` and `bte` signals to mark sequential DMA transfers as linear incrementing bursts.

The default behavior remains unchanged.

## Motivation

The current Wishbone DMA reader and writer generate standard Wishbone classic cycles. This is functionally correct, but it does not provide burst information to downstream interconnects or memory controllers.

For memory-backed DMA transfers, especially when accessing LiteDRAM or other burst-aware Wishbone slaves, it can be useful to explicitly indicate that a sequence of accesses is part of an incrementing burst.

This PR makes that possible while keeping the existing legacy behavior as the default.

## Changes

This PR adds:

- A new optional argument to `WishboneDMAReader`:

```python
with_burst=False
````

* A new optional argument to `WishboneDMAWriter`:

```python
with_burst=False
```

* Optional generation of Wishbone burst metadata:

```text
CTI = 010  -> incrementing burst
CTI = 111  -> end of burst
BTE = 00   -> linear burst
```

When `with_burst=True`, intermediate beats are tagged as incrementing burst cycles and the last beat is tagged as end-of-burst.

When `with_burst=False`, the DMA modules keep their previous behavior.

## Example usage

```python
self.submodules.dma_reader = WishboneDMAReader(
    bus=reader_bus,
    with_csr=True,
    with_burst=True,
)

self.submodules.dma_writer = WishboneDMAWriter(
    bus=writer_bus,
    with_csr=True,
    with_burst=True,
)
```

## Backward compatibility

This change is backward-compatible.

The new parameter defaults to `False`, so existing designs that instantiate the DMA modules without `with_burst` continue to behave as before:

```python
WishboneDMAReader(bus=bus, with_csr=True)
WishboneDMAWriter(bus=bus, with_csr=True)
```

In this mode, no burst tagging is added by the DMA modules.

## Design choices

### Opt-in behavior

Burst tagging is disabled by default because the original DMA modules did not promise burst-capable behavior. This avoids changing the semantics of existing designs.

### Linear bursts only

The DMA control logic generates sequential addresses using `base + offset`, so the appropriate Wishbone burst type is linear:

```text
BTE = 00
```

Wrapping bursts are not used.

### End-of-burst tagging

The modules use the existing stream `last` information to determine when to emit:

```text
CTI = 111
```

This matches the existing DMA transfer boundary logic.

### Minimal changes

The implementation intentionally keeps the original DMA logic intact and only adds optional CTI/BTE generation. This makes the change easy to review and compare against the previous implementation.

## Testing

This feature was validated by first forcing the `cti` signal externally at the SoC level for both DMA reader and writer. The same logic was then moved into the DMA modules behind the `with_burst` parameter.

Expected behavior with `with_burst=True` for a multi-beat transfer:

```text
beat 0: CTI = 010
beat 1: CTI = 010
...
last beat: CTI = 111
BTE = 00
```

Expected behavior with `with_burst=False`:

```text
legacy Wishbone DMA behavior is preserved
```
