### PR TITLE
Add strtoull to the picolibc build list

### DIFF
--- a/litex/soc/software/libc/Makefile
+++ b/litex/soc/software/libc/Makefile
@@ -130,6 +130,7 @@ MINIMAL_PICOLIBC_SRCS = \
 	$(PICOLIBC_SRC_DIR)/libc/stdio/printf.c \
 	$(PICOLIBC_SRC_DIR)/libc/stdio/puts.c \
 	$(PICOLIBC_SRC_DIR)/libc/stdio/strtoul.c \
+	$(PICOLIBC_SRC_DIR)/libc/stdio/strtoull.c \
 	$(PICOLIBC_SRC_DIR)/libc/stdlib/lldiv.c \
 	$(PICOLIBC_SRC_DIR)/libc/machine/riscv/memcpy-asm.S \
 	$(PICOLIBC_SRC_DIR)/libc/machine/riscv/memmove.S \


### PR DESCRIPTION
sdram_hw_test_handler makes use of strtoull and building fails without it.