### PR TITLE
cpu: Coreblocks update

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -25,7 +25,7 @@ Copyright (c) 2018-2023 Antmicro <Antmicro.com>
 Copyright (c) 2019      Antony Pavlov <antonynpavlov@gmail.com>
 Copyright (c) 2019      Antti Lukats <Antti.Lukats@googlemail.com>
 Copyright (c) 2025-2026 Aoba Fujino <41146f@gmail.com>
-Copyright (c) 2025      Aria Węgrzyn <piotro@piotro.eu>
+Copyright (c) 2024-2026 Aria Węgrzyn <git@ariac.at>
 Copyright (c) 2019-2020 Arnaud Durand <arnaud.durand@unifr.ch>
 Copyright (c) 2022-2023 Arne Jansen <arne@die-jansens.de>
 Copyright (c) 2023      Artur Kowalski <artur.kowalski@3mdeb.com>
@@ -190,7 +190,6 @@ Copyright (c) 2018      phlipped <phlipped@gmail.com>
 Copyright (c) 2020      Piense <piense@gmail.com>
 Copyright (c) 2017      Pierre-Olivier Vauboin <po@lambdaconcept>
 Copyright (c) 2020      Piotr Esden-Tempski <piotr@esden.net>
-Copyright (c) 2024-2025 Piotr Wegrzyn <piotro@piotro.eu>
 Copyright (c) 2015      psmears <patrick@smears.org>
 Copyright (c) 2023      Radek Pesina <radek.pesina@motec.com.au>
 Copyright (c) 2020      Rangel Ivanov <rangelivanov88@gmail.com>

--- a/litex/soc/cores/cpu/coreblocks/core.py
+++ b/litex/soc/cores/cpu/coreblocks/core.py
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import os
-import shutil
 import subprocess
 import logging
 
@@ -13,7 +12,6 @@ from migen import *
 
 from litex import get_data_mod
 from litex.build.xilinx.vivado import XilinxVivadoToolchain
-from litex.soc.cores.cpu.amaranth import import_from_pythondata
 from litex.soc.cores.cpu import CPU, CPU_GCC_TRIPLE_RISCV32
 from litex.soc.integration.soc import SoCRegion
 from litex.soc.interconnect import wishbone
@@ -150,28 +148,17 @@ class Coreblocks(CPU):
             cli_params.append("--enable-vivado-hacks")
 
         data_mod = get_data_mod("cpu", "coreblocks")
-        sdir = data_mod.data_location
 
-        if data_mod.RUN_NATIVE:
-            command = ["python3", os.path.join(sdir, "scripts", "gen_verilog.py")]
+        if os.getenv("LITEX_COREBLOCKS_RUN_NATIVE", "0") != "0":
+            # run generation from `coreblocks` (not `pythondata-cpu-coreblocks`) package
+            # requires manual installation in the enviroment, mainly for dev/hacking
+            command = ["python3", "-m", "coreblocks.gen_verilog"]
         else:
-            # Deterministic external helper path: use a configured Python interpreter
-            # (defaults to python3.<required>) to execute pythondata's wrapper script.
-            helper_python = os.getenv("LITEX_COREBLOCKS_HELPER_PYTHON", f"python3.{data_mod.PYTHON3_VERSION}")
-            helper_script = os.path.join(sdir, "..", "gen_verilog_wrapper.py")
-            if shutil.which(helper_python):
-                command = [helper_python, helper_script]
-            elif shutil.which("pipx"):
-                self.logger.warning(
-                    "Coreblocks helper interpreter '%s' was not found, falling back to pipx.",
-                    helper_python)
-                command = ["pipx", "run", f"--python=3.{data_mod.PYTHON3_VERSION}",
-                           "--fetch-missing-python", helper_script]
-            else:
-                raise OSError(
-                    f"Coreblocks external elaboration requires '{helper_python}' "
-                    "or pipx. Install one of them or set "
-                    "LITEX_COREBLOCKS_HELPER_PYTHON to a valid Python executable.")
+            # generation form `pythondata-cpu-coreblocks` wrapper script
+            # it runs coreblocks in isolated enviroment with correct python version and separate dependencies
+            # this is a recommended way of runnning coreblocks because of delicate package requirements
+            helper_script = os.path.join(*data_mod.__path__, "gen_verilog_wrapper.py")
+            command = ["python3", helper_script]
 
         command += cli_params
 
@@ -179,70 +166,11 @@ class Coreblocks(CPU):
         if subprocess.call(command):
             raise OSError("Unable to elaborate Coreblocks CPU, please check your coreblocks, Amaranth/Yosys, and requirements install")
 
-    def _do_finalize_with_converter(self):
-        try:
-            from litex.build.amaranth2v_converter import Amaranth2VConverter
-            coreblocks_gen = import_from_pythondata("cpu", "coreblocks", "scripts.gen_verilog")
-            with coreblocks_gen.DependencyContext(coreblocks_gen.DependencyManager()):
-                core_config = coreblocks_gen.str_to_coreconfig[CPU_VARIANTS[self.variant]]
-                core_config = core_config.replace(start_pc=self.reset_address)
-                core_genp   = coreblocks_gen.GenParams(core_config)
-                amaranth_cpu = coreblocks_gen.Core(gen_params=core_genp)
-
-                if self.variant in LINUX_CAPABLE_VARIANTS:
-                    # Adds CoreSoCks wrapper around the core that adds extra peripherals for full OS support.
-                    amaranth_cpu = coreblocks_gen.Socks(amaranth_cpu, core_gen_params=core_genp)
-
-                amaranth_cpu = coreblocks_gen.TransactronContextComponent(
-                    amaranth_cpu, dependency_manager=coreblocks_gen.DependencyContext.get())
-        except Exception as e:
-            self.logger.warning("Coreblocks native Amaranth conversion unavailable: %s", str(e))
-            return False
-
-        self.converter = Amaranth2VConverter(self.platform,
-            name        = "top",
-            module      = amaranth_cpu,
-            ports       = dict(
-                # Clk / Rst.
-                i_sync_clk = ClockSignal("sys"),
-                i_sync_rst = ResetSignal("sys") | self.reset,
-
-                # IRQ.
-                i_interrupts = self.interrupts_full,
-
-                # Ibus.
-                o_wb_instr_stb   = self.ibus.stb,
-                o_wb_instr_cyc   = self.ibus.cyc,
-                o_wb_instr_we    = self.ibus.we,
-                o_wb_instr_adr   = self.ibus.adr,
-                o_wb_instr_dat_w = self.ibus.dat_w,
-                o_wb_instr_sel   = self.ibus.sel,
-                i_wb_instr_ack   = self.ibus.ack,
-                i_wb_instr_err   = self.ibus.err,
-                i_wb_instr_dat_r = self.ibus.dat_r,
-
-                # Dbus.
-                o_wb_data_stb   = self.dbus.stb,
-                o_wb_data_cyc   = self.dbus.cyc,
-                o_wb_data_we    = self.dbus.we,
-                o_wb_data_adr   = self.dbus.adr,
-                o_wb_data_dat_w = self.dbus.dat_w,
-                o_wb_data_sel   = self.dbus.sel,
-                i_wb_data_ack   = self.dbus.ack,
-                i_wb_data_err   = self.dbus.err,
-                i_wb_data_dat_r = self.dbus.dat_r,
-            ),
-        )
-        self.logger.info("Using Coreblocks native Amaranth2VConverter integration.")
-        return True
-
     def do_finalize(self):
         assert hasattr(self, "reset_address")
 
-        # Prefer native Amaranth conversion when dependencies are available.
-        # Fallback to external elaboration wrapper otherwise.
-        if self._do_finalize_with_converter():
-            return
+        # native LiteX Amaranth conversion is not recommended, Coreblocks depends on custom Verilog fix-ups
+        # and locked yosys version, both of them are handled by generation with coreblocks.gen_verilog script
 
         verilog_filename = os.path.join(self.platform.output_dir, "gateware", "core.v")
         self.elaborate(

--- a/litex/soc/cores/cpu/coreblocks/core.py
+++ b/litex/soc/cores/cpu/coreblocks/core.py
@@ -1,7 +1,7 @@
 #
 # This file is part of LiteX.
 #
-# Copyright (c) 2023-2025 Piotr Wegrzyn (Coreforge Foundation) <piotro@piotro.eu>
+# Copyright (c) 2023-2026 Aria Węgrzyn (Coreforge Foundation) <git@ariac.at>
 # SPDX-License-Identifier: BSD-2-Clause
 
 import os

--- a/litex/soc/cores/cpu/coreblocks/core.py
+++ b/litex/soc/cores/cpu/coreblocks/core.py
@@ -57,6 +57,8 @@ class Coreblocks(CPU):
     def gcc_flags(self):
         flags =  GCC_FLAGS[self.variant]
         flags += "-D__coreblocks__ "
+        if self.variant in LINUX_CAPABLE_VARIANTS:
+            flags += "-D__riscv_plic__"
         return flags
 
     def __init__(self, platform, variant="standard"):
@@ -65,7 +67,7 @@ class Coreblocks(CPU):
         self.human_name   = f"Coreblocks-{CPU_VARIANTS[variant]}"
         self.logger       = logging.getLogger("Coreblocks")
         self.reset        = Signal()
-        self.interrupt    = Signal(16) # hart-local 16 platform interrupts - ids 16+n
+        self.interrupt    = Signal(16)
 
         self.ibus         = ibus = wishbone.Interface()
         self.dbus         = dbus = wishbone.Interface()
@@ -74,9 +76,16 @@ class Coreblocks(CPU):
 
         # # #
 
-        self.interrupts_full = Signal(32)
-        # Shift interrupts to platform range
-        self.comb += self.interrupts_full.eq(self.interrupt << 16)
+        if variant in LINUX_CAPABLE_VARIANTS: 
+            # Using PLIC - interrupts are wired directly to PLIC controller
+            # Note that bit 0 will be ignored, as interrupt source 0 in PLIC is reserved
+            interrupts_signal = self.interrupt
+        else:
+            # Shift interrupts to platform range if using hart interrupt controller
+            # interrupts will have ids 16+n
+            interrupts_full = Signal(32)
+            self.comb += interrupts_full.eq(self.interrupt << 16)
+            interrupts_signal = interrupts_full
 
         self.cpu_params = dict(
             # Clk / Rst.
@@ -84,7 +93,7 @@ class Coreblocks(CPU):
             i_rst = ResetSignal("sys") | self.reset,
 
             ## IRQ.
-            i_interrupts = self.interrupts_full,
+            i_interrupts = interrupts_signal, 
 
             # Ibus.
             o_wb_instr__stb   = ibus.stb,
@@ -121,8 +130,9 @@ class Coreblocks(CPU):
         }
 
         if self.variant in LINUX_CAPABLE_VARIANTS:
-            mem_map |= {
-                "clint":    0xe100_0000, # fixed in CoreSoCks
+            mem_map |= { # fixed in CoreSoCks
+                "clint":    0xe100_0000,
+                "plic":     0xe200_0000,
             }
 
         return mem_map

--- a/litex/soc/cores/cpu/coreblocks/csr-defs.h
+++ b/litex/soc/cores/cpu/coreblocks/csr-defs.h
@@ -9,7 +9,10 @@
 // mip
 #define CSR_IRQ_PENDING 0x344
 
+#ifndef __riscv_plic__
+// for hart local interrupt controller:
 // first platform irq - enables offset in internal software
 #define FIRQ_OFFSET     16
+#endif
 
 #endif	/* CSR_DEFS__H */

--- a/litex/soc/cores/cpu/coreblocks/irq.h
+++ b/litex/soc/cores/cpu/coreblocks/irq.h
@@ -21,16 +21,44 @@ static inline void irq_setie(unsigned int ie)
 	if(ie) csrs(mstatus,CSR_MSTATUS_MIE); else csrc(mstatus,CSR_MSTATUS_MIE);
 }
 
+#ifdef __riscv_plic__
+
+#define PLIC_BASE    0xe2000000L // Base address and per-pin priority array
+#define PLIC_PENDING 0xe2001000L // Bit field matching currently pending pins
+#define PLIC_ENABLED 0xe2002000L // Bit field corresponding to the current mask
+#define PLIC_THRSHLD 0xe2200000L // Per-pin priority must be >= this to trigger
+#define PLIC_CLAIM   0xe2200004L // Claim & completion register address
+
+#define PLIC_EXT_IRQ_BASE 0
+
+
 static inline unsigned int irq_getmask(void)
 {
-	unsigned int mask;
-	asm volatile ("csrr %0, %1" : "=r"(mask) : "i"(CSR_IRQ_MASK));
-	return (mask>>FIRQ_OFFSET);
+	return *((unsigned int *)PLIC_ENABLED) >> PLIC_EXT_IRQ_BASE;
 }
 
 static inline void irq_setmask(unsigned int mask)
 {
-	asm volatile ("csrw %0, %1" :: "i"(CSR_IRQ_MASK), "r"(mask<<FIRQ_OFFSET));
+	*((unsigned int *)PLIC_ENABLED) = mask << PLIC_EXT_IRQ_BASE;
+}
+
+static inline unsigned int irq_pending(void)
+{
+	return *((unsigned int *)PLIC_PENDING) >> PLIC_EXT_IRQ_BASE;
+}
+
+#else
+
+static inline unsigned int irq_getmask(void)
+{
+	unsigned int mask;
+	asm volatile ("csrr %0, %1" : "=r"(mask) : "i"(CSR_IRQ_MASK));
+	return (mask >> FIRQ_OFFSET);
+}
+
+static inline void irq_setmask(unsigned int mask)
+{
+	asm volatile ("csrw %0, %1" :: "i"(CSR_IRQ_MASK), "r"(mask << FIRQ_OFFSET));
 }
 
 static inline unsigned int irq_pending(void)
@@ -39,6 +67,8 @@ static inline unsigned int irq_pending(void)
 	asm volatile ("csrr %0, %1" : "=r"(pending) : "i"(CSR_IRQ_PENDING));
 	return (pending >> FIRQ_OFFSET);
 }
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -52,6 +52,7 @@ def boot_test(cpu_type="vexriscv", cpu_variant="standard", args="", output_dir=N
     return is_success
 
 TESTED_CPUS = [
+    "coreblocks",   # (riscv   / softcore)
     #"cv32e40p",     # (riscv   / softcore)
     "femtorv",      # (riscv   / softcore)
     "firev",        # (riscv   / softcore)
@@ -68,7 +69,6 @@ TESTED_CPUS = [
     "minerva",      # (riscv   / softcore)
 ]
 UNTESTED_CPUS = [
-    "coreblocks",   # (riscv   / softcore) -> Broken install?
     "blackparrot",  # (riscv   / softcore) -> Broken install?
     "cortex_m1",    # (arm     / softcore) -> Proprietary code.
     "cortex_m3",    # (arm     / softcore) -> Proprieraty code.


### PR DESCRIPTION
Changes:
- add PLIC support. 
 Used by default in Linux-capable configs. Interrupts are wired directly to PLIC.
 In simpler variants without PLIC interrupts are wired directly to RISC-V hart local interrupt controller, as in original code (shifted). Both schemes are supported in `irq.h`
- Packaging changes
  Coreblocks is now distributed as standalone package.
  I made changes to [pythondata-cpu-coreblocksx](https://github.com/litex-hub/pythondata-cpu-coreblocks) to simplify packaging process. pythondata package now runs isolated pipx verilog generation from pinned coreblocks commit (without submodule and dependency duplication).
This is the preffered way of running elaboration, because we depend on very fragile packages and python version, yosys version.
For developer use, `coreblocks` package can be installed directly in venv, and `LITEX_COREBLOCKS_RUN_NATIVE` flag specified to run it directly from installed package instead.
Everything is documented in pythondatas' package readme.
- Native Amaranth conversion removal
  I'm very sorry to remove your native Amaranth conversion work, but we depend on some amaranth hacks that are applied in internal verilog generation (for now e.g. `--enable-vivado-hacks` to workaround Vivado synthesis bugs). Due to fragile nature of verilog generation with such a big project, I would strongly prefer generating verilog source with our generation code (preferably isolated), and using it in LiteX.
- Custom core configurations can be injected with `COREBLOCKS_CORECONFIG_FILE` env var (waiting for merge in Coreblocks), documented in pythondata.
  