### PR TITLE
soc/interconnect/axi: fix up-converter lane handling

### DIFF
--- a/litex/soc/interconnect/axi/axi_full.py
+++ b/litex/soc/interconnect/axi/axi_full.py
@@ -235,53 +235,213 @@ class AXIUpConverter(LiteXModule):
 
         # # #
 
-        # Note: Assuming size of "axi_from" burst >= "axi_to" data_width.
+        lane_bits = log2_int(ratio)
+        lane_lsb  = log2_int(dw_from//8)
+
+        # Convert each narrow AXI beat into one wide single-beat transfer. This preserves the
+        # address-selected data/strb lane for short or unaligned bursts.
 
         # Write path -------------------------------------------------------------------------------
 
-        # AW Channel.
+        aw = AXIStreamInterface(
+            layout   = ax_description(axi_from.address_width, version=axi_from.version),
+            id_width = axi_from.id_width)
+        self.submodules.aw_burst2beat = AXIBurst2Beat(axi_from.aw, aw)
+
+        aw_layout = [
+            ("addr",   len(axi_to.aw.addr)),
+            ("size",   len(axi_to.aw.size)),
+            ("lock",   len(axi_to.aw.lock)),
+            ("prot",   len(axi_to.aw.prot)),
+            ("cache",  len(axi_to.aw.cache)),
+            ("qos",    len(axi_to.aw.qos)),
+            ("region", len(axi_to.aw.region)),
+            ("id",     len(axi_to.aw.id)),
+            ("dest",   len(axi_to.aw.dest)),
+            ("user",   len(axi_to.aw.user)),
+            ("lane",   lane_bits),
+        ]
+        aw_cmd  = stream.SyncFIFO(aw_layout, 16)
+        aw_data = stream.SyncFIFO([("lane", lane_bits)], 16)
+        b_info  = stream.SyncFIFO([("id", len(axi_to.b.id))], 16)
+        self.submodules += aw_cmd, aw_data, b_info
+
+        aw_fifos_ready = Signal()
         self.comb += [
-            axi_from.aw.connect(axi_to.aw, omit={"len", "size"}),
-            axi_to.aw.len.eq( axi_from.aw.len >> log2_int(ratio)),
-            axi_to.aw.size.eq(axi_from.aw.size + log2_int(ratio)),
+            aw_fifos_ready.eq(aw_cmd.sink.ready & aw_data.sink.ready),
+            aw.ready.eq(aw_fifos_ready),
+
+            aw_cmd.sink.valid.eq(aw.valid & aw_data.sink.ready),
+            aw_cmd.sink.addr.eq(aw.addr),
+            aw_cmd.sink.size.eq(axi_from.aw.size),
+            aw_cmd.sink.lock.eq(axi_from.aw.lock),
+            aw_cmd.sink.prot.eq(axi_from.aw.prot),
+            aw_cmd.sink.cache.eq(axi_from.aw.cache),
+            aw_cmd.sink.qos.eq(axi_from.aw.qos),
+            aw_cmd.sink.region.eq(axi_from.aw.region),
+            aw_cmd.sink.id.eq(aw.id),
+            aw_cmd.sink.dest.eq(axi_from.aw.dest),
+            aw_cmd.sink.user.eq(axi_from.aw.user),
+            aw_cmd.sink.lane.eq(aw.addr[lane_lsb:lane_lsb + lane_bits]),
+            aw_cmd.sink.last.eq(aw.last),
+
+            aw_data.sink.valid.eq(aw.valid & aw_cmd.sink.ready),
+            aw_data.sink.lane.eq(aw.addr[lane_lsb:lane_lsb + lane_bits]),
+        ]
+
+        self.comb += [
+            axi_to.aw.valid.eq(aw_cmd.source.valid & b_info.sink.ready),
+            axi_to.aw.addr.eq(aw_cmd.source.addr),
+            axi_to.aw.burst.eq(BURST_INCR),
+            axi_to.aw.len.eq(0),
+            axi_to.aw.size.eq(aw_cmd.source.size),
+            axi_to.aw.lock.eq(aw_cmd.source.lock),
+            axi_to.aw.prot.eq(aw_cmd.source.prot),
+            axi_to.aw.cache.eq(aw_cmd.source.cache),
+            axi_to.aw.qos.eq(aw_cmd.source.qos),
+            axi_to.aw.region.eq(aw_cmd.source.region),
+            axi_to.aw.id.eq(aw_cmd.source.id),
+            axi_to.aw.dest.eq(aw_cmd.source.dest),
+            axi_to.aw.user.eq(aw_cmd.source.user),
+            aw_cmd.source.ready.eq(axi_to.aw.ready & b_info.sink.ready),
+
+            b_info.sink.valid.eq(aw_cmd.source.valid & axi_to.aw.ready),
+            b_info.sink.id.eq(aw_cmd.source.id),
+            b_info.sink.last.eq(aw_cmd.source.last),
         ]
 
         # W Channel.
-        w_converter = stream.StrideConverter(
-            description_from = [("data", dw_from), ("strb", dw_from//8)],
-            description_to   = [("data",   dw_to), ("strb",   dw_to//8)],
-        )
-        self.submodules += w_converter
-        self.comb += axi_from.w.connect(w_converter.sink, omit={"id", "dest", "user"})
-        self.comb += w_converter.source.connect(axi_to.w)
-        self.comb += axi_to.w.id.eq(axi_from.w.id)
-        self.comb += axi_to.w.dest.eq(axi_from.w.dest)
-        self.comb += axi_to.w.user.eq(axi_from.w.user)
+        self.comb += [
+            axi_to.w.valid.eq(axi_from.w.valid & aw_data.source.valid),
+            axi_from.w.ready.eq(axi_to.w.ready & aw_data.source.valid),
+            aw_data.source.ready.eq(axi_from.w.valid & axi_to.w.ready),
+            axi_to.w.data.eq(0),
+            axi_to.w.strb.eq(0),
+            axi_to.w.last.eq(1),
+            axi_to.w.id.eq(axi_from.w.id),
+            axi_to.w.dest.eq(axi_from.w.dest),
+            axi_to.w.user.eq(axi_from.w.user),
+        ]
+        for i in range(ratio):
+            self.comb += If(aw_data.source.lane == i,
+                axi_to.w.data[i*dw_from:(i + 1)*dw_from].eq(axi_from.w.data),
+                axi_to.w.strb[i*(dw_from//8):(i + 1)*(dw_from//8)].eq(axi_from.w.strb),
+            )
 
         # B Channel.
-        self.comb += axi_to.b.connect(axi_from.b)
+        b_resp = Signal(2, reset=RESP_OKAY)
+        self.comb += [
+            axi_from.b.valid.eq(axi_to.b.valid & b_info.source.valid & b_info.source.last),
+            axi_from.b.resp.eq(Mux(axi_to.b.resp != RESP_OKAY, axi_to.b.resp, b_resp)),
+            axi_from.b.id.eq(axi_to.b.id),
+            axi_from.b.dest.eq(axi_to.b.dest),
+            axi_from.b.user.eq(axi_to.b.user),
+            axi_to.b.ready.eq(b_info.source.valid & (~b_info.source.last | axi_from.b.ready)),
+            b_info.source.ready.eq(axi_to.b.valid & axi_to.b.ready),
+        ]
+        self.sync += If(axi_to.b.valid & axi_to.b.ready,
+            If(b_info.source.last,
+                b_resp.eq(RESP_OKAY)
+            ).Elif(axi_to.b.resp != RESP_OKAY,
+                b_resp.eq(axi_to.b.resp)
+            )
+        )
 
         # Read path --------------------------------------------------------------------------------
 
-        # AR Channel.
+        ar = AXIStreamInterface(
+            layout   = ax_description(axi_from.address_width, version=axi_from.version),
+            id_width = axi_from.id_width)
+        self.submodules.ar_burst2beat = AXIBurst2Beat(axi_from.ar, ar)
+
+        ar_layout = [
+            ("addr",   len(axi_to.ar.addr)),
+            ("size",   len(axi_to.ar.size)),
+            ("lock",   len(axi_to.ar.lock)),
+            ("prot",   len(axi_to.ar.prot)),
+            ("cache",  len(axi_to.ar.cache)),
+            ("qos",    len(axi_to.ar.qos)),
+            ("region", len(axi_to.ar.region)),
+            ("id",     len(axi_to.ar.id)),
+            ("dest",   len(axi_to.ar.dest)),
+            ("user",   len(axi_to.ar.user)),
+            ("lane",   lane_bits),
+        ]
+        ar_cmd = stream.SyncFIFO(ar_layout, 16)
+        r_info = stream.SyncFIFO([("lane", lane_bits)], 16)
+        r_fifo = stream.SyncFIFO([
+            ("data", dw_from),
+            ("resp", len(axi_from.r.resp)),
+            ("id",   len(axi_from.r.id)),
+            ("dest", len(axi_from.r.dest)),
+            ("user", len(axi_from.r.user)),
+        ], 16)
+        self.submodules += ar_cmd, r_info, r_fifo
+
         self.comb += [
-            axi_from.ar.connect(axi_to.ar, omit={"len", "size"}),
-            axi_to.ar.len.eq( axi_from.ar.len >> log2_int(ratio)),
-            axi_to.ar.size.eq(axi_from.ar.size + log2_int(ratio)),
+            ar_cmd.sink.valid.eq(ar.valid),
+            ar.ready.eq(ar_cmd.sink.ready),
+            ar_cmd.sink.addr.eq(ar.addr),
+            ar_cmd.sink.size.eq(axi_from.ar.size),
+            ar_cmd.sink.lock.eq(axi_from.ar.lock),
+            ar_cmd.sink.prot.eq(axi_from.ar.prot),
+            ar_cmd.sink.cache.eq(axi_from.ar.cache),
+            ar_cmd.sink.qos.eq(axi_from.ar.qos),
+            ar_cmd.sink.region.eq(axi_from.ar.region),
+            ar_cmd.sink.id.eq(ar.id),
+            ar_cmd.sink.dest.eq(axi_from.ar.dest),
+            ar_cmd.sink.user.eq(axi_from.ar.user),
+            ar_cmd.sink.lane.eq(ar.addr[lane_lsb:lane_lsb + lane_bits]),
+            ar_cmd.sink.last.eq(ar.last),
+        ]
+
+        self.comb += [
+            axi_to.ar.valid.eq(ar_cmd.source.valid & r_info.sink.ready),
+            axi_to.ar.addr.eq(ar_cmd.source.addr),
+            axi_to.ar.burst.eq(BURST_INCR),
+            axi_to.ar.len.eq(0),
+            axi_to.ar.size.eq(ar_cmd.source.size),
+            axi_to.ar.lock.eq(ar_cmd.source.lock),
+            axi_to.ar.prot.eq(ar_cmd.source.prot),
+            axi_to.ar.cache.eq(ar_cmd.source.cache),
+            axi_to.ar.qos.eq(ar_cmd.source.qos),
+            axi_to.ar.region.eq(ar_cmd.source.region),
+            axi_to.ar.id.eq(ar_cmd.source.id),
+            axi_to.ar.dest.eq(ar_cmd.source.dest),
+            axi_to.ar.user.eq(ar_cmd.source.user),
+            ar_cmd.source.ready.eq(axi_to.ar.ready & r_info.sink.ready),
+
+            r_info.sink.valid.eq(ar_cmd.source.valid & axi_to.ar.ready),
+            r_info.sink.lane.eq(ar_cmd.source.lane),
+            r_info.sink.last.eq(ar_cmd.source.last),
         ]
 
         # R Channel.
-        r_converter = stream.StrideConverter(
-            description_from = [("data",   dw_to)],
-            description_to   = [("data", dw_from)],
-        )
-        self.submodules += r_converter
-        self.comb += axi_to.r.connect(r_converter.sink, omit={"id", "dest", "user", "resp"})
-        self.comb += r_converter.source.connect(axi_from.r)
-        self.comb += axi_from.r.resp.eq(axi_to.r.resp)
-        self.comb += axi_from.r.id.eq(axi_to.r.id)
-        self.comb += axi_from.r.user.eq(axi_to.r.user)
-        self.comb += axi_from.r.dest.eq(axi_to.r.dest)
+        r_data = Signal(dw_from)
+        for i in range(ratio):
+            self.comb += If(r_info.source.lane == i,
+                r_data.eq(axi_to.r.data[i*dw_from:(i + 1)*dw_from])
+            )
+        self.comb += [
+            r_fifo.sink.valid.eq(axi_to.r.valid & r_info.source.valid),
+            r_fifo.sink.data.eq(r_data),
+            r_fifo.sink.resp.eq(axi_to.r.resp),
+            r_fifo.sink.id.eq(axi_to.r.id),
+            r_fifo.sink.dest.eq(axi_to.r.dest),
+            r_fifo.sink.user.eq(axi_to.r.user),
+            r_fifo.sink.last.eq(r_info.source.last),
+            axi_to.r.ready.eq(r_info.source.valid & r_fifo.sink.ready),
+            r_info.source.ready.eq(axi_to.r.valid & axi_to.r.ready),
+
+            axi_from.r.valid.eq(r_fifo.source.valid),
+            axi_from.r.data.eq(r_fifo.source.data),
+            axi_from.r.resp.eq(r_fifo.source.resp),
+            axi_from.r.last.eq(r_fifo.source.last),
+            axi_from.r.id.eq(r_fifo.source.id),
+            axi_from.r.dest.eq(r_fifo.source.dest),
+            axi_from.r.user.eq(r_fifo.source.user),
+            r_fifo.source.ready.eq(axi_from.r.ready),
+        ]
 
 class AXIDownConverter(LiteXModule):
     """AXI4-Full data-width down-converter.

--- a/litex/soc/software/bios/cmds/cmd_litesdcard.c
+++ b/litex/soc/software/bios/cmds/cmd_litesdcard.c
@@ -79,11 +79,13 @@ define_command(sdcard_freq, sdcard_freq_handler, "Set SDCard clock freq", LITESD
 static void sdcard_read_handler(int nb_params, char **params)
 {
 	unsigned int block;
+	unsigned long addr;
 	char *c;
 	uint8_t buf[512];
+	uint8_t *dst = buf;
 
 	if (nb_params < 1) {
-		printf("sdcard_read <block>\n");
+		printf("sdcard_read <block> [addr]\n");
 		return;
 	}
 
@@ -92,9 +94,17 @@ static void sdcard_read_handler(int nb_params, char **params)
 		printf("Error: invalid block number\n");
 		return;
 	}
+	if (nb_params >= 2) {
+		addr = strtoul(params[1], &c, 0);
+		if (*c != 0) {
+			printf("Error: invalid destination address\n");
+			return;
+		}
+		dst = (uint8_t *)(uintptr_t)addr;
+	}
 
-	sdcard_read(block, 1, buf);
-	dump_bytes((unsigned int *)buf, 512, (unsigned long) buf);
+	sdcard_read(block, 1, dst);
+	dump_bytes((unsigned int *)dst, 512, (unsigned long)dst);
 }
 
 define_command(sdcard_read, sdcard_read_handler, "Read SDCard block", LITESDCARD_CMDS);

--- a/test/test_axi.py
+++ b/test/test_axi.py
@@ -616,6 +616,52 @@ class TestAXI(unittest.TestCase):
         dut = DUT(64, 32)
         run_simulation(dut, [read_generator(dut), write_generator(dut)], vcd_name="sim.vcd")
 
+    def test_axi_up_converter_single_beat_lane_writes(self):
+        class DUT(LiteXModule):
+            def __init__(self, dw_narrow=128, dw_wide=256, mem_bytes=4096):
+                self.axi_narrow = AXIInterface(data_width=dw_narrow, address_width=32, id_width=4)
+                self.axi_wide   = AXIInterface(data_width=dw_wide,   address_width=32, id_width=4)
+                self.converter  = AXIUpConverter(self.axi_narrow, self.axi_wide)
+                self.sram       = AXISRAM(mem_bytes, bus=self.axi_wide, init=[0]*(mem_bytes//(dw_wide//8)))
+                self.errors     = 0
+
+        def gen(dut):
+            size  = log2_int(dut.axi_narrow.data_width//8)
+            bytes = dut.axi_narrow.data_width//8
+            beats = [
+                0x00000003000000020000000100000000,
+                0x00000007000000060000000500000004,
+                0x0000000b0000000a0000000900000008,
+                0x0000000f0000000e0000000d0000000c,
+            ]
+
+            # Single-beat writes hit alternating lanes of each wider target word. This is the
+            # pattern used by Rocket's L2 when accepting SDCard DMA writes.
+            for i, beat in enumerate(beats):
+                resp = yield from axi_write_single(dut.axi_narrow, i*bytes, beat, size=size)
+                if resp != RESP_OKAY:
+                    dut.errors += 1
+
+            for i, expected in enumerate(beats):
+                data, resp = yield from axi_read_single(dut.axi_narrow, i*bytes, size=size)
+                if resp != RESP_OKAY or data != expected:
+                    dut.errors += 1
+
+            burst = [beat ^ 0x11111111111111111111111111111111 for beat in beats]
+            resp = yield from axi_write_burst(dut.axi_narrow, 0x100, burst, size=size)
+            if resp != RESP_OKAY:
+                dut.errors += 1
+            mem0 = (yield dut.sram.mem[0x100//(dut.axi_wide.data_width//8)])
+            mem1 = (yield dut.sram.mem[0x120//(dut.axi_wide.data_width//8)])
+            assert mem0 == (burst[0] | (burst[1] << dut.axi_narrow.data_width)), hex(mem0)
+            assert mem1 == (burst[2] | (burst[3] << dut.axi_narrow.data_width)), hex(mem1)
+            read = yield from axi_read_burst(dut.axi_narrow, 0x100, len(burst), size=size)
+            assert read == burst, ([hex(d) for d in read], [hex(d) for d in burst])
+
+        dut = DUT()
+        run_simulation(dut, gen(dut))
+        self.assertEqual(dut.errors, 0)
+
     def test_axi_down_converter_burst(self):
         # Exercises AXIDownConverter (now also used by SoC.add_sdram for the
         # CPU.mem_axi.data_width > LiteDRAM.port.data_width case) on real bursts:


### PR DESCRIPTION
Rocket L2 can issue 128-bit accesses into a 256-bit LiteDRAM port when coherent DMA traffic reaches main RAM. The previous AXIUpConverter widened bursts and packed data with StrideConverter, which corrupted short/single-beat transfers by shifting data into the wrong half of the wide word and leaving the other lane stale.

Convert each narrow beat into a lane-selected wide single-beat transfer, preserving the address-selected data and strobe lane. Queue read responses so the selected lane remains stable until the narrow-side master accepts the beat.

Add regression coverage for 128-to-256 lane writes and burst round-trips. Also allow the BIOS sdcard_read command to take an optional destination address so the Rocket SDCard DMA path can be checked directly in SDRAM.

Reproduced and verified with Rocket litex_sim using --sdram-data-width=256 and --with-sdcard.

Fixes: #2464