### PR TITLE
sim/qemu: add QEMU CPU co-simulation for LiteX SIM.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Install Tools
         run: |
           sudo apt-get install wget build-essential ninja-build help2man
+          sudo apt-get install pkg-config python3-venv libglib2.0-dev libpixman-1-dev libfdt-dev device-tree-compiler
           sudo apt-get install libevent-dev libjson-c-dev flex bison
           sudo apt-get install libfl-dev libfl2 zlib1g-dev
 
@@ -40,7 +41,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          python3 -m pip install setuptools wheel requests pexpect meson pytest pytest-xdist pytest-split
+          python3 -m pip install setuptools wheel requests pexpect meson distlib pytest pytest-xdist pytest-split
 
       # Install (n)Migen / LiteX / Cores
       - name: Install LiteX
@@ -147,6 +148,70 @@ jobs:
       # Install Project
       - name: Install Project
         run: python3 setup.py develop --user
+
+      # Build the patched QEMU once for the dedicated co-simulation
+      # integration test. The regular pytest shards skip this test unless
+      # LITEX_QEMU_COSIM_TEST is set by the step below.
+      - name: Build patched QEMU
+        if: matrix.group == 1
+        env:
+          LD_LIBRARY_PATH: ""
+          PKG_CONFIG_PATH: ""
+        run: |
+          export PATH="${pythonLocation}/bin:${HOME}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+          qemu_root="${RUNNER_TEMP}/qemu-litex"
+          # Use a mirrored 8.2.x archive so CI is not dependent on download.qemu.org.
+          # Keep parallelism low: this build only feeds one smoke test and can
+          # otherwise hit memory pressure on hosted runners.
+          qemu_build_log="${RUNNER_TEMP}/qemu-litex-build.log"
+          set +e
+          python3 litex/build/sim/qemu/build_qemu_litex.py \
+            --source=archive \
+            --qemu-ref=v8.2.2 \
+            --archive-url=https://sources.cdn.openwrt.org/qemu-8.2.2.tar.xz \
+            --src-dir="${qemu_root}/src" \
+            --install-dir="${qemu_root}/install" \
+            --targets=riscv32-softmmu \
+            --minimal-devices \
+            --system-fdt \
+            --disable-download \
+            --jobs=2 2>&1 | tee "${qemu_build_log}"
+          qemu_build_status=${PIPESTATUS[0]}
+          set -e
+          if [ "${qemu_build_status}" -ne 0 ]; then
+            qemu_build_tail="$(python3 -c 'import pathlib, sys; s = pathlib.Path(sys.argv[1]).read_text(errors="replace").replace("\r", "\n"); s = "\n".join(s.splitlines()[-80:]); print(s.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A"))' "${qemu_build_log}")"
+            echo "::error title=Patched QEMU build failed::${qemu_build_tail}"
+            exit "${qemu_build_status}"
+          fi
+
+      - name: Check patched QEMU
+        if: matrix.group == 1
+        env:
+          LD_LIBRARY_PATH: ""
+          PKG_CONFIG_PATH: ""
+        run: |
+          export PATH="${pythonLocation}/bin:${HOME}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+          qemu_root="${RUNNER_TEMP}/qemu-litex"
+          qemu_check_log="${RUNNER_TEMP}/qemu-litex-check.log"
+          set +e
+          python3 litex/build/sim/qemu/check_qemu_litex.py --variants=rv32 --qemu-dir="${qemu_root}/install/bin" 2>&1 | tee "${qemu_check_log}"
+          qemu_check_status=${PIPESTATUS[0]}
+          set -e
+          if [ "${qemu_check_status}" -ne 0 ]; then
+            qemu_check_tail="$(python3 -c 'import pathlib, sys; s = pathlib.Path(sys.argv[1]).read_text(errors="replace").replace("\r", "\n"); s = "\n".join(s.splitlines()[-80:]); print(s.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A"))' "${qemu_check_log}")"
+            echo "::error title=Patched QEMU check failed::${qemu_check_tail}"
+            exit "${qemu_check_status}"
+          fi
+
+      - name: Run QEMU Co-Simulation Integration Test
+        if: matrix.group == 1
+        env:
+          LITEX_QEMU_COSIM_TEST: "1"
+          LD_LIBRARY_PATH: ""
+          PKG_CONFIG_PATH: ""
+        run: |
+          export PATH="${RUNNER_TEMP}/qemu-litex/install/bin:${pythonLocation}/bin:${HOME}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+          python3 -m pytest -v test/test_integration.py::test_qemu_cpu
 
       # Generate .test_durations so pytest-split's least_duration algorithm
       # can pack shards optimally (longest tests first, fill remaining

--- a/litex/build/sim/core/modules/Makefile
+++ b/litex/build/sim/core/modules/Makefile
@@ -1,5 +1,5 @@
 include ../variables.mak
-MODULES = xgmii_ethernet ethernet serial2console serial2tcp clocker sim_perf spdeeprom gmii_ethernet jtagremote $(if $(VIDEO), video)
+MODULES = xgmii_ethernet ethernet serial2console serial2tcp clocker sim_perf spdeeprom gmii_ethernet jtagremote qemu_axi $(if $(VIDEO), video)
 
 .PHONY: $(MODULES) $(EXTRA_MOD_LIST)
 all: $(MODULES) $(EXTRA_MOD_LIST)

--- a/litex/build/sim/core/modules/qemu_axi/Makefile
+++ b/litex/build/sim/core/modules/qemu_axi/Makefile
@@ -1,0 +1,2 @@
+include ../../variables.mak
+include $(SRC_DIR)/modules/rules.mak

--- a/litex/build/sim/core/modules/qemu_axi/qemu_axi.c
+++ b/litex/build/sim/core/modules/qemu_axi/qemu_axi.c
@@ -1,0 +1,758 @@
+#include "sim_qemu.h"
+
+#define QEMU_AXI_RESP_OKAY 0
+#define QEMU_AXI_RESP_SLVERR 2
+#define QEMU_AXI_SIZE_32B  2
+#define QEMU_AXI_BURST_FIXED 0
+#define QEMU_AXI_BURST_INCR 1
+
+struct session_s {
+  uint8_t  *awvalid;
+  uint8_t  *awready;
+  uint32_t *awaddr;
+  uint8_t  *awburst;
+  uint8_t  *awlen;
+  uint8_t  *awsize;
+  uint8_t  *awlock;
+  uint8_t  *awprot;
+  uint8_t  *awcache;
+  uint8_t  *awqos;
+  uint8_t  *awregion;
+  uint8_t  *awid;
+  uint8_t  *awuser;
+  uint8_t  *wvalid;
+  uint8_t  *wready;
+  uint8_t  *wlast;
+  uint32_t *wdata;
+  uint8_t  *wstrb;
+  uint8_t  *wuser;
+  uint8_t  *bvalid;
+  uint8_t  *bready;
+  uint8_t  *bresp;
+  uint8_t  *bid;
+  uint8_t  *buser;
+  uint8_t  *arvalid;
+  uint8_t  *arready;
+  uint32_t *araddr;
+  uint8_t  *arburst;
+  uint8_t  *arlen;
+  uint8_t  *arsize;
+  uint8_t  *arlock;
+  uint8_t  *arprot;
+  uint8_t  *arcache;
+  uint8_t  *arqos;
+  uint8_t  *arregion;
+  uint8_t  *arid;
+  uint8_t  *aruser;
+  uint8_t  *rvalid;
+  uint8_t  *rready;
+  uint8_t  *rlast;
+  uint8_t  *rresp;
+  uint32_t *rdata;
+  uint8_t  *rid;
+  uint8_t  *ruser;
+  uint8_t  *sys_clk;
+  uint32_t *irq;
+  uint8_t  *reset;
+
+  clk_edge_state_t clk_edge;
+
+  uint8_t  *ram_awvalid;
+  uint8_t  *ram_awready;
+  uint32_t *ram_awaddr;
+  uint8_t  *ram_awburst;
+  uint8_t  *ram_awlen;
+  uint8_t  *ram_awsize;
+  uint8_t  *ram_awlock;
+  uint8_t  *ram_awprot;
+  uint8_t  *ram_awcache;
+  uint8_t  *ram_awqos;
+  uint8_t  *ram_awregion;
+  uint8_t  *ram_awid;
+  uint8_t  *ram_awuser;
+  uint8_t  *ram_wvalid;
+  uint8_t  *ram_wready;
+  uint8_t  *ram_wlast;
+  uint32_t *ram_wdata;
+  uint8_t  *ram_wstrb;
+  uint8_t  *ram_wuser;
+  uint8_t  *ram_bvalid;
+  uint8_t  *ram_bready;
+  uint8_t  *ram_bresp;
+  uint8_t  *ram_bid;
+  uint8_t  *ram_buser;
+  uint8_t  *ram_arvalid;
+  uint8_t  *ram_arready;
+  uint32_t *ram_araddr;
+  uint8_t  *ram_arburst;
+  uint8_t  *ram_arlen;
+  uint8_t  *ram_arsize;
+  uint8_t  *ram_arlock;
+  uint8_t  *ram_arprot;
+  uint8_t  *ram_arcache;
+  uint8_t  *ram_arqos;
+  uint8_t  *ram_arregion;
+  uint8_t  *ram_arid;
+  uint8_t  *ram_aruser;
+  uint8_t  *ram_rvalid;
+  uint8_t  *ram_rready;
+  uint8_t  *ram_rlast;
+  uint8_t  *ram_rresp;
+  uint32_t *ram_rdata;
+  uint8_t  *ram_rid;
+  uint8_t  *ram_ruser;
+
+  int ram_fd;
+  int ram_enabled;
+  char ram_path[512];
+  uint64_t ram_size;
+  uint8_t *ram_mem;
+
+  int ram_write_active;
+  uint32_t ram_wr_addr;
+  uint8_t ram_wr_len;
+  uint8_t ram_wr_size;
+  uint8_t ram_wr_burst;
+  uint8_t ram_wr_id;
+  uint8_t ram_wr_beat;
+  uint8_t ram_wr_resp;
+  int ram_b_valid;
+  uint8_t ram_b_resp;
+  uint8_t ram_b_id;
+
+  int ram_read_active;
+  uint32_t ram_rd_addr;
+  uint8_t ram_rd_len;
+  uint8_t ram_rd_size;
+  uint8_t ram_rd_burst;
+  uint8_t ram_rd_id;
+  uint8_t ram_rd_beat;
+  int ram_r_valid;
+  uint32_t ram_r_data;
+  uint8_t ram_r_resp;
+  uint8_t ram_r_id;
+  uint8_t ram_r_last;
+
+  struct event *ev;
+  int fd;
+  int port;
+  char bind[64];
+  uint8_t rxbuf[LITEX_SIM_QEMU_MSG_SIZE];
+  size_t rx_len;
+
+  int req_valid;
+  int active;
+  int reset_latched;
+  int aw_done;
+  int w_done;
+  int b_seen;
+  int ar_done;
+  int r_seen;
+  uint8_t b_resp;
+  uint8_t r_resp;
+  struct litex_sim_qemu_request_s req;
+  struct litex_sim_qemu_txn_s txns[4];
+  int txn_count;
+  int txn_index;
+  uint64_t resp_data;
+};
+
+static struct event_base *base;
+
+static void qemu_axi_drive_idle(struct session_s *s)
+{
+  if (!s->awvalid) {
+    return;
+  }
+  *s->awvalid = 0;
+  *s->awaddr  = 0;
+  *s->awburst = 0;
+  *s->awlen   = 0;
+  *s->awsize  = 0;
+  *s->awlock  = 0;
+  *s->awprot  = 0;
+  *s->awcache = 0;
+  *s->awqos   = 0;
+  *s->awregion = 0;
+  *s->awid    = 0;
+  *s->awuser  = 0;
+  *s->wvalid  = 0;
+  *s->wlast   = 0;
+  *s->wdata   = 0;
+  *s->wstrb   = 0;
+  *s->wuser   = 0;
+  *s->bready  = 0;
+  *s->arvalid = 0;
+  *s->araddr  = 0;
+  *s->arburst = 0;
+  *s->arlen   = 0;
+  *s->arsize  = 0;
+  *s->arlock  = 0;
+  *s->arprot  = 0;
+  *s->arcache = 0;
+  *s->arqos   = 0;
+  *s->arregion = 0;
+  *s->arid    = 0;
+  *s->aruser  = 0;
+  *s->rready  = 0;
+}
+
+static uint32_t qemu_axi_irq(struct session_s *s)
+{
+  return s->irq ? *s->irq : 0;
+}
+
+static void qemu_axi_latch_reset(struct session_s *s)
+{
+  if (s->reset && *s->reset) {
+    s->reset_latched = 1;
+  }
+}
+
+static uint64_t qemu_axi_reset_status(struct session_s *s)
+{
+  uint64_t reset = s->reset_latched || (s->reset && *s->reset);
+
+  s->reset_latched = 0;
+  return reset;
+}
+
+static void qemu_axi_close_client(struct session_s *s)
+{
+  if (s->ev) {
+    event_del(s->ev);
+    event_free(s->ev);
+    s->ev = NULL;
+  }
+  if (s->fd >= 0) {
+    close(s->fd);
+    s->fd = -1;
+  }
+  s->rx_len = 0;
+  s->req_valid = 0;
+  s->active = 0;
+  qemu_axi_drive_idle(s);
+}
+
+static int qemu_axi_send_response(struct session_s *s, uint16_t status, uint64_t data)
+{
+  int ret;
+
+  ret = litex_sim_qemu_send_response(s->fd, status, qemu_axi_irq(s), data);
+  if (ret != RC_OK) {
+    qemu_axi_close_client(s);
+  }
+  return ret;
+}
+
+static void qemu_axi_read_handler(int fd, short event, void *arg)
+{
+  struct session_s *s = (struct session_s *)arg;
+  enum litex_sim_qemu_read_rc ret;
+
+  (void)event;
+
+  ret = litex_sim_qemu_read_request(fd, s->rxbuf, &s->rx_len,
+    &s->req_valid, &s->req);
+  if (ret == LITEX_SIM_QEMU_READ_CLOSED) {
+    qemu_axi_close_client(s);
+  } else if (ret == LITEX_SIM_QEMU_READ_BAD_REQ) {
+    qemu_axi_send_response(s, LITEX_SIM_QEMU_STATUS_BAD_REQ, 0);
+  }
+}
+
+static void qemu_axi_accept_cb(struct evconnlistener *listener,
+  evutil_socket_t fd, struct sockaddr *address, int socklen, void *ctx)
+{
+  struct session_s *s = (struct session_s *)ctx;
+
+  (void)listener;
+  (void)address;
+  (void)socklen;
+
+  qemu_axi_close_client(s);
+  s->fd = fd;
+  evutil_make_socket_nonblocking(fd);
+  s->ev = event_new(base, fd, EV_READ | EV_PERSIST, qemu_axi_read_handler, s);
+  event_add(s->ev, NULL);
+  printf("[qemu_axi] client connected\n");
+}
+
+static void qemu_axi_accept_error_cb(struct evconnlistener *listener, void *ctx)
+{
+  struct event_base *event_base = evconnlistener_get_base(listener);
+
+  (void)ctx;
+  fprintf(stderr, "[qemu_axi] listener error\n");
+  event_base_loopexit(event_base, NULL);
+}
+
+static int qemu_axi_start(void *b)
+{
+  base = (struct event_base *)b;
+  printf("[qemu_axi] loaded (%p)\n", base);
+  return RC_OK;
+}
+
+static int qemu_axi_new(void **sess, char *args)
+{
+  int ret = RC_OK;
+  struct session_s *s = NULL;
+
+  if (!sess) {
+    return RC_INVARG;
+  }
+
+  s = (struct session_s *)malloc(sizeof(struct session_s));
+  if (!s) {
+    return RC_NOENMEM;
+  }
+  memset(s, 0, sizeof(struct session_s));
+  s->fd = -1;
+  s->ram_fd = -1;
+
+  ret = litex_sim_qemu_parse_bridge_args(args, s->bind, sizeof(s->bind),
+    &s->port, "qemu_axi");
+  if (ret != RC_OK) {
+    goto out;
+  }
+
+  ret = litex_sim_qemu_mem_parse_optional_args(args, s->ram_path, sizeof(s->ram_path),
+    &s->ram_size, &s->ram_enabled, "qemu_axi");
+  if (ret != RC_OK) {
+    goto out;
+  }
+
+  if (s->ram_enabled) {
+    ret = litex_sim_qemu_mem_map(&s->ram_fd, &s->ram_mem,
+      s->ram_path, s->ram_size, "qemu_axi");
+    if (ret != RC_OK) {
+      goto out;
+    }
+  }
+
+  ret = litex_sim_qemu_listen(base, "qemu_axi", s->bind, s->port,
+    qemu_axi_accept_cb, qemu_axi_accept_error_cb, s);
+
+out:
+  *sess = (void *)s;
+  return ret;
+}
+
+static int qemu_axi_add_pads(void *sess, struct pad_list_s *plist)
+{
+  int ret = RC_OK;
+  struct session_s *s = (struct session_s *)sess;
+  struct pad_s *pads;
+
+  if (!sess || !plist) {
+    return RC_INVARG;
+  }
+
+  pads = plist->pads;
+  if (!strcmp(plist->name, "qemu_axi")) {
+    ret |= litex_sim_qemu_pads_get(pads, "awvalid",  (void **)&s->awvalid,  "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awready",  (void **)&s->awready,  "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awaddr",   (void **)&s->awaddr,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awburst",  (void **)&s->awburst,  "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awlen",    (void **)&s->awlen,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awsize",   (void **)&s->awsize,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awlock",   (void **)&s->awlock,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awprot",   (void **)&s->awprot,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awcache",  (void **)&s->awcache,  "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awqos",    (void **)&s->awqos,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awregion", (void **)&s->awregion, "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awid",     (void **)&s->awid,     "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awuser",   (void **)&s->awuser,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "wvalid",   (void **)&s->wvalid,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "wready",   (void **)&s->wready,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "wlast",    (void **)&s->wlast,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "wdata",    (void **)&s->wdata,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "wstrb",    (void **)&s->wstrb,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "wuser",    (void **)&s->wuser,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "bvalid",   (void **)&s->bvalid,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "bready",   (void **)&s->bready,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "bresp",    (void **)&s->bresp,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "bid",      (void **)&s->bid,      "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "buser",    (void **)&s->buser,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arvalid",  (void **)&s->arvalid,  "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arready",  (void **)&s->arready,  "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "araddr",   (void **)&s->araddr,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arburst",  (void **)&s->arburst,  "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arlen",    (void **)&s->arlen,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arsize",   (void **)&s->arsize,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arlock",   (void **)&s->arlock,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arprot",   (void **)&s->arprot,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arcache",  (void **)&s->arcache,  "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arqos",    (void **)&s->arqos,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arregion", (void **)&s->arregion, "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arid",     (void **)&s->arid,     "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "aruser",   (void **)&s->aruser,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "rvalid",   (void **)&s->rvalid,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "rready",   (void **)&s->rready,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "rlast",    (void **)&s->rlast,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "rresp",    (void **)&s->rresp,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "rdata",    (void **)&s->rdata,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "rid",      (void **)&s->rid,      "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "ruser",    (void **)&s->ruser,    "qemu_axi");
+  } else if (!strcmp(plist->name, "qemu_axi_shared_ram")) {
+    ret |= litex_sim_qemu_pads_get(pads, "awvalid",  (void **)&s->ram_awvalid,  "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awready",  (void **)&s->ram_awready,  "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awaddr",   (void **)&s->ram_awaddr,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awburst",  (void **)&s->ram_awburst,  "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awlen",    (void **)&s->ram_awlen,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awsize",   (void **)&s->ram_awsize,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awlock",   (void **)&s->ram_awlock,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awprot",   (void **)&s->ram_awprot,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awcache",  (void **)&s->ram_awcache,  "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awqos",    (void **)&s->ram_awqos,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awregion", (void **)&s->ram_awregion, "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awid",     (void **)&s->ram_awid,     "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "awuser",   (void **)&s->ram_awuser,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "wvalid",   (void **)&s->ram_wvalid,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "wready",   (void **)&s->ram_wready,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "wlast",    (void **)&s->ram_wlast,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "wdata",    (void **)&s->ram_wdata,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "wstrb",    (void **)&s->ram_wstrb,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "wuser",    (void **)&s->ram_wuser,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "bvalid",   (void **)&s->ram_bvalid,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "bready",   (void **)&s->ram_bready,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "bresp",    (void **)&s->ram_bresp,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "bid",      (void **)&s->ram_bid,      "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "buser",    (void **)&s->ram_buser,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arvalid",  (void **)&s->ram_arvalid,  "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arready",  (void **)&s->ram_arready,  "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "araddr",   (void **)&s->ram_araddr,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arburst",  (void **)&s->ram_arburst,  "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arlen",    (void **)&s->ram_arlen,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arsize",   (void **)&s->ram_arsize,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arlock",   (void **)&s->ram_arlock,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arprot",   (void **)&s->ram_arprot,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arcache",  (void **)&s->ram_arcache,  "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arqos",    (void **)&s->ram_arqos,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arregion", (void **)&s->ram_arregion, "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "arid",     (void **)&s->ram_arid,     "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "aruser",   (void **)&s->ram_aruser,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "rvalid",   (void **)&s->ram_rvalid,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "rready",   (void **)&s->ram_rready,   "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "rlast",    (void **)&s->ram_rlast,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "rresp",    (void **)&s->ram_rresp,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "rdata",    (void **)&s->ram_rdata,    "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "rid",      (void **)&s->ram_rid,      "qemu_axi");
+    ret |= litex_sim_qemu_pads_get(pads, "ruser",    (void **)&s->ram_ruser,    "qemu_axi");
+  } else if (!strcmp(plist->name, "qemu_irq")) {
+    ret |= litex_sim_qemu_pads_get(pads, "qemu_irq", (void **)&s->irq, "qemu_axi");
+  } else if (!strcmp(plist->name, "qemu_reset")) {
+    ret |= litex_sim_qemu_pads_get(pads, "qemu_reset", (void **)&s->reset, "qemu_axi");
+  } else if (!strcmp(plist->name, "sys_clk")) {
+    ret |= litex_sim_qemu_pads_get(pads, "sys_clk", (void **)&s->sys_clk, "qemu_axi");
+  }
+
+  return ret;
+}
+
+static uint8_t qemu_axi_shared_ram_write(struct session_s *s,
+  uint32_t addr, uint32_t data, uint8_t strb)
+{
+  uint64_t word_addr = (uint64_t)addr & ~3ULL;
+
+  if (word_addr + 4 > s->ram_size) {
+    return QEMU_AXI_RESP_SLVERR;
+  }
+
+  litex_sim_qemu_mem_write32(s->ram_mem, word_addr, data, strb);
+  return QEMU_AXI_RESP_OKAY;
+}
+
+static uint8_t qemu_axi_shared_ram_read(struct session_s *s, uint32_t addr, uint32_t *data)
+{
+  uint64_t word_addr = (uint64_t)addr & ~3ULL;
+
+  if (word_addr + 4 > s->ram_size) {
+    *data = 0;
+    return QEMU_AXI_RESP_SLVERR;
+  }
+
+  *data = litex_sim_qemu_mem_read32(s->ram_mem, word_addr);
+  return QEMU_AXI_RESP_OKAY;
+}
+
+static uint32_t qemu_axi_shared_ram_next_addr(uint32_t addr, uint8_t size, uint8_t burst)
+{
+  uint32_t step = 1u << size;
+
+  if (step > 4) {
+    step = 4;
+  }
+  if (burst == QEMU_AXI_BURST_FIXED) {
+    return addr;
+  }
+  return addr + step;
+}
+
+static void qemu_axi_shared_ram_drive(struct session_s *s)
+{
+  *s->ram_awready = !s->ram_write_active && !s->ram_b_valid;
+  *s->ram_wready  = s->ram_write_active && !s->ram_b_valid;
+  *s->ram_bvalid  = s->ram_b_valid;
+  *s->ram_bresp   = s->ram_b_resp;
+  *s->ram_bid     = s->ram_b_id;
+  *s->ram_buser   = 0;
+  *s->ram_arready = !s->ram_read_active && !s->ram_r_valid;
+  *s->ram_rvalid  = s->ram_r_valid;
+  *s->ram_rresp   = s->ram_r_resp;
+  *s->ram_rdata   = s->ram_r_data;
+  *s->ram_rid     = s->ram_r_id;
+  *s->ram_rlast   = s->ram_r_last;
+  *s->ram_ruser   = 0;
+}
+
+static void qemu_axi_shared_ram_start_read_beat(struct session_s *s)
+{
+  s->ram_r_resp = qemu_axi_shared_ram_read(s, s->ram_rd_addr, &s->ram_r_data);
+  s->ram_r_id = s->ram_rd_id;
+  s->ram_r_last = s->ram_rd_beat >= s->ram_rd_len;
+  s->ram_r_valid = 1;
+
+  if (!s->ram_r_last) {
+    s->ram_rd_beat++;
+    s->ram_rd_addr = qemu_axi_shared_ram_next_addr(
+      s->ram_rd_addr, s->ram_rd_size, s->ram_rd_burst);
+  }
+}
+
+static void qemu_axi_shared_ram_tick(struct session_s *s)
+{
+  if (!s->ram_enabled || !s->ram_awvalid) {
+    return;
+  }
+
+  if (s->ram_b_valid && *s->ram_bready) {
+    s->ram_b_valid = 0;
+  }
+
+  if (s->ram_r_valid && *s->ram_rready) {
+    if (s->ram_r_last) {
+      s->ram_read_active = 0;
+    }
+    s->ram_r_valid = 0;
+  }
+
+  if (!s->ram_write_active && !s->ram_b_valid && *s->ram_awvalid) {
+    s->ram_write_active = 1;
+    s->ram_wr_addr  = *s->ram_awaddr;
+    s->ram_wr_len   = *s->ram_awlen;
+    s->ram_wr_size  = *s->ram_awsize;
+    s->ram_wr_burst = *s->ram_awburst;
+    s->ram_wr_id    = *s->ram_awid;
+    s->ram_wr_beat  = 0;
+    s->ram_wr_resp  = QEMU_AXI_RESP_OKAY;
+  }
+
+  if (s->ram_write_active && !s->ram_b_valid && *s->ram_wvalid) {
+    uint8_t resp = qemu_axi_shared_ram_write(s,
+      s->ram_wr_addr, *s->ram_wdata, *s->ram_wstrb);
+    if (resp != QEMU_AXI_RESP_OKAY) {
+      s->ram_wr_resp = resp;
+    }
+    if (*s->ram_wlast || s->ram_wr_beat >= s->ram_wr_len) {
+      s->ram_b_resp = s->ram_wr_resp;
+      s->ram_b_id = s->ram_wr_id;
+      s->ram_b_valid = 1;
+      s->ram_write_active = 0;
+    } else {
+      s->ram_wr_beat++;
+      s->ram_wr_addr = qemu_axi_shared_ram_next_addr(
+        s->ram_wr_addr, s->ram_wr_size, s->ram_wr_burst);
+    }
+  }
+
+  if (!s->ram_read_active && !s->ram_r_valid && *s->ram_arvalid) {
+    s->ram_read_active = 1;
+    s->ram_rd_addr  = *s->ram_araddr;
+    s->ram_rd_len   = *s->ram_arlen;
+    s->ram_rd_size  = *s->ram_arsize;
+    s->ram_rd_burst = *s->ram_arburst;
+    s->ram_rd_id    = *s->ram_arid;
+    s->ram_rd_beat  = 0;
+  }
+
+  if (s->ram_read_active && !s->ram_r_valid) {
+    qemu_axi_shared_ram_start_read_beat(s);
+  }
+
+  qemu_axi_shared_ram_drive(s);
+}
+
+static int qemu_axi_build_txns(struct session_s *s)
+{
+  s->txn_index = 0;
+  return litex_sim_qemu_build_txns(s->txns,
+    sizeof(s->txns) / sizeof(s->txns[0]),
+    &s->txn_count, &s->resp_data,
+    s->req.addr, s->req.data, s->req.size);
+}
+
+static void qemu_axi_reset_txn_state(struct session_s *s)
+{
+  s->aw_done = 0;
+  s->w_done = 0;
+  s->b_seen = 0;
+  s->ar_done = 0;
+  s->r_seen = 0;
+  s->b_resp = 0;
+  s->r_resp = 0;
+}
+
+static void qemu_axi_capture_read(struct session_s *s)
+{
+  litex_sim_qemu_capture_read(&s->txns[s->txn_index],
+    *s->rdata, &s->resp_data);
+}
+
+static void qemu_axi_finish_txn(struct session_s *s, uint8_t resp)
+{
+  if (resp != QEMU_AXI_RESP_OKAY) {
+    qemu_axi_send_response(s, LITEX_SIM_QEMU_STATUS_ERR, 0);
+    s->active = 0;
+    s->req_valid = 0;
+    return;
+  }
+
+  s->txn_index++;
+  if (s->txn_index >= s->txn_count) {
+    qemu_axi_send_response(s, LITEX_SIM_QEMU_STATUS_OK, s->resp_data);
+    s->active = 0;
+    s->req_valid = 0;
+  } else {
+    qemu_axi_reset_txn_state(s);
+  }
+}
+
+static void qemu_axi_drive_txn(struct session_s *s)
+{
+  struct litex_sim_qemu_txn_s *txn = &s->txns[s->txn_index];
+
+  if (s->req.op == LITEX_SIM_QEMU_OP_WRITE) {
+    *s->awvalid = !s->aw_done;
+    *s->awaddr  = txn->addr;
+    *s->awburst = QEMU_AXI_BURST_INCR;
+    *s->awlen   = 0;
+    *s->awsize  = QEMU_AXI_SIZE_32B;
+    *s->awlock  = 0;
+    *s->awprot  = 0;
+    *s->awcache = 0x3;
+    *s->awqos   = 0;
+    *s->awregion = 0;
+    *s->awid    = 0;
+    *s->awuser  = 0;
+    *s->wvalid  = !s->w_done;
+    *s->wlast   = 1;
+    *s->wdata   = txn->data;
+    *s->wstrb   = txn->strb;
+    *s->wuser   = 0;
+    *s->bready  = s->b_seen;
+    *s->arvalid = 0;
+    *s->rready  = 0;
+  } else {
+    *s->awvalid = 0;
+    *s->wvalid  = 0;
+    *s->bready  = 0;
+    *s->arvalid = !s->ar_done;
+    *s->araddr  = txn->addr;
+    *s->arburst = QEMU_AXI_BURST_INCR;
+    *s->arlen   = 0;
+    *s->arsize  = QEMU_AXI_SIZE_32B;
+    *s->arlock  = 0;
+    *s->arprot  = 0;
+    *s->arcache = 0x3;
+    *s->arqos   = 0;
+    *s->arregion = 0;
+    *s->arid    = 0;
+    *s->aruser  = 0;
+    *s->rready  = s->r_seen;
+  }
+}
+
+static int qemu_axi_tick(void *sess, uint64_t time_ps)
+{
+  struct session_s *s = (struct session_s *)sess;
+
+  (void)time_ps;
+
+  if (!s || !s->sys_clk || !clk_pos_edge(&s->clk_edge, *s->sys_clk)) {
+    return RC_OK;
+  }
+  qemu_axi_latch_reset(s);
+  qemu_axi_shared_ram_tick(s);
+
+  if (s->active && s->req.op == LITEX_SIM_QEMU_OP_WRITE) {
+    int aw_valid = !s->aw_done;
+    int w_valid  = (s->aw_done || (aw_valid && *s->awready)) && !s->w_done;
+    if (s->b_seen) {
+      qemu_axi_finish_txn(s, s->b_resp);
+    } else {
+      if (aw_valid && *s->awready) {
+        s->aw_done = 1;
+      }
+      if (w_valid && *s->wready) {
+        s->w_done = 1;
+      }
+      if (*s->bvalid) {
+        s->b_resp = *s->bresp;
+        s->b_seen = 1;
+      }
+    }
+  }
+
+  if (s->active && s->req.op == LITEX_SIM_QEMU_OP_READ) {
+    int ar_valid = !s->ar_done;
+    if (s->r_seen) {
+      qemu_axi_finish_txn(s, s->r_resp);
+    } else {
+      if (ar_valid && *s->arready) {
+        s->ar_done = 1;
+      }
+      if (*s->rvalid) {
+        qemu_axi_capture_read(s);
+        s->r_resp = *s->rresp;
+        s->r_seen = 1;
+      }
+    }
+  }
+
+  if (!s->active && s->req_valid) {
+    if (s->req.op == LITEX_SIM_QEMU_OP_IRQ) {
+      qemu_axi_send_response(s, LITEX_SIM_QEMU_STATUS_OK, qemu_axi_reset_status(s));
+      s->req_valid = 0;
+    } else if (qemu_axi_build_txns(s) != RC_OK) {
+      qemu_axi_send_response(s, LITEX_SIM_QEMU_STATUS_BAD_REQ, 0);
+      s->req_valid = 0;
+    } else {
+      qemu_axi_reset_txn_state(s);
+      s->active = 1;
+    }
+  }
+
+  if (s->active) {
+    qemu_axi_drive_txn(s);
+  } else {
+    qemu_axi_drive_idle(s);
+  }
+
+  return RC_OK;
+}
+
+static struct ext_module_s ext_mod = {
+  "qemu_axi",
+  qemu_axi_start,
+  qemu_axi_new,
+  qemu_axi_add_pads,
+  NULL,
+  qemu_axi_tick
+};
+
+int litex_sim_ext_module_init(int (*register_module)(struct ext_module_s *))
+{
+  return register_module(&ext_mod);
+}

--- a/litex/build/sim/core/sim_qemu.h
+++ b/litex/build/sim/core/sim_qemu.h
@@ -1,0 +1,464 @@
+#ifndef LITEX_BUILD_SIM_CORE_SIM_QEMU_H
+#define LITEX_BUILD_SIM_CORE_SIM_QEMU_H
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <arpa/inet.h>
+#include <event2/event.h>
+#include <event2/listener.h>
+#include <event2/util.h>
+#include <json-c/json.h>
+
+#include "error.h"
+#include "modules.h"
+
+#define LITEX_SIM_QEMU_REQ_MAGIC 0x3051584c /* "LXQ0" */
+#define LITEX_SIM_QEMU_RSP_MAGIC 0x3052584c /* "LXR0" */
+#define LITEX_SIM_QEMU_VERSION   1
+#define LITEX_SIM_QEMU_MSG_SIZE  32
+
+enum litex_sim_qemu_op {
+  LITEX_SIM_QEMU_OP_READ  = 0,
+  LITEX_SIM_QEMU_OP_WRITE = 1,
+  LITEX_SIM_QEMU_OP_IRQ   = 2,
+};
+
+enum litex_sim_qemu_status {
+  LITEX_SIM_QEMU_STATUS_OK      = 0,
+  LITEX_SIM_QEMU_STATUS_ERR     = 1,
+  LITEX_SIM_QEMU_STATUS_BAD_REQ = 2,
+};
+
+struct litex_sim_qemu_request_s {
+  uint16_t op;
+  uint32_t size;
+  uint64_t addr;
+  uint64_t data;
+};
+
+struct litex_sim_qemu_txn_s {
+  uint32_t addr;
+  uint32_t data;
+  uint8_t strb;
+  uint8_t bytes;
+  uint8_t offset;
+  uint8_t resp_shift;
+};
+
+enum litex_sim_qemu_read_rc {
+  LITEX_SIM_QEMU_READ_OK = 0,
+  LITEX_SIM_QEMU_READ_BAD_REQ,
+  LITEX_SIM_QEMU_READ_CLOSED,
+};
+
+static inline uint16_t litex_sim_qemu_rd_le16(const uint8_t *p)
+{
+  return ((uint16_t)p[0]) | ((uint16_t)p[1] << 8);
+}
+
+static inline uint32_t litex_sim_qemu_rd_le32(const uint8_t *p)
+{
+  return ((uint32_t)p[0]) |
+    ((uint32_t)p[1] << 8) |
+    ((uint32_t)p[2] << 16) |
+    ((uint32_t)p[3] << 24);
+}
+
+static inline uint64_t litex_sim_qemu_rd_le64(const uint8_t *p)
+{
+  return ((uint64_t)litex_sim_qemu_rd_le32(p)) |
+    ((uint64_t)litex_sim_qemu_rd_le32(p + 4) << 32);
+}
+
+static inline void litex_sim_qemu_wr_le16(uint8_t *p, uint16_t v)
+{
+  p[0] = v & 0xff;
+  p[1] = (v >> 8) & 0xff;
+}
+
+static inline void litex_sim_qemu_wr_le32(uint8_t *p, uint32_t v)
+{
+  p[0] = v & 0xff;
+  p[1] = (v >> 8) & 0xff;
+  p[2] = (v >> 16) & 0xff;
+  p[3] = (v >> 24) & 0xff;
+}
+
+static inline void litex_sim_qemu_wr_le64(uint8_t *p, uint64_t v)
+{
+  litex_sim_qemu_wr_le32(p, v & 0xffffffffu);
+  litex_sim_qemu_wr_le32(p + 4, v >> 32);
+}
+
+static inline int litex_sim_qemu_pads_get(struct pad_s *pads, const char *name,
+  void **signal, const char *module_name)
+{
+  int i;
+
+  if (!pads || !name || !signal) {
+    return RC_INVARG;
+  }
+
+  *signal = NULL;
+  for (i = 0; pads[i].name; i++) {
+    if (!strcmp(pads[i].name, name)) {
+      *signal = pads[i].signal;
+      return RC_OK;
+    }
+  }
+
+  fprintf(stderr, "[%s] missing pad: %s\n", module_name, name);
+  return RC_ERROR;
+}
+
+static inline int litex_sim_qemu_parse_bridge_args(char *args, char *bind,
+  size_t bind_size, int *port, const char *module_name)
+{
+  json_object *args_json = NULL;
+  json_object *obj = NULL;
+
+  *port = 1235;
+  snprintf(bind, bind_size, "%s", "127.0.0.1");
+
+  if (!args) {
+    return RC_OK;
+  }
+
+  args_json = json_tokener_parse(args);
+  if (!args_json) {
+    fprintf(stderr, "[%s] could not parse args: %s\n", module_name, args);
+    return RC_JSERROR;
+  }
+
+  if (json_object_object_get_ex(args_json, "port", &obj)) {
+    *port = json_object_get_int(obj);
+  }
+  if (json_object_object_get_ex(args_json, "bind", &obj)) {
+    snprintf(bind, bind_size, "%s", json_object_get_string(obj));
+  }
+
+  json_object_put(args_json);
+  return RC_OK;
+}
+
+static inline int litex_sim_qemu_parse_request(const uint8_t *rxbuf,
+  struct litex_sim_qemu_request_s *req)
+{
+  uint32_t magic = litex_sim_qemu_rd_le32(rxbuf + 0);
+  uint16_t version = litex_sim_qemu_rd_le16(rxbuf + 4);
+  uint16_t op = litex_sim_qemu_rd_le16(rxbuf + 6);
+  uint32_t size = litex_sim_qemu_rd_le32(rxbuf + 8);
+
+  if (magic != LITEX_SIM_QEMU_REQ_MAGIC || version != LITEX_SIM_QEMU_VERSION) {
+    return RC_ERROR;
+  }
+
+  if (op == LITEX_SIM_QEMU_OP_IRQ) {
+    if (size != 0) {
+      return RC_ERROR;
+    }
+  } else if ((op != LITEX_SIM_QEMU_OP_READ && op != LITEX_SIM_QEMU_OP_WRITE) ||
+             (size != 1 && size != 2 && size != 4 && size != 8)) {
+    return RC_ERROR;
+  }
+
+  req->op   = op;
+  req->size = size;
+  req->addr = litex_sim_qemu_rd_le64(rxbuf + 16);
+  req->data = litex_sim_qemu_rd_le64(rxbuf + 24);
+  return RC_OK;
+}
+
+static inline enum litex_sim_qemu_read_rc litex_sim_qemu_read_request(int fd,
+  uint8_t *rxbuf, size_t *rx_len, int *req_valid,
+  struct litex_sim_qemu_request_s *req)
+{
+  while (*rx_len < LITEX_SIM_QEMU_MSG_SIZE && !*req_valid) {
+    ssize_t r = recv(fd, rxbuf + *rx_len, LITEX_SIM_QEMU_MSG_SIZE - *rx_len, 0);
+    if (r > 0) {
+      *rx_len += (size_t)r;
+      continue;
+    }
+    if (r == 0) {
+      return LITEX_SIM_QEMU_READ_CLOSED;
+    }
+    if (errno == EINTR) {
+      continue;
+    }
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      break;
+    }
+    return LITEX_SIM_QEMU_READ_CLOSED;
+  }
+
+  if (*rx_len == LITEX_SIM_QEMU_MSG_SIZE) {
+    *rx_len = 0;
+    if (litex_sim_qemu_parse_request(rxbuf, req) != RC_OK) {
+      return LITEX_SIM_QEMU_READ_BAD_REQ;
+    }
+    *req_valid = 1;
+  }
+
+  return LITEX_SIM_QEMU_READ_OK;
+}
+
+static inline int litex_sim_qemu_send_response(int fd, uint16_t status,
+  uint32_t irq, uint64_t data)
+{
+  uint8_t rsp[LITEX_SIM_QEMU_MSG_SIZE];
+  size_t done = 0;
+
+  if (fd < 0) {
+    return RC_ERROR;
+  }
+
+  memset(rsp, 0, sizeof(rsp));
+  litex_sim_qemu_wr_le32(rsp + 0, LITEX_SIM_QEMU_RSP_MAGIC);
+  litex_sim_qemu_wr_le16(rsp + 4, LITEX_SIM_QEMU_VERSION);
+  litex_sim_qemu_wr_le16(rsp + 6, status);
+  litex_sim_qemu_wr_le32(rsp + 8, irq);
+  litex_sim_qemu_wr_le64(rsp + 16, data);
+
+  while (done < sizeof(rsp)) {
+    ssize_t r = send(fd, rsp + done, sizeof(rsp) - done, 0);
+    if (r > 0) {
+      done += (size_t)r;
+      continue;
+    }
+    if (r < 0 && errno == EINTR) {
+      continue;
+    }
+    if (r < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+      return RC_OK;
+    }
+    return RC_ERROR;
+  }
+
+  return RC_OK;
+}
+
+static inline int litex_sim_qemu_listen(struct event_base *base,
+  const char *module_name, const char *bind, int port,
+  evconnlistener_cb accept_cb, evconnlistener_errorcb error_cb, void *ctx)
+{
+  struct evconnlistener *listener;
+  struct sockaddr_in sin;
+
+  memset(&sin, 0, sizeof(sin));
+  sin.sin_family = AF_INET;
+  sin.sin_port = htons((uint16_t)port);
+  if (inet_pton(AF_INET, bind, &sin.sin_addr) != 1) {
+    fprintf(stderr, "[%s] invalid bind address: %s\n", module_name, bind);
+    return RC_ERROR;
+  }
+
+  listener = evconnlistener_new_bind(base, accept_cb, ctx,
+    LEV_OPT_CLOSE_ON_FREE | LEV_OPT_REUSEABLE, -1,
+    (struct sockaddr *)&sin, sizeof(sin));
+  if (!listener) {
+    fprintf(stderr, "[%s] could not bind %s:%d\n", module_name, bind, port);
+    return RC_ERROR;
+  }
+  evconnlistener_set_error_cb(listener, error_cb);
+  printf("[%s] listening on %s:%d\n", module_name, bind, port);
+
+  return RC_OK;
+}
+
+static inline int litex_sim_qemu_build_txns(struct litex_sim_qemu_txn_s *txns,
+  int max_txns, int *txn_count, uint64_t *resp_data, uint64_t addr,
+  uint64_t data, uint32_t size)
+{
+  uint32_t remaining = size;
+  uint8_t resp_shift = 0;
+
+  *txn_count = 0;
+  *resp_data = 0;
+
+  while (remaining) {
+    struct litex_sim_qemu_txn_s *txn;
+    uint8_t offset = addr & 0x3;
+    uint8_t bytes = 4 - offset;
+    uint8_t i;
+
+    if (bytes > remaining) {
+      bytes = remaining;
+    }
+    if (*txn_count >= max_txns) {
+      return RC_ERROR;
+    }
+
+    txn = &txns[(*txn_count)++];
+    memset(txn, 0, sizeof(*txn));
+    txn->addr = addr;
+    txn->bytes = bytes;
+    txn->offset = offset;
+    txn->resp_shift = resp_shift;
+    txn->strb = ((1u << bytes) - 1u) << offset;
+
+    for (i = 0; i < bytes; i++) {
+      uint8_t byte = (data >> ((resp_shift + i) * 8)) & 0xff;
+      txn->data |= ((uint32_t)byte) << ((offset + i) * 8);
+    }
+
+    addr += bytes;
+    remaining -= bytes;
+    resp_shift += bytes;
+  }
+
+  return RC_OK;
+}
+
+static inline void litex_sim_qemu_capture_read(struct litex_sim_qemu_txn_s *txn,
+  uint32_t word, uint64_t *resp_data)
+{
+  uint8_t i;
+
+  for (i = 0; i < txn->bytes; i++) {
+    uint8_t byte = (word >> ((txn->offset + i) * 8)) & 0xff;
+    *resp_data |= ((uint64_t)byte) << ((txn->resp_shift + i) * 8);
+  }
+}
+
+static inline uint64_t litex_sim_qemu_mem_parse_size(const char *value)
+{
+  char *end = NULL;
+  uint64_t size;
+
+  if (!value) {
+    return 0;
+  }
+
+  errno = 0;
+  size = strtoull(value, &end, 0);
+  if (errno || end == value) {
+    return 0;
+  }
+
+  if (!strcmp(end, "K") || !strcmp(end, "k")) {
+    size *= 1024ULL;
+  } else if (!strcmp(end, "M") || !strcmp(end, "m")) {
+    size *= 1024ULL * 1024ULL;
+  } else if (!strcmp(end, "G") || !strcmp(end, "g")) {
+    size *= 1024ULL * 1024ULL * 1024ULL;
+  } else if (*end != '\0') {
+    return 0;
+  }
+
+  return size;
+}
+
+static inline int litex_sim_qemu_mem_parse_optional_args(char *args, char *path,
+  size_t path_size, uint64_t *size, int *enabled, const char *module_name)
+{
+  json_object *args_json = NULL;
+  json_object *obj = NULL;
+
+  snprintf(path, path_size, "%s", "qemu-main-ram.bin");
+  *size = 0;
+  *enabled = 0;
+
+  if (!args) {
+    return RC_OK;
+  }
+
+  args_json = json_tokener_parse(args);
+  if (!args_json) {
+    fprintf(stderr, "[%s] could not parse args: %s\n", module_name, args);
+    return RC_JSERROR;
+  }
+
+  if (json_object_object_get_ex(args_json, "path", &obj)) {
+    snprintf(path, path_size, "%s", json_object_get_string(obj));
+  }
+  if (json_object_object_get_ex(args_json, "size", &obj)) {
+    *enabled = 1;
+    if (json_object_get_type(obj) == json_type_string) {
+      *size = litex_sim_qemu_mem_parse_size(json_object_get_string(obj));
+    } else {
+      *size = (uint64_t)json_object_get_int64(obj);
+    }
+  }
+
+  json_object_put(args_json);
+
+  if (*enabled && *size == 0) {
+    fprintf(stderr, "[%s] invalid size\n", module_name);
+    return RC_INVARG;
+  }
+
+  return RC_OK;
+}
+
+static inline int litex_sim_qemu_mem_map(int *fd, uint8_t **mem,
+  const char *path, uint64_t size, const char *module_name)
+{
+  *fd = open(path, O_RDWR | O_CREAT, 0666);
+  if (*fd < 0) {
+    fprintf(stderr, "[%s] could not open %s: %s\n", module_name, path, strerror(errno));
+    return RC_ERROR;
+  }
+
+  if (ftruncate(*fd, (off_t)size) < 0) {
+    fprintf(stderr, "[%s] could not size %s: %s\n", module_name, path, strerror(errno));
+    close(*fd);
+    *fd = -1;
+    return RC_ERROR;
+  }
+
+  *mem = mmap(NULL, (size_t)size, PROT_READ | PROT_WRITE, MAP_SHARED, *fd, 0);
+  if (*mem == MAP_FAILED) {
+    *mem = NULL;
+    fprintf(stderr, "[%s] could not mmap %s: %s\n", module_name, path, strerror(errno));
+    close(*fd);
+    *fd = -1;
+    return RC_ERROR;
+  }
+
+  printf("[%s] mapped %s (%llu bytes)\n",
+    module_name, path, (unsigned long long)size);
+
+  return RC_OK;
+}
+
+static inline int litex_sim_qemu_mem_close(int fd, uint8_t *mem, uint64_t size)
+{
+  if (mem) {
+    munmap(mem, (size_t)size);
+  }
+  if (fd >= 0) {
+    close(fd);
+  }
+  return RC_OK;
+}
+
+static inline uint32_t litex_sim_qemu_mem_read32(uint8_t *mem, uint64_t addr)
+{
+  return ((uint32_t)mem[addr + 0]) |
+    ((uint32_t)mem[addr + 1] << 8) |
+    ((uint32_t)mem[addr + 2] << 16) |
+    ((uint32_t)mem[addr + 3] << 24);
+}
+
+static inline void litex_sim_qemu_mem_write32(uint8_t *mem, uint64_t addr,
+  uint32_t data, uint8_t sel)
+{
+  int i;
+
+  for (i = 0; i < 4; i++) {
+    if (sel & (1 << i)) {
+      mem[addr + i] = (data >> (8 * i)) & 0xff;
+    }
+  }
+}
+
+#endif /* LITEX_BUILD_SIM_CORE_SIM_QEMU_H */

--- a/litex/build/sim/qemu/README.md
+++ b/litex/build/sim/qemu/README.md
@@ -1,0 +1,206 @@
+# LiteX SIM QEMU Co-Simulation Bridge
+
+This directory documents the QEMU-side contract used by `litex_sim --cpu-type=qemu`.
+The LiteX repository does not contain QEMU sources, so the actual QEMU machine/device
+has to be added to a QEMU checkout.
+
+## Build Patched QEMU
+
+The helper below clones QEMU `v8.2.4`, applies `qemu-litex-sim-v8.2.4.patch`,
+builds the RV32/RV64 system emulators, and copies the binaries to
+`build/qemu-litex/bin/`:
+
+```sh
+python3 litex/build/sim/qemu/build_qemu_litex.py
+```
+
+For CI or reproducible local builds without a QEMU git checkout, use the
+official release archive:
+
+```sh
+python3 litex/build/sim/qemu/build_qemu_litex.py --source=archive
+```
+
+The resulting binaries can be passed directly to `litex_sim`:
+
+```sh
+python3 -m litex.tools.litex_sim \
+  --cpu-type=qemu \
+  --cpu-variant=rv32 \
+  --qemu-binary build/qemu-litex/bin/qemu-system-riscv32
+```
+
+When the helper-installed binary exists, `litex_sim` will also find it
+automatically for the selected RV32/RV64 variant.
+
+RV64 is selected with `--cpu-variant=rv64`:
+
+```sh
+python3 -m litex.tools.litex_sim \
+  --cpu-type=qemu \
+  --cpu-variant=rv64
+```
+
+To only check that the patched machine is present:
+
+```sh
+python3 litex/build/sim/qemu/check_qemu_litex.py
+```
+
+## Linux Boot Smoke
+
+`litex_sim` can pass Linux-oriented boot assets through to QEMU:
+
+```sh
+python3 -m litex.tools.litex_sim \
+  --cpu-type=qemu \
+  --cpu-variant=rv64 \
+  --qemu-binary build/qemu-litex/bin/qemu-system-riscv64 \
+  --qemu-firmware path/to/fw_dynamic.bin \
+  --qemu-kernel path/to/Image \
+  --qemu-dtb path/to/litex.dtb \
+  --qemu-initrd path/to/rootfs.cpio \
+  --qemu-append "console=liteuart earlycon"
+```
+
+The `litex-sim` QEMU machine provides the RISC-V local interrupt pieces Linux
+expects: QEMU owns the ACLINT/CLINT timer/software interrupt block and the
+SiFive-compatible PLIC, while LiteX/Verilator owns the SoC peripherals. The
+bridge is mapped over the CPU IO window, so Linux can access non-CSR LiteX
+windows such as LiteEth MAC buffers or framebuffer regions in addition to the
+CSR window. Peripheral DMA to integrated main RAM requires the shared RAM path
+described below.
+
+## Shared Main RAM
+
+When `--cpu-type=qemu` is used with `--integrated-main-ram-size`,
+`litex_sim` now backs main RAM with a shared file by default. QEMU maps the
+file with `memory-backend-file` and Verilator exposes the same file as the
+LiteX `main_ram` slave through the bus-native QEMU simulation module.
+
+This gives Verilated LiteX masters, including DMA-capable peripherals, a real
+path to the same main RAM storage that QEMU uses for CPU accesses:
+
+```sh
+python3 -m litex.tools.litex_sim \
+  --cpu-type=qemu \
+  --cpu-variant=rv32 \
+  --integrated-main-ram-size=0x100000
+```
+
+The default backing file is `<output-dir>/qemu-main-ram.bin`, so with the
+default build directory it is `build/sim/qemu-main-ram.bin`. It is recreated
+at simulation start and is preloaded from `--ram-init` when that option is
+used. Use `--qemu-shared-ram-path` to choose another file:
+
+```sh
+python3 -m litex.tools.litex_sim \
+  --cpu-type=qemu \
+  --integrated-main-ram-size=0x100000 \
+  --qemu-shared-ram-path=/tmp/litex-main-ram.bin
+```
+
+The shared RAM path still uses a simple 32-bit single-word access path to the
+mapped backing file internally and exposes it as a `qemu_axi_shared_ram` full
+AXI interface. LiteX adapts this interface when the SoC bus is AXI-Lite or
+Wishbone. It shares storage, not cache management: software that mixes CPU caches and
+peripheral DMA still needs the normal cache maintenance/uncached mapping
+discipline.
+
+## Bus Standards
+
+The working bridge protocol is single-beat MMIO. The QEMU CPU wrapper exposes
+a full AXI master and LiteX adapts it to the selected SoC `--bus-standard` when
+needed:
+
+```sh
+python3 -m litex.tools.litex_sim \
+  --cpu-type=qemu \
+  --bus-standard=axi-lite \
+  --qemu-no-run
+```
+
+The QEMU simulation module is always `qemu_axi`. The supported SoC bus
+standards are `wishbone`, `axi-lite`, and `axi`. A quick build-time smoke can
+elaborate one selection without launching QEMU or compiling generated
+software/gateware:
+
+```sh
+python3 -m litex.tools.litex_sim \
+  --cpu-type=qemu \
+  --cpu-variant=rv32 \
+  --bus-standard=axi \
+  --integrated-main-ram-size=0x100000 \
+  --qemu-no-run \
+  --no-compile
+```
+
+The v1 QEMU MMIO protocol still issues each QEMU access as a blocking
+single-beat transaction; LiteX converts it when the SoC bus is AXI-Lite or
+Wishbone.
+
+## Expected QEMU Machine
+
+The LiteX launcher starts QEMU with:
+
+```sh
+qemu-system-riscv32 \
+  -M litex-sim,xlen=32,bridge-host=127.0.0.1,bridge-port=1235,\
+bridge-base=0x80000000,bridge-size=0x80000000,irq-poll-us=1000,\
+reset-addr=0x0,rom-base=0x0,sram-base=0x10000000,main-ram-base=0x40000000,\
+clint-base=0xf0010000,clint-size=0x10000,plic-base=0xf0c00000,plic-size=0x400000,\
+timebase-freq=1000000,\
+csr-base=0xf0000000,csr-size=0x10000 \
+  -m 67108864B \
+  -nographic -serial none -monitor none \
+  -bios build/sim/software/bios/bios.bin
+```
+
+For RV64, `qemu-system-riscv64` is used and `xlen=64` is passed.
+
+The QEMU `litex-sim` machine should:
+
+- Instantiate a RISC-V CPU matching `xlen`.
+- Own executable ROM/RAM locally inside QEMU.
+- Own the RISC-V ACLINT/CLINT and PLIC windows locally inside QEMU.
+- Map the LiteX CPU IO window as a low-priority QEMU `MemoryRegion`.
+- Forward each MMIO read/write to the LiteX bridge protocol described below.
+- Treat non-zero bridge status as a bus error.
+- Update QEMU PLIC inputs from the `irq` field returned with each response.
+- Poll the bridge with `op=2` when `irq-poll-us` is non-zero, so LiteX-originated
+  interrupts can wake QEMU even when the CPU is not otherwise touching MMIO.
+- Reset the QEMU CPU when an IRQ poll reports a latched LiteX CPU reset.
+
+## Protocol
+
+All multi-byte fields are little-endian. QEMU opens one TCP connection to
+`bridge-host:bridge-port` and performs one blocking request at a time.
+
+Request, 32 bytes:
+
+| Offset | Field   | Size | Value |
+|--------|---------|------|-------|
+| 0      | magic   | 4    | `0x3051584c` (`LXQ0`) |
+| 4      | version | 2    | `1` |
+| 6      | op      | 2    | `0` read, `1` write, `2` IRQ poll |
+| 8      | size    | 4    | `1`, `2`, `4`, or `8`; `0` for IRQ poll |
+| 12     | reserved| 4    | `0` |
+| 16     | addr    | 8    | byte address |
+| 24     | data    | 8    | write data, little-endian |
+
+Response, 32 bytes:
+
+| Offset | Field   | Size | Value |
+|--------|---------|------|-------|
+| 0      | magic   | 4    | `0x3052584c` (`LXR0`) |
+| 4      | version | 2    | `1` |
+| 6      | status  | 2    | `0` ok, `1` Wishbone error, `2` bad request |
+| 8      | irq     | 4    | current LiteX interrupt bitmask |
+| 12     | reserved| 4    | `0` |
+| 16     | data    | 8    | read data, or reset status for IRQ poll |
+| 24     | reserved| 8    | `0` |
+
+For an IRQ poll request, QEMU sends `op=2`, `size=0`, `addr=0`, and `data=0`.
+The LiteX simulation module replies immediately without issuing a bus
+transaction. The response `irq` mask carries the current LiteX interrupt pins,
+and response `data[0]` reports a latched LiteX CPU reset request.

--- a/litex/build/sim/qemu/__init__.py
+++ b/litex/build/sim/qemu/__init__.py
@@ -1,0 +1,5 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause

--- a/litex/build/sim/qemu/build_qemu_litex.py
+++ b/litex/build/sim/qemu/build_qemu_litex.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import shutil
+import tarfile
+import argparse
+import subprocess
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+
+QEMU_REF     = "v8.2.4"
+QEMU_REPO    = "https://gitlab.com/qemu-project/qemu.git"
+QEMU_TARGETS = "riscv32-softmmu,riscv64-softmmu"
+
+
+def repo_root():
+    return Path(__file__).resolve().parents[4]
+
+
+def run(cmd, cwd=None, env=None):
+    print("+ {}".format(" ".join(str(c) for c in cmd)), flush=True)
+    subprocess.run([str(c) for c in cmd], cwd=cwd, check=True, env=env)
+
+
+def git_env(src_dir):
+    # Keep `git apply` from discovering a repository that *contains* the QEMU
+    # source tree. When QEMU is extracted under build/ inside the LiteX checkout
+    # (the default with --source=archive, which has no .git of its own), git
+    # would otherwise resolve the patch's a/ b/ paths against the *outer* LiteX
+    # repo root and silently "Skip" every file (and --check still returns 0, so
+    # the patch looks applied while litex_sim.c is never created). Capping the
+    # ceiling at src_dir's parent blocks discovery of any enclosing repo while
+    # still letting --source=git use the QEMU checkout's own .git in src_dir.
+    env     = os.environ.copy()
+    ceiling = str(Path(src_dir).resolve().parent)
+    current = env.get("GIT_CEILING_DIRECTORIES")
+    env["GIT_CEILING_DIRECTORIES"] = ceiling if not current else ceiling + os.pathsep + current
+    return env
+
+
+def qemu_version(qemu_ref):
+    return qemu_ref[1:] if qemu_ref.startswith("v") else qemu_ref
+
+
+def qemu_archive_url(qemu_ref):
+    return "https://download.qemu.org/qemu-{}.tar.xz".format(qemu_version(qemu_ref))
+
+
+def is_qemu_source(src_dir):
+    return (src_dir / "configure").exists() and (src_dir / "hw" / "riscv").exists()
+
+
+def download_file(url, path):
+    tmp_path = path.with_name(path.name + ".tmp")
+    if tmp_path.exists():
+        tmp_path.unlink()
+
+    try:
+        if shutil.which("curl"):
+            run([
+                "curl",
+                "--silent",
+                "--show-error",
+                "--fail",
+                "--location",
+                "--retry", "5",
+                "--retry-delay", "5",
+                "--connect-timeout", "20",
+                "--output", tmp_path,
+                url,
+            ])
+        elif shutil.which("wget"):
+            run([
+                "wget",
+                "--tries=5",
+                "--timeout=20",
+                "--output-document", tmp_path,
+                url,
+            ])
+        else:
+            request = urllib.request.Request(
+                url,
+                headers={"User-Agent": "LiteX-QEMU-CoSim/1.0"},
+            )
+            with urllib.request.urlopen(request, timeout=60) as response:
+                with tmp_path.open("wb") as archive:
+                    shutil.copyfileobj(response, archive)
+        tmp_path.replace(path)
+    except Exception:
+        if tmp_path.exists():
+            tmp_path.unlink()
+        raise
+
+
+def download_archive(args):
+    archive_path = args.archive_path
+    if archive_path is None:
+        archive_name = Path(urllib.parse.urlparse(args.archive_url).path).name
+        if not archive_name:
+            archive_name = "qemu-{}.tar.xz".format(qemu_version(args.qemu_ref))
+        archive_path = args.install_dir / "downloads" / archive_name
+
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    if not archive_path.exists():
+        print("Downloading {} to {}.".format(args.archive_url, archive_path), flush=True)
+        download_file(args.archive_url, archive_path)
+    return archive_path.resolve()
+
+
+def extract_archive(args, archive_path):
+    tmp_dir = args.src_dir.parent / "{}-extract".format(args.src_dir.name)
+    if tmp_dir.exists():
+        shutil.rmtree(tmp_dir)
+    tmp_dir.mkdir(parents=True)
+
+    try:
+        with tarfile.open(archive_path) as archive:
+            members = archive.getmembers()
+            for member in members:
+                member_path = Path(member.name)
+                if member_path.is_absolute() or ".." in member_path.parts:
+                    raise SystemExit("{} contains unsafe path {}.".format(archive_path, member.name))
+            archive.extractall(tmp_dir, members=members)
+
+        roots = [path for path in tmp_dir.iterdir() if path.is_dir()]
+        if len(roots) != 1:
+            raise SystemExit("{} did not extract to a single source directory.".format(archive_path))
+        shutil.move(str(roots[0]), args.src_dir)
+    finally:
+        if tmp_dir.exists():
+            shutil.rmtree(tmp_dir)
+
+
+def ensure_git_source(args):
+    src_dir = args.src_dir
+    if src_dir.exists():
+        if not is_qemu_source(src_dir):
+            raise SystemExit("{} exists but does not look like a QEMU source tree.".format(src_dir))
+        if (src_dir / ".git").exists():
+            if not args.no_update:
+                run(["git", "fetch", "--tags", "--depth", "1", "origin", args.qemu_ref], cwd=src_dir)
+            run(["git", "checkout", args.qemu_ref], cwd=src_dir)
+            return
+        else:
+            raise SystemExit("{} exists but is not a git checkout.".format(src_dir))
+
+    if args.no_clone:
+        raise SystemExit("{} does not exist and --no-clone was used.".format(src_dir))
+
+    src_dir.parent.mkdir(parents=True, exist_ok=True)
+    run([
+        "git", "clone",
+        "--branch", args.qemu_ref,
+        "--depth", "1",
+        args.repo_url,
+        src_dir,
+    ])
+
+
+def ensure_archive_source(args):
+    src_dir = args.src_dir
+    if src_dir.exists():
+        if not is_qemu_source(src_dir):
+            raise SystemExit("{} exists but does not look like a QEMU source tree.".format(src_dir))
+        return
+
+    if args.no_clone:
+        raise SystemExit("{} does not exist and --no-clone was used.".format(src_dir))
+
+    src_dir.parent.mkdir(parents=True, exist_ok=True)
+    extract_archive(args, download_archive(args))
+
+
+def ensure_source(args):
+    if args.source == "archive":
+        ensure_archive_source(args)
+    else:
+        ensure_git_source(args)
+
+
+def apply_patch(args):
+    if args.no_patch:
+        return
+
+    env = git_env(args.src_dir)
+    check_cmd = ["git", "apply", "--check", args.patch]
+    reverse_check_cmd = ["git", "apply", "--reverse", "--check", args.patch]
+    check = subprocess.run(
+        [str(c) for c in check_cmd],
+        cwd=args.src_dir,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    if check.returncode == 0:
+        run(["git", "apply", args.patch], cwd=args.src_dir, env=env)
+        return
+
+    reverse_check = subprocess.run(
+        [str(c) for c in reverse_check_cmd],
+        cwd=args.src_dir,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if reverse_check.returncode == 0:
+        print("{} is already applied.".format(args.patch))
+        return
+
+    raise SystemExit(
+        "Could not apply {}; QEMU tree is not at the expected state.\n{}\n{}".format(
+            args.patch,
+            check.stderr,
+            reverse_check.stderr,
+        )
+    )
+
+
+def configure_qemu(args, build_dir):
+    build_dir.mkdir(parents=True, exist_ok=True)
+
+    configure = args.src_dir / "configure"
+    targets = [target.strip() for target in args.targets.split(",") if target.strip()]
+    cmd = [
+        configure,
+        "--target-list={}".format(args.targets),
+        "--prefix={}".format(args.install_dir),
+        "--disable-werror",
+        "--disable-docs",
+        "--disable-tools",
+        "--disable-gtk",
+        "--disable-sdl",
+        "--disable-vnc",
+        "--disable-curses",
+        "--disable-slirp",
+        "--disable-guest-agent",
+        "--disable-strip",
+    ]
+    if args.minimal_devices:
+        cmd.append("--without-default-devices")
+        for target in targets:
+            arch = target.removesuffix("-softmmu")
+            if arch.startswith("riscv"):
+                cmd.append("--with-devices-{}=litex-sim".format(arch))
+    if args.system_fdt:
+        cmd.append("--enable-fdt=system")
+    if args.disable_download:
+        cmd.append("--disable-download")
+    run(cmd, cwd=build_dir)
+
+
+def build_qemu(args):
+    build_dir = args.src_dir / "build-litex-sim"
+    if args.reconfigure or not (build_dir / "build.ninja").exists():
+        configure_qemu(args, build_dir)
+    if args.no_build:
+        return
+
+    targets = [target.strip() for target in args.targets.split(",") if target.strip()]
+    binaries = ["qemu-system-{}".format(target.removesuffix("-softmmu")) for target in targets]
+
+    run(["ninja", "-C", build_dir, "-j{}".format(args.jobs), *binaries])
+
+    bin_dir = args.install_dir / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    for binary in binaries:
+        src = build_dir / binary
+        if not src.exists():
+            raise SystemExit("{} was not built.".format(src))
+        dst = bin_dir / binary
+        shutil.copy2(src, dst)
+        dst.chmod(dst.stat().st_mode | 0o111)
+        print("Installed {}".format(dst))
+
+
+def main():
+    root = repo_root()
+    qemu_dir = root / "build" / "qemu-litex"
+    parser = argparse.ArgumentParser(description="Build QEMU with LiteX SIM co-simulation support.")
+    parser.add_argument("--src-dir",     type=Path, default=qemu_dir / "src", help="QEMU source checkout.")
+    parser.add_argument("--install-dir", type=Path, default=qemu_dir,         help="Install/copy destination.")
+    parser.add_argument("--source",      default="git", choices=["git", "archive"], help="QEMU source provider.")
+    parser.add_argument("--repo-url",    default=QEMU_REPO,                   help="QEMU git repository URL.")
+    parser.add_argument("--qemu-ref",    default=QEMU_REF,                    help="QEMU branch/tag/commit to checkout.")
+    parser.add_argument("--archive-url", default=None,                        help="QEMU source archive URL.")
+    parser.add_argument("--archive-path", type=Path, default=None,            help="Local QEMU source archive.")
+    parser.add_argument("--patch",       type=Path, default=Path(__file__).with_name("qemu-litex-sim-v8.2.4.patch"))
+    parser.add_argument("--targets",     default=QEMU_TARGETS,                help="Comma-separated QEMU target list.")
+    parser.add_argument("--jobs",        default=os.cpu_count() or 1, type=int, help="Parallel build jobs.")
+    parser.add_argument("--no-clone",    action="store_true", help="Require --src-dir to already exist.")
+    parser.add_argument("--no-update",   action="store_true", help="Do not fetch updates when --src-dir exists.")
+    parser.add_argument("--no-patch",    action="store_true", help="Skip applying the LiteX QEMU patch.")
+    parser.add_argument("--no-build",    action="store_true", help="Configure/patch only; do not run ninja.")
+    parser.add_argument("--reconfigure", action="store_true", help="Run QEMU configure even if build.ninja exists.")
+    parser.add_argument("--minimal-devices", action="store_true", help="Configure QEMU without default devices.")
+    parser.add_argument("--system-fdt",  action="store_true", help="Require the system libfdt dependency.")
+    parser.add_argument("--disable-download", action="store_true", help="Disable QEMU subproject downloads.")
+    args = parser.parse_args()
+
+    args.src_dir = args.src_dir.resolve()
+    args.install_dir = args.install_dir.resolve()
+    args.patch = args.patch.resolve()
+    if args.archive_url is None:
+        args.archive_url = qemu_archive_url(args.qemu_ref)
+    if args.archive_path is not None:
+        args.archive_path = args.archive_path.resolve()
+
+    ensure_source(args)
+    apply_patch(args)
+    build_qemu(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/litex/build/sim/qemu/check_qemu_litex.py
+++ b/litex/build/sim/qemu/check_qemu_litex.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import sys
+import shutil
+import argparse
+import subprocess
+from pathlib import Path
+
+
+def repo_root():
+    return Path(__file__).resolve().parents[4]
+
+
+def qemu_name(variant):
+    return "qemu-system-riscv{}".format(64 if variant == "rv64" else 32)
+
+
+def resolve_binary(args, variant):
+    override = getattr(args, "qemu_binary_{}".format(variant))
+    if override is not None:
+        return override
+
+    candidate = args.qemu_dir / qemu_name(variant)
+    if candidate.exists():
+        return candidate
+
+    path_binary = shutil.which(qemu_name(variant))
+    if path_binary is not None:
+        return Path(path_binary)
+
+    raise SystemExit("Could not find {}; use --qemu-dir or --qemu-binary-{}.".format(qemu_name(variant), variant))
+
+
+def check_machine(binary):
+    proc = subprocess.run(
+        [str(binary), "-machine", "help"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise SystemExit("{} -machine help failed:\n{}".format(binary, proc.stdout))
+    if "litex-sim" not in proc.stdout:
+        with open(binary, "rb") as f:
+            has_litex_string = b"litex-sim" in f.read()
+        raise SystemExit(
+            "{} does not expose the litex-sim machine "
+            "(binary contains litex-sim: {}).\n{}".format(
+                binary,
+                has_litex_string,
+                proc.stdout,
+            )
+        )
+    print("OK: {} exposes litex-sim".format(binary))
+
+
+def litex_smoke(binary, variant):
+    cmd = [
+        sys.executable,
+        "-m", "litex.tools.litex_sim",
+        "--cpu-type=qemu",
+        "--cpu-variant={}".format(variant),
+        "--qemu-binary", str(binary),
+        "--qemu-no-run",
+        "--no-compile-gateware",
+    ]
+    print("+ {}".format(" ".join(cmd)))
+    subprocess.run(cmd, check=True)
+
+
+def main():
+    qemu_dir = repo_root() / "build" / "qemu-litex" / "bin"
+    parser = argparse.ArgumentParser(description="Check LiteX SIM patched QEMU binaries.")
+    parser.add_argument("--qemu-dir", type=Path, default=qemu_dir, help="Directory containing qemu-system-riscv32/64.")
+    parser.add_argument("--qemu-binary-rv32", type=Path, default=None, help="Explicit RV32 QEMU binary.")
+    parser.add_argument("--qemu-binary-rv64", type=Path, default=None, help="Explicit RV64 QEMU binary.")
+    parser.add_argument("--variants", default="rv32,rv64", help="Comma-separated variants to check.")
+    parser.add_argument("--litex-smoke", action="store_true", help="Also run a LiteX --qemu-no-run build smoke.")
+    args = parser.parse_args()
+
+    variants = [variant.strip() for variant in args.variants.split(",") if variant.strip()]
+    for variant in variants:
+        if variant not in ["rv32", "rv64"]:
+            raise SystemExit("Unsupported variant: {}".format(variant))
+        binary = resolve_binary(args, variant)
+        check_machine(binary)
+        if args.litex_smoke:
+            litex_smoke(binary, variant)
+
+
+if __name__ == "__main__":
+    main()

--- a/litex/build/sim/qemu/cosim.py
+++ b/litex/build/sim/qemu/cosim.py
@@ -1,0 +1,266 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import sys
+import json
+import shlex
+import shutil
+import subprocess
+
+from litex.soc.integration.soc import SoCRegion, auto_int
+
+
+# Helpers ------------------------------------------------------------------------------------------
+
+def qemu_xlen(cpu_variant):
+    return 64 if cpu_variant == "rv64" else 32
+
+
+def qemu_default_binary(cpu_variant):
+    name = "qemu-system-riscv{}".format(qemu_xlen(cpu_variant))
+    repo_binary = os.path.abspath(os.path.join(
+        os.path.dirname(__file__),
+        "..", "..", "..", "..",
+        "build", "qemu-litex", "bin",
+        name,
+    ))
+    return repo_binary if os.path.exists(repo_binary) else name
+
+
+def qemu_resolve_binary(binary, cpu_variant):
+    binary = binary or qemu_default_binary(cpu_variant)
+    return os.path.abspath(binary) if os.path.exists(binary) else binary
+
+
+def qemu_binary(args):
+    if hasattr(args, "qemu_binary_resolved"):
+        return args.qemu_binary_resolved
+    return qemu_resolve_binary(args.qemu_binary, qemu_variant(args))
+
+
+def qemu_variant(args):
+    return "rv32" if args.cpu_variant in [None, "standard"] else args.cpu_variant
+
+
+def qemu_shared_ram_default_path(args):
+    output_dir = args.output_dir or os.path.join("build", "sim")
+    return os.path.abspath(os.path.join(output_dir, "qemu-main-ram.bin"))
+
+
+def qemu_shared_ram_path(args):
+    return os.path.abspath(args.qemu_shared_ram_path or qemu_shared_ram_default_path(args))
+
+
+def qemu_prepare_shared_ram_file(path, size, init_data=None, data_width=32):
+    bytes_per_data = data_width//8
+
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        f.truncate(size)
+
+    if not init_data:
+        return
+
+    with open(path, "r+b") as f:
+        for n, data in enumerate(init_data):
+            offset = n*bytes_per_data
+            if offset + bytes_per_data > size:
+                raise ValueError("RAM init data is larger than QEMU shared RAM.")
+            f.seek(offset)
+            f.write(int(data).to_bytes(bytes_per_data, byteorder="little"))
+
+
+# Arguments ----------------------------------------------------------------------------------------
+
+def qemu_add_args(parser):
+    parser.add_argument("--qemu-bind",         default="127.0.0.1", help="Bind address for the QEMU transaction bridge.")
+    parser.add_argument("--qemu-port",         default=1235, type=int, help="TCP port for the QEMU transaction bridge.")
+    parser.add_argument("--qemu-binary",       default=None, help="QEMU binary to launch (default: qemu-system-riscv32/64).")
+    parser.add_argument("--qemu-firmware",     default=None, help="Firmware/BIOS passed to QEMU -bios; use 'none' to disable.")
+    parser.add_argument("--qemu-kernel",       default=None, help="Kernel image passed to QEMU -kernel.")
+    parser.add_argument("--qemu-dtb",          default=None, help="Device tree blob passed to QEMU -dtb.")
+    parser.add_argument("--qemu-initrd",       default=None, help="Initrd image passed to QEMU -initrd.")
+    parser.add_argument("--qemu-append",       default=None, help="Kernel command line passed to QEMU -append.")
+    parser.add_argument("--qemu-ram-size",     default=None, type=auto_int, help="QEMU RAM size in bytes.")
+    parser.add_argument("--qemu-shared-ram-path", default=None,        help="Shared RAM backing file used with QEMU integrated main RAM.")
+    parser.add_argument("--qemu-extra-args",   default="", help="Extra arguments appended to the QEMU command line.")
+    parser.add_argument("--qemu-wait-timeout", default=120.0, type=float, help="Seconds to wait for the QEMU transaction bridge before launching QEMU; <= 0 waits forever.")
+    parser.add_argument("--qemu-irq-poll-us",  default=1000, type=int, help="QEMU-side LiteX IRQ polling interval in microseconds; 0 disables polling.")
+    parser.add_argument("--qemu-no-run",       action="store_true", help="Do not auto-launch QEMU when using --cpu-type=qemu.")
+
+
+def qemu_configure(args, parser, soc_kwargs):
+    qemu_enabled = soc_kwargs.get("cpu_type", None) == "qemu"
+    args.qemu_shared_ram_enabled = (
+        qemu_enabled and
+        bool(args.integrated_main_ram_size)
+    )
+    args.qemu_shared_ram_path_resolved = qemu_shared_ram_path(args)
+    args.qemu_binary_resolved          = qemu_resolve_binary(args.qemu_binary, qemu_variant(args))
+    if args.qemu_shared_ram_enabled:
+        if args.qemu_ram_size is not None and args.qemu_ram_size != args.integrated_main_ram_size:
+            parser.error("--qemu-ram-size must match --integrated-main-ram-size when shared RAM is enabled.")
+        soc_kwargs["integrated_main_ram_size"] = 0
+    return qemu_enabled
+
+
+# Simulation Modules -------------------------------------------------------------------------------
+
+def qemu_add_sim_modules(sim_config, args, parser):
+    interfaces = ["qemu_axi", "qemu_irq", "qemu_reset"]
+    module_args = {
+        "bind" : args.qemu_bind,
+        "port" : args.qemu_port,
+    }
+    if args.qemu_shared_ram_enabled:
+        interfaces.append("qemu_axi_shared_ram")
+        module_args.update({
+            "path" : args.qemu_shared_ram_path_resolved,
+            "size" : args.integrated_main_ram_size,
+        })
+    sim_config.add_module("qemu_axi", interfaces, clocks="sys_clk", args=module_args)
+    if not args.qemu_no_run:
+        binary = qemu_binary(args)
+        if shutil.which(binary) is None and not os.path.exists(binary):
+            parser.error("{} not found; install a patched QEMU or use --qemu-no-run.".format(binary))
+
+
+def qemu_add_shared_ram(soc, args, init_data=None, data_width=32):
+    from litex.soc.cores.cpu.qemu.core import QEMUSharedRAM
+
+    qemu_prepare_shared_ram_file(
+        path       = args.qemu_shared_ram_path_resolved,
+        size       = args.integrated_main_ram_size,
+        init_data  = init_data,
+        data_width = data_width,
+    )
+    soc.add_module(name="main_ram", module=QEMUSharedRAM(soc.platform))
+    soc.bus.add_slave(name="main_ram", slave=soc.main_ram.bus, region=SoCRegion(
+        origin = soc.mem_map["main_ram"],
+        size   = args.integrated_main_ram_size,
+        mode   = "rwx",
+    ))
+    soc.integrated_main_ram_size = args.integrated_main_ram_size
+
+
+# QEMU Command -------------------------------------------------------------------------------------
+
+def qemu_machine_arg(soc, args):
+    def region_origin(name, default=0):
+        if name in soc.bus.regions:
+            return soc.bus.regions[name].origin
+        return soc.mem_map.get(name, default)
+
+    def region_size(name, default=0):
+        if name in soc.bus.regions:
+            return soc.bus.regions[name].size
+        return default
+
+    def bridge_region():
+        if soc.cpu.io_regions:
+            return sorted(soc.cpu.io_regions.items())[0]
+        return region_origin("csr"), region_size("csr")
+
+    bridge_base, bridge_size = bridge_region()
+    props = [
+        "litex-sim",
+        "xlen={}".format(qemu_xlen(qemu_variant(args))),
+        "bridge-host={}".format(args.qemu_bind),
+        "bridge-port={}".format(args.qemu_port),
+        "bridge-base=0x{:x}".format(bridge_base),
+        "bridge-size=0x{:x}".format(bridge_size),
+        "irq-poll-us={}".format(args.qemu_irq_poll_us),
+        "reset-addr=0x{:x}".format(getattr(soc.cpu, "reset_address", region_origin("rom"))),
+        "rom-base=0x{:x}".format(region_origin("rom")),
+        "sram-base=0x{:x}".format(region_origin("sram")),
+        "main-ram-base=0x{:x}".format(region_origin("main_ram")),
+        "clint-base=0x{:x}".format(region_origin("clint")),
+        "clint-size=0x{:x}".format(region_size("clint", 0x1_0000)),
+        "plic-base=0x{:x}".format(region_origin("plic")),
+        "plic-size=0x{:x}".format(region_size("plic", 0x40_0000)),
+        "timebase-freq={}".format(getattr(soc, "sys_clk_freq", 1000000)),
+        "csr-base=0x{:x}".format(region_origin("csr")),
+        "csr-size=0x{:x}".format(region_size("csr")),
+    ]
+    if getattr(args, "qemu_shared_ram_enabled", False):
+        props.append("memory-backend=litex_main_ram")
+    return ",".join(props)
+
+
+def qemu_command(builder, soc, args):
+    qemu_ram_size = args.qemu_ram_size or args.integrated_main_ram_size or 64*1024*1024
+    bios          = args.qemu_firmware
+    if bios is None:
+        bios = args.rom_init or builder.get_bios_filename()
+
+    cmd = [qemu_binary(args)]
+    if getattr(args, "qemu_shared_ram_enabled", False):
+        cmd += [
+            "-object",
+            "memory-backend-file,id=litex_main_ram,mem-path={},size={},share=on".format(
+                args.qemu_shared_ram_path_resolved,
+                qemu_ram_size,
+            ),
+        ]
+    cmd += [
+        "-M", qemu_machine_arg(soc, args),
+        "-m", "{}B".format(qemu_ram_size),
+        "-nographic",
+        "-serial", "none",
+        "-monitor", "none",
+    ]
+    if bios:
+        cmd += ["-bios", bios]
+    if args.qemu_kernel:
+        cmd += ["-kernel", args.qemu_kernel]
+    if args.qemu_dtb:
+        cmd += ["-dtb", args.qemu_dtb]
+    if args.qemu_initrd:
+        cmd += ["-initrd", args.qemu_initrd]
+    if args.qemu_append:
+        cmd += ["-append", args.qemu_append]
+    if args.qemu_extra_args:
+        cmd += shlex.split(args.qemu_extra_args)
+    return cmd
+
+
+def qemu_spawn_when_bridge_ready(cmd, host, port, timeout):
+    waiter = r"""
+import os
+import sys
+import json
+import time
+import socket
+
+cmd = json.loads(sys.argv[1])
+host = sys.argv[2]
+port = int(sys.argv[3])
+timeout = float(sys.argv[4])
+deadline = None if timeout <= 0 else time.time() + timeout
+
+while True:
+    try:
+        s = socket.create_connection((host, port), timeout=0.25)
+        s.close()
+        break
+    except OSError:
+        if deadline is not None and time.time() >= deadline:
+            print("[litex_sim] ERROR: timed out waiting for QEMU transaction bridge", file=sys.stderr)
+            sys.exit(1)
+        time.sleep(0.05)
+
+print("[litex_sim] Starting QEMU: {}".format(" ".join(cmd)))
+os.execvp(cmd[0], cmd)
+"""
+    return subprocess.Popen([
+        sys.executable,
+        "-c", waiter,
+        json.dumps(cmd),
+        host,
+        str(port),
+        str(timeout),
+    ])

--- a/litex/build/sim/qemu/qemu-litex-sim-v8.2.4.patch
+++ b/litex/build/sim/qemu/qemu-litex-sim-v8.2.4.patch
@@ -1,0 +1,692 @@
+diff --git a/configs/devices/riscv32-softmmu/litex-sim.mak b/configs/devices/riscv32-softmmu/litex-sim.mak
+new file mode 100644
+index 0000000..eb69046
+--- /dev/null
++++ b/configs/devices/riscv32-softmmu/litex-sim.mak
+@@ -0,0 +1,4 @@
++CONFIG_SEMIHOSTING=y
++CONFIG_ARM_COMPATIBLE_SEMIHOSTING=y
++CONFIG_RISCV_ACLINT=y
++CONFIG_SIFIVE_PLIC=y
+diff --git a/configs/devices/riscv64-softmmu/litex-sim.mak b/configs/devices/riscv64-softmmu/litex-sim.mak
+new file mode 100644
+index 0000000..eb69046
+--- /dev/null
++++ b/configs/devices/riscv64-softmmu/litex-sim.mak
+@@ -0,0 +1,4 @@
++CONFIG_SEMIHOSTING=y
++CONFIG_ARM_COMPATIBLE_SEMIHOSTING=y
++CONFIG_RISCV_ACLINT=y
++CONFIG_SIFIVE_PLIC=y
+diff --git a/hw/riscv/litex_sim.c b/hw/riscv/litex_sim.c
+new file mode 100644
+index 0000000..f0188c9
+--- /dev/null
++++ b/hw/riscv/litex_sim.c
+@@ -0,0 +1,637 @@
++/*
++ * QEMU RISC-V LiteX SIM co-simulation machine
++ *
++ * This machine is intentionally small: QEMU owns the CPU and local memories,
++ * while LiteX/Verilator owns the CSR/peripheral window reached through a
++ * blocking TCP request/response bridge.
++ *
++ * SPDX-License-Identifier: GPL-2.0-or-later
++ */
++
++#include "qemu/osdep.h"
++#include "qapi/error.h"
++#include "exec/address-spaces.h"
++#include "exec/memory.h"
++#include "hw/boards.h"
++#include "hw/hw.h"
++#include "hw/intc/riscv_aclint.h"
++#include "hw/intc/sifive_plic.h"
++#include "hw/irq.h"
++#include "hw/loader.h"
++#include "hw/qdev-properties.h"
++#include "hw/riscv/boot.h"
++#include "hw/riscv/riscv_hart.h"
++#include "hw/sysbus.h"
++#include "sysemu/device_tree.h"
++#include "qemu/error-report.h"
++#include "qemu/module.h"
++#include "qemu/sockets.h"
++#include "qemu/timer.h"
++#include "qemu/units.h"
++#include "qom/object.h"
++#include "sysemu/runstate.h"
++#include "target/riscv/cpu.h"
++
++#define TYPE_LITEX_SIM_MACHINE MACHINE_TYPE_NAME("litex-sim")
++typedef struct LiteXSimMachineState LiteXSimMachineState;
++DECLARE_INSTANCE_CHECKER(LiteXSimMachineState, LITEX_SIM_MACHINE,
++                         TYPE_LITEX_SIM_MACHINE)
++
++#define LITEX_SIM_REQ_MAGIC 0x3051584c /* LXQ0 */
++#define LITEX_SIM_RSP_MAGIC 0x3052584c /* LXR0 */
++#define LITEX_SIM_VERSION   1
++#define LITEX_SIM_OP_READ   0
++#define LITEX_SIM_OP_WRITE  1
++#define LITEX_SIM_OP_IRQ    2
++#define LITEX_SIM_IRQ_BASE  0
++
++#define LITEX_SIM_PLIC_PRIORITY_BASE  0x000000
++#define LITEX_SIM_PLIC_PENDING_BASE   0x001000
++#define LITEX_SIM_PLIC_ENABLE_BASE    0x002000
++#define LITEX_SIM_PLIC_ENABLE_STRIDE  0x000080
++#define LITEX_SIM_PLIC_CONTEXT_BASE   0x200000
++#define LITEX_SIM_PLIC_CONTEXT_STRIDE 0x001000
++#define LITEX_SIM_PLIC_NUM_SOURCES    33
++#define LITEX_SIM_PLIC_NUM_PRIORITIES 7
++
++struct LiteXSimMachineState {
++    MachineState parent;
++
++    RISCVHartArrayState cpus;
++    DeviceState *plic;
++    MemoryRegion rom;
++    MemoryRegion sram;
++    MemoryRegion bridge;
++    QEMUTimer *irq_poll_timer;
++
++    char *bridge_host;
++    uint32_t bridge_port;
++    uint32_t xlen;
++    uint32_t timebase_freq;
++    uint32_t irq_poll_us;
++    uint64_t reset_addr;
++    uint64_t rom_base;
++    uint64_t rom_size;
++    uint64_t sram_base;
++    uint64_t sram_size;
++    uint64_t main_ram_base;
++    uint64_t bridge_base;
++    uint64_t bridge_size;
++    uint64_t clint_base;
++    uint64_t clint_size;
++    uint64_t plic_base;
++    uint64_t plic_size;
++    uint64_t csr_base;
++    uint64_t csr_size;
++
++    int bridge_fd;
++    bool bridge_busy;
++    uint32_t irq_mask;
++};
++
++static bool litex_sim_read_full(int fd, void *buf, size_t len)
++{
++    uint8_t *p = buf;
++
++    while (len) {
++        ssize_t ret = recv(fd, p, len, 0);
++
++        if (ret < 0 && errno == EINTR) {
++            continue;
++        }
++        if (ret <= 0) {
++            return false;
++        }
++        p   += ret;
++        len -= ret;
++    }
++
++    return true;
++}
++
++static void litex_sim_close_bridge(LiteXSimMachineState *s)
++{
++    if (s->bridge_fd >= 0) {
++        qemu_close(s->bridge_fd);
++        s->bridge_fd = -1;
++    }
++}
++
++static bool litex_sim_connect_bridge(LiteXSimMachineState *s, Error **errp)
++{
++    g_autofree char *addr = g_strdup_printf("%s:%u",
++                                            s->bridge_host,
++                                            s->bridge_port);
++
++    if (s->bridge_fd >= 0) {
++        return true;
++    }
++
++    s->bridge_fd = inet_connect(addr, errp);
++    if (s->bridge_fd < 0) {
++        return false;
++    }
++
++    qemu_socket_set_block(s->bridge_fd);
++    return true;
++}
++
++static void litex_sim_update_irq(LiteXSimMachineState *s, uint32_t irq_mask)
++{
++    uint32_t changed = s->irq_mask ^ irq_mask;
++    int irq;
++
++    if (s->plic) {
++        for (irq = 0; irq < 32; irq++) {
++            uint32_t mask = 1u << irq;
++
++            if (changed & mask) {
++                qemu_set_irq(qdev_get_gpio_in(s->plic,
++                                              LITEX_SIM_IRQ_BASE + irq),
++                             !!(irq_mask & mask));
++            }
++        }
++    } else {
++        bool level = irq_mask != 0;
++
++        riscv_cpu_update_mip(&s->cpus.harts[0].env, MIP_MEIP,
++                             BOOL_TO_MASK(level));
++    }
++    s->irq_mask = irq_mask;
++}
++
++static void litex_sim_update_reset(LiteXSimMachineState *s,
++                                   uint64_t reset_status)
++{
++    if (reset_status & 1) {
++        s->irq_mask = 0;
++        qemu_system_reset_request(SHUTDOWN_CAUSE_GUEST_RESET);
++    }
++}
++
++static bool litex_sim_bridge_xfer_once(LiteXSimMachineState *s,
++                                       uint16_t op,
++                                       hwaddr addr,
++                                       unsigned size,
++                                       uint64_t wdata,
++                                       uint64_t *rdata,
++                                       uint16_t *status,
++                                       Error **errp)
++{
++    uint8_t req[32] = {0};
++    uint8_t rsp[32];
++
++    stl_le_p(req + 0, LITEX_SIM_REQ_MAGIC);
++    stw_le_p(req + 4, LITEX_SIM_VERSION);
++    stw_le_p(req + 6, op);
++    stl_le_p(req + 8, size);
++    stq_le_p(req + 16, addr);
++    stq_le_p(req + 24, wdata);
++
++    if (!litex_sim_connect_bridge(s, errp)) {
++        return false;
++    }
++
++    if (qemu_send_full(s->bridge_fd, req, sizeof(req)) != sizeof(req)) {
++        error_setg_errno(errp, errno, "LiteX bridge send failed");
++        return false;
++    }
++
++    if (!litex_sim_read_full(s->bridge_fd, rsp, sizeof(rsp))) {
++        error_setg_errno(errp, errno, "LiteX bridge receive failed");
++        return false;
++    }
++
++    if (ldl_le_p(rsp + 0) != LITEX_SIM_RSP_MAGIC ||
++        lduw_le_p(rsp + 4) != LITEX_SIM_VERSION) {
++        error_setg(errp, "LiteX bridge returned an invalid response");
++        return false;
++    }
++
++    *status = lduw_le_p(rsp + 6);
++    litex_sim_update_irq(s, ldl_le_p(rsp + 8));
++    if (rdata) {
++        *rdata = ldq_le_p(rsp + 16);
++    }
++
++    return true;
++}
++
++static uint64_t litex_sim_bridge_xfer(LiteXSimMachineState *s,
++                                      uint16_t op,
++                                      hwaddr addr,
++                                      unsigned size,
++                                      uint64_t wdata)
++{
++    Error *err = NULL;
++    uint64_t rdata = 0;
++    uint16_t status = 0;
++
++    s->bridge_busy = true;
++    if (!litex_sim_bridge_xfer_once(s, op, addr, size, wdata,
++                                    &rdata, &status, &err)) {
++        error_free_or_abort(&err);
++        litex_sim_close_bridge(s);
++        if (!litex_sim_bridge_xfer_once(s, op, addr, size, wdata,
++                                        &rdata, &status, &err)) {
++            error_report_err(err);
++            hw_error("LiteX bridge transaction failed");
++        }
++    }
++
++    if (status != 0) {
++        hw_error("LiteX bridge returned status %u for %s at 0x%" HWADDR_PRIx,
++                 status, op == LITEX_SIM_OP_READ ? "read" : "write", addr);
++    }
++
++    s->bridge_busy = false;
++    return rdata;
++}
++
++static uint64_t litex_sim_mmio_read(void *opaque, hwaddr addr, unsigned size)
++{
++    LiteXSimMachineState *s = opaque;
++
++    return litex_sim_bridge_xfer(s, LITEX_SIM_OP_READ,
++                                 s->bridge_base + addr, size, 0);
++}
++
++static void litex_sim_mmio_write(void *opaque, hwaddr addr,
++                                 uint64_t value, unsigned size)
++{
++    LiteXSimMachineState *s = opaque;
++
++    litex_sim_bridge_xfer(s, LITEX_SIM_OP_WRITE,
++                          s->bridge_base + addr, size, value);
++}
++
++static const MemoryRegionOps litex_sim_mmio_ops = {
++    .read = litex_sim_mmio_read,
++    .write = litex_sim_mmio_write,
++    .endianness = DEVICE_LITTLE_ENDIAN,
++    .valid = {
++        .min_access_size = 1,
++        .max_access_size = 8,
++        .unaligned = true,
++    },
++    .impl = {
++        .min_access_size = 1,
++        .max_access_size = 8,
++        .unaligned = true,
++    },
++};
++
++static char *litex_sim_get_bridge_host(Object *obj, Error **errp)
++{
++    LiteXSimMachineState *s = LITEX_SIM_MACHINE(obj);
++
++    return g_strdup(s->bridge_host);
++}
++
++static void litex_sim_set_bridge_host(Object *obj, const char *value,
++                                      Error **errp)
++{
++    LiteXSimMachineState *s = LITEX_SIM_MACHINE(obj);
++
++    g_free(s->bridge_host);
++    s->bridge_host = g_strdup(value);
++}
++
++static void litex_sim_schedule_irq_poll(LiteXSimMachineState *s)
++{
++    if (s->irq_poll_timer && s->irq_poll_us) {
++        timer_mod(s->irq_poll_timer,
++                  qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL) +
++                  (int64_t)s->irq_poll_us * 1000);
++    }
++}
++
++static void litex_sim_irq_poll_cb(void *opaque)
++{
++    LiteXSimMachineState *s = opaque;
++    Error *err = NULL;
++    uint64_t rdata = 0;
++    uint16_t status = 0;
++
++    if (!s->bridge_busy) {
++        s->bridge_busy = true;
++        if (!litex_sim_bridge_xfer_once(s, LITEX_SIM_OP_IRQ, 0, 0, 0,
++                                        &rdata, &status, &err)) {
++            if (err) {
++                error_free(err);
++            }
++            litex_sim_close_bridge(s);
++        } else if (status == 0) {
++            litex_sim_update_reset(s, rdata);
++        }
++        s->bridge_busy = false;
++    }
++
++    litex_sim_schedule_irq_poll(s);
++}
++
++static DeviceState *litex_sim_create_plic(LiteXSimMachineState *s)
++{
++    char *hart_config = g_strdup("MS");
++    DeviceState *plic;
++
++    plic = sifive_plic_create(
++        s->plic_base,
++        hart_config,
++        1,
++        0,
++        LITEX_SIM_PLIC_NUM_SOURCES,
++        LITEX_SIM_PLIC_NUM_PRIORITIES,
++        LITEX_SIM_PLIC_PRIORITY_BASE,
++        LITEX_SIM_PLIC_PENDING_BASE,
++        LITEX_SIM_PLIC_ENABLE_BASE,
++        LITEX_SIM_PLIC_ENABLE_STRIDE,
++        LITEX_SIM_PLIC_CONTEXT_BASE,
++        LITEX_SIM_PLIC_CONTEXT_STRIDE,
++        s->plic_size);
++    g_free(hart_config);
++    return plic;
++}
++
++static void litex_sim_create_local_interrupts(LiteXSimMachineState *s)
++{
++    riscv_aclint_swi_create(s->clint_base, 0, 1, false);
++    riscv_aclint_mtimer_create(
++        s->clint_base + RISCV_ACLINT_SWI_SIZE,
++        RISCV_ACLINT_DEFAULT_MTIMER_SIZE,
++        0,
++        1,
++        RISCV_ACLINT_DEFAULT_MTIMECMP,
++        RISCV_ACLINT_DEFAULT_MTIME,
++        s->timebase_freq,
++        true);
++
++    s->plic = litex_sim_create_plic(s);
++
++    if (s->irq_poll_us) {
++        s->irq_poll_timer = timer_new_ns(QEMU_CLOCK_VIRTUAL,
++                                         litex_sim_irq_poll_cb, s);
++        litex_sim_schedule_irq_poll(s);
++    }
++}
++
++static void litex_sim_board_init(MachineState *machine)
++{
++    LiteXSimMachineState *s = LITEX_SIM_MACHINE(machine);
++    MemoryRegion *system_memory = get_system_memory();
++    const char *firmware = machine->firmware;
++    ssize_t firmware_size;
++    bool linux_boot = (machine->kernel_filename != NULL);
++
++#if defined(TARGET_RISCV32)
++    if (s->xlen != 32) {
++        error_report("qemu-system-riscv32 requires litex-sim,xlen=32");
++        exit(1);
++    }
++#elif defined(TARGET_RISCV64)
++    if (s->xlen != 64) {
++        error_report("qemu-system-riscv64 requires litex-sim,xlen=64");
++        exit(1);
++    }
++#endif
++
++    if (machine->smp.cpus != 1) {
++        error_report("litex-sim currently supports exactly one CPU");
++        exit(1);
++    }
++
++    object_initialize_child(OBJECT(machine), "cpus", &s->cpus,
++                            TYPE_RISCV_HART_ARRAY);
++    object_property_set_str(OBJECT(&s->cpus), "cpu-type",
++                            machine->cpu_type, &error_abort);
++    object_property_set_int(OBJECT(&s->cpus), "hartid-base", 0, &error_abort);
++    object_property_set_int(OBJECT(&s->cpus), "num-harts", 1, &error_abort);
++    object_property_set_int(OBJECT(&s->cpus), "resetvec",
++                            s->reset_addr, &error_abort);
++    sysbus_realize(SYS_BUS_DEVICE(&s->cpus), &error_fatal);
++
++    litex_sim_create_local_interrupts(s);
++
++    /*
++     * Executable ROM at rom_base. For a bare-metal / LiteX BIOS boot it holds
++     * the firmware passed via -bios. For a Linux (-kernel) boot it is populated
++     * below by riscv_setup_rom_reset_vec with the reset vector that jumps to the
++     * S-mode firmware; the region must exist first since that helper writes into
++     * it rather than creating it.
++     */
++    memory_region_init_rom(&s->rom, NULL, "litex.rom",
++                           s->rom_size, &error_fatal);
++    memory_region_add_subregion(system_memory, s->rom_base, &s->rom);
++
++    if (!linux_boot && firmware && strcmp(firmware, "none")) {
++        firmware_size = load_image_mr(firmware, &s->rom);
++        if (firmware_size < 0) {
++            error_report("unable to load LiteX BIOS '%s'", firmware);
++            exit(1);
++        }
++    }
++
++    memory_region_init_ram(&s->sram, NULL, "litex.sram",
++                           s->sram_size, &error_fatal);
++    memory_region_add_subregion(system_memory, s->sram_base, &s->sram);
++
++    memory_region_add_subregion(system_memory, s->main_ram_base, machine->ram);
++
++    memory_region_init_io(&s->bridge, NULL, &litex_sim_mmio_ops, s,
++                          "litex.bridge", s->bridge_size);
++    memory_region_add_subregion_overlap(system_memory, s->bridge_base,
++                                        &s->bridge, -1);
++
++    /*
++     * Linux boot: QEMU owns the CPU, ROM/RAM, ACLINT/CLINT and PLIC. S-mode
++     * firmware (OpenSBI, -bios; defaults to QEMU's bundled generic) is loaded at
++     * the start of main RAM, the kernel right after it, and the LiteX-aware
++     * device tree (-dtb) high in RAM. A small reset vector in the LiteX ROM
++     * jumps to the firmware with the fdt pointer in a1. The kernel reaches its
++     * console (liteuart) and the other LiteX peripherals over the bridge.
++     */
++    if (linux_boot) {
++        int fdt_size;
++        uint64_t kernel_entry, fdt_load_addr;
++        target_ulong firmware_end_addr, kernel_start_addr;
++
++        if (!machine->dtb) {
++            error_report("litex-sim Linux boot (-kernel) requires a device tree (-dtb)");
++            exit(1);
++        }
++        machine->fdt = load_device_tree(machine->dtb, &fdt_size);
++        if (!machine->fdt) {
++            error_report("unable to load device tree '%s'", machine->dtb);
++            exit(1);
++        }
++
++        firmware_end_addr = riscv_find_and_load_firmware(machine,
++            riscv_default_firmware_name(&s->cpus), s->main_ram_base, NULL);
++
++        kernel_start_addr = riscv_calc_kernel_start_addr(&s->cpus,
++                                                         firmware_end_addr);
++        kernel_entry = riscv_load_kernel(machine, &s->cpus, kernel_start_addr,
++                                         true, NULL);
++
++        fdt_load_addr = riscv_compute_fdt_addr(s->main_ram_base,
++                                               machine->ram_size, machine);
++        riscv_load_fdt(fdt_load_addr, machine->fdt);
++
++        riscv_setup_rom_reset_vec(machine, &s->cpus, s->main_ram_base,
++                                  s->rom_base, s->rom_size,
++                                  kernel_entry, fdt_load_addr);
++    }
++}
++
++static void litex_sim_machine_instance_init(Object *obj)
++{
++    LiteXSimMachineState *s = LITEX_SIM_MACHINE(obj);
++
++    s->bridge_host  = g_strdup("127.0.0.1");
++    s->bridge_port  = 1235;
++    s->bridge_fd    = -1;
++    s->xlen         = sizeof(target_ulong) == 8 ? 64 : 32;
++    s->timebase_freq = RISCV_ACLINT_DEFAULT_TIMEBASE_FREQ;
++    s->irq_poll_us  = 1000;
++
++#if defined(TARGET_RISCV64)
++    s->reset_addr   = 0x10000000;
++    s->rom_base     = 0x10000000;
++    s->rom_size     = 0x00020000;
++    s->sram_base    = 0x11000000;
++    s->sram_size    = 0x00002000;
++    s->main_ram_base = 0x80000000;
++    s->bridge_base  = 0x12000000;
++    s->bridge_size  = 0x6e000000;
++    s->clint_base   = 0x02000000;
++    s->clint_size   = 0x00010000;
++    s->plic_base    = 0x0c000000;
++    s->plic_size    = 0x00400000;
++    s->csr_base     = 0x12000000;
++    s->csr_size     = 0x00010000;
++#else
++    s->reset_addr   = 0x00000000;
++    s->rom_base     = 0x00000000;
++    s->rom_size     = 0x00020000;
++    s->sram_base    = 0x10000000;
++    s->sram_size    = 0x00002000;
++    s->main_ram_base = 0x40000000;
++    s->bridge_base  = 0x80000000;
++    s->bridge_size  = 0x80000000;
++    s->clint_base   = 0xf0010000;
++    s->clint_size   = 0x00010000;
++    s->plic_base    = 0xf0c00000;
++    s->plic_size    = 0x00400000;
++    s->csr_base     = 0xf0000000;
++    s->csr_size     = 0x00010000;
++#endif
++
++    object_property_add_str(obj, "bridge-host",
++                            litex_sim_get_bridge_host,
++                            litex_sim_set_bridge_host);
++    object_property_set_description(obj, "bridge-host",
++                                    "LiteX bridge TCP host");
++    object_property_add_uint32_ptr(obj, "bridge-port",
++                                   &s->bridge_port,
++                                   OBJ_PROP_FLAG_READWRITE);
++    object_property_set_description(obj, "bridge-port",
++                                    "LiteX bridge TCP port");
++    object_property_add_uint32_ptr(obj, "irq-poll-us",
++                                   &s->irq_poll_us,
++                                   OBJ_PROP_FLAG_READWRITE);
++    object_property_set_description(obj, "irq-poll-us",
++                                    "LiteX IRQ bridge polling interval in us");
++    object_property_add_uint32_ptr(obj, "xlen",
++                                   &s->xlen,
++                                   OBJ_PROP_FLAG_READWRITE);
++    object_property_add_uint32_ptr(obj, "timebase-freq",
++                                   &s->timebase_freq,
++                                   OBJ_PROP_FLAG_READWRITE);
++    object_property_add_uint64_ptr(obj, "reset-addr",
++                                   &s->reset_addr,
++                                   OBJ_PROP_FLAG_READWRITE);
++    object_property_add_uint64_ptr(obj, "rom-base",
++                                   &s->rom_base,
++                                   OBJ_PROP_FLAG_READWRITE);
++    object_property_add_uint64_ptr(obj, "rom-size",
++                                   &s->rom_size,
++                                   OBJ_PROP_FLAG_READWRITE);
++    object_property_add_uint64_ptr(obj, "sram-base",
++                                   &s->sram_base,
++                                   OBJ_PROP_FLAG_READWRITE);
++    object_property_add_uint64_ptr(obj, "sram-size",
++                                   &s->sram_size,
++                                   OBJ_PROP_FLAG_READWRITE);
++    object_property_add_uint64_ptr(obj, "main-ram-base",
++                                   &s->main_ram_base,
++                                   OBJ_PROP_FLAG_READWRITE);
++    object_property_add_uint64_ptr(obj, "bridge-base",
++                                   &s->bridge_base,
++                                   OBJ_PROP_FLAG_READWRITE);
++    object_property_add_uint64_ptr(obj, "bridge-size",
++                                   &s->bridge_size,
++                                   OBJ_PROP_FLAG_READWRITE);
++    object_property_add_uint64_ptr(obj, "clint-base",
++                                   &s->clint_base,
++                                   OBJ_PROP_FLAG_READWRITE);
++    object_property_add_uint64_ptr(obj, "clint-size",
++                                   &s->clint_size,
++                                   OBJ_PROP_FLAG_READWRITE);
++    object_property_add_uint64_ptr(obj, "plic-base",
++                                   &s->plic_base,
++                                   OBJ_PROP_FLAG_READWRITE);
++    object_property_add_uint64_ptr(obj, "plic-size",
++                                   &s->plic_size,
++                                   OBJ_PROP_FLAG_READWRITE);
++    object_property_add_uint64_ptr(obj, "csr-base",
++                                   &s->csr_base,
++                                   OBJ_PROP_FLAG_READWRITE);
++    object_property_add_uint64_ptr(obj, "csr-size",
++                                   &s->csr_size,
++                                   OBJ_PROP_FLAG_READWRITE);
++}
++
++static void litex_sim_machine_finalize(Object *obj)
++{
++    LiteXSimMachineState *s = LITEX_SIM_MACHINE(obj);
++
++    if (s->irq_poll_timer) {
++        timer_del(s->irq_poll_timer);
++        timer_free(s->irq_poll_timer);
++    }
++    litex_sim_close_bridge(s);
++    g_free(s->bridge_host);
++}
++
++static void litex_sim_machine_class_init(ObjectClass *oc, void *data)
++{
++    MachineClass *mc = MACHINE_CLASS(oc);
++
++    mc->desc = "LiteX SIM co-simulation machine";
++    mc->init = litex_sim_board_init;
++    mc->max_cpus = 1;
++    mc->default_cpus = 1;
++    mc->default_cpu_type = TYPE_RISCV_CPU_BASE;
++    mc->default_ram_size = 64 * MiB;
++    mc->default_ram_id = "litex.main_ram";
++}
++
++static const TypeInfo litex_sim_machine_typeinfo = {
++    .name          = TYPE_LITEX_SIM_MACHINE,
++    .parent        = TYPE_MACHINE,
++    .class_init    = litex_sim_machine_class_init,
++    .instance_init = litex_sim_machine_instance_init,
++    .instance_finalize = litex_sim_machine_finalize,
++    .instance_size = sizeof(LiteXSimMachineState),
++};
++
++void litex_sim_machine_init_register_types(void);
++
++void litex_sim_machine_init_register_types(void)
++{
++    if (object_class_by_name(TYPE_LITEX_SIM_MACHINE)) {
++        return;
++    }
++
++    type_register_static(&litex_sim_machine_typeinfo);
++}
+diff --git a/hw/riscv/meson.build b/hw/riscv/meson.build
+index 2f7ee81..694ac5a 100644
+--- a/hw/riscv/meson.build
++++ b/hw/riscv/meson.build
+@@ -9,4 +9,5 @@ riscv_ss.add(when: 'CONFIG_SIFIVE_E', if_true: files('sifive_e.c'))
+ riscv_ss.add(when: 'CONFIG_SIFIVE_U', if_true: files('sifive_u.c'))
+ riscv_ss.add(when: 'CONFIG_SPIKE', if_true: files('spike.c'))
+ riscv_ss.add(when: 'CONFIG_MICROCHIP_PFSOC', if_true: files('microchip_pfsoc.c'))
++riscv_ss.add(files('litex_sim.c'))
+ riscv_ss.add(when: 'CONFIG_ACPI', if_true: files('virt-acpi-build.c'))
+diff --git a/system/runstate.c b/system/runstate.c
+index ea9d6c2..4989683 100644
+--- a/system/runstate.c
++++ b/system/runstate.c
+@@ -70,4 +70,5 @@ static RunState current_run_state = RUN_STATE_PRELAUNCH;
+ static RunState vmstop_requested = RUN_STATE__MAX;
+ static QemuMutex vmstop_lock;
+-
++void litex_sim_machine_init_register_types(void);
++
+ typedef struct {
+@@ -817,2 +817,7 @@ void qemu_init_subsystems(void)
+     module_call_init(MODULE_INIT_QOM);
++    /*
++     * LiteX SIM is an out-of-tree RISC-V machine. Register it directly after
++     * QOM init so minimal-device builds do not depend on default machine lists.
++     */
++    litex_sim_machine_init_register_types();
+     module_call_init(MODULE_INIT_MIGRATION);

--- a/litex/soc/cores/cpu/qemu/__init__.py
+++ b/litex/soc/cores/cpu/qemu/__init__.py
@@ -1,0 +1,1 @@
+from litex.soc.cores.cpu.qemu.core import QEMU

--- a/litex/soc/cores/cpu/qemu/boot-helper.S
+++ b/litex/soc/cores/cpu/qemu/boot-helper.S
@@ -1,0 +1,5 @@
+.section    .text, "ax", @progbits
+.global     boot_helper
+
+boot_helper:
+	jr a3

--- a/litex/soc/cores/cpu/qemu/core.py
+++ b/litex/soc/cores/cpu/qemu/core.py
@@ -1,0 +1,159 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+
+from litex.gen import *
+
+from litex.build.generic_platform import Pins
+
+from litex.soc.interconnect import axi
+from litex.soc.cores.cpu import CPU, CPU_GCC_TRIPLE_RISCV32, CPU_GCC_TRIPLE_RISCV64
+from litex.soc.integration.soc import SoCRegion
+
+# Variants -----------------------------------------------------------------------------------------
+
+CPU_VARIANTS = ["standard", "rv32", "rv64"]
+
+# GCC Flags ----------------------------------------------------------------------------------------
+
+GCC_FLAGS = {
+    "rv32": "-march=rv32i2p0_mac  -mabi=ilp32 ",
+    "rv64": "-march=rv64i2p0_mac  -mabi=lp64 -mcmodel=medany ",
+}
+
+# Helpers ------------------------------------------------------------------------------------------
+
+def _qemu_bus_interface():
+    return axi.AXIInterface(data_width=32, address_width=32)
+
+
+def _qemu_bus_pad_name(shared_ram=False):
+    return "qemu_axi_shared_ram" if shared_ram else "qemu_axi"
+
+
+def _qemu_region_is_in_io_regions(region_origin, region_size, io_regions):
+    for origin, size in io_regions.items():
+        if region_origin >= origin and region_origin + region_size <= origin + size:
+            return True
+    return False
+
+# QEMU ---------------------------------------------------------------------------------------------
+
+
+class QEMU(CPU):
+    category             = "emulator"
+    family               = "riscv"
+    name                 = "qemu"
+    human_name           = "QEMU RISC-V"
+    variants             = CPU_VARIANTS
+    data_width           = 32
+    endianness           = "little"
+    gcc_triple           = CPU_GCC_TRIPLE_RISCV32
+    linker_output_format = "elf32-littleriscv"
+    nop                  = "nop"
+
+    def __init__(self, platform, variant="standard"):
+        if variant == "standard":
+            variant = "rv32"
+
+        self.platform = platform
+        self.variant  = variant
+        self.xlen     = 64 if variant == "rv64" else 32
+        self.reset    = Signal()
+
+        self.bus          = _qemu_bus_interface()
+        self.periph_buses = [self.bus]
+        self.memory_buses = []
+
+        self.interrupt           = Signal(32)
+        self.interrupts          = {}
+        self.reserved_interrupts = {"noirq": 0}
+
+        if self.xlen == 64:
+            self.data_width           = 64
+            self.gcc_triple           = CPU_GCC_TRIPLE_RISCV64
+            self.linker_output_format = "elf64-littleriscv"
+            self.mem_map = {
+                "clint"    : 0x0200_0000,
+                "plic"     : 0x0c00_0000,
+                "rom"      : 0x1000_0000,
+                "sram"     : 0x1100_0000,
+                "csr"      : 0x1200_0000,
+                "ethmac"   : 0x3000_0000,
+                "main_ram" : 0x8000_0000,
+            }
+            self.io_regions = {0x1200_0000: 0x6e00_0000}
+        else:
+            self.data_width           = 32
+            self.gcc_triple           = CPU_GCC_TRIPLE_RISCV32
+            self.linker_output_format = "elf32-littleriscv"
+            self.mem_map = {
+                "clint"    : 0xf001_0000,
+                "plic"     : 0xf0c0_0000,
+                "rom"      : 0x0000_0000,
+                "sram"     : 0x1000_0000,
+                "main_ram" : 0x4000_0000,
+                "csr"      : 0xf000_0000,
+            }
+            self.io_regions = {0x8000_0000: 0x8000_0000}
+
+        self._add_sim_pads(platform, _qemu_bus_pad_name())
+
+    @property
+    def gcc_flags(self):
+        flags  = "-mno-save-restore "
+        flags += GCC_FLAGS[self.variant]
+        flags += "-D__qemu__ -D__riscv_plic__ -DUART_POLLING "
+        return flags
+
+    def _add_sim_pads(self, platform, name):
+        platform.add_extension(self.bus.get_ios(name))
+        platform.add_extension([("qemu_irq", 0, Pins(len(self.interrupt)))])
+        platform.add_extension([("qemu_reset", 0, Pins(1))])
+        self.comb += self.bus.connect_to_pads(platform.request(name), mode="slave")
+        self.comb += platform.request("qemu_irq").eq(self.interrupt)
+        self.comb += platform.request("qemu_reset").eq(self.reset)
+
+    def set_reset_address(self, reset_address):
+        self.reset_address = reset_address
+
+    def add_jtag(self, pads):
+        pass
+
+    def add_soc_components(self, soc):
+        soc.add_config("CPU_COUNT", 1)
+        soc.add_config("CPU_ISA",   "rv{}imac".format(self.xlen))
+        soc.add_config("CPU_MMU",   {32: "sv32", 64: "sv39"}[self.xlen])
+
+        for name, size in {
+            "clint" : 0x1_0000,
+            "plic"  : 0x40_0000,
+        }.items():
+            origin = soc.mem_map.get(name)
+            cached = not _qemu_region_is_in_io_regions(
+                region_origin = origin,
+                region_size   = size,
+                io_regions    = self.io_regions,
+            )
+            soc.bus.add_region(name, SoCRegion(
+                origin = origin,
+                size   = size,
+                cached = cached,
+                linker = True,
+            ))
+
+# QEMU Shared RAM ----------------------------------------------------------------------------------
+
+class QEMUSharedRAM(LiteXModule):
+    def __init__(self, platform, name=None):
+        name     = _qemu_bus_pad_name(shared_ram=True) if name is None else name
+        self.bus = _qemu_bus_interface()
+        self._add_sim_pads(platform, name)
+
+    def _add_sim_pads(self, platform, name):
+        platform.add_extension(self.bus.get_ios(name))
+        self.comb += self.bus.connect_to_pads(platform.request(name), mode="master")

--- a/litex/soc/cores/cpu/qemu/crt0.S
+++ b/litex/soc/cores/cpu/qemu/crt0.S
@@ -1,0 +1,135 @@
+.global main
+.global isr
+.global _start
+
+_start:
+	j crt_init
+	nop
+	nop
+	nop
+	nop
+	nop
+	nop
+	nop
+
+.global trap_entry
+trap_entry:
+#if __riscv_xlen == 64
+	sd x1,  - 1*8(sp)
+	sd x5,  - 2*8(sp)
+	sd x6,  - 3*8(sp)
+	sd x7,  - 4*8(sp)
+	sd x10, - 5*8(sp)
+	sd x11, - 6*8(sp)
+	sd x12, - 7*8(sp)
+	sd x13, - 8*8(sp)
+	sd x14, - 9*8(sp)
+	sd x15, -10*8(sp)
+	sd x16, -11*8(sp)
+	sd x17, -12*8(sp)
+	sd x28, -13*8(sp)
+	sd x29, -14*8(sp)
+	sd x30, -15*8(sp)
+	sd x31, -16*8(sp)
+	addi sp, sp, -16*8
+	call isr
+	ld x1,  15*8(sp)
+	ld x5,  14*8(sp)
+	ld x6,  13*8(sp)
+	ld x7,  12*8(sp)
+	ld x10, 11*8(sp)
+	ld x11, 10*8(sp)
+	ld x12,  9*8(sp)
+	ld x13,  8*8(sp)
+	ld x14,  7*8(sp)
+	ld x15,  6*8(sp)
+	ld x16,  5*8(sp)
+	ld x17,  4*8(sp)
+	ld x28,  3*8(sp)
+	ld x29,  2*8(sp)
+	ld x30,  1*8(sp)
+	ld x31,  0*8(sp)
+	addi sp, sp, 16*8
+#else
+	sw x1,  - 1*4(sp)
+	sw x5,  - 2*4(sp)
+	sw x6,  - 3*4(sp)
+	sw x7,  - 4*4(sp)
+	sw x10, - 5*4(sp)
+	sw x11, - 6*4(sp)
+	sw x12, - 7*4(sp)
+	sw x13, - 8*4(sp)
+	sw x14, - 9*4(sp)
+	sw x15, -10*4(sp)
+	sw x16, -11*4(sp)
+	sw x17, -12*4(sp)
+	sw x28, -13*4(sp)
+	sw x29, -14*4(sp)
+	sw x30, -15*4(sp)
+	sw x31, -16*4(sp)
+	addi sp, sp, -16*4
+	call isr
+	lw x1,  15*4(sp)
+	lw x5,  14*4(sp)
+	lw x6,  13*4(sp)
+	lw x7,  12*4(sp)
+	lw x10, 11*4(sp)
+	lw x11, 10*4(sp)
+	lw x12,  9*4(sp)
+	lw x13,  8*4(sp)
+	lw x14,  7*4(sp)
+	lw x15,  6*4(sp)
+	lw x16,  5*4(sp)
+	lw x17,  4*4(sp)
+	lw x28,  3*4(sp)
+	lw x29,  2*4(sp)
+	lw x30,  1*4(sp)
+	lw x31,  0*4(sp)
+	addi sp, sp, 16*4
+#endif
+	mret
+	.text
+
+crt_init:
+	la sp, _fstack
+	la a0, trap_entry
+	csrw mtvec, a0
+
+data_init:
+	la a0, _fdata
+	la a1, _edata
+	la a2, _fdata_rom
+data_loop:
+	beq a0, a1, data_done
+#if __riscv_xlen == 64
+	ld a3, 0(a2)
+	sd a3, 0(a0)
+	addi a0, a0, 8
+	addi a2, a2, 8
+#else
+	lw a3, 0(a2)
+	sw a3, 0(a0)
+	addi a0, a0, 4
+	addi a2, a2, 4
+#endif
+	j data_loop
+data_done:
+
+bss_init:
+	la a0, _fbss
+	la a1, _ebss
+bss_loop:
+	beq a0, a1, bss_done
+#if __riscv_xlen == 64
+	sd zero, 0(a0)
+	addi a0, a0, 8
+#else
+	sw zero, 0(a0)
+	addi a0, a0, 4
+#endif
+	j bss_loop
+bss_done:
+
+	call main
+infinit_loop:
+	j infinit_loop

--- a/litex/soc/cores/cpu/qemu/csr-defs.h
+++ b/litex/soc/cores/cpu/qemu/csr-defs.h
@@ -1,0 +1,6 @@
+#ifndef CSR_DEFS__H
+#define CSR_DEFS__H
+
+#define CSR_MSTATUS_MIE 0x8
+
+#endif /* CSR_DEFS__H */

--- a/litex/soc/cores/cpu/qemu/irq.h
+++ b/litex/soc/cores/cpu/qemu/irq.h
@@ -1,0 +1,54 @@
+#ifndef __IRQ_H
+#define __IRQ_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <system.h>
+#include <generated/mem.h>
+#include <generated/soc.h>
+
+// QEMU exposes a SiFive-compatible Platform-Level Interrupt Controller (PLIC)
+// at the LiteX-generated PLIC memory region.
+
+#define PLIC_PENDING      (PLIC_BASE + 0x001000L) // Bit field matching currently pending pins
+#define PLIC_ENABLED      (PLIC_BASE + 0x002000L) // Bit field corresponding to the current mask
+#define PLIC_THRSHLD      (PLIC_BASE + 0x200000L) // Per-pin priority must be >= this to trigger
+#define PLIC_CLAIM        (PLIC_BASE + 0x200004L) // Claim & completion register address
+
+#define PLIC_EXT_IRQ_BASE 0
+
+static inline unsigned int irq_getie(void)
+{
+	return (csrr(mstatus) & CSR_MSTATUS_MIE) != 0;
+}
+
+static inline void irq_setie(unsigned int ie)
+{
+	if (ie)
+		csrs(mstatus, CSR_MSTATUS_MIE);
+	else
+		csrc(mstatus, CSR_MSTATUS_MIE);
+}
+
+static inline unsigned int irq_getmask(void)
+{
+	return *((unsigned int *)PLIC_ENABLED) >> PLIC_EXT_IRQ_BASE;
+}
+
+static inline void irq_setmask(unsigned int mask)
+{
+	*((unsigned int *)PLIC_ENABLED) = mask << PLIC_EXT_IRQ_BASE;
+}
+
+static inline unsigned int irq_pending(void)
+{
+	return *((unsigned int *)PLIC_PENDING) >> PLIC_EXT_IRQ_BASE;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __IRQ_H */

--- a/litex/soc/cores/cpu/qemu/system.h
+++ b/litex/soc/cores/cpu/qemu/system.h
@@ -1,0 +1,49 @@
+#ifndef __SYSTEM_H
+#define __SYSTEM_H
+
+#include <csr-defs.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+__attribute__((unused)) static void flush_cpu_icache(void)
+{
+}
+
+__attribute__((unused)) static void flush_cpu_dcache(void)
+{
+}
+
+void flush_l2_cache(void);
+
+void busy_wait(unsigned int ms);
+void busy_wait_us(unsigned int us);
+
+#define csrr(reg) ({ unsigned long __tmp; \
+	asm volatile ("csrr %0, " #reg : "=r"(__tmp)); \
+	__tmp; })
+
+#define csrw(reg, val) ({ \
+	if (__builtin_constant_p(val) && (unsigned long)(val) < 32) \
+		asm volatile ("csrw " #reg ", %0" :: "i"(val)); \
+	else \
+		asm volatile ("csrw " #reg ", %0" :: "r"(val)); })
+
+#define csrs(reg, bit) ({ \
+	if (__builtin_constant_p(bit) && (unsigned long)(bit) < 32) \
+		asm volatile ("csrrs x0, " #reg ", %0" :: "i"(bit)); \
+	else \
+		asm volatile ("csrrs x0, " #reg ", %0" :: "r"(bit)); })
+
+#define csrc(reg, bit) ({ \
+	if (__builtin_constant_p(bit) && (unsigned long)(bit) < 32) \
+		asm volatile ("csrrc x0, " #reg ", %0" :: "i"(bit)); \
+	else \
+		asm volatile ("csrrc x0, " #reg ", %0" :: "r"(bit)); })
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __SYSTEM_H */

--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -10,15 +10,16 @@
 # Copyright (c) 2026 Aoba Fujino <41146f@gmail.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
-import sys
+import os
 import subprocess
-import argparse
 
 from migen import *
 
 from litex.build.generic_platform import *
 from litex.build.sim              import SimPlatform
 from litex.build.sim.config       import SimConfig
+from litex.build.sim.qemu.cosim   import qemu_add_args, qemu_configure, qemu_add_sim_modules
+from litex.build.sim.qemu.cosim   import qemu_add_shared_ram, qemu_command, qemu_spawn_when_bridge_ready
 
 from litex.soc.integration.common   import *
 from litex.soc.integration.builder  import *
@@ -463,6 +464,9 @@ def sim_args(parser):
     # JTAG
     parser.add_argument("--with-jtagremote",      action="store_true", help="Enable jtagremote support")
 
+    # QEMU co-simulation.
+    qemu_add_args(parser)
+
     # GPIO.
     parser.add_argument("--with-gpio",            action="store_true",     help="Enable Tristate GPIO (32 pins).")
 
@@ -495,6 +499,7 @@ def main():
         parser.error("--sim-speed-interval must be greater than 0.")
 
     soc_kwargs = soc_core_argdict(args)
+    qemu_enabled = qemu_configure(args, parser, soc_kwargs)
 
     sys_clk_freq = int(1e6)
     sim_config           = SimConfig()
@@ -529,6 +534,10 @@ def main():
             sim_speed_interfaces.append("serial")
             sim_speed_console = True
 
+    # QEMU co-simulation bridge.
+    if qemu_enabled:
+        qemu_add_sim_modules(sim_config, args, parser)
+
     # Create config SoC that will be used to prepare/configure real one.
     conf_soc = SimSoC(**soc_kwargs)
 
@@ -541,14 +550,16 @@ def main():
 
     # RAM / SDRAM.
     ram_boot_address = None
-    soc_kwargs["integrated_main_ram_size"] = args.integrated_main_ram_size
+    main_ram_init = []
     if args.integrated_main_ram_size:
         if args.ram_init is not None:
-            soc_kwargs["integrated_main_ram_init"] = get_mem_data(args.ram_init,
+            main_ram_init = get_mem_data(args.ram_init,
                 data_width = conf_soc.bus.data_width,
                 endianness = conf_soc.cpu.endianness,
                 offset     = conf_soc.mem_map["main_ram"]
             )
+            if not args.qemu_shared_ram_enabled:
+                soc_kwargs["integrated_main_ram_init"] = main_ram_init
             ram_boot_address = get_boot_address(args.ram_init)
     elif args.with_sdram:
         from litedram.modules   import parse_spd_hexdump
@@ -619,6 +630,13 @@ def main():
         trace_reset_on         = int(float(args.trace_start)) > 0 or int(float(args.trace_end)) > 0,
         spi_flash_init         = None if args.spi_flash_init is None else get_mem_data(args.spi_flash_init, endianness="big"),
         **soc_kwargs)
+    if args.qemu_shared_ram_enabled:
+        qemu_add_shared_ram(
+            soc        = soc,
+            args       = args,
+            init_data  = main_ram_init,
+            data_width = conf_soc.bus.data_width,
+        )
     if ram_boot_address is not None:
         if ram_boot_address == 0:
             ram_boot_address = conf_soc.mem_map["main_ram"]
@@ -630,18 +648,34 @@ def main():
             soc.add_constant("REMOTEIP{}".format(i+1), int(args.remote_ip.split(".")[i]))
 
     # Build/Run ------------------------------------------------------------------------------------
+    qemu_proc = None
+
     def pre_run_callback(vns):
+        nonlocal qemu_proc
         if args.trace:
             generate_gtkw_savefile(builder, vns, args.trace_fst)
+        if qemu_enabled and not args.qemu_no_run:
+            qemu_cmd = qemu_command(builder, soc, args)
+            print("[litex_sim] QEMU command: {}".format(" ".join(qemu_cmd)))
+            qemu_proc = qemu_spawn_when_bridge_ready(
+                cmd     = qemu_cmd,
+                host    = args.qemu_bind,
+                port    = args.qemu_port,
+                timeout = args.qemu_wait_timeout,
+            )
 
     builder = Builder(soc, **parser.builder_argdict)
-    builder.build(
-        sim_config       = sim_config,
-        interactive      = not args.non_interactive,
-        video            = args.with_video_framebuffer or args.with_video_terminal or args.with_video_colorbars,
-        pre_run_callback = pre_run_callback,
-        **parser.toolchain_argdict,
-    )
+    try:
+        builder.build(
+            sim_config       = sim_config,
+            interactive      = not args.non_interactive,
+            video            = args.with_video_framebuffer or args.with_video_terminal or args.with_video_colorbars,
+            pre_run_callback = pre_run_callback,
+            **parser.toolchain_argdict,
+        )
+    finally:
+        if qemu_proc is not None and qemu_proc.poll() is None:
+            qemu_proc.terminate()
 
 if __name__ == "__main__":
     main()

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -83,8 +83,9 @@ def _litex_boards_target(filename):
 
 def boot_test(cpu_type="vexriscv", cpu_variant="standard", args="", output_dir=None):
     output_arg = f' --output-dir={output_dir}' if output_dir else ''
+    litex_sim = f"{sys.executable} -m litex.tools.litex_sim"
     cmd = (
-        f'litex_sim --cpu-type={cpu_type} --cpu-variant={cpu_variant} {args}'
+        f'{litex_sim} --cpu-type={cpu_type} --cpu-variant={cpu_variant} {args}'
         f'{output_arg} --opt-level=O0 --jobs {_sim_jobs()}'
     )
     litex_prompt = [r'\033\[[0-9;]+mlitex\033\[[0-9;]+m>']
@@ -278,6 +279,20 @@ UNTESTED_CPUS = [
 def test_cpu(cpu, request, tmp_path):
     variant = TESTED_CPU_VARIANTS.get(cpu, "standard")
     assert boot_test(cpu_type=cpu, cpu_variant=variant, output_dir=str(tmp_path))
+
+@pytest.mark.skipif(
+    os.environ.get("LITEX_QEMU_COSIM_TEST") != "1",
+    reason="QEMU co-simulation test requires a patched QEMU binary.",
+)
+@pytest.mark.parametrize("bus_standard", ["wishbone", "axi-lite", "axi"])
+def test_qemu_cpu(tmp_path, bus_standard):
+    port = _get_free_tcp_port()
+    assert boot_test(
+        cpu_type="qemu",
+        cpu_variant="rv32",
+        args=f"--bus-standard={bus_standard} --integrated-main-ram-size=0x100000 --qemu-port={port}",
+        output_dir=str(tmp_path),
+    )
 
 BUS_OPTIONS = [
     ("--bus-standard", ["wishbone", "axi-lite", "axi"]),


### PR DESCRIPTION
## Purpose

This PR adds a prototype QEMU co-simulation mode for `litex_sim`: QEMU runs the
RISC-V CPU while the regular LiteX SoC, interconnect and peripherals remain in
Verilator.

The goal is to make CPU-heavy simulation workloads significantly faster without
losing LiteX's normal simulated peripheral model. This also provides a path for
Linux-oriented experiments where instruction execution should happen in QEMU,
while LiteX-specific MMIO and DMA-visible memory remain observable in the
Verilated SoC.

## Summary

- Add a `qemu` RISC-V CPU integration with RV32 and RV64 variants.
- Expose the QEMU CPU as a full AXI LiteX bus master and rely on LiteX's
  existing bus adapters for `wishbone`, `axi-lite` and `axi` SoC bus standards.
- Add a `qemu_axi` `litex_sim` external module that bridges QEMU MMIO accesses
  to LiteX over a small blocking TCP request/response protocol.
- Add IRQ polling and LiteX CPU reset propagation through the same bridge.
- Wire QEMU launch support into `litex_sim --cpu-type=qemu`, including automatic
  bridge readiness waiting.
- Add shared integrated main RAM support so QEMU CPU accesses and Verilated
  LiteX DMA/peripheral accesses can target the same backing storage.
- Add a QEMU `litex-sim` machine patch for QEMU 8.2.x and document the bridge
  protocol.
- Add helper scripts to build/check the patched QEMU binaries.
- Add Linux boot asset plumbing for `-bios`, `-kernel`, `-dtb`, `-initrd` and
  `-append`.
- Add guarded CI/test coverage for the patched QEMU path and the supported LiteX
  bus standards.

## Design

QEMU owns CPU execution, executable local memory and the RISC-V local interrupt
blocks. LiteX/Verilator owns the regular SoC MMIO/peripheral window. QEMU maps
that LiteX IO window as a QEMU memory region and forwards each MMIO access to
the Verilator-side `qemu_axi` module over the bridge protocol.

The bridge presents a 32-bit full AXI master to LiteX. LiteX then adapts this
master to the configured SoC bus when needed, so the same QEMU CPU integration
can elaborate with `wishbone`, `axi-lite` and `axi` SoC bus standards.

When `--cpu-type=qemu` is used with integrated main RAM, `litex_sim` replaces
the generated LiteX RAM with `QEMUSharedRAM`. QEMU maps the same file through
`memory-backend-file`, while Verilator maps it through the `qemu_axi` external
module's optional `qemu_axi_shared_ram` interface. This lets LiteX bus masters,
including DMA-capable peripherals, access the same main RAM storage as the QEMU
CPU.

## User Flow

Build the patched QEMU binaries:

```sh
python3 litex/build/sim/qemu/build_qemu_litex.py
```

Run a basic QEMU-backed LiteX SIM:

```sh
python3 -m litex.tools.litex_sim \
  --cpu-type=qemu \
  --cpu-variant=rv32 \
  --integrated-main-ram-size=0x100000
```

Run RV64:

```sh
python3 -m litex.tools.litex_sim \
  --cpu-type=qemu \
  --cpu-variant=rv64 \
  --integrated-main-ram-size=0x100000
```

Check the patched QEMU binaries:

```sh
python3 litex/build/sim/qemu/check_qemu_litex.py
```

Check LiteX elaboration without launching QEMU:

```sh
python3 -m litex.tools.litex_sim \
  --cpu-type=qemu \
  --cpu-variant=rv32 \
  --bus-standard=axi \
  --integrated-main-ram-size=0x100000 \
  --qemu-no-run \
  --no-compile
```

Use `--bus-standard=wishbone`, `--bus-standard=axi-lite` or
`--bus-standard=axi` to select the LiteX SoC bus.

## Notes And Limitations

- The bridge protocol is intentionally simple and blocking.
- The QEMU MMIO path currently forwards one QEMU access at a time. The
  Verilator-side bridge emits simple AXI transactions; it is not a native AXI
  burst/ID traffic generator.
- AXI-Lite and Wishbone support use LiteX's existing bus conversion path.
- Shared main RAM shares storage, not CPU cache state. Software using DMA still
  needs normal cache maintenance or uncached mappings.
- Linux boot plumbing is present, but a complete Linux target still needs
  matching firmware, DTB and software configuration for the simulated platform.
- Remote/Etherbone support is intentionally deferred to a follow-up PR to keep
  this first QEMU co-simulation PR focused on `litex_sim`.

## Validation

The cleaned branch was validated with:

```sh
git diff --check origin/master..HEAD
git log --check --pretty=oneline origin/master..HEAD
python3 -m py_compile \
  litex/tools/litex_sim.py \
  litex/soc/cores/cpu/qemu/core.py \
  litex/build/sim/qemu/cosim.py \
  litex/build/sim/qemu/build_qemu_litex.py \
  litex/build/sim/qemu/check_qemu_litex.py
gcc -c -Wall -Werror -fPIC -Ilitex/build/sim/core \
  litex/build/sim/core/modules/qemu_axi/qemu_axi.c \
  -o /tmp/qemu_axi.o
python3 -m litex.tools.litex_sim \
  --cpu-type=qemu \
  --cpu-variant=rv32 \
  --bus-standard=axi \
  --integrated-main-ram-size=0x100000 \
  --qemu-no-run \
  --no-compile
python3 -m litex.tools.litex_sim \
  --cpu-type=qemu \
  --cpu-variant=rv64 \
  --bus-standard=axi-lite \
  --integrated-main-ram-size=0x100000 \
  --qemu-no-run \
  --no-compile
git apply --stat litex/build/sim/qemu/qemu-litex-sim-v8.2.4.patch
pytest -q test/test_sim_platform.py test/test_sim_verilator.py \
  test/test_integration.py::test_qemu_cpu
```

Earlier smoke runs also built and launched the Verilator/QEMU pair for RV32 and
RV64 with shared integrated main RAM, reached the LiteX BIOS prompt, and passed
the BIOS main RAM memtest.
