### PR TITLE
bios: Fix bugs/robustness issues and improve usability.

### DIFF
--- a/litex/soc/cores/bitbang.py
+++ b/litex/soc/cores/bitbang.py
@@ -45,7 +45,8 @@ class I2CMaster(LiteXModule):
             CSRField("sda", size=1, offset=2, reset=1, description="Drives the state of the SDA pad.")],
             name="w")
         self._r = CSRStatus(fields=[
-            CSRField("sda", size=1, offset=0, description="Contains the current state of the SDA pad.")],
+            CSRField("sda", size=1, offset=0, description="Contains the current state of the SDA pad."),
+            CSRField("scl", size=1, offset=1, description="Contains the current state of the SCL pad.")],
             name="r")
 
         self.default_dev = default_dev
@@ -62,8 +63,9 @@ class I2CMaster(LiteXModule):
         """
         # SCL
         self.specials += Tristate(pads.scl,
-            o  = 0,                  # I2C uses Pull-ups, only drive low.
-            oe = ~self._w.fields.scl # Drive when scl is low.
+            o  = 0,                   # I2C uses Pull-ups, only drive low.
+            oe = ~self._w.fields.scl, # Drive when scl is low.
+            i  = self._r.fields.scl   # Readback to detect slave clock stretching.
         )
         # SDA
         self.specials += Tristate(pads.sda,
@@ -108,6 +110,7 @@ class I2CMasterSim(I2CMaster):
 
         self.comb += [
             pads.scl.eq(self._w.fields.scl),
+            self._r.fields.scl.eq(self._w.fields.scl), # No open-drain in sim: read back the driven value.
             _sda_oe.eq( self._w.fields.oe),
             _sda_w.eq(  self._w.fields.sda),
             If(_sda_oe,

--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -511,6 +511,8 @@ def get_i2c_header(i2c_init_values):
         r += "\t\t.ops.w_scl_offset   = CSR_{}_W_SCL_OFFSET,\n".format(name.upper())
         r += "\t\t.ops.w_sda_offset   = CSR_{}_W_SDA_OFFSET,\n".format(name.upper())
         r += "\t\t.ops.w_oe_offset    = CSR_{}_W_OE_OFFSET,\n".format(name.upper())
+        r += "\t\t.ops.r_sda_offset   = CSR_{}_R_SDA_OFFSET,\n".format(name.upper())
+        r += "\t\t.ops.r_scl_offset   = CSR_{}_R_SCL_OFFSET,\n".format(name.upper())
         r += "\t\t.name               = \"{}\"\n".format(name)
         r += "\t},\n"
     r += "};\n\n"

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -321,7 +321,7 @@ int serialboot(void)
 				uart_write(SFL_ACK_SUCCESS);
 				break;
 			}
-			/* On SFL_CMD_ABORT ... */
+			/* On SFL_CMD_JUMP ... */
 			case SFL_CMD_JUMP: {
 				uint32_t jump_addr;
 

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -237,10 +237,11 @@ int serialboot(void)
 			if (uart_read_nonblock()) {
 				unsigned char data;
 				data = uart_read();
-				if (i == 0) {
-					timer0_load(CMD_TIMEOUT_DELAY);
+				/* Reload the inter-byte timeout: a full frame can take longer
+				   than CMD_TIMEOUT_DELAY at low baudrates. */
+				timer0_load(CMD_TIMEOUT_DELAY);
+				if (i == 0)
 					frame.payload_length = data;
-				}
 				if (i == 1) frame.crc[0] = data;
 				if (i == 2) frame.crc[1] = data;
 				if (i == 3) frame.cmd    = data;

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -427,15 +427,17 @@ static void boot_from_json_buffer(const char *json_buffer, int size,
 		memset(json_value,  0, sizeof(json_value));
 		/* Elements are JSON strings with 1 children */
 		if ((t[i].type == JSMN_STRING) && (t[i].size == 1)) {
-			/* Get Element's filename */
+			/* Get Element's filename. Abort instead of skipping the entry:
+			   booting with one of the listed images missing (e.g. a kernel
+			   without its device tree) would fail in harder-to-debug ways. */
 			if (!json_token_to_string(json_name, sizeof(json_name), json_buffer, &t[i])) {
 				printf("Error: boot JSON filename is too long\n");
-				continue;
+				return;
 			}
 			/* Get Element's address */
 			if (!json_token_to_string(json_value, sizeof(json_value), json_buffer, &t[i+1])) {
 				printf("Error: boot JSON value for \"%s\" is too long\n", json_name);
-				continue;
+				return;
 			}
 			/* Skip bootargs (optional) */
 			if (strcmp(json_name, "bootargs") == 0) {

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -839,8 +839,10 @@ static int copy_file_from_sdcard_to_ram(const char * filename, unsigned long ram
 	unsigned long length;
 
 	fr = f_mount(&fs, "", 1);
-	if (fr != FR_OK)
+	if (fr != FR_OK) {
+		printf("Error: filesystem mount failed (FatFs error %d)\n", fr);
 		return 0;
+	}
 	fr = f_open(&file, filename, FA_READ);
 	if (fr != FR_OK) {
 		printf("%s file not found.\n", filename);
@@ -900,8 +902,10 @@ static void sdcardboot_from_json(const char * filename)
 
 	/* Read JSON file */
 	fr = f_mount(&fs, "", 1);
-	if (fr != FR_OK)
+	if (fr != FR_OK) {
+		printf("Error: filesystem mount failed (FatFs error %d)\n", fr);
 		return;
+	}
 	fr = f_open(&file, filename, FA_READ);
 	if (fr != FR_OK) {
 		printf("%s file not found.\n", filename);
@@ -983,8 +987,10 @@ static int copy_file_from_sata_to_ram(const char * filename, unsigned long ram_a
 	unsigned long length;
 
 	fr = f_mount(&fs, "", 1);
-	if (fr != FR_OK)
+	if (fr != FR_OK) {
+		printf("Error: filesystem mount failed (FatFs error %d)\n", fr);
 		return 0;
+	}
 	fr = f_open(&file, filename, FA_READ);
 	if (fr != FR_OK) {
 		printf("%s file not found.\n", filename);
@@ -1044,8 +1050,10 @@ static void sataboot_from_json(const char * filename)
 
 	/* Read JSON file */
 	fr = f_mount(&fs, "", 1);
-	if (fr != FR_OK)
+	if (fr != FR_OK) {
+		printf("Error: filesystem mount failed (FatFs error %d)\n", fr);
 		return;
+	}
 	fr = f_open(&file, filename, FA_READ);
 	if (fr != FR_OK) {
 		printf("%s file not found.\n", filename);

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -746,14 +746,14 @@ static unsigned int check_image_in_flash(unsigned int base_address)
 
 	length = MMPTR(base_address);
 	if((length < 32) || (length > 16*1024*1024)) {
-		printf("Error: invalid image length 0x%08lx\n", length);
+		printf("Error: invalid image length 0x%08lx\n", (unsigned long)length);
 		return 0;
 	}
 
 	crc = MMPTR(base_address + 4);
 	got_crc = crc32((unsigned char *)(base_address + 8), length);
 	if(crc != got_crc) {
-		printf("CRC failed (expected %08lx, got %08lx)\n", crc, got_crc);
+		printf("CRC failed (expected %08lx, got %08lx)\n", (unsigned long)crc, (unsigned long)got_crc);
 		return 0;
 	}
 
@@ -777,7 +777,7 @@ static int copy_image_from_flash_to_ram(unsigned int flash_address, unsigned lon
 				(unsigned long)length, (unsigned long)max_size);
 			return 0;
 		}
-		printf("Copying 0x%08x to 0x%08lx (%ld bytes)...\n", flash_address, ram_address, length);
+		printf("Copying 0x%08x to 0x%08lx (%lu bytes)...\n", flash_address, ram_address, (unsigned long)length);
 		offset = 0;
 		init_progression_bar(length);
 		while (length > 0) {
@@ -799,22 +799,18 @@ static int copy_image_from_flash_to_ram(unsigned int flash_address, unsigned lon
 
 void flashboot(void)
 {
-	uint32_t length;
-	uint32_t result;
-
 	printf("Booting from flash...\n");
-	length = check_image_in_flash(FLASH_BOOT_ADDRESS);
-	if(!length)
-		return;
 
 #ifdef MAIN_RAM_BASE
 	/* When Main RAM is available, copy the code from the Flash and execute it
-	from Main RAM since faster */
-	result = copy_image_from_flash_to_ram(FLASH_BOOT_ADDRESS, MAIN_RAM_BASE);
-	if(!result)
+	from Main RAM since faster. The image is checked as part of the copy, no
+	need to check it twice (the CRC over flash is slow). */
+	if(!copy_image_from_flash_to_ram(FLASH_BOOT_ADDRESS, MAIN_RAM_BASE))
 		return;
 	boot(0, 0, 0, MAIN_RAM_BASE);
 #else
+	if(!check_image_in_flash(FLASH_BOOT_ADDRESS))
+		return;
 	/* When Main RAM is not available, execute the code directly from Flash (XIP).
        The code starts after (a) length and (b) CRC -- both uint32_t */
 	boot(0, 0, 0, (FLASH_BOOT_ADDRESS + 2 * sizeof(uint32_t)));

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -401,9 +401,11 @@ static void boot_from_json_buffer(const char *json_buffer, int size,
 	int i;
 	int count;
 
-	/* FIXME: modify/increase if too limiting */
-	char json_name[32];
-	char json_value[32];
+	/* Keep the larger parsing buffers static to limit stack pressure in the
+	   boot paths (see boot_json_buffer). json_name must accommodate long
+	   filenames (FatFs is built with LFN support). */
+	static char json_name[256];
+	static char json_value[64];
 
 	unsigned long boot_r1 = 0;
 	unsigned long boot_r2 = 0;
@@ -414,12 +416,16 @@ static void boot_from_json_buffer(const char *json_buffer, int size,
 	uint8_t boot_addr_found = 0;
 
 	/* Parse JSON file */
-	jsmntok_t t[32];
+	static jsmntok_t t[64];
 	jsmn_parser p;
 	jsmn_init(&p);
 	count = jsmn_parse(&p, json_buffer, size, t, sizeof(t)/sizeof(*t));
 	if (count < 0) {
-		printf("Error: failed to parse boot JSON (%d)\n", count);
+		if (count == JSMN_ERROR_NOMEM)
+			printf("Error: too many entries in boot JSON (max %d tokens)\n",
+				(int)(sizeof(t)/sizeof(*t)));
+		else
+			printf("Error: failed to parse boot JSON (%d)\n", count);
 		return;
 	}
 	for (i=0; i<count-1; i++) {
@@ -738,6 +744,17 @@ void netboot(int nb_params, char **params)
 
 #ifdef FLASH_BOOT_ADDRESS
 
+/* Sanity limit on the flash image length field (catches erased/garbage
+   flash). Defaults to the Main RAM size when available since the image has to
+   fit there anyway; override with FLASH_BOOT_MAX_SIZE if needed. */
+#ifndef FLASH_BOOT_MAX_SIZE
+#ifdef MAIN_RAM_SIZE
+#define FLASH_BOOT_MAX_SIZE MAIN_RAM_SIZE
+#else
+#define FLASH_BOOT_MAX_SIZE (16*1024*1024)
+#endif
+#endif
+
 static unsigned int check_image_in_flash(unsigned int base_address)
 {
 	uint32_t length;
@@ -745,7 +762,7 @@ static unsigned int check_image_in_flash(unsigned int base_address)
 	uint32_t got_crc;
 
 	length = MMPTR(base_address);
-	if((length < 32) || (length > 16*1024*1024)) {
+	if((length < 32) || (length > FLASH_BOOT_MAX_SIZE)) {
 		printf("Error: invalid image length 0x%08lx\n", (unsigned long)length);
 		return 0;
 	}

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -80,14 +80,12 @@ enum {
 #if defined(MAIN_RAM_BASE) || defined(SRAM_BASE)
 static int boot_region_max_size(unsigned long addr, unsigned long base, unsigned long size, size_t *max_size)
 {
-	unsigned long end = base + size;
-
-	if (end < base)
-		return 0;
-	if ((addr < base) || (addr >= end))
+	/* Compare offsets instead of region end so that regions ending exactly at
+	   the top of the address space (base + size wrapping to 0) are accepted. */
+	if ((addr < base) || ((addr - base) >= size))
 		return 0;
 
-	*max_size = end - addr;
+	*max_size = size - (addr - base);
 	return 1;
 }
 #endif

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -1071,6 +1071,7 @@ static void sataboot_from_json(const char * filename)
 	boot_from_json_buffer(boot_json_buffer, length, sataboot_json_load, NULL);
 }
 
+#ifdef MAIN_RAM_BASE
 static void sataboot_from_bin(const char * filename)
 {
 	uint32_t result;
@@ -1079,6 +1080,7 @@ static void sataboot_from_bin(const char * filename)
 		return;
 	boot(0, 0, 0, MAIN_RAM_BASE);
 }
+#endif
 
 void sataboot(void)
 {
@@ -1089,9 +1091,11 @@ void sataboot(void)
 	printf("Booting from boot.json...\n");
 	sataboot_from_json("boot.json");
 
+#ifdef MAIN_RAM_BASE
 	/* Boot from boot.bin */
 	printf("Booting from boot.bin...\n");
 	sataboot_from_bin("boot.bin");
+#endif
 
 	/* Boot failed if we are here... */
 	printf("SATA boot failed.\n");

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -941,8 +941,13 @@ static void sdcardboot_from_bin(const char * filename)
 }
 #endif
 
-void sdcardboot(void)
+void sdcardboot(int nb_params, char **params)
 {
+	char * filename = NULL;
+
+	if (nb_params > 0)
+		filename = params[0];
+
 #ifdef CSR_SPISDCARD_BASE
 	printf("Booting from SDCard in SPI-Mode...\n");
 	fatfs_set_ops_spisdcard();	/* use spisdcard disk access ops */
@@ -952,15 +957,20 @@ void sdcardboot(void)
 	fatfs_set_ops_sdcard();		/* use sdcard disk access ops */
 #endif
 
-	/* Boot from boot.json */
-	printf("Booting from boot.json...\n");
-	sdcardboot_from_json("boot.json");
+	if (filename) {
+		printf("Booting from %s (JSON)...\n", filename);
+		sdcardboot_from_json(filename);
+	} else {
+		/* Boot from boot.json */
+		printf("Booting from boot.json...\n");
+		sdcardboot_from_json("boot.json");
 
 #ifdef MAIN_RAM_BASE
-	/* Boot from boot.bin */
-	printf("Booting from boot.bin...\n");
-	sdcardboot_from_bin("boot.bin");
+		/* Boot from boot.bin */
+		printf("Booting from boot.bin...\n");
+		sdcardboot_from_bin("boot.bin");
 #endif
+	}
 
 	/* Boot failed if we are here... */
 	printf("SDCard boot failed.\n");
@@ -1089,20 +1099,30 @@ static void sataboot_from_bin(const char * filename)
 }
 #endif
 
-void sataboot(void)
+void sataboot(int nb_params, char **params)
 {
+	char * filename = NULL;
+
+	if (nb_params > 0)
+		filename = params[0];
+
 	printf("Booting from SATA...\n");
 	fatfs_set_ops_sata();		/* use sata disk access ops */
 
-	/* Boot from boot.json */
-	printf("Booting from boot.json...\n");
-	sataboot_from_json("boot.json");
+	if (filename) {
+		printf("Booting from %s (JSON)...\n", filename);
+		sataboot_from_json(filename);
+	} else {
+		/* Boot from boot.json */
+		printf("Booting from boot.json...\n");
+		sataboot_from_json("boot.json");
 
 #ifdef MAIN_RAM_BASE
-	/* Boot from boot.bin */
-	printf("Booting from boot.bin...\n");
-	sataboot_from_bin("boot.bin");
+		/* Boot from boot.bin */
+		printf("Booting from boot.bin...\n");
+		sataboot_from_bin("boot.bin");
 #endif
+	}
 
 	/* Boot failed if we are here... */
 	printf("SATA boot failed.\n");

--- a/litex/soc/software/bios/boot.h
+++ b/litex/soc/software/bios/boot.h
@@ -37,7 +37,7 @@ int serialboot(void);
 void netboot(int nb_params, char **params);
 void flashboot(void);
 void romboot(void);
-void sdcardboot(void);
-void sataboot(void);
+void sdcardboot(int nb_params, char **params);
+void sataboot(int nb_params, char **params);
 
 #endif /* __BOOT_H */

--- a/litex/soc/software/bios/cmds/cmd_bios.c
+++ b/litex/soc/software/bios/cmds/cmd_bios.c
@@ -55,6 +55,8 @@ static void ident_handler(int nb_params, char **params)
 	int i;
 	for(i=0;i<IDENT_SIZE;i++)
 		buffer[i] = MMPTR(CSR_IDENTIFIER_MEM_BASE + CONFIG_CSR_ALIGNMENT/8*i);
+	/* Identifier memory may be smaller than IDENT_SIZE: force termination. */
+	buffer[IDENT_SIZE-1] = 0;
 #else
 	buffer[0] = 0;
 #endif
@@ -77,7 +79,7 @@ static void uptime_handler(int nb_params, char **params)
 
 	timer0_uptime_latch_write(1);
 	uptime = timer0_uptime_cycles_read();
-	printf("Uptime: %lld sys_clk cycles - %lld seconds\n",
+	printf("Uptime: %llu sys_clk cycles - %llu seconds\n",
 		uptime,
 		uptime / CONFIG_CLOCK_FREQUENCY
 	);

--- a/litex/soc/software/bios/cmds/cmd_i2c.c
+++ b/litex/soc/software/bios/cmds/cmd_i2c.c
@@ -44,8 +44,8 @@ static void i2c_write_handler(int nb_params, char **params)
 		return;
 	}
 
-	if (nb_params - 1 > sizeof(write_params)) {
-		printf("Error: maximum data length is %zu\n", sizeof(write_params));
+	if (nb_params > (int)sizeof(write_params)) {
+		printf("Error: maximum data length is %zu\n", sizeof(write_params) - 3);
 		return;
 	}
 
@@ -55,6 +55,11 @@ static void i2c_write_handler(int nb_params, char **params)
 			printf("Error: invalid parameter %d\n", i);
 			return;
 		}
+	}
+
+	if ((write_params[2] < 1) || (write_params[2] > 4)) {
+		printf("Error: addr_size needs to be between 1 and 4\n");
+		return;
 	}
 
 	if (!i2c_write(write_params[0], addr, &write_params[3], nb_params - 3, write_params[2])) {

--- a/litex/soc/software/bios/cmds/cmd_liteeth.c
+++ b/litex/soc/software/bios/cmds/cmd_liteeth.c
@@ -127,6 +127,11 @@ static void mdio_dump_handler(int nb_params, char **params)
 		printf("Error: invalid count\n");
 		return;
 	}
+	/* MDIO register space is 5-bit */
+	if (count > 32) {
+		printf("Clamping count to the 32-register MDIO space\n");
+		count = 32;
+	}
 
 	printf("MDIO dump @0x%x:\n", phyadr);
 	for (i = 0; i < count; i++) {
@@ -203,14 +208,14 @@ static void eth_ping_handler(int nb_params, char **params)
 		return;
 	}
 
-	// FIXME!!!
 	unsigned ip_[4];
 	unsigned ip = 0;
 	if (parse_ip(params[0], ip_) != 0)
 		return;
 	ip = IPTOINT(ip_[0], ip_[1], ip_[2], ip_[3]);
 
-	send_ping(ip, 32);
+	if (send_ping(ip, 32) < 0)
+		printf("Error: failed to send ping request\n");
 }
 define_command(ping, eth_ping_handler, "Ping the given IP address", LITEETH_CMDS);
 #endif

--- a/litex/soc/software/bios/cmds/cmd_litesata.c
+++ b/litex/soc/software/bios/cmds/cmd_litesata.c
@@ -124,12 +124,10 @@ static void sata_write_handler(int nb_params, char **params)
 	}
 
 	c = params[1];
-	if (params[1] != NULL) {
-		for(i=0; i<512; i++) {
-			buf[i] = *c;
-			if(*(++c) == 0) {
-				c = params[1];
-			}
+	for(i=0; i<512; i++) {
+		buf[i] = *c;
+		if(*(++c) == 0) {
+			c = params[1];
 		}
 	}
 	dump_bytes((unsigned int *)buf, 512, (unsigned long) buf);
@@ -244,6 +242,8 @@ static void sata_rwtest_handler(int nb_params, char **params)
 
 	if (nb_params < 4) {
 		printf("sata_rwtest <sector> <address> <count> <str>\n");
+		printf("  Warning: overwrites <count> disk sectors starting at <sector>\n");
+		printf("  and 2*512*<count> bytes of memory at <address>.\n");
 		return;
 	}
 

--- a/litex/soc/software/bios/cmds/cmd_litesata.c
+++ b/litex/soc/software/bios/cmds/cmd_litesata.c
@@ -49,7 +49,10 @@ static void sata_read_handler(int nb_params, char **params)
 		return;
 	}
 
-	sata_read(sector, 1, buf);
+	if (sata_read(sector, 1, buf) != 0) {
+		printf("Error: SATA read failed\n");
+		return;
+	}
 	dump_bytes((unsigned int *)buf, 512, (unsigned long) buf);
 }
 
@@ -88,7 +91,8 @@ static void sata_sec2mem_handler(int nb_params, char **params)
 		}
 	}
 
-	sata_read(sec, cnt, dst);
+	if (sata_read(sec, cnt, dst) != 0)
+		printf("Error: SATA read failed\n");
 }
 
 define_command(sata_sec2mem, sata_sec2mem_handler, "Read SATA into memory", LITESATA_CMDS);
@@ -129,7 +133,8 @@ static void sata_write_handler(int nb_params, char **params)
 		}
 	}
 	dump_bytes((unsigned int *)buf, 512, (unsigned long) buf);
-	sata_write(sector, 1, buf);
+	if (sata_write(sector, 1, buf) != 0)
+		printf("Error: SATA write failed\n");
 }
 
 define_command(sata_write, sata_write_handler, "Write SATA sector", LITESATA_CMDS);
@@ -167,7 +172,8 @@ static void sata_mem2sec_handler(int nb_params, char **params)
 		}
 	}
 
-	sata_write(sec, cnt, src);
+	if (sata_write(sec, cnt, src) != 0)
+		printf("Error: SATA write failed\n");
 }
 
 define_command(sata_mem2sec, sata_mem2sec_handler, "Write SATA from memory", LITESATA_CMDS);
@@ -176,67 +182,17 @@ define_command(sata_mem2sec, sata_mem2sec_handler, "Write SATA from memory", LIT
 /* LiteSATA read/write test */
 #if defined(CSR_SATA_SECTOR2MEM_BASE) && defined(CSR_SATA_MEM2SECTOR_BASE)
 #include <string.h>
-static int sata_rd(uint32_t sector, uint32_t count, void *mem)
-{
-	uint32_t done_cnt;
-	uint8_t retry_cnt;
-
-	for (retry_cnt = 8; retry_cnt > 0; retry_cnt--) {
-		sata_sector2mem_base_write((uint64_t)(uintptr_t)mem);
-		sata_sector2mem_sector_write(sector);
-		sata_sector2mem_nsectors_write(count);
-		sata_sector2mem_start_write(1);
-		for (done_cnt = 0x0000ffff; done_cnt > 0; done_cnt --) {
-			if ((sata_sector2mem_done_read() & 0x1) != 0) {
-				if ((sata_sector2mem_error_read() & 0x1) == 0)
-					return 0;
-				else {
-					printf("sata_rd: op failed, retry\n");
-					break;
-				}
-			}
-		}
-		printf("sata_rd: op timeout (done_cnt)\n");
-		busy_wait_us(10);
-	}
-	printf("sata_rd: out of retries\n");
-	return -1;
-}
 
 static int sata_rd_1(uint32_t sector, uint32_t count, void *mem)
 {
 	while(count--) {
-		sata_read(sector++, 1, mem);
+		if (sata_read(sector++, 1, mem) != 0) {
+			printf("sata_rd_1: read failed at sector %lu\n", (unsigned long)(sector - 1));
+			return -1;
+		}
 		mem += 512;
 	}
 	return 0;
-}
-
-static int sata_wr(uint32_t sector, uint32_t count, void *mem)
-{
-	uint32_t done_cnt;
-	uint8_t retry_cnt;
-
-	for (retry_cnt = 8; retry_cnt > 0; retry_cnt--) {
-		sata_mem2sector_base_write((uint64_t)(uintptr_t)mem);
-		sata_mem2sector_sector_write(sector);
-		sata_mem2sector_nsectors_write(count);
-		sata_mem2sector_start_write(1);
-		for (done_cnt = 0x000fffff; done_cnt > 0; done_cnt --) {
-			if ((sata_mem2sector_done_read() & 0x1) != 0) {
-				if ((sata_mem2sector_error_read() & 0x1) == 0)
-					return 0;
-				else {
-					printf("sata_wr: op failed, retry\n");
-					break;
-				}
-			}
-		}
-		printf("sata_wr: op timeout (done_cnt)\n");
-		busy_wait_us(10);
-	}
-	printf("sata_wr: out of retries\n");
-	return -1;
 }
 
 static int sata_mem_cmp(char *mem1, char *mem2, uint32_t count)
@@ -266,10 +222,14 @@ static int sata_do_rwtest(uint32_t sec, uint32_t cnt, char *mem, char *str)
 				c = str;
 		}
 	}
-	if (sata_wr(sec, cnt, mem) < 0)
+	if (sata_write(sec, cnt, (uint8_t *)mem) != 0) {
+		printf("sata_do_rwtest: write failed\n");
 		return -1;
-	if (sata_rd(sec, cnt, mem + 512*cnt) < 0)
+	}
+	if (sata_read(sec, cnt, (uint8_t *)(mem + 512*cnt)) != 0) {
+		printf("sata_do_rwtest: read failed\n");
 		return -1;
+	}
 	if (sata_mem_cmp(mem, mem + 512*cnt, cnt) == 0)
 		return 0;
 	printf("compare failed, retrying with single-sector reads:\n");

--- a/litex/soc/software/bios/cmds/cmd_litesdcard.c
+++ b/litex/soc/software/bios/cmds/cmd_litesdcard.c
@@ -103,7 +103,10 @@ static void sdcard_read_handler(int nb_params, char **params)
 		dst = (uint8_t *)(uintptr_t)addr;
 	}
 
-	sdcard_read(block, 1, dst);
+	if (sdcard_read(block, 1, dst) != SD_OK) {
+		printf("Error: SDCard read failed\n");
+		return;
+	}
 	dump_bytes((unsigned int *)dst, 512, (unsigned long)dst);
 }
 
@@ -145,7 +148,8 @@ static void sdcard_write_handler(int nb_params, char **params)
 		}
 	}
 	dump_bytes((unsigned int *)buf, 512, (unsigned long) buf);
-	sdcard_write(block, 1, buf);
+	if (sdcard_write(block, 1, buf) != SD_OK)
+		printf("Error: SDCard write failed\n");
 }
 
 define_command(sdcard_write, sdcard_write_handler, "Write SDCard block", LITESDCARD_CMDS);

--- a/litex/soc/software/bios/cmds/cmd_litesdcard.c
+++ b/litex/soc/software/bios/cmds/cmd_litesdcard.c
@@ -79,13 +79,14 @@ define_command(sdcard_freq, sdcard_freq_handler, "Set SDCard clock freq", LITESD
 static void sdcard_read_handler(int nb_params, char **params)
 {
 	unsigned int block;
+	unsigned int count = 1;
 	unsigned long addr;
 	char *c;
 	uint8_t buf[512];
 	uint8_t *dst = buf;
 
 	if (nb_params < 1) {
-		printf("sdcard_read <block> [addr]\n");
+		printf("sdcard_read <block> [addr] [count]\n");
 		return;
 	}
 
@@ -102,19 +103,28 @@ static void sdcard_read_handler(int nb_params, char **params)
 		}
 		dst = (uint8_t *)(uintptr_t)addr;
 	}
+	if (nb_params >= 3) {
+		count = strtoul(params[2], &c, 0);
+		if (*c != 0) {
+			printf("Error: invalid count\n");
+			return;
+		}
+	}
 
-	if (sdcard_read(block, 1, dst) != SD_OK) {
+	if (sdcard_read(block, count, dst) != SD_OK) {
 		printf("Error: SDCard read failed\n");
 		return;
 	}
-	dump_bytes((unsigned int *)dst, 512, (unsigned long)dst);
+	/* Only dump single-block reads (multi-block reads are memory loads) */
+	if (count == 1)
+		dump_bytes((unsigned int *)dst, 512, (unsigned long)dst);
 }
 
 define_command(sdcard_read, sdcard_read_handler, "Read SDCard block", LITESDCARD_CMDS);
 #endif
 
 /**
- * Command "sdwrite"
+ * Command "sdcard_write"
  *
  * Perform SDCard block write
  *
@@ -139,12 +149,10 @@ static void sdcard_write_handler(int nb_params, char **params)
 	}
 
 	c = params[1];
-	if (params[1] != NULL) {
-		for(i=0; i<512; i++) {
-			buf[i] = *c;
-			if(*(++c) == 0) {
-				c = params[1];
-			}
+	for(i=0; i<512; i++) {
+		buf[i] = *c;
+		if(*(++c) == 0) {
+			c = params[1];
 		}
 	}
 	dump_bytes((unsigned int *)buf, 512, (unsigned long) buf);

--- a/litex/soc/software/bios/cmds/cmd_mem.c
+++ b/litex/soc/software/bios/cmds/cmd_mem.c
@@ -110,8 +110,18 @@ static void mem_write_handler(int nb_params, char **params)
 		}
 	}
 
-	if (nb_params == 4)
+	if (nb_params == 4) {
 		size = strtoul(params[3], &c, 0);
+		if (*c != 0) {
+			printf("Error: invalid size\n");
+			return;
+		}
+	}
+
+	if ((size != 1) && (size != 2) && (size != 4)) {
+		printf("Error: invalid size (1, 2 or 4)\n");
+		return;
+	}
 
 	for (i = 0; i < count; i++) {
 		switch (size) {
@@ -127,9 +137,6 @@ static void mem_write_handler(int nb_params, char **params)
 			*(uint32_t *)addr = value;
 			addr += 4;
 			break;
-		default:
-			printf("Error: invalid size\n");
-			return;
 		}
 	}
 }
@@ -193,7 +200,9 @@ static void mem_test_handler(int nb_params, char **params)
 {
 	char *c;
 	unsigned int *addr;
-	unsigned long maxsize = ~0uL;
+	/* Default to the same bounded size as the boot-time memtest: testing
+	   "everything" from addr would write over the BIOS data/stack. */
+	unsigned long maxsize = MEMTEST_DATA_SIZE;
 
 	if (nb_params < 1) {
 		printf("mem_test <addr> [maxsize]\n");

--- a/litex/soc/software/bios/cmds/cmd_mem.c
+++ b/litex/soc/software/bios/cmds/cmd_mem.c
@@ -158,7 +158,7 @@ static void mem_copy_handler(int nb_params, char **params)
 	unsigned int i;
 
 	if (nb_params < 2) {
-		printf("mem_copy <dst> <src> [count]\n");
+		printf("mem_copy <dst> <src> [count (32-bit words)]\n");
 		return;
 	}
 
@@ -294,7 +294,7 @@ static void mem_cmp_handler(int nb_params, char **params)
 	unsigned int i;
 	bool same = true;
 	if (nb_params < 3) {
-		printf("mem_cmp <addr1> <addr2> <count>\n");
+		printf("mem_cmp <addr1> <addr2> <count (32-bit words)>\n");
 		return;
 	}
 

--- a/litex/soc/software/bios/cmds/cmd_spiflash.c
+++ b/litex/soc/software/bios/cmds/cmd_spiflash.c
@@ -76,8 +76,10 @@ static void flash_from_sdcard_handler(int nb_params, char **params)
 	char* filename = params[0];
 
 	fr = f_mount(&fs, "", 1);
-	if (fr != FR_OK)
+	if (fr != FR_OK) {
+		printf("Error: filesystem mount failed (FatFs error %d)\n", fr);
 		return;
+	}
 	fr = f_open(&file, filename, FA_READ);
 	if (fr != FR_OK) {
 		printf("%s file not found.\n", filename);

--- a/litex/soc/software/bios/cmds/cmd_spiflash.c
+++ b/litex/soc/software/bios/cmds/cmd_spiflash.c
@@ -53,7 +53,8 @@ static void flash_write_handler(int nb_params, char **params)
 		}
 	}
 
-	spiflash_write_stream(addr, (unsigned char *)mem_addr, count);
+	if (spiflash_write_stream(addr, (unsigned char *)mem_addr, count) != (int)count)
+		printf("Error: flash write failed (is the region erased? see flash_erase_range)\n");
 }
 
 define_command(flash_write, flash_write_handler, "Write to flash", SPIFLASH_CMDS);
@@ -102,7 +103,12 @@ static void flash_from_sdcard_handler(int nb_params, char **params)
 		if (br == 0) {
 			break;
 		} else {
-			spiflash_write_stream(offset, buf, br);
+			if (spiflash_write_stream(offset, buf, br) != (int)br) {
+				printf("Error: flash write failed (is the region erased? see flash_erase_range)\n");
+				f_close(&file);
+				f_mount(0, "", 0);
+				return;
+			}
 		}
 
 		offset += br;

--- a/litex/soc/software/bios/command.h
+++ b/litex/soc/software/bios/command.h
@@ -7,8 +7,6 @@
 
 #define MAX_PARAM	8
 
-#define HIST_DEPTH	10	/* Used in string list, complete.c */
-
 #define SYSTEM_CMDS		0
 #define BOOT_CMDS		1
 #define MEM_CMDS		2

--- a/litex/soc/software/bios/complete.c
+++ b/litex/soc/software/bios/complete.c
@@ -14,70 +14,39 @@
 #include "command.h"
 #include "complete.h"
 
+/* Maximum number of completion candidates: must cover all registered
+   commands so that the common prefix is computed over the full match set. */
+#define COMPLETE_MAX_MATCHES 128
+
 static int tab_pressed = 0;
 
-char sl[HIST_DEPTH][CMD_LINE_BUFFER_SIZE];
-int sl_idx = 0;
+/* Candidates are pointers to the (static) command names, no copies needed. */
+static const char *sl[COMPLETE_MAX_MATCHES];
+static int sl_count = 0;
 
 char out[CMD_LINE_BUFFER_SIZE];
 
 static void string_list_init(void)
 {
-	int i;
-	for (i = 0; i < HIST_DEPTH; i++)
-		sl[i][0] = 0;
+	sl_count = 0;
 }
 
 static int string_list_add(const char *string)
 {
-	int i;
-	for (i = 0; i < HIST_DEPTH; i++) {
-		if (sl[i][0] == 0) {
-			strncpy(&sl[i][0], string, CMD_LINE_BUFFER_SIZE - 1);
-			sl[i][CMD_LINE_BUFFER_SIZE - 1] = 0;
-			return 0;
-		}
-	}
-	return -1;
-}
-
-static int string_list_empty(void)
-{
-	int i;
-	for (i = 0; i < HIST_DEPTH; i++)
-		if (sl[i][0] != 0)
-			return 0;
-	return 1;
-}
-
-static int string_list_count(void)
-{
-	int i, count = 0;
-	for (i = 0; i < HIST_DEPTH; i++)
-		if (sl[i][0] != 0)
-			count++;
-	return count;
-}
-
-static char *list_first_entry(void)
-{
-	int i;
-	for (i = 0; i < HIST_DEPTH; i++)
-		if (sl[i][0] != 0)
-			return &sl[i][0];
-	return NULL;
+	if (sl_count >= COMPLETE_MAX_MATCHES)
+		return -1;
+	sl[sl_count++] = string;
+	return 0;
 }
 
 static void string_list_print_by_column(void)
 {
-	int len = 0, num, i = 0, j;
+	int len = 0, num, i, j;
 
-	for (i = 0; i < HIST_DEPTH; i++) {
-		if (sl[i][0] != 0) {
-			int l = strlen(&sl[i][0]) + 4;
-			if (l > len)
-				len = l;
-		}
+	for (i = 0; i < sl_count; i++) {
+		int l = strlen(sl[i]) + 4;
+		if (l > len)
+			len = l;
 	}
 
 	if (!len)
@@ -88,13 +57,11 @@ static void string_list_print_by_column(void)
 		num = 1;
 
 	i = 0;
-	for (j = 0; j < HIST_DEPTH; j++) {
-		if (sl[j][0] != 0) {
-			if (!(++i % num))
-				printf("%s\n", &sl[j][0]);
-			else
-				printf("%-*s", len, &sl[j][0]);
-		}
+	for (j = 0; j < sl_count; j++) {
+		if (!(++i % num))
+			printf("%s\n", sl[j]);
+		else
+			printf("%-*s", len, sl[j]);
 	}
 	if (i % num)
 		printf("\n");
@@ -116,8 +83,8 @@ int complete(char *instr, char **outstr)
 	int changed;
 	int outpos = 0;
 	int reprint = 0;
-	char *first_entry;
-	char *entry;
+	const char *first_entry;
+	const char *entry;
 	int i;
 
 	string_list_init();
@@ -126,13 +93,13 @@ int complete(char *instr, char **outstr)
 	pos = strlen(instr);
 
 	*outstr = "";
-	if (string_list_empty())
+	if (sl_count == 0)
 		reprint = 0;
 	else
 	{
 		out[0] = 0;
 
-		first_entry = list_first_entry();
+		first_entry = sl[0];
 
 		while (outpos < CMD_LINE_BUFFER_SIZE - 1) {
 			entry = first_entry;
@@ -141,12 +108,10 @@ int complete(char *instr, char **outstr)
 				break;
 
 			changed = 0;
-			for (i = 0; i < HIST_DEPTH; i++) {
-				if (sl[i][0] != 0) {
-					if ((!sl[i][pos]) || (ch != sl[i][pos])) {
-						changed = 1;
-						break;
-					}
+			for (i = 0; i < sl_count; i++) {
+				if ((!sl[i][pos]) || (ch != sl[i][pos])) {
+					changed = 1;
+					break;
 				}
 			}
 
@@ -156,7 +121,7 @@ int complete(char *instr, char **outstr)
 			pos++;
 		}
 
-		if ((string_list_count() != 1) && !outpos && tab_pressed) {
+		if ((sl_count != 1) && !outpos && tab_pressed) {
 			printf("\n");
 			string_list_print_by_column();
 			reprint = 1;

--- a/litex/soc/software/bios/complete.c
+++ b/litex/soc/software/bios/complete.c
@@ -87,6 +87,7 @@ static void string_list_print_by_column(void)
 	if (num == 0)
 		num = 1;
 
+	i = 0;
 	for (j = 0; j < HIST_DEPTH; j++) {
 		if (sl[j][0] != 0) {
 			if (!(++i % num))
@@ -142,9 +143,7 @@ int complete(char *instr, char **outstr)
 			changed = 0;
 			for (i = 0; i < HIST_DEPTH; i++) {
 				if (sl[i][0] != 0) {
-					if (!sl[i][pos])
-						break;
-					if (ch != sl[i][pos]) {
+					if ((!sl[i][pos]) || (ch != sl[i][pos])) {
 						changed = 1;
 						break;
 					}

--- a/litex/soc/software/bios/helpers.c
+++ b/litex/soc/software/bios/helpers.c
@@ -43,11 +43,11 @@ void bios_print_status(const char *label, int success)
 	printf("%s: %s\n", label, success ? "OK" : "failed");
 }
 
-void dump_bytes(unsigned int *ptr, int count, unsigned long addr)
+void dump_bytes(unsigned int *ptr, unsigned int count, unsigned long addr)
 {
 	unsigned char *dptr = (unsigned char *)ptr;
 	unsigned char data[NUMBER_OF_BYTES_ON_A_LINE];
-	int line_bytes = 0, i = 0;
+	unsigned int line_bytes = 0, i = 0;
 
 
 	fputs("Memory dump:", stdout);

--- a/litex/soc/software/bios/helpers.c
+++ b/litex/soc/software/bios/helpers.c
@@ -138,8 +138,10 @@ int get_param(char *buf, char **cmd, char **params)
 		if (*buf == 0)
 			return nb_param;
 
-		if (nb_param >= MAX_PARAM)
+		if (nb_param >= MAX_PARAM) {
+			printf("Warning: too many parameters (max %d), excess ignored\n", MAX_PARAM);
 			return nb_param;
+		}
 
 		params[nb_param++] = buf;
 

--- a/litex/soc/software/bios/helpers.h
+++ b/litex/soc/software/bios/helpers.h
@@ -3,7 +3,7 @@
 
 struct command_struct;
 
-void dump_bytes(unsigned int *ptr, int count, unsigned long addr);
+void dump_bytes(unsigned int *ptr, unsigned int count, unsigned long addr);
 void crcbios(void);
 void bios_print_section(const char *name);
 void bios_print_status(const char *label, int success);

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -99,7 +99,7 @@ define_boot_method(rom, rom_boot_method, ROM_BOOT_PRIORITY);
 #endif
 static int sdcard_boot_method(void)
 {
-	sdcardboot();
+	sdcardboot(0, NULL);
 	return BOOT_METHOD_CONTINUE;
 }
 define_boot_method(sdcard, sdcard_boot_method, SDCARD_BOOT_PRIORITY);
@@ -111,7 +111,7 @@ define_boot_method(sdcard, sdcard_boot_method, SDCARD_BOOT_PRIORITY);
 #endif
 static int sata_boot_method(void)
 {
-	sataboot();
+	sataboot(0, NULL);
 	return BOOT_METHOD_CONTINUE;
 }
 define_boot_method(sata, sata_boot_method, SATA_BOOT_PRIORITY);

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -285,8 +285,8 @@ __attribute__((__used__)) int main(int i, char **c)
 	/* Initialize and test SPIRAM */
 #ifdef CSR_SPIRAM_BASE
 	spiram_init();
-#endif
 	printf("\n");
+#endif
 
 	/* Initialize and test DRAM */
 #ifdef CSR_SDRAM_BASE
@@ -307,9 +307,8 @@ __attribute__((__used__)) int main(int i, char **c)
 	/* Initialize and test SPIFLASH */
 #ifdef CSR_SPIFLASH_BASE
 	spiflash_init();
-#endif
 	printf("\n");
-
+#endif
 
 	/* Initialize Video Framebuffer FIXME: Move */
 #ifdef CSR_VIDEO_FRAMEBUFFER_BASE
@@ -345,9 +344,12 @@ __attribute__((__used__)) int main(int i, char **c)
 		printf("\n");
 		if (buffer[0] != 0) {
 			nb_params = get_param(buffer, &command, params);
-			cmd = command_dispatcher(command, nb_params, params);
-			if (!cmd)
-				printf("Command not found\n");
+			/* Ignore whitespace-only lines */
+			if (*command != 0) {
+				cmd = command_dispatcher(command, nb_params, params);
+				if (!cmd)
+					printf("Command not found\n");
+			}
 		}
 		printf("%s", PROMPT);
 	}

--- a/litex/soc/software/bios/readline.c
+++ b/litex/soc/software/bios/readline.c
@@ -302,6 +302,14 @@ int readline(char *buf, int len)
 			BEGINNING_OF_LINE();
 			ERASE_TO_EOL();
 			break;
+		case KEY_CLEAR_SCREEN:
+			printf(ANSI_CLEAR_SCREEN "%s", PROMPT);
+			/* Redisplay the current line, cursor back at num */
+			putnstr(buf, eol_num);
+			wlen = eol_num - num;
+			while (wlen--)
+				getcmd_putch(CTL_BACKSPACE);
+			break;
 		case DEL:
 		case KEY_DEL7:
 		case 8:
@@ -372,7 +380,7 @@ int readline(char *buf, int len)
 	buf[eol_num] = '\0';
 
 #ifndef BIOS_CONSOLE_NO_HISTORY
-	if (buf[0] && buf[0] != CREAD_HIST_CHAR)
+	if (buf[0])
 		cread_add_to_hist(buf);
 	hist_cur = hist_add_idx;
 #endif

--- a/litex/soc/software/bios/readline.c
+++ b/litex/soc/software/bios/readline.c
@@ -58,7 +58,7 @@ void set_idle_hook(void (*fptr)(void)) {
 static int read_key(void)
 {
 	char c;
-	char esc[5];
+	char esc[8];
 
 	if (idle_hook_ptr != NULL) {
 		while (!uart_read_nonblock()) {
@@ -69,16 +69,20 @@ static int read_key(void)
 	c = getchar();
 
 	if (c == 27) {
-		int i = 0;
+		unsigned int i = 0;
 		esc[i++] = getchar();
 		esc[i++] = getchar();
 		if (isdigit(esc[1])) {
 			while(1) {
-				esc[i] = getchar();
-				if (esc[i++] == '~')
-					break;
-				if (i == ARRAY_SIZE(esc))
+				if (i == ARRAY_SIZE(esc) - 1)
 					return -1;
+				esc[i] = getchar();
+				/* CSI sequences terminate with a byte in the 0x40-0x7e range. */
+				if ((esc[i] >= 0x40) && (esc[i] <= 0x7e)) {
+					i++;
+					break;
+				}
+				i++;
 			}
 		}
 		esc[i] = 0;

--- a/litex/soc/software/bios/readline.c
+++ b/litex/soc/software/bios/readline.c
@@ -207,7 +207,7 @@ int readline(char *buf, int len)
 	unsigned int eol_num = 0;
 	unsigned int wlen;
 	int insert = 1;
-	unsigned char ichar;
+	int ichar;
 
 #ifndef BIOS_CONSOLE_NO_AUTOCOMPLETE
 	char tmp;
@@ -221,6 +221,10 @@ int readline(char *buf, int len)
 	while (1) {
 
 		ichar = read_key();
+
+		/* Ignore unrecognized escape sequences. */
+		if (ichar < 0)
+			continue;
 
 		if ((ichar == '\n') || (ichar == '\r'))
 			break;

--- a/litex/soc/software/bios/readline.h
+++ b/litex/soc/software/bios/readline.h
@@ -49,7 +49,6 @@ struct esc_cmds {
 #define CTL_BACKSPACE		('\b')
 #define DEL			255
 #define DEL7			127
-#define CREAD_HIST_CHAR		('!')
 
 #define HIST_MAX		10
 

--- a/litex/soc/software/bios/readline.h
+++ b/litex/soc/software/bios/readline.h
@@ -24,7 +24,7 @@
 
 struct esc_cmds {
 	const char *seq;
-	char val;
+	int val;
 };
 
 #define CTL_CH(c)		((c) - 'a' + 1)

--- a/litex/soc/software/bios/readline.h
+++ b/litex/soc/software/bios/readline.h
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#define CMD_LINE_BUFFER_SIZE	64
+#define CMD_LINE_BUFFER_SIZE	128
 
 #ifdef BIOS_CONSOLE_NO_ANSI
 #define ANSI_BOLD		""
@@ -45,8 +45,6 @@ struct esc_cmds {
 #define KEY_PAGEUP		135		/* Cursor Key Page Up	*/
 #define KEY_PAGEDOWN		136		/* Cursor Key Page Down	*/
 #define KEY_DEL			137		/* Cursor Key Del	*/
-
-#define MAX_CMDBUF_SIZE		256
 
 #define CTL_BACKSPACE		('\b')
 #define DEL			255

--- a/litex/soc/software/bios/readline_simple.c
+++ b/litex/soc/software/bios/readline_simple.c
@@ -62,6 +62,11 @@ int readline(char *s, int size)
 			fputs("\n", stdout);
 			return 0;
 		default:
+			/* Only store printable characters: escape sequences (arrow/
+			   function keys) and control characters would end up as garbage
+			   in the command buffer. */
+			if (!isascii(c[0]) || !isprint(c[0]))
+				break;
 			if (ptr < (size - 1)) {
 				fputs(c, stdout);
 				s[ptr] = c[0];

--- a/litex/soc/software/bios/sim_debug.c
+++ b/litex/soc/software/bios/sim_debug.c
@@ -61,9 +61,11 @@ int sim_trace_on(void) {
 void sim_finish(void) {
 #ifdef CSR_SIM_FINISH_BASE
   sim_trace(0);
+#ifdef CSR_SIM_MARKER_BASE
   if (n_markers > 0) {
     sim_markers_summary();
   }
+#endif
   sim_finish_finish_write(1);
 #else
   printf("No sim_finish CSR\n");

--- a/litex/soc/software/libbase/i2c.c
+++ b/litex/soc/software/libbase/i2c.c
@@ -16,6 +16,12 @@
 #define I2C_PERIOD	(U_SECOND / I2C_FREQ_HZ)
 #define I2C_DELAY(n)	busy_wait_us(n * I2C_PERIOD / 4)
 
+/* Maximum time (in us) a slave may stretch the clock before we give up
+   waiting (SMBus specifies 35ms as the limit). */
+#ifndef I2C_SCL_STRETCH_TIMEOUT_US
+#define I2C_SCL_STRETCH_TIMEOUT_US 35000
+#endif
+
 int current_i2c_dev = DEFAULT_I2C_DEV;
 
 struct i2c_dev *get_i2c_devs(void) { return i2c_devs; }
@@ -71,6 +77,28 @@ static inline void i2c_oe_scl_sda(bool oe, bool scl, bool sda)
 	);
 }
 
+static inline int i2c_read_sda(void)
+{
+	struct i2c_ops ops = i2c_devs[current_i2c_dev].ops;
+
+	return (ops.read() >> ops.r_sda_offset) & 1;
+}
+
+/* Call after releasing SCL: a slave may hold SCL low to stretch the clock
+   until it is ready. Bounded so a stuck line cannot hang the BIOS; on timeout
+   we proceed (and the transaction will fail with a NACK/bad data as before). */
+static void i2c_wait_scl_high(void)
+{
+	struct i2c_ops ops = i2c_devs[current_i2c_dev].ops;
+	int timeout;
+
+	for (timeout = 0; timeout < I2C_SCL_STRETCH_TIMEOUT_US; timeout++) {
+		if ((ops.read() >> ops.r_scl_offset) & 1)
+			return;
+		busy_wait_us(1);
+	}
+}
+
 // START condition: 1-to-0 transition of SDA when SCL is 1
 static void i2c_start(void)
 {
@@ -100,6 +128,7 @@ static void i2c_transmit_bit(int value)
 	i2c_oe_scl_sda(1, 0, value);
 	I2C_DELAY(1);
 	i2c_oe_scl_sda(1, 1, value);
+	i2c_wait_scl_high();
 	I2C_DELAY(2);
 	i2c_oe_scl_sda(1, 0, value);
 	I2C_DELAY(1);
@@ -112,9 +141,10 @@ static int i2c_receive_bit(void)
 	i2c_oe_scl_sda(0, 0, 0);
 	I2C_DELAY(1);
 	i2c_oe_scl_sda(0, 1, 0);
+	i2c_wait_scl_high();
 	I2C_DELAY(1);
 	// read in the middle of SCL high
-	value = i2c_devs[current_i2c_dev].ops.read() & 1;
+	value = i2c_read_sda();
 	I2C_DELAY(1);
 	i2c_oe_scl_sda(0, 0, 0);
 	I2C_DELAY(1);

--- a/litex/soc/software/libbase/i2c.h
+++ b/litex/soc/software/libbase/i2c.h
@@ -17,6 +17,8 @@ struct i2c_ops {
 	int w_scl_offset;
 	int w_sda_offset;
 	int w_oe_offset;
+	int r_sda_offset;
+	int r_scl_offset;
 };
 
 struct i2c_dev {

--- a/litex/soc/software/libbase/memtest.c
+++ b/litex/soc/software/libbase/memtest.c
@@ -125,21 +125,34 @@ int memtest_bus(unsigned int *addr, unsigned long size)
 int memtest_addr(unsigned int *addr, unsigned long size, int random)
 {
 	volatile unsigned int *array = addr;
-	int i, errors;
+	unsigned long i, words;
+	int errors;
 	unsigned short seed_16;
-	unsigned short rdata;
+	unsigned int rdata;
 
-	/* Skip when size < 16KB */
-	if (size < 0x10000)
+	/* Skip when size < 4KB */
+	if (size < 0x1000)
 		return 0;
+
+	/* The index is derived from a 16-bit seed: limit the tested zone to its
+	   64K-word (256KB) span. */
+	if (size > 0x40000)
+		size = 0x40000;
+	words = size/4;
+
+	/* The LFSR sequence only visits each index once over a full 64K-word
+	   region; on smaller regions the modulo would alias different seeds to
+	   the same index and report false errors, so use sequential indexing. */
+	if (random && (words != 0x10000))
+		random = 0;
 
 	errors  = 0;
 	seed_16 = 1;
 
 	/* Write datas*/
-	for(i=0; i<size/4; i++) {
+	for(i=0; i<words; i++) {
 		seed_16 = seed_to_data_16(seed_16, random);
-		array[(unsigned int) seed_16] = i;
+		array[(unsigned long) seed_16 % words] = i;
 	}
 
 	/* Flush caches */
@@ -148,14 +161,14 @@ int memtest_addr(unsigned int *addr, unsigned long size, int random)
 
 	/* Read/Verify datas */
 	seed_16 = 1;
-	for(i=0; i<size/4; i++) {
+	for(i=0; i<words; i++) {
 		seed_16 = seed_to_data_16(seed_16, random);
-		rdata = array[(unsigned int) seed_16];
+		rdata = array[(unsigned long) seed_16 % words];
 		if(rdata != i) {
 			errors++;
 #ifdef MEMTEST_ADDR_DEBUG
 			if (MEMTEST_DEBUG_MAX_ERRORS < 0 || errors <= MEMTEST_DEBUG_MAX_ERRORS)
-				printf("memtest_addr error @ %p: 0x%08x vs 0x%08x\n", addr + i, rdata, i);
+				printf("memtest_addr error @ %p: 0x%08x vs 0x%08lx\n", addr + i, rdata, i);
 #endif
 		}
 	}

--- a/litex/soc/software/libbase/uart.c
+++ b/litex/soc/software/libbase/uart.c
@@ -71,8 +71,11 @@ char uart_read(void)
 
 	if(irq_getie()) {
 		while(rx_consume == rx_produce);
-	} else if (rx_consume == rx_produce) {
-		return 0;
+	} else {
+		/* Interrupts are disabled, so the ISR cannot fill the ring buffer:
+		   harvest the RX FIFO ourselves. */
+		while(rx_consume == rx_produce)
+			uart_isr();
 	}
 
 	c = rx_buf[rx_consume];
@@ -82,6 +85,8 @@ char uart_read(void)
 
 int uart_read_nonblock(void)
 {
+	if(!irq_getie() && (rx_consume == rx_produce))
+		uart_isr();
 	return (rx_consume != rx_produce);
 }
 
@@ -92,8 +97,12 @@ void uart_write(char c)
 
 	if(irq_getie()) {
 		while(tx_produce_next == tx_consume);
-	} else if(tx_produce_next == tx_consume) {
-		return;
+	} else {
+		/* Interrupts are disabled, so the ISR cannot drain the ring buffer:
+		   do it ourselves instead of silently dropping the character (e.g.
+		   long printf output from an exception handler). */
+		while(tx_produce_next == tx_consume)
+			uart_isr();
 	}
 
 	oldmask = irq_getmask();
@@ -124,7 +133,10 @@ void uart_init(void)
 
 void uart_sync(void)
 {
-	while(tx_consume != tx_produce);
+	while(tx_consume != tx_produce) {
+		if(!irq_getie())
+			uart_isr();
+	}
 }
 
 #else

--- a/litex/soc/software/libliteeth/tftp.c
+++ b/litex/soc/software/libliteeth/tftp.c
@@ -186,8 +186,10 @@ static void rx_callback(uint32_t src_ip, uint16_t src_port,
 		/* Block numbers are 16-bit and wrap on transfers > 64MB, so compare
 		   them modulo 2^16 and track the write offset separately. */
 		if(block == (uint16_t)(next_data_block - 1)) {
-			/* Duplicate of the previous block: re-acknowledge. */
-			send_ack(block);
+			/* Duplicate of the previous block: re-acknowledge (only when a block has
+			   actually been received; a spurious block 0 at transfer start is dropped). */
+			if((current_offset != 0) || (next_data_block != 1))
+				send_ack(block);
 			return;
 		}
 		if(block != next_data_block)

--- a/litex/soc/software/libliteeth/tftp.c
+++ b/litex/soc/software/libliteeth/tftp.c
@@ -8,6 +8,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <stddef.h>
 #include <limits.h>
 #include <string.h>
@@ -94,6 +95,8 @@ static int last_ack; /* signed, so we can use -1 */
 static uint32_t server_ip;
 static uint16_t data_port;
 static uint16_t next_data_block;
+static size_t current_offset;
+static size_t block_size; /* negotiated block size, 0 while unknown */
 static int tftp_write;
 
 static int check_server(uint32_t src_ip, uint16_t src_port)
@@ -130,51 +133,86 @@ static void rx_callback(uint32_t src_ip, uint16_t src_port,
 		return;
 	}
 	if (opcode == TFTP_OACK) { /* Option Acknowledgement */
+		size_t pos;
+		size_t start;
+		const char *name = NULL;
+
 		if(!check_server(src_ip, src_port)) return;
+		/* RFC 2348: the server may grant a smaller block size than the one
+		   requested or omit the option entirely (512-byte default). Parse
+		   the granted value instead of assuming our request was honored.
+		   The payload is a sequence of NUL-terminated name/value strings. */
+		block_size = 512;
+		start = 2;
+		for(pos = 2; pos < length; pos++) {
+			if(data[pos] != 0)
+				continue;
+			if(name == NULL) {
+				name = (const char *)&data[start];
+			} else {
+				if(strcmp(name, "blksize") == 0) {
+					unsigned long value = strtoul((const char *)&data[start], NULL, 10);
+					if((value >= 8) && (value <= BLOCK_SIZE))
+						block_size = value;
+				}
+				name = NULL;
+			}
+			start = pos + 1;
+		}
 		if(!tftp_write)
 			send_ack(0);
 		last_ack = 0;
 		return;
 	}
-	if(block < 1) return;
+	if(opcode == TFTP_ERROR) { /* Error */
+		if(!check_server(src_ip, src_port)) return;
+		/* For ERROR packets, bytes 2-3 are the error code and a NetASCII
+		   message follows; report them instead of failing silently. */
+		if(length > 4)
+			printf("TFTP error %d: %.*s\n", block, (int)(length - 4), (char *)&data[4]);
+		else
+			printf("TFTP error %d\n", block);
+		total_length = -1;
+		transfer_finished = 1;
+		return;
+	}
 	if(opcode == TFTP_DATA) { /* Data */
-		size_t write_offset;
-
 		if(tftp_write) return;
 		if(!check_server(src_ip, src_port)) return;
+		/* No OACK seen: server without option support, RFC default size. */
+		if(block_size == 0)
+			block_size = 512;
 		length -= 4;
+		/* Block numbers are 16-bit and wrap on transfers > 64MB, so compare
+		   them modulo 2^16 and track the write offset separately. */
 		if(block == (uint16_t)(next_data_block - 1)) {
+			/* Duplicate of the previous block: re-acknowledge. */
 			send_ack(block);
 			return;
 		}
 		if(block != next_data_block)
 			return;
-		write_offset = ((size_t)block - 1)*BLOCK_SIZE;
-		if ((length > dst_buffer_size) || (write_offset > (dst_buffer_size - length))) {
+		if ((length > dst_buffer_size) || (current_offset > (dst_buffer_size - length))) {
 			total_length = -1;
 			transfer_finished = 1;
 			return;
 		}
-		if((write_offset + length) > INT_MAX) {
+		if((current_offset + length) > INT_MAX) {
 			total_length = -1;
 			transfer_finished = 1;
 			return;
 		}
 
-		offset = write_offset;
+		offset = current_offset;
 		for(i=0;i<length;i++)
 			dst_buffer[offset+i] = data[i+4];
-		total_length = write_offset + length;
+		current_offset += length;
+		total_length = current_offset;
 		next_data_block++;
-		if(length < BLOCK_SIZE)
+		if(length < block_size)
 			transfer_finished = 1;
 
 		send_ack(block);
-	}
-	if(opcode == TFTP_ERROR) { /* Error */
-		if(!check_server(src_ip, src_port)) return;
-		total_length = -1;
-		transfer_finished = 1;
 	}
 }
 
@@ -194,6 +232,8 @@ int tftp_get(uint32_t ip, uint16_t server_port, const char *filename,
 	server_ip = ip;
 	data_port = 0;
 	next_data_block = 1;
+	current_offset = 0;
+	block_size = 0;
 	last_ack = -1;
 	tftp_write = 0;
 
@@ -257,6 +297,8 @@ int tftp_put(uint32_t ip, uint16_t server_port, const char *filename,
 	server_ip = ip;
 	data_port = 0;
 	next_data_block = 1;
+	current_offset = 0;
+	block_size = 0;
 	last_ack = -1;
 	tftp_write = 1;
 
@@ -285,9 +327,13 @@ int tftp_put(uint32_t ip, uint16_t server_port, const char *filename,
 	}
 
 send_data:
+	/* A plain ACK 0 (no OACK) means the server does not support options
+	   and expects the RFC default block size. */
+	if(block_size == 0)
+		block_size = 512;
 	do {
 		block++;
-		send = sent+BLOCK_SIZE > size ? size-sent : BLOCK_SIZE;
+		send = sent+block_size > size ? size-sent : block_size;
 		tries = 5;
 		while(1) {
 			packet_data = udp_get_tx_buffer();
@@ -297,7 +343,8 @@ send_data:
 				udp_service();
 				if(transfer_finished)
 					goto fail;
-				if(last_ack == block)
+				/* Block numbers wrap modulo 2^16 on transfers > 64MB. */
+				if(last_ack == (uint16_t)block)
 					goto next;
 			}
 			if (!--tries)
@@ -306,7 +353,7 @@ send_data:
 next:
 		sent += send;
 		buffer += send;
-	} while (send == BLOCK_SIZE);
+	} while (send == block_size);
 
 	udp_set_callback(NULL);
 

--- a/litex/soc/software/libliteeth/tftp.c
+++ b/litex/soc/software/libliteeth/tftp.c
@@ -268,6 +268,9 @@ int tftp_get(uint32_t ip, uint16_t server_port, const char *filename,
 		if(length_before != total_length) {
 			i = 12000000;
 			length_before = total_length;
+			/* TFTP does not know the file size up front: print one '#' per
+			   downloaded MB, plus a spinner for intra-MB activity. */
+			show_progress(total_length >> 20);
 			if ((total_length & (0x8000 - 1)) == 0)
 				show_progress(-1);
 		}

--- a/litex/soc/software/libliteeth/udp.c
+++ b/litex/soc/software/libliteeth/udp.c
@@ -340,10 +340,13 @@ static uint16_t ip_checksum(uint32_t r, void *buffer, uint32_t length, int compl
 	uint32_t i;
 
 	ptr = (uint8_t *)buffer;
-	length >>= 1;
 
-	for(i=0;i<length;i++)
+	for(i=0;i<(length >> 1);i++)
 		r += ((uint32_t)(ptr[2*i]) << 8)|(uint32_t)(ptr[2*i+1]) ;
+
+	/* Odd length: pad the last byte with zero (RFC 1071). */
+	if(length & 1)
+		r += (uint32_t)(ptr[length-1]) << 8;
 
 	/* Add overflows */
 	while(r >> 16)
@@ -414,10 +417,6 @@ int udp_send(uint16_t src_port, uint16_t dst_port, uint32_t length)
 
 	h.zero = 0;
 	r = ip_checksum(0, &h, sizeof(struct pseudo_header), 0);
-	if(length & 1) {
-		txbuffer->frame.contents.udp.payload[length] = 0;
-		length++;
-	}
 	r = ip_checksum(r, &txbuffer->frame.contents.udp.udp,
 		sizeof(struct udp_header)+length, 1);
 	txbuffer->frame.contents.udp.udp.checksum = htons(r);

--- a/litex/soc/software/liblitesata/sata.c
+++ b/litex/soc/software/liblitesata/sata.c
@@ -96,47 +96,76 @@ int sata_init(int show) {
 
 #endif
 
+/* Bound retries and completion waits: a missing or failing disk must not hang
+   the BIOS forever. */
+#ifndef SATA_OP_RETRIES
+#define SATA_OP_RETRIES 8
+#endif
+#ifndef SATA_OP_TIMEOUT_US
+#define SATA_OP_TIMEOUT_US 100000
+#endif
+
 #ifdef CSR_SATA_SECTOR2MEM_BASE
 
-void sata_read(uint32_t sector, uint32_t count, uint8_t* buf)
+int sata_read(uint32_t sector, uint32_t count, uint8_t* buf)
 {
-	uint8_t done = 0;
+	unsigned int retries;
+	unsigned int timeout;
 
-	while (done == 0) {
+	for (retries = 0; retries < SATA_OP_RETRIES; retries++) {
 		sata_sector2mem_base_write((uint64_t)(uintptr_t) buf);
 		sata_sector2mem_sector_write(sector);
 		sata_sector2mem_nsectors_write(count);
 		sata_sector2mem_start_write(1);
-		while ((sata_sector2mem_done_read() & 0x1) == 0);
-		done = ((sata_sector2mem_error_read() & 0x1) == 0);
+		for (timeout = SATA_OP_TIMEOUT_US; timeout > 0; timeout--) {
+			if ((sata_sector2mem_done_read() & 0x1) != 0) {
+				if ((sata_sector2mem_error_read() & 0x1) == 0) {
+#ifndef CONFIG_CPU_HAS_DMA_BUS
+					/* Flush caches */
+					flush_cpu_dcache();
+					flush_l2_cache();
+#endif
+					return 0;
+				}
+				/* Error: retry */
+				break;
+			}
+			busy_wait_us(1);
+		}
 		busy_wait_us(10);
 	}
 
-#ifndef CONFIG_CPU_HAS_DMA_BUS
-	/* Flush caches */
-	flush_cpu_dcache();
-	flush_l2_cache();
-#endif
+	return -1;
 }
 
 #endif
 
 #ifdef CSR_SATA_MEM2SECTOR_BASE
 
-void sata_write(uint32_t sector, uint32_t count, uint8_t* buf)
+int sata_write(uint32_t sector, uint32_t count, uint8_t* buf)
 {
-	uint8_t done = 0;
+	unsigned int retries;
+	unsigned int timeout;
 
 	/* Write sectors */
-	while (done == 0) {
+	for (retries = 0; retries < SATA_OP_RETRIES; retries++) {
 		sata_mem2sector_base_write((uint64_t)(uintptr_t) buf);
 		sata_mem2sector_sector_write(sector);
 		sata_mem2sector_nsectors_write(count);
 		sata_mem2sector_start_write(1);
-		while ((sata_mem2sector_done_read() & 0x1) == 0);
-		done = ((sata_mem2sector_error_read() & 0x1) == 0);
+		for (timeout = SATA_OP_TIMEOUT_US; timeout > 0; timeout--) {
+			if ((sata_mem2sector_done_read() & 0x1) != 0) {
+				if ((sata_mem2sector_error_read() & 0x1) == 0)
+					return 0;
+				/* Error: retry */
+				break;
+			}
+			busy_wait_us(1);
+		}
 		busy_wait_us(10);
 	}
+
+	return -1;
 }
 
 #endif
@@ -162,7 +191,8 @@ static DSTATUS sata_disk_initialize(BYTE drv) {
 }
 
 static DRESULT sata_disk_read(BYTE drv, BYTE *buf, LBA_t sector, UINT count) {
-	sata_read(sector, count, buf);
+	if (sata_read(sector, count, buf) != 0)
+		return RES_ERROR;
 	return RES_OK;
 }
 

--- a/litex/soc/software/liblitesata/sata.h
+++ b/litex/soc/software/liblitesata/sata.h
@@ -23,13 +23,13 @@ void fatfs_set_ops_sata(void);
 
 #ifdef CSR_SATA_SECTOR2MEM_BASE
 
-void sata_read(uint32_t sector, uint32_t count, uint8_t* buf);
+int sata_read(uint32_t sector, uint32_t count, uint8_t* buf);
 
 #endif
 
 #ifdef CSR_SATA_MEM2SECTOR_BASE
 
-void sata_write(uint32_t sector, uint32_t count, uint8_t* buf);
+int sata_write(uint32_t sector, uint32_t count, uint8_t* buf);
 
 #endif
 

--- a/litex/soc/software/liblitesdcard/sdcard.c
+++ b/litex/soc/software/liblitesdcard/sdcard.c
@@ -133,6 +133,29 @@ static inline int sdcard_send_command(uint32_t arg, uint8_t cmd, uint8_t rsp) {
 	return sdcard_wait_cmd_done();
 }
 
+/* Retry a command a bounded number of times instead of forever: a removed or
+   failing card must not hang the BIOS. */
+#ifndef SDCARD_CMD_RETRIES
+#define SDCARD_CMD_RETRIES 16
+#endif
+
+static int sdcard_send_command_retry(uint32_t arg, uint8_t cmd, uint8_t rsp) {
+	int status;
+	int retries;
+	for (retries = 0; retries < SDCARD_CMD_RETRIES; retries++) {
+		status = sdcard_send_command(arg, cmd, rsp);
+		if (status == SD_OK)
+			return SD_OK;
+	}
+	return status;
+}
+
+/* Bounded wait (in us) on SDCard DMAs: no data arrives when the data command
+   failed, so the done bit may never rise. */
+#ifndef SDCARD_DMA_TIMEOUT_US
+#define SDCARD_DMA_TIMEOUT_US 1000000
+#endif
+
 int sdcard_go_idle(void) {
 #ifdef SDCARD_DEBUG
 	printf("CMD0: GO_IDLE\n");
@@ -217,9 +240,10 @@ int sdcard_switch(unsigned int mode, unsigned int group, unsigned int value) {
 #endif
 	sdcard_core_block_length_write(64);
 	sdcard_core_block_count_write(1);
-	while (sdcard_send_command(arg, 6,
+	if (sdcard_send_command_retry(arg, 6,
 		(SDCARD_CTRL_DATA_TRANSFER_READ << 5) |
-		SDCARD_CTRL_RESPONSE_SHORT | SDCARD_CTRL_RESPONSE_CRC) != SD_OK);
+		SDCARD_CTRL_RESPONSE_SHORT | SDCARD_CTRL_RESPONSE_CRC) != SD_OK)
+		return SD_TIMEOUT;
 	return sdcard_wait_data_done();
 }
 
@@ -229,9 +253,10 @@ int sdcard_app_send_scr(void) {
 #endif
 	sdcard_core_block_length_write(8);
 	sdcard_core_block_count_write(1);
-	while (sdcard_send_command(0, 51,
+	if (sdcard_send_command_retry(0, 51,
 		(SDCARD_CTRL_DATA_TRANSFER_READ << 5) |
-		SDCARD_CTRL_RESPONSE_SHORT | SDCARD_CTRL_RESPONSE_CRC) != SD_OK);
+		SDCARD_CTRL_RESPONSE_SHORT | SDCARD_CTRL_RESPONSE_CRC) != SD_OK)
+		return SD_TIMEOUT;
 	return sdcard_wait_data_done();
 }
 
@@ -248,9 +273,10 @@ int sdcard_write_single_block(unsigned int blockaddr) {
 #endif
 	sdcard_core_block_length_write(512);
 	sdcard_core_block_count_write(1);
-	while (sdcard_send_command(blockaddr, 24,
+	if (sdcard_send_command_retry(blockaddr, 24,
 	    (SDCARD_CTRL_DATA_TRANSFER_WRITE << 5) |
-	    SDCARD_CTRL_RESPONSE_SHORT | SDCARD_CTRL_RESPONSE_CRC) != SD_OK);
+	    SDCARD_CTRL_RESPONSE_SHORT | SDCARD_CTRL_RESPONSE_CRC) != SD_OK)
+		return SD_TIMEOUT;
 	return sdcard_wait_data_done();
 }
 
@@ -260,9 +286,10 @@ int sdcard_write_multiple_block(unsigned int blockaddr, unsigned int blockcnt) {
 #endif
 	sdcard_core_block_length_write(512);
 	sdcard_core_block_count_write(blockcnt);
-	while (sdcard_send_command(blockaddr, 25,
+	if (sdcard_send_command_retry(blockaddr, 25,
 	    (SDCARD_CTRL_DATA_TRANSFER_WRITE << 5) |
-	    SDCARD_CTRL_RESPONSE_SHORT | SDCARD_CTRL_RESPONSE_CRC) != SD_OK);
+	    SDCARD_CTRL_RESPONSE_SHORT | SDCARD_CTRL_RESPONSE_CRC) != SD_OK)
+		return SD_TIMEOUT;
 	return sdcard_wait_data_done();
 }
 
@@ -272,9 +299,10 @@ int sdcard_read_single_block(unsigned int blockaddr) {
 #endif
 	sdcard_core_block_length_write(512);
 	sdcard_core_block_count_write(1);
-	while (sdcard_send_command(blockaddr, 17,
+	if (sdcard_send_command_retry(blockaddr, 17,
 	    (SDCARD_CTRL_DATA_TRANSFER_READ << 5) |
-	    SDCARD_CTRL_RESPONSE_SHORT | SDCARD_CTRL_RESPONSE_CRC) != SD_OK);
+	    SDCARD_CTRL_RESPONSE_SHORT | SDCARD_CTRL_RESPONSE_CRC) != SD_OK)
+		return SD_TIMEOUT;
 	return sdcard_wait_data_done();
 }
 
@@ -284,9 +312,10 @@ int sdcard_read_multiple_block(unsigned int blockaddr, unsigned int blockcnt) {
 #endif
 	sdcard_core_block_length_write(512);
 	sdcard_core_block_count_write(blockcnt);
-	while (sdcard_send_command(blockaddr, 18,
+	if (sdcard_send_command_retry(blockaddr, 18,
 	    (SDCARD_CTRL_DATA_TRANSFER_READ << 5) |
-	    SDCARD_CTRL_RESPONSE_SHORT | SDCARD_CTRL_RESPONSE_CRC) != SD_OK);
+	    SDCARD_CTRL_RESPONSE_SHORT | SDCARD_CTRL_RESPONSE_CRC) != SD_OK)
+		return SD_TIMEOUT;
 	return sdcard_wait_data_done();
 }
 
@@ -415,6 +444,8 @@ static void sdcard_decode_scr(const uint32_t *scr, bool *support_4bit)
 static int sdcard_get_scr(uint32_t *buf, uint16_t rca)
 {
 #ifdef CSR_SDCARD_BLOCK2MEM_DMA_BASE_ADDR
+	unsigned int timeout;
+
 	sdcard_block2mem_dma_enable_write(0);
 	sdcard_block2mem_dma_base_write((uint64_t)(uintptr_t)buf);
 	sdcard_block2mem_dma_length_write(8);
@@ -430,7 +461,14 @@ static int sdcard_get_scr(uint32_t *buf, uint16_t rca)
 
 #ifdef CSR_SDCARD_BLOCK2MEM_DMA_BASE_ADDR
 	/* Wait for DMA Writer to complete */
-	while ((sdcard_block2mem_dma_done_read() & 0x1) == 0);
+	timeout = SDCARD_DMA_TIMEOUT_US;
+	while ((sdcard_block2mem_dma_done_read() & 0x1) == 0) {
+		if (timeout-- == 0) {
+			sdcard_block2mem_dma_enable_write(0);
+			return 0;
+		}
+		busy_wait_us(1);
+	}
 
 #ifndef CONFIG_CPU_HAS_DMA_BUS
 	/* Flush caches */
@@ -553,8 +591,11 @@ int sdcard_init(void) {
 
 #ifdef CSR_SDCARD_BLOCK2MEM_DMA_BASE_ADDR
 
-void sdcard_read(uint32_t block, uint32_t count, uint8_t* buf)
+int sdcard_read(uint32_t block, uint32_t count, uint8_t* buf)
 {
+	int status;
+	unsigned int timeout;
+
 	while (count) {
 		uint32_t nblocks;
 #ifdef SDCARD_CMD18_SUPPORT
@@ -570,22 +611,39 @@ void sdcard_read(uint32_t block, uint32_t count, uint8_t* buf)
 
 		/* Read Block(s) from SDCard */
 		if (nblocks > 1) {
+			status = SD_OK;
 			if (support_cmd23 != 0) {
-				sdcard_set_block_count(nblocks);
+				status = sdcard_set_block_count(nblocks);
 			}
 
-			sdcard_read_multiple_block(block, nblocks);
+			if (status == SD_OK)
+				status = sdcard_read_multiple_block(block, nblocks);
 
 			if (support_cmd23 == 0) {
-				sdcard_stop_transmission();
+				int stop_status = sdcard_stop_transmission();
+				if (status == SD_OK)
+					status = stop_status;
 			}
 		}
 		else {
-			sdcard_read_single_block(block);
+			status = sdcard_read_single_block(block);
+		}
+
+		/* On error, no data will arrive: don't wait for the DMA */
+		if (status != SD_OK) {
+			sdcard_block2mem_dma_enable_write(0);
+			return status;
 		}
 
 		/* Wait for DMA Writer to complete */
-		while ((sdcard_block2mem_dma_done_read() & 0x1) == 0);
+		timeout = SDCARD_DMA_TIMEOUT_US;
+		while ((sdcard_block2mem_dma_done_read() & 0x1) == 0) {
+			if (timeout-- == 0) {
+				sdcard_block2mem_dma_enable_write(0);
+				return SD_TIMEOUT;
+			}
+			busy_wait_us(1);
+		}
 
 		/* Update Block/Buffer/Count */
 		block += nblocks;
@@ -598,14 +656,19 @@ void sdcard_read(uint32_t block, uint32_t count, uint8_t* buf)
 	flush_cpu_dcache();
 	flush_l2_cache();
 #endif
+
+	return SD_OK;
 }
 
 #endif
 
 #ifdef CSR_SDCARD_MEM2BLOCK_DMA_BASE_ADDR
 
-void sdcard_write(uint32_t block, uint32_t count, uint8_t* buf)
+int sdcard_write(uint32_t block, uint32_t count, uint8_t* buf)
 {
+	int status;
+	unsigned int timeout;
+
 	while (count) {
 		uint32_t nblocks;
 #ifdef SDCARD_CMD25_SUPPORT
@@ -621,27 +684,46 @@ void sdcard_write(uint32_t block, uint32_t count, uint8_t* buf)
 
 		/* Write Block(s) to SDCard */
 		if (nblocks > 1) {
+			status = SD_OK;
 			if (support_cmd23 != 0) {
-				sdcard_set_block_count(nblocks);
+				status = sdcard_set_block_count(nblocks);
 			}
 
-			sdcard_write_multiple_block(block, nblocks);
+			if (status == SD_OK)
+				status = sdcard_write_multiple_block(block, nblocks);
 
 			if (support_cmd23 == 0) {
-				sdcard_stop_transmission();
+				int stop_status = sdcard_stop_transmission();
+				if (status == SD_OK)
+					status = stop_status;
 			}
 		} else {
-			sdcard_write_single_block(block);
+			status = sdcard_write_single_block(block);
+		}
+
+		/* On error, no data will be transferred: don't wait for the DMA */
+		if (status != SD_OK) {
+			sdcard_mem2block_dma_enable_write(0);
+			return status;
 		}
 
 		/* Wait for DMA Reader to complete */
-		while ((sdcard_mem2block_dma_done_read() & 0x1) == 0);
+		timeout = SDCARD_DMA_TIMEOUT_US;
+		while ((sdcard_mem2block_dma_done_read() & 0x1) == 0) {
+			if (timeout-- == 0) {
+				sdcard_mem2block_dma_enable_write(0);
+				return SD_TIMEOUT;
+			}
+			busy_wait_us(1);
+		}
 
 		/* Update Block/Buffer/Count */
 		block += nblocks;
 		buf   += 512*nblocks;
 		count -= nblocks;
 	}
+
+	return SD_OK;
 }
 #endif
 
@@ -664,7 +746,8 @@ static DSTATUS sd_disk_initialize(BYTE drv) {
 }
 
 static DRESULT sd_disk_read(BYTE drv, BYTE *buf, LBA_t block, UINT count) {
-	sdcard_read(block, count, buf);
+	if (sdcard_read(block, count, buf) != SD_OK)
+		return RES_ERROR;
 	return RES_OK;
 }
 

--- a/litex/soc/software/liblitesdcard/sdcard.c
+++ b/litex/soc/software/liblitesdcard/sdcard.c
@@ -49,6 +49,14 @@ static unsigned int support_cmd23;
 #define support_cmd23 0
 #endif
 
+/* OCR CCS bit: 1 on high/extended capacity cards (block addressing), 0 on
+   ver2.00+ standard capacity cards (byte addressing). */
+static unsigned int sdcard_ccs = 1;
+
+static inline uint32_t sdcard_block_to_addr(uint32_t block) {
+	return sdcard_ccs ? block : block * 512;
+}
+
 /*-----------------------------------------------------------------------*/
 /* SDCard command helpers                                                */
 /*-----------------------------------------------------------------------*/
@@ -534,6 +542,10 @@ int sdcard_init(void) {
 	if (timeout == 0)
 		return 0;
 
+	/* Get the CCS bit from the OCR: standard capacity ver2.00+ cards (CCS=0)
+	   take byte addresses in block commands instead of block addresses. */
+	sdcard_ccs = (r[0] >> 30) & 0x1;
+
 	/* Send identification */
 	if (sdcard_all_send_cid() != SD_OK)
 		return 0;
@@ -617,7 +629,7 @@ int sdcard_read(uint32_t block, uint32_t count, uint8_t* buf)
 			}
 
 			if (status == SD_OK)
-				status = sdcard_read_multiple_block(block, nblocks);
+				status = sdcard_read_multiple_block(sdcard_block_to_addr(block), nblocks);
 
 			if (support_cmd23 == 0) {
 				int stop_status = sdcard_stop_transmission();
@@ -626,7 +638,7 @@ int sdcard_read(uint32_t block, uint32_t count, uint8_t* buf)
 			}
 		}
 		else {
-			status = sdcard_read_single_block(block);
+			status = sdcard_read_single_block(sdcard_block_to_addr(block));
 		}
 
 		/* On error, no data will arrive: don't wait for the DMA */
@@ -690,7 +702,7 @@ int sdcard_write(uint32_t block, uint32_t count, uint8_t* buf)
 			}
 
 			if (status == SD_OK)
-				status = sdcard_write_multiple_block(block, nblocks);
+				status = sdcard_write_multiple_block(sdcard_block_to_addr(block), nblocks);
 
 			if (support_cmd23 == 0) {
 				int stop_status = sdcard_stop_transmission();
@@ -698,7 +710,7 @@ int sdcard_write(uint32_t block, uint32_t count, uint8_t* buf)
 					status = stop_status;
 			}
 		} else {
-			status = sdcard_write_single_block(block);
+			status = sdcard_write_single_block(sdcard_block_to_addr(block));
 		}
 
 		/* On error, no data will be transferred: don't wait for the DMA */

--- a/litex/soc/software/liblitesdcard/sdcard.h
+++ b/litex/soc/software/liblitesdcard/sdcard.h
@@ -110,8 +110,8 @@ void sdcard_decode_csd(void);
 /*-----------------------------------------------------------------------*/
 
 int sdcard_init(void);
-void sdcard_read(uint32_t sector, uint32_t count, uint8_t* buf);
-void sdcard_write(uint32_t sector, uint32_t count, uint8_t* buf);
+int sdcard_read(uint32_t sector, uint32_t count, uint8_t* buf);
+int sdcard_write(uint32_t sector, uint32_t count, uint8_t* buf);
 void fatfs_set_ops_sdcard(void);
 
 #endif /* CSR_SDCARD_BASE */

--- a/litex/soc/software/liblitesdcard/spisdcard.c
+++ b/litex/soc/software/liblitesdcard/spisdcard.c
@@ -136,7 +136,7 @@ static uint8_t spisdcardreceive_block(uint8_t *buf) {
     spisdcard_mosi_write(0xff);
     for (i=0; i<512; i++) {
         spisdcard_control_write(8*SPI_LENGTH | SPI_START);
-        while (spisdcard_status_read() != SPI_DONE);
+        while ((spisdcard_status_read() & SPI_DONE) != SPI_DONE);
         *buf++ = spisdcard_miso_read();
     }
 

--- a/litex/soc/software/liblitesdcard/spisdcard.c
+++ b/litex/soc/software/liblitesdcard/spisdcard.c
@@ -28,6 +28,10 @@
 #define SPISDCARD_CLK_FREQ 20000000
 #endif
 
+/* OCR CCS bit: 1 on high/extended capacity cards (block addressing), 0 on
+   ver2.00+ standard capacity cards (byte addressing). */
+static uint8_t spisdcard_ccs = 1;
+
 /*-----------------------------------------------------------------------*/
 /* SPI SDCard clocker functions                                          */
 /*-----------------------------------------------------------------------*/
@@ -248,6 +252,13 @@ uint8_t spisdcard_init(void) {
     if (timeout == 0)
         return 0;
 
+    /* Get the CCS bit from the OCR: standard capacity ver2.00+ cards (CCS=0)
+       take byte addresses in block commands instead of block addresses. */
+    if (spisdcardsend_cmd(CMD58, 0) != 0)
+        return 0;
+    spisdcardread_bytes(buf, 4); /* Get trailing bytes of R3 response (OCR) */
+    spisdcard_ccs = (buf[0] >> 6) & 0x1;
+
     /* Set SPI clk freq to operational frequency */
     spi_set_clk_freq(SPISDCARD_CLK_FREQ);
 
@@ -276,11 +287,15 @@ static DSTATUS spisd_disk_initialize(BYTE drv) {
 
 static DRESULT spisd_disk_read(BYTE drv, BYTE *buf, LBA_t block, UINT count) {
     uint8_t cmd;
+    uint32_t addr;
     if (count > 1)
         cmd = CMD18; /* READ_MULTIPLE_BLOCK */
     else
         cmd = CMD17; /* READ_SINGLE_BLOCK */
-    if (spisdcardsend_cmd(cmd, block) == 0) {
+    /* Standard capacity cards take byte addresses (cards <= 2GB, so the
+       byte address always fits in 32-bit). */
+    addr = spisdcard_ccs ? block : block * 512;
+    if (spisdcardsend_cmd(cmd, addr) == 0) {
         while(count > 0) {
             if (spisdcardreceive_block(buf) == 0)
                 break;

--- a/litex/soc/software/liblitespi/spiflash.c
+++ b/litex/soc/software/liblitespi/spiflash.c
@@ -311,9 +311,12 @@ void spiflash_erase_4k_sector(uint32_t addr)
 	transfer_cmd(w_buf, r_buf, 4);
 }
 
+/* Returns the number of bytes written and verified, or -1 when the readback
+   verification failed (e.g. region not erased beforehand). */
 int spiflash_write_stream(uint32_t addr, uint8_t *stream, uint32_t len)
 {
 	int res = 0;
+	uint32_t errors = 0;
 	uint32_t w_len = min(len, SPI_FLASH_BLOCK_SIZE);
 	uint32_t offset = 0;
 	uint32_t j = 0;
@@ -338,6 +341,7 @@ int spiflash_write_stream(uint32_t addr, uint8_t *stream, uint32_t len)
 			uint8_t* peek = (((uint8_t*)SPIFLASH_BASE)+addr+offset+j);
 			if (*peek != stream[offset+j]) {
 				printf("Error: verify failed at 0x%08lx (0x%02x should be 0x%02x)\n", (uint32_t)peek, *peek, stream[offset+j]);
+				errors++;
 			}
 		}
 
@@ -348,6 +352,8 @@ int spiflash_write_stream(uint32_t addr, uint8_t *stream, uint32_t len)
 #ifdef SPIFLASH_DEBUG
   printf("\n");
 #endif
+	if (errors)
+		return -1;
 	return res;
 }
 

--- a/test/test_bios_boot.py
+++ b/test/test_bios_boot.py
@@ -413,12 +413,20 @@ def test_bios_boot_helpers_host_coverage(tmp_path):
             return 0;
         }}
 
-        static int test_manifest_ignores_oversized_tokens_and_malformed_json(void)
+        static int test_manifest_rejects_oversized_tokens_and_malformed_json(void)
         {{
-            const char *long_name =
-                "{{\\"this-filename-is-far-too-long-for-the-buffer.bin\\": \\"0x1000\\"}}";
+            /* Name longer than the 256-byte json_name buffer: the manifest must be rejected
+               without any load (a partial boot would fail in harder-to-debug ways). */
+            static char long_name[512];
             const char *malformed = "{{\\"image.bin\\": \\"0x1000\\"";
             struct load_ctx ctx = {{ .fail_after = -1 }};
+            int n = 0;
+
+            long_name[n++] = '{{';
+            long_name[n++] = '"';
+            for (int i = 0; i < 300; i++)
+                long_name[n++] = 'a';
+            n += sprintf(&long_name[n], "\\": \\"0x1000\\"}}");
 
             boot_from_json_buffer(long_name, strlen(long_name), record_load, &ctx);
             REQUIRE(ctx.count == 0);
@@ -430,15 +438,17 @@ def test_bios_boot_helpers_host_coverage(tmp_path):
 
         static int test_manifest_rejects_token_pressure_and_bad_registers(void)
         {{
-            const char *too_many_tokens =
-                "{{\\"a\\":\\"0x1000\\",\\"b\\":\\"0x1000\\",\\"c\\":\\"0x1000\\","
-                "\\"d\\":\\"0x1000\\",\\"e\\":\\"0x1000\\",\\"f\\":\\"0x1000\\","
-                "\\"g\\":\\"0x1000\\",\\"h\\":\\"0x1000\\",\\"i\\":\\"0x1000\\","
-                "\\"j\\":\\"0x1000\\",\\"k\\":\\"0x1000\\",\\"l\\":\\"0x1000\\","
-                "\\"m\\":\\"0x1000\\",\\"n\\":\\"0x1000\\",\\"o\\":\\"0x1000\\","
-                "\\"p\\":\\"0x1000\\"}}";
+            /* 33 entries = 67 jsmn tokens, exceeding the 64-token budget: the manifest must
+               be rejected (JSMN_ERROR_NOMEM) without any load. */
+            static char too_many_tokens[1024];
             const char *bad_r1 = "{{\\"r1\\": \\"bad\\", \\"image.bin\\": \\"0x1000\\"}}";
             struct load_ctx ctx = {{ .fail_after = -1 }};
+            int n = 0;
+
+            n += sprintf(&too_many_tokens[n], "{{");
+            for (int i = 0; i < 33; i++)
+                n += sprintf(&too_many_tokens[n], "%s\\"k%02d\\": \\"0x1000\\"", i ? "," : "", i);
+            n += sprintf(&too_many_tokens[n], "}}");
 
             boot_from_json_buffer(too_many_tokens, strlen(too_many_tokens), record_load, &ctx);
             REQUIRE(ctx.count == 0);
@@ -567,7 +577,7 @@ def test_bios_boot_helpers_host_coverage(tmp_path):
                 return 1;
             if (test_manifest_rejects_bad_addresses_and_load_failures())
                 return 1;
-            if (test_manifest_ignores_oversized_tokens_and_malformed_json())
+            if (test_manifest_rejects_oversized_tokens_and_malformed_json())
                 return 1;
             if (test_manifest_rejects_token_pressure_and_bad_registers())
                 return 1;

--- a/test/test_bios_network.py
+++ b/test/test_bios_network.py
@@ -94,6 +94,8 @@ def test_liteeth_tftp_receive_bounds_host_coverage(tmp_path):
             server_ip = 0;
             data_port = 0;
             next_data_block = 1;
+            current_offset = 0;
+            block_size = 0;
             tftp_write = 0;
         }}
 


### PR DESCRIPTION
This PR is the result of a systematic review of the LiteX BIOS (`litex/soc/software/bios/` and the libbase/libliteeth/liblitesdcard/liblitesata/liblitespi code on its boot path) for bugs, robustness issues and usability problems. 31 commits, one fix per commit.

## Memory safety / correctness

- **readline**: fix a 1-byte stack overflow in the escape-sequence parser, reachable from ordinary keystrokes (Ctrl+Delete/Shift+Delete), and stop unrecognized keys (F1-F12, Ctrl+arrows) from acting as backspace (`read_key()`'s -1 truncated to DEL through an `unsigned char`).
- **complete**: fix the common-prefix computation when one command name is a strict prefix of another, and the completion column layout.
- **boot**: accept load regions ending exactly at the top of the address space (`base + size` wrapping to 0 rejected the whole region, e.g. `MAIN_RAM_BASE=0xC0000000` + 1GB).
- Build fixes: `sataboot_from_bin()` missing its `MAIN_RAM_BASE` guard, `sim_finish()` using `n_markers` without `CSR_SIM_MARKER_BASE`.

## Boot reliability

- **serialboot**: reload the SFL frame timeout on every received byte (a whole frame had to fit in 0.25s, breaking serialboot at low baudrates).
- **netboot/TFTP**: fix transfers > 64MB (16-bit block-number wrap), parse the OACK blksize instead of assuming the request was granted (a server without option support silently returned a 512-byte truncated image as *success*), and print TFTP server error messages.
- **boot.json**: abort instead of half-booting when an entry cannot be parsed (e.g. jumping to a kernel with its device tree silently skipped); raise the name/token limits and report "too many entries" explicitly.
- **flashboot**: single CRC pass instead of two over (slow, often XIP) flash; image size cap tied to `MAIN_RAM_SIZE` instead of a hardcoded 16MiB; fix `uint32_t` printed with `%lx`/`%ld` (garbage on 64-bit CPUs).
- Report `f_mount` failures everywhere instead of failing silently.

## Hang elimination & storage correctness

- **litesdcard**: bound the six infinite command-retry loops and the DMA-done waits (a removed/failing card hard-hung the BIOS); propagate read/write errors through `sd_disk_read` to FatFs instead of handing it stale buffers; support standard-capacity ver2 cards (CCS bit was never checked, so SDSC cards were byte- vs block-address mis-addressed); fix an unmasked SPI status wait that hangs with `aligned`-mode SPIMaster.
- **litesata**: move the bounded retry/timeout logic (previously private to `sata_rwtest`) into `sata_read()`/`sata_write()` so no SATA command can hang the console; propagate errors to FatFs and the commands.
- **liteeth/udp**: fix `ip_checksum()` dropping the last byte of odd-length buffers (bad ICMP checksums).
- **libbase/memtest**: `memtest_addr` never ran with default build options (silently passing) and wrote out of bounds when enabled; `mem_test` without a size defaulted to write-testing ~4GiB over the BIOS stack.
- **libbase/uart**: service the UART manually when interrupts are disabled (panic `printf` output was silently truncated, reads returned NUL).
- **libbase/i2c + soc/cores/bitbang**: support I2C clock stretching - adds an SCL readback field to the I2CMaster status CSR (backward-compatible layout) and a bounded SCL-high wait in the bit-banged driver.

## Usability

- 128-char command line; tab-completion over all registered commands (was capped at 10 of ~70); optional boot.json filename for `sdcardboot`/`sataboot`; netboot progress marks; console polish (whitespace-only lines, Ctrl-L clear screen, warning when arguments beyond `MAX_PARAM` are dropped, escape filtering in the lite console); `sdcard_read [count]`; clarified help strings (`mem_copy`/`mem_cmp` word units, `sata_rwtest` memory/disk footprint); error checking on flash writes with a hint at `flash_erase_range`.

## Verification

- BIOS builds verified with `litex_sim` (featured config with ethernet+sdcard+spiflash, and `--cpu-type=serv` for the minimal/no-IRQ configuration).
- Python unit tests pass (`test_bitbang.py`, `test_export.py`, `test_i2c.py` for the gateware/export change).
- End-to-end Verilator run: BIOS boots to the `litex>` prompt; `ident`, `mem_read`, `mem_test` default size and whitespace-line handling exercised live at the console.

**Note**: the SD/SATA hardware paths compile and are logic-reviewed, but were only exercised as far as simulation allows - a quick smoke test on real hardware with a card/disk is recommended before merging.