### PR TITLE
Update gowin emcu to match hardware-connected signals

### DIFF
--- a/litex/soc/cores/cpu/gowin_emcu/core.py
+++ b/litex/soc/cores/cpu/gowin_emcu/core.py
@@ -111,16 +111,17 @@ class GowinEMCU(CPU):
             i_DAPSWCLKTCK = 0,
 
             # TARGFLASH0 / AHBLite Master.
+            # NOTE: The open signals are connected in hardware and deliberately disconnected by nextpnr
             o_TARGFLASH0HSEL      = ahb_flash.sel,
             o_TARGFLASH0HADDR     = ahb_flash.addr,
             o_TARGFLASH0HTRANS    = ahb_flash.trans,
-            o_TARGFLASH0HSIZE     = ahb_flash.size,
-            o_TARGFLASH0HBURST    = ahb_flash.burst,
+            o_TARGFLASH0HSIZE     = Open(4),
+            o_TARGFLASH0HBURST    = Open(3),
             o_TARGFLASH0HREADYMUX = Open(),
-            i_TARGFLASH0HRDATA    = ahb_flash.rdata,
+            i_TARGFLASH0HRDATA    = Open(32),
             i_TARGFLASH0HRUSER    = 0b000,
             i_TARGFLASH0HRESP     = ahb_flash.resp,
-            i_TARGFLASH0EXRESP    = 0b0,
+            i_TARGFLASH0EXRESP    = Open(),
             i_TARGFLASH0HREADYOUT = ahb_flash.readyout,
 
             # TARGEXP0 / AHBLite Master.
@@ -232,8 +233,9 @@ class GowinEMCU(CPU):
                 fsm.act("WAIT",
                     NextState("IDLE")
                 )
-                self.specials += Instance("FLASH256K",
-                    o_DOUT  = bus.rdata,
+                # NOTE: The DOUT ⇒ EMCU connection is implement in hardware
+                self.specials.flash = Instance("FLASH256K",
+                    o_DOUT  = Signal(32),
                     i_DIN   = Signal(32),
                     i_XADR  = addr[6:],
                     i_YADR  = addr[:6],
@@ -244,6 +246,8 @@ class GowinEMCU(CPU):
                     i_ERASE = 0,
                     i_NVSTR = 0
                 )
+                # As no output is used in RTL, yosys would otherwise discard it
+                self.flash.attr.add("keep")
 
         flash = ResetInserter()(AHBFlash(ahb_flash))
         self.comb += flash.reset.eq(~bus_reset_n)

--- a/litex/soc/cores/cpu/gowin_emcu/core.py
+++ b/litex/soc/cores/cpu/gowin_emcu/core.py
@@ -257,16 +257,5 @@ class GowinEMCU(CPU):
         # ---------------------------------
         self.submodules += ahb.AHB2Wishbone(ahb_targexp0, self.pbus)
 
-    def connect_jtag(self, pads):
-        self.cpu_params.update(
-            i_DAPSWDITMS  = pads.tms,
-            i_DAPTDI      = pads.tdi,
-            o_DAPTDO      = pads.tdo,
-            o_DAPNTDOEN   = Signal(),
-            i_DAPNTRST    = ~self.reset,
-            i_DAPSWCLKTCK = pads.tck,
-            o_DAPJTAGNSW  = Signal(),  # Indicates debug mode, JTAG or SWD
-        )
-
     def do_finalize(self):
         self.specials += Instance("EMCU", **self.cpu_params)


### PR DESCRIPTION
Quite a few of the signals on the EMCU primitive are connected in hardware and deliberately [disconnected by nextpnr](https://github.com/YosysHQ/nextpnr/blob/32324500c4ae33670df429d2e8e2a83b51b062ab/himbaechel/uarch/gowin/pack.cc#L518) during the build. This includes the flash read data and most debug signals. 

EDIT: at least the flash changes don't really change anything and are more-so for accuracy. Feel free to not close/drop this commit if it doesn't seem useful.