### PR TITLE
soc/cores/clock/intel_agilex.py: set self_reset_en to TRUE to allows auto reset when lock is lost

### DIFF
--- a/litex/soc/cores/clock/intel_agilex.py
+++ b/litex/soc/cores/clock/intel_agilex.py
@@ -218,7 +218,7 @@ class AgilexPLL(IntelClocking):
             p_ref_clk_1_freq              = Constant(0, 32),
             p_ref_clk_delay               = 0,
             p_ref_clk_n_div               = config["n"],
-            p_self_reset_en               = "FALSE",
+            p_self_reset_en               = "TRUE",
             p_set_dutycycle               = "SET_DUTYCYCLE_FRACTION",
             p_set_fractional              = "SET_FRACTIONAL_FRACTION",
             p_set_freq                    = "SET_FREQ_DIVISION_VERIFY",


### PR DESCRIPTION
Agilex pll (`tennm_ph2_iopll`) may performs an auto reset when the input signal/lock is lost. The current status is to disable this feature with some drawback for external clock coming from a device is disabled during a reset or something similar.

This commit enables unconditionally this feature.