### PR TITLE
sim/ethernet: handle both GMII and bare frames on TX for tap0

### DIFF
--- a/litex/build/sim/core/modules/ethernet/ethernet.c
+++ b/litex/build/sim/core/modules/ethernet/ethernet.c
@@ -101,7 +101,7 @@ static int ethernet_start(void *b)
 {
   base = (struct event_base *) b;
   printf("[ethernet] loaded (%p)\n", base);
-  return RC_OK;
+return RC_OK;
 }
 
 void event_handler(int fd, short event, void *arg)
@@ -203,40 +203,60 @@ out:
 static int ethernet_tick(void *sess, uint64_t time_ps)
 {
   static clk_edge_state_t edge;
-  char c;
+  static int in_frame    = 0;
+  static int preamble    = 0;
+  static int skip_fcs    = 0;
+  unsigned char c;
   struct session_s *s = (struct session_s*)sess;
   struct eth_packet_s *pep;
 
-  if(!clk_pos_edge(&edge, *s->sys_clk)) {
+  if(!clk_pos_edge(&edge, *s->sys_clk))
     return RC_OK;
-  }
 
   *s->tx_ready = 1;
   if(*s->tx_valid == 1) {
-    c = *s->tx;
-    s->databuf[s->datalen++]=c;
+    c = (unsigned char)*s->tx;
+    if(!in_frame) {
+      if(c == 0x55) {
+        preamble = 1;               /* octet de préambule, ignore */
+      } else if(c == 0xd5 && preamble) {
+        in_frame = 1;               /* SFD trouvé → prochain octet = Dst MAC */
+        skip_fcs = 1;               /* mode préambule : FCS présent en fin */
+      } else if(!preamble) {
+        in_frame = 1;               /* pas de préambule : trame nue */
+        skip_fcs = 0;               /* pas de FCS non plus */
+        s->databuf[s->datalen++] = c; /* premier octet = Dst MAC, à garder */
+      }
+    } else {
+      s->databuf[s->datalen++] = c;
+    }
   } else {
     if(s->datalen) {
-      tapcfg_write(s->tapcfg, s->databuf, s->datalen);
-      s->datalen=0;
+      int len = (skip_fcs && s->datalen > 4) ? s->datalen - 4 : s->datalen;
+      tapcfg_write(s->tapcfg, s->databuf, len);
+      s->datalen = 0;
     }
+    in_frame = 0;
+    preamble = 0;
+    skip_fcs = 0;
   }
 
-  *s->rx_valid=0;
+  /* RX : tap0 → SoC — trame nue, inchangé */
+  *s->rx_valid = 0;
   if(s->inlen) {
-    *s->rx_valid=1;
+    *s->rx_valid = 1;
     *s->rx = s->inbuf[s->insent++];
     if(s->insent == s->inlen) {
-      s->insent =0;
-      s->inlen = 0;
+      s->insent = 0;
+      s->inlen  = 0;
     }
   } else {
     if(s->ethpack) {
       memcpy(s->inbuf, s->ethpack->data, s->ethpack->len);
       s->inlen = s->ethpack->len;
-      pep=s->ethpack->next;
+      pep = s->ethpack->next;
       free(s->ethpack);
-      s->ethpack=pep;
+      s->ethpack = pep;
     }
   }
   return RC_OK;


### PR DESCRIPTION
## sim/ethernet: strip GMII preamble and FCS before writing to tap0

### Problem

The `ethernet_tick()` function in `litex/build/sim/core/modules/ethernet.c` accumulates every byte emitted on the `source` signals and writes them verbatim to the TAP interface via `tapcfg_write()`.

This causes an issue depending on the module connected to the PHY:
1. **LiteEthMAC** outputs a complete GMII byte stream on TX (7 bytes preamble `0x55`, 1 byte SFD `0xd5`, the Ethernet frame, and a 4 bytes FCS). Writing this full stream shifts the frame by 8 bytes on the TAP interface. This produces corrupted Ethernet headers that the Linux kernel silently discards.
2. **Etherbone** (when `with_preamble_crc = False` in `LiteEthPHYModel`) outputs bare frames without preamble or FCS, which works perfectly with the current code.

**Observed symptom on tap0 with LiteEthMAC (tcpdump):**
`55:d5:ff:ff:ff:ff > 55:55:55:55:55:55, ethertype Unknown (0xffff), length 72`
The ARP/ICMP payload was present and correct at a +8 byte offset, but the malformed header prevented any host↔SoC communication.

### Fix

This PR introduces a lightweight state machine in the TX path of `ethernet_tick()` to dynamically support both use cases:

1. **For GMII streams (LiteEthMAC):** It detects the preamble and the SFD byte (`0xd5`). It starts accumulating only from the following byte (first byte of dst MAC) and flags the frame to strip the last 4 bytes (FCS) before calling `tapcfg_write()`.
2. **For bare frames (Etherbone):** If the first byte is not a preamble, it assumes a bare frame. It accumulates everything and does not strip any FCS at the end.

The RX path (tap0 → SoC) remains unchanged.

### Testing

Verified in Verilator simulation with `LiteEthPHYModel` on a TAP interface (`tap0`):
- Both `LiteEthMAC` (192.168.1.50) and `Etherbone` (192.168.1.51) can coexist and operate correctly.
- `ping` from host to both IP addresses returns 5/5 replies.
- `tcpdump -i tap0` shows correct ARP request/reply exchanges followed by valid ICMP echo requests/replies, with no `0xffff` ethertype corruption.