### PR TITLE
soc/integration: Fix bugs/robustness issues and improve usability.

### DIFF
--- a/litex/gen/fhdl/module.py
+++ b/litex/gen/fhdl/module.py
@@ -61,7 +61,6 @@ class LiteXModule(Module, AutoCSR, AutoDoc):
 
         # - m += module_x  equivalent of Migen's m.submodules += module_x.
         if isinstance(other, Module):
-            print(other)
             m.submodules += other
         # - m += special_x  equivalent of Migen's m.specials += special_x.
         elif isinstance(other, Special):

--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -30,7 +30,17 @@ from litex.soc.integration import export, soc
 # Helpers ------------------------------------------------------------------------------------------
 
 def _makefile_escape(s):
-    return s.replace("\\", "\\\\")
+    return s.replace("\\", "\\\\").replace("$", "$$")
+
+def _check_makefile_path(p):
+    # Make cannot represent spaces in its space-separated path lists (PACKAGE_DIRS etc.) and "#"
+    # starts a comment: fail loudly instead of generating a corrupt variables.mak that breaks the
+    # software build with confusing errors.
+    if any(c in p for c in " \t\n#"):
+        raise ValueError(
+            f"Unsupported character in build path {p!r}: "
+            "Make cannot handle spaces/'#' in paths, use a path without them.")
+    return p
 
 def _create_dir(d, remove_if_exists=False):
     dir_path = os.path.realpath(d)
@@ -144,7 +154,8 @@ class Builder:
             self.add_software_library(name)
 
         # JSONs.
-        self.jsons = []
+        self.jsons         = []
+        self._jsons_merged = False
 
     def add_software_package(self, name, src_dir=None):
         if src_dir is None:
@@ -164,25 +175,30 @@ class Builder:
             exclude_constants = ["_INTERRUPT"]
         self.jsons.append((filename, origin, name, exclude_constants))
 
+    def _load_jsons(self):
+        # Parse each JSON file only once for the mem_regions/constants/csr_regions getters.
+        if not hasattr(self, "_jsons_cache"):
+            self._jsons_cache = [
+                (export.load_csr_json(filename, origin, name), exclude)
+                for filename, origin, name, exclude in self.jsons]
+        return self._jsons_cache
+
     def _get_json_mem_regions(self):
         mem_regions = {}
-        for filename, origin, name, _ in self.jsons:
-            _, _, _mem_regions = export.load_csr_json(filename, origin, name)
+        for (_, _, _mem_regions), _ in self._load_jsons():
             mem_regions.update(_mem_regions)
         return mem_regions
 
     def _get_json_constants(self):
         constants = {}
-        for filename, origin, name, exclude in self.jsons:
-            _, _constants, _ = export.load_csr_json(filename, origin, name)
+        for (_, _constants, _), exclude in self._load_jsons():
             _constants = {k: v for k, v in _constants.items() if not any(ex in k for ex in exclude)}
             constants.update(_constants)
         return constants
 
     def _get_json_csr_regions(self):
         csr_regions = {}
-        for filename, origin, name, _ in self.jsons:
-            _csr_regions, _, _ = export.load_csr_json(filename, origin, name)
+        for (_csr_regions, _, _), _ in self._load_jsons():
             csr_regions.update(_csr_regions)
         return csr_regions
 
@@ -207,7 +223,7 @@ class Builder:
 
         # Define packages and libraries.
         define("PACKAGES",     " ".join(name    for name, src_dir in self.software_packages))
-        define("PACKAGE_DIRS", " ".join(src_dir for name, src_dir in self.software_packages))
+        define("PACKAGE_DIRS", " ".join(_check_makefile_path(src_dir) for name, src_dir in self.software_packages))
         define("LIBS",         " ".join(self.software_libraries))
         define("ALWAYS_LINK_LIBS", " ".join(self.software_always_link_libraries))
 
@@ -219,15 +235,15 @@ class Builder:
         picolibc_directory    = get_data_mod("software", "picolibc").data_location
         compiler_rt_directory = get_data_mod("software", "compiler_rt").data_location
 
-        define("SOC_DIRECTORY",         soc_directory)
-        define("PICOLIBC_DIRECTORY",    picolibc_directory)
+        define("SOC_DIRECTORY",         _check_makefile_path(soc_directory))
+        define("PICOLIBC_DIRECTORY",    _check_makefile_path(picolibc_directory))
         define("PICOLIBC_FORMAT",       self.bios_format)
         define("LIBC_MODE",             self.libc_mode)
-        define("COMPILER_RT_DIRECTORY", compiler_rt_directory)
+        define("COMPILER_RT_DIRECTORY", _check_makefile_path(compiler_rt_directory))
         variables_contents.append("export BUILDINC_DIRECTORY")
-        define("BUILDINC_DIRECTORY", self.include_dir)
+        define("BUILDINC_DIRECTORY", _check_makefile_path(self.include_dir))
         for name, src_dir in self.software_packages:
-            define(name.upper() + "_DIRECTORY", src_dir)
+            define(name.upper() + "_DIRECTORY", _check_makefile_path(src_dir))
 
         # Define BIOS variables.
         define("LTO", f"{self.bios_lto:d}")
@@ -244,10 +260,13 @@ class Builder:
         _create_dir(self.include_dir)
         _create_dir(self.generated_dir)
 
-        # Integrate JSON files.
-        self._merge_json_items(self.soc.mem_regions,  self._get_json_mem_regions(), "memory region")
-        self._merge_json_items(self.soc.constants,    self._get_json_constants(),    "constant")
-        self._merge_json_items(self.soc.csr_regions,  self._get_json_csr_regions(),  "CSR region")
+        # Integrate JSON files (only once: the items are merged into the SoC's dicts in place, so a
+        # second build() on the same Builder would raise spurious collision errors).
+        if not self._jsons_merged:
+            self._merge_json_items(self.soc.mem_regions,  self._get_json_mem_regions(), "memory region")
+            self._merge_json_items(self.soc.constants,    self._get_json_constants(),    "constant")
+            self._merge_json_items(self.soc.csr_regions,  self._get_json_csr_regions(),  "CSR region")
+            self._jsons_merged = True
 
         # Generate BIOS files when the SoC uses it.
         if with_bios:
@@ -277,7 +296,7 @@ class Builder:
         # Generate Memory Regions to memory.x if specified.
         if self.memory_x is not None:
             memory_x_contents = export.get_memory_x(self.soc)
-            write_to_file(os.path.realpath(self.memory_x), memory_x_contents)
+            self._export_write(self.memory_x, memory_x_contents)
 
         # Generate SoC Config/Constants to soc.h.
         soc_contents = export.get_soc_header(self.soc.constants)
@@ -307,6 +326,13 @@ class Builder:
                 self.soc.sdram.controller.settings.geom)
             write_to_file(os.path.join(self.generated_dir, "sdram_phy.h"), sdram_contents)
 
+    @staticmethod
+    def _export_write(path, contents):
+        # User-specified export paths may point to not-yet-existing directories.
+        path = os.path.realpath(path)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        write_to_file(path, contents)
+
     def _generate_csr_map(self):
         # JSON Export.
         if self.csr_json is not None:
@@ -315,7 +341,7 @@ class Builder:
                 csr_regions = self.soc.csr_regions,
                 constants   = self.soc.constants,
                 mem_regions = self.soc.mem_regions)
-            write_to_file(os.path.realpath(self.csr_json), csr_json_contents)
+            self._export_write(self.csr_json, csr_json_contents)
 
         # CSV Export.
         if self.csr_csv is not None:
@@ -324,12 +350,12 @@ class Builder:
                 csr_regions = self.soc.csr_regions,
                 constants   = self.soc.constants,
                 mem_regions = self.soc.mem_regions)
-            write_to_file(os.path.realpath(self.csr_csv), csr_csv_contents)
+            self._export_write(self.csr_csv, csr_csv_contents)
 
         # SVD Export.
         if self.csr_svd is not None:
             csr_svd_contents = export.get_csr_svd(self.soc)
-            write_to_file(os.path.realpath(self.csr_svd), csr_svd_contents)
+            self._export_write(self.csr_svd, csr_svd_contents)
 
     def _check_meson(self):
         # Check Meson install/version.
@@ -521,8 +547,8 @@ def builder_args(parser):
     builder_group.add_argument("--no-compile",            action="store_true", help="Disable software and gateware compilation.")
     builder_group.add_argument("--no-compile-software",   action="store_true", help="Disable software compilation only.")
     builder_group.add_argument("--no-compile-gateware",   action="store_true", help="Disable gateware compilation only.")
-    builder_group.add_argument("--soc-csv", "--csr-csv",  default=None,        help=f"Write SoC mapping to the specified CSV file. {export_help}")
-    builder_group.add_argument("--soc-json", "--csr-json", default=None,       help=f"Write SoC mapping to the specified JSON file. {export_help}")
+    builder_group.add_argument("--soc-csv", "--csr-csv",  default=None,        help=f"Write SoC mapping to the specified CSV file (always generated, default: <output-dir>/csr.csv). {export_help}")
+    builder_group.add_argument("--soc-json", "--csr-json", default=None,       help=f"Write SoC mapping to the specified JSON file (always generated, default: <output-dir>/csr.json). {export_help}")
     builder_group.add_argument("--soc-svd", "--csr-svd",  default=None,        help=f"Write SoC mapping to the specified SVD file. {export_help}")
     builder_group.add_argument("--memory-x",              default=None,        help=f"Write SoC memory regions to the specified Memory-X file. {export_help}")
     builder_group.add_argument("--doc",                   action="store_true", help="Generate SoC documentation.")

--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -185,6 +185,21 @@ def get_mem_header(regions):
     r += "#endif\n"
     return r
 
+def _c_string_literal(s):
+    # json.dumps escapes quotes/backslashes suitably for C, but encodes control characters as
+    # \uXXXX universal-character-names, which are ill-formed in C below U+00A0 (the generated
+    # header would not compile). Escape them as hex with string-splicing to avoid escape run-on.
+    r = "\""
+    for c in s:
+        if c in "\"\\":
+            r += "\\" + c
+        elif (ord(c) < 0x20) or (ord(c) == 0x7f):
+            r += "\\x{:02x}\"\"".format(ord(c))
+        else:
+            r += c
+    r += "\""
+    return r
+
 def get_soc_header(constants, with_access_functions=True):
     r = generated_banner("//")
     r += "#ifndef __GENERATED_SOC_H\n#define __GENERATED_SOC_H\n"
@@ -197,7 +212,7 @@ def get_soc_header(constants, with_access_functions=True):
             r += "#define "+name+"\n"
             continue
         if isinstance(value, str):
-            value = json.dumps(value)
+            value = _c_string_literal(value)
             ctype = "const char *"
         else:
             if isinstance(value, bool):
@@ -205,9 +220,21 @@ def get_soc_header(constants, with_access_functions=True):
             ctype = "int32_t"
             if isinstance(value, int):
                 if value >= 0:
-                    ctype = "uint64_t" if value > 0xffffffff else "uint32_t"
+                    if value > 0xffffffffffffffff:
+                        raise ValueError(f"Constant {name} value {value} does not fit in a 64-bit C type.")
+                    # >32-bit values need an explicit suffix: an unsuffixed decimal literal above
+                    # INT64_MAX is ill-formed C and values above UINT32_MAX must not be truncated.
+                    if value > 0xffffffff:
+                        ctype = "uint64_t"
+                        value = f"0x{value:x}ULL"
+                    else:
+                        ctype = "uint32_t"
                 else:
-                    ctype = "int64_t" if value < -0x80000000 else "int32_t"
+                    if value < -0x8000000000000000:
+                        raise ValueError(f"Constant {name} value {value} does not fit in a 64-bit C type.")
+                    if value < -0x80000000:
+                        ctype = "int64_t"
+                        value = f"{value}LL"
             value = str(value)
         r += "#define "+name+" "+value+"\n"
         if with_access_functions:
@@ -222,14 +249,15 @@ def get_soc_header(constants, with_access_functions=True):
     r += "\n#endif\n"
     return r
 
-def _generate_csr_header_includes_c(with_access_functions):
+def _generate_csr_header_includes_c(with_access_functions, with_fields_access_functions=False):
     includes = ""
     if with_access_functions:
         includes += "#include <generated/soc.h>\n"
     includes += "#ifndef __GENERATED_CSR_H\n"
     includes += "#define __GENERATED_CSR_H\n"
-    if with_access_functions:
+    if with_access_functions or with_fields_access_functions:
         includes += "#include <stdint.h>\n"
+    if with_access_functions:
         includes += "#include <system.h>\n"
         includes += "#ifndef CSR_ACCESSORS_DEFINED\n"
         includes += "#include <hw/common.h>\n"
@@ -375,7 +403,7 @@ def _generate_csr_field_definitions_c(csr, name):
         field_defs += f"#define CSR_{name.upper()}_{csr.name.upper()}_{field.name.upper()}_SIZE {size}\n"
     return field_defs
 
-def _generate_csr_field_accessors_c(name, csr, field):
+def _generate_csr_field_accessors_c(name, csr, field, with_access_functions=True):
     accessors = ""
     if csr.size > 64:
         return accessors
@@ -388,26 +416,30 @@ def _generate_csr_field_accessors_c(name, csr, field):
     accessors += f"static inline {ctype} {field_name}_extract({ctype} oldword) {{\n"
     accessors += f"\t{ctype} mask = 0x{(1 << int(size)) - 1:x};\n"
     accessors += f"\treturn ((oldword >> {offset}) & mask);\n}}\n"
-    accessors += f"static inline {ctype} {field_name}_read(void) {{\n"
-    accessors += f"\t{ctype} word = {reg_name}_read();\n"
-    accessors += f"\treturn {field_name}_extract(word);\n}}\n"
+    # The register-level _read()/_write() functions only exist with access functions enabled: only
+    # emit the pure _extract/_replace helpers without them.
+    if with_access_functions:
+        accessors += f"static inline {ctype} {field_name}_read(void) {{\n"
+        accessors += f"\t{ctype} word = {reg_name}_read();\n"
+        accessors += f"\treturn {field_name}_extract(word);\n}}\n"
     if not getattr(csr, "read_only", False):
         accessors += f"static inline {ctype} {field_name}_replace({ctype} oldword, {ctype} plain_value) {{\n"
         accessors += f"\t{ctype} mask = 0x{(1 << int(size)) - 1:x};\n"
         accessors += f"\treturn (oldword & (~(mask << {offset}))) | ((mask & plain_value) << {offset});\n}}\n"
-        accessors += f"static inline void {field_name}_write({ctype} plain_value) {{\n"
-        accessors += f"\t{ctype} oldword = {reg_name}_read();\n"
-        accessors += f"\t{ctype} newword = {field_name}_replace(oldword, plain_value);\n"
-        accessors += f"\t{reg_name}_write(newword);\n}}\n"
+        if with_access_functions:
+            accessors += f"static inline void {field_name}_write({ctype} plain_value) {{\n"
+            accessors += f"\t{ctype} oldword = {reg_name}_read();\n"
+            accessors += f"\t{ctype} newword = {field_name}_replace(oldword, plain_value);\n"
+            accessors += f"\t{reg_name}_write(newword);\n}}\n"
     return accessors
 
-def _generate_csr_field_functions_c(csr, name):
+def _generate_csr_field_functions_c(csr, name, with_access_functions=True):
     field_funcs = ""
     for field in csr.fields.fields:
-        field_funcs += _generate_csr_field_accessors_c(name, csr, field)
+        field_funcs += _generate_csr_field_accessors_c(name, csr, field, with_access_functions)
     return field_funcs
 
-def _generate_csr_fields_access_functions_c(name, region, origin, alignment, csr_base, with_csr_base_define):
+def _generate_csr_fields_access_functions_c(name, region, origin, alignment, csr_base, with_csr_base_define, with_access_functions=True):
     base_define = with_csr_base_define and not isinstance(region, MockCSRRegion)
     region_defs = f"\n/* {name.upper()} Fields Access Functions */\n"
 
@@ -416,7 +448,7 @@ def _generate_csr_fields_access_functions_c(name, region, origin, alignment, csr
             nr = (csr.size + region.busword - 1) // region.busword
             origin += alignment // 8 * nr
             if hasattr(csr, "fields"):
-                region_defs += _generate_csr_field_functions_c(csr, name)
+                region_defs += _generate_csr_field_functions_c(csr, name, with_access_functions)
     return region_defs
 
 # CSR Header.
@@ -438,7 +470,7 @@ def get_csr_header(regions, constants, csr_ordering="big", csr_base=None, with_c
     r += "\n"
     r += generated_separator("//", "CSR Includes.")
     r += "\n"
-    r += _generate_csr_header_includes_c(with_access_functions)
+    r += _generate_csr_header_includes_c(with_access_functions, with_fields_access_functions)
     if csr_base is None:
         _csr_base = regions[next(iter(regions))].origin if len(regions) else 0
     else:
@@ -482,7 +514,7 @@ def get_csr_header(regions, constants, csr_ordering="big", csr_base=None, with_c
         r += "#if LITEX_CSR_FIELDS_ACCESS_FUNCTIONS\n"
         for name, region in regions.items():
             origin = _get_csr_region_origin(region, _csr_base)
-            r += _generate_csr_fields_access_functions_c(name, region, origin, alignment, csr_base, with_csr_base_define)
+            r += _generate_csr_fields_access_functions_c(name, region, origin, alignment, csr_base, with_csr_base_define, with_access_functions)
         r += "#endif /* LITEX_CSR_FIELDS_ACCESS_FUNCTIONS */\n"
 
     r += "\n#endif /* ! __GENERATED_CSR_H */\n"
@@ -581,8 +613,12 @@ def get_csr_json(soc=None, csr_regions=None, constants=None, mem_regions=None):
         if not isinstance(region.obj, Memory):
             for csr in region.obj:
                 _size = (csr.size + region.busword - 1)//region.busword
+                # Use the same predicate as the csr.h generation so that imported regions
+                # (MockCSRs, which carry read_only) keep their type on re-export.
                 _type = "rw"
-                if isinstance(csr, CSRStatus) and not hasattr(csr, "wr_data"):
+                if getattr(csr, "read_only", False):
+                    _type = "ro"
+                elif isinstance(csr, CSRStatus) and not hasattr(csr, "wr_data"):
                     _type = "ro"
                 csr_origin = _get_csr_origin(csr, region_origin)
                 d["csr_registers"][name + "_" + csr.name] = {

--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -780,6 +780,11 @@ def get_csr_csv(soc=None, csr_regions=None, constants=None, mem_regions=None):
 
 # SVD Export --------------------------------------------------------------------------------------
 
+def _svd_cdata(description):
+    # A literal "]]>" inside a CDATA section would terminate it and break the whole SVD: split it
+    # across two CDATA sections (standard XML escaping technique).
+    return "<![CDATA[{}]]>".format(str(description).replace("]]>", "]]]]><![CDATA[>"))
+
 def get_csr_svd(soc, vendor="litex", name="soc", description=None):
     def sub_csr_bit_range(busword, csr, offset):
         nwords = (csr.size + busword - 1)//busword
@@ -793,7 +798,7 @@ def get_csr_svd(soc, vendor="litex", name="soc", description=None):
         svd.append('                <register>')
         svd.append('                    <name>{}</name>'.format(csr.short_numbered_name))
         if description is not None:
-            svd.append('                    <description><![CDATA[{}]]></description>'.format(description))
+            svd.append('                    <description>{}</description>'.format(_svd_cdata(description)))
         svd.append('                    <addressOffset>0x{:04x}</addressOffset>'.format(csr_address))
         svd.append('                    <resetValue>0x{:02x}</resetValue>'.format(csr.reset_value))
         svd.append('                    <size>{}</size>'.format(length))
@@ -810,8 +815,8 @@ def get_csr_svd(soc, vendor="litex", name="soc", description=None):
                     field.offset + field.size - 1, field.offset))
                 svd.append('                            <lsb>{}</lsb>'.format(field.offset))
                 if field.description is not None:
-                    svd.append('                            <description><![CDATA[{}]]></description>'.format(
-                        reflow(field.description)))
+                    svd.append('                            <description>{}</description>'.format(
+                        _svd_cdata(reflow(field.description))))
                 svd.append('                        </field>')
         else:
             field_size = csr.size
@@ -852,11 +857,11 @@ def get_csr_svd(soc, vendor="litex", name="soc", description=None):
     svd.append('    <vendor>{}</vendor>'.format(vendor))
     svd.append('    <name>{}</name>'.format(name.upper()))
     if description is not None:
-        svd.append('    <description><![CDATA[{}]]></description>'.format(reflow(description)))
+        svd.append('    <description>{}</description>'.format(_svd_cdata(reflow(description))))
     else:
         fmt = "%Y-%m-%d %H:%M:%S"
         build_time = datetime.datetime.fromtimestamp(time.time()).strftime(fmt)
-        svd.append('    <description><![CDATA[{}]]></description>'.format(reflow("Litex SoC " + build_time)))
+        svd.append('    <description>{}</description>'.format(_svd_cdata(reflow("Litex SoC " + build_time))))
     svd.append('')
     svd.append('    <addressUnitBits>8</addressUnitBits>')
     svd.append('    <width>32</width>')
@@ -874,8 +879,8 @@ def get_csr_svd(soc, vendor="litex", name="soc", description=None):
         svd.append('            <baseAddress>0x{:08X}</baseAddress>'.format(region.origin))
         svd.append('            <groupName>{}</groupName>'.format(region.name.upper()))
         if len(region.sections) > 0:
-            svd.append('            <description><![CDATA[{}]]></description>'.format(
-                reflow(region.sections[0].body())))
+            svd.append('            <description>{}</description>'.format(
+                _svd_cdata(reflow(region.sections[0].body()))))
         svd.append('            <registers>')
         for csr in region.csrs:
             description = None

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -111,10 +111,14 @@ class SoCRegion:
         self.logger    = logging.getLogger("SoCRegion")
         self.origin    = origin
         self.decode    = decode
-        if not isinstance(size, int):
-            raise ValueError("Region size must be an integer.")
+        if (not isinstance(size, int)) or isinstance(size, bool):
+            self.logger.error("Region size must be an {} (got {}).".format(
+                colorer("integer"), colorer(repr(size), color="red")))
+            raise SoCError()
         if size <= 0:
-            raise ValueError("Region size must be positive.")
+            self.logger.error("Region size must be {} (got {}).".format(
+                colorer("positive"), colorer(size, color="red")))
+            raise SoCError()
         self.size      = size
         if size != 2**log2_int(size, False):
             self.logger.info("Region size {} internally from {} to {}.".format(
@@ -382,7 +386,9 @@ class SoCBusHandler(LiteXModule):
                 colorer("allocated" if allocated else "added", color="cyan" if allocated else "green"),
                 str(region)))
         else:
-            self.logger.error("{} is not a supported Region.".format(colorer(name, color="red")))
+            self.logger.error("{} is not a supported Region (got {}, expected SoCRegion/SoCIORegion).".format(
+                colorer(name, color="red"),
+                colorer(type(region).__name__, color="red")))
             raise SoCError()
 
     def alloc_region(self, name, size, cached=True, linker=False, mode="rw"):
@@ -1262,7 +1268,7 @@ class SoC(LiteXModule):
             reserved_regions = bus_reserved_regions,
            )
 
-        # SoC Bus Handler --------------------------------------------------------------------------
+        # SoC CSR Handler --------------------------------------------------------------------------
         self.csr = SoCCSRHandler(
             data_width    = csr_data_width,
             address_width = csr_address_width,
@@ -2733,7 +2739,7 @@ class LiteXSoC(SoC):
 
         # Debug.
         if software_debug:
-            self.add_constant("SPISDCARD_DEBUG")
+            self.add_constant(f"{name}_DEBUG")
 
     # Add SDCard -----------------------------------------------------------------------------------
     def add_sdcard(self, name="sdcard", sdcard_name="sdcard", software_debug=False, **kwargs):
@@ -2773,7 +2779,7 @@ class LiteXSoC(SoC):
                     self.block2mem = block2mem = SDBlock2MemDMA(bus=bus, endianness=soc.cpu.endianness)
                     self.comb += core.source.connect(block2mem.sink)
                     dma_bus = getattr(soc, "dma_bus", soc.bus)
-                    dma_bus.add_master(master=bus)
+                    dma_bus.add_master(name=f"{name}_block2mem", master=bus)
 
                 # Mem2Block DMA.
                 if "write" in mode:
@@ -2786,7 +2792,7 @@ class LiteXSoC(SoC):
                     self.mem2block = mem2block = SDMem2BlockDMA(bus=bus, endianness=soc.cpu.endianness)
                     self.comb += mem2block.source.connect(core.sink)
                     dma_bus = getattr(soc, "dma_bus", soc.bus)
-                    dma_bus.add_master(master=bus)
+                    dma_bus.add_master(name=f"{name}_mem2block", master=bus)
 
                 # Interrupts.
                 self.ev = ev = EventManager()
@@ -3023,6 +3029,10 @@ class LiteXSoC(SoC):
             if msi_type in ["msi", "msi-multi-vector"]:
                 self.comb += msi.source.connect(phy.msi)
             self.msis = dict(msis or {})
+        elif msis:
+            self.logger.warning("PCIe {} {}: requires with_msi=True.".format(
+                colorer("msis", color="yellow"),
+                colorer("ignored", color="yellow")))
 
         # DMAs.
         def _pcie_dma_depth(name, depth, index, default=None):
@@ -3064,8 +3074,13 @@ class LiteXSoC(SoC):
             if with_dma_table and map_dma_irqs:
                 self.msis[f"{name.upper()}_DMA{i}_WRITER"] = dma.writer.irq
                 self.msis[f"{name.upper()}_DMA{i}_READER"] = dma.reader.irq
-        self.add_constant("DMA_CHANNELS",   ndmas)
-        self.add_constant("DMA_ADDR_WIDTH", address_width)
+        # Prefix the constants with the instance name so a second add_pcie() does not abort on
+        # duplicate constants; keep the legacy unprefixed constants for the default instance.
+        self.add_constant(f"{name}_DMA_CHANNELS",   ndmas)
+        self.add_constant(f"{name}_DMA_ADDR_WIDTH", address_width)
+        if name == "pcie":
+            self.add_constant("DMA_CHANNELS",   ndmas)
+            self.add_constant("DMA_ADDR_WIDTH", address_width)
 
         # Map/Connect MSI IRQs.
         if with_msi and auto_map_msi_irqs:
@@ -3579,13 +3594,15 @@ def soc_core_args(parser, cpu_type="vexriscv", cpu_variant=None):
     soc_group.add_argument("--uart-name",                default="serial",    type=str,      help="UART type/name.")
     soc_group.add_argument("--uart-baudrate",            default=115200,      type=auto_int, help="UART baudrate.")
     soc_group.add_argument("--uart-fifo-depth",          default=16,          type=auto_int, help="UART FIFO depth.")
+    soc_group.add_argument("--uart-with-dynamic-baudrate", action="store_true",              help="Enable dynamic UART baudrate (tuning CSR).")
+    soc_group.add_argument("--uart-rx-fifo-rx-we",       action="store_true",                help="Use FIFO RX We on UART RX path.")
 
     # UARTBone parameters.
     soc_group.add_argument("--with-uartbone",            action="store_true",                help="Enable UARTBone.")
 
     # JTAGBone parameters.
     soc_group.add_argument("--with-jtagbone",            action="store_true",                help="Enable JTAGBone support.")
-    soc_group.add_argument("--jtagbone-chain",           default=1,          type=int,       help="JTAGBone chain index.")
+    soc_group.add_argument("--jtagbone-chain",           default=1,          type=auto_int,  help="JTAGBone chain index.")
 
     # Timer parameters.
     soc_group.add_argument("--no-timer",                 action="store_true",                help="Disable timer.")

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -3325,6 +3325,16 @@ class SoCCore(LiteXSoC):
             irq_reserved_irqs    = {},
         )
 
+        # Warn on unknown arguments: they would otherwise be silently ignored (typos, unsupported
+        # options). l2_size is deliberately tolerated: soc_core_argdict passes it through for the
+        # targets to consume.
+        for kwarg in kwargs:
+            if kwarg in ["l2_size"]:
+                continue
+            self.logger.warning("SoCCore: unknown argument {} {}.".format(
+                colorer(kwarg, color="yellow"),
+                colorer("ignored", color="yellow")))
+
         # Parameters management --------------------------------------------------------------------
 
         # CPU.

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1346,9 +1346,9 @@ class SoC(LiteXModule):
             address_width = self.bus.address_width,
             bursting      = self.bus.bursting
         )
+        self.check_if_exists(name)
         ram = ram_cls(size, bus=ram_bus, init=contents, read_only=("w" not in mode), name=name)
         self.bus.add_slave(name=name, slave=ram.bus, region=SoCRegion(origin=origin, size=size, mode=mode))
-        self.check_if_exists(name)
         self.logger.info("RAM {} {} {}.".format(
             colorer(name),
             colorer("added", color="green"),
@@ -2347,7 +2347,7 @@ class LiteXSoC(SoC):
                 colorer("data_width"), colorer(data_width, color="red")))
             raise SoCError()
         with_sys_datapath = (data_width == 32)
-        self.check_if_exists(name + "_ethcore")
+        self.check_if_exists(f"ethcore_{name}")
         ethcore = LiteEthUDPIPCore(
             phy         = phy,
             mac_address = mac_address,
@@ -2611,12 +2611,11 @@ class LiteXSoC(SoC):
         # PHY.
         spiram_phy = phy
         if spiram_phy is None:
-            self.check_if_exists(f"{name}_phy")
             spiram_pads = self.platform.request(name if mode == "1x" else name + mode, number=number)
             spiram_phy = LiteSPIPHY(spiram_pads, module, device=self.platform.device, default_divisor=default_divisor, rate=rate, **kwargs)
 
         # Core.
-        self.check_if_exists(f"{name}_mmap")
+        self.check_if_exists(name)
         spiram = LiteSPI(spiram_phy, mmap_endianness=self.cpu.endianness, with_mmap_write=True, **kwargs)
         spiram.add_module(name="phy", module=spiram_phy)
         self.add_module(name=name, module=spiram)

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -283,6 +283,16 @@ class SoCBusHandler(LiteXModule):
             self.logger.error("{} already declared as Region:".format(colorer(name, color="red")))
             self.logger.error(self)
             raise SoCError()
+        # Check Region fits in the Bus Address Space (the decode extent for SoCRegions, since the
+        # decoder matches the full power-of-2 window).
+        if isinstance(region, SoCRegion) and (region.origin is not None):
+            if (region.origin < 0) or (self._region_overlap_end(region) > 2**self.address_width):
+                self.logger.error("{} Region {} {}-bit Bus Address Space:".format(
+                    colorer(name, color="red"),
+                    colorer("does not fit in", color="red"),
+                    colorer(self.address_width)))
+                self.logger.error(str(region))
+                raise SoCError()
         # Check if is SoCIORegion.
         if isinstance(region, SoCIORegion):
             io_regions = dict(self.io_regions)
@@ -297,6 +307,22 @@ class SoCBusHandler(LiteXModule):
                 self.logger.error(str(io_regions[overlap[0]]))
                 self.logger.error(str(io_regions[overlap[1]]))
                 raise SoCError()
+            # Re-check existing Bus Regions against the new IO Region: they were only validated
+            # against the IO Regions present when they were added (e.g. Regions reserved/allocated
+            # before the CPU adds its IO Regions). A cached Region must not lie in an IO Region and
+            # an overlapping Region must be fully contained.
+            if self.io_regions_check:
+                for r_name, r in self.regions.items():
+                    if self.check_regions_overlap({name: region, r_name: r}, check_linker=True) is None:
+                        continue
+                    if r.cached or (not self.check_region_is_in(r, region)):
+                        self.logger.error("{} Region overlaps new IO Region {}{}:".format(
+                            colorer(r_name, color="red"),
+                            colorer(name),
+                            " and is cached" if r.cached else " without being fully contained"))
+                        self.logger.error(str(r))
+                        self.logger.error(str(region))
+                        raise SoCError()
             self.io_regions[name] = region
             self.logger.info("{} Region {} at {}.".format(
                 colorer(name,    color="underline"),
@@ -716,8 +742,24 @@ class SoCBusHandler(LiteXModule):
                     colorer("not found", color="red")))
                 raise SoCError()
         else:
+            # SoCIORegions describe IO decode windows, not Slave mappings: accepting one here would
+            # only register it in io_regions and crash with a KeyError at finalize.
+            if isinstance(region, SoCIORegion):
+                self.logger.error("{} Bus Slave Region must be a {} (use SoCRegion(cached=False) for a Slave in an IO Region).".format(
+                    colorer(name, color="red"),
+                    colorer("SoCRegion")))
+                raise SoCError()
             self.add_region(name, region)
             region_added = True
+        # Check decoded Region origin alignment early, with the Slave's name (the decoder would
+        # only raise at finalize, without naming the offending Region).
+        if (region.origin is not None) and (region.origin & (region.size_pow2 - 1)):
+            self.logger.error("{} Region origin must be aligned on size:".format(
+                colorer(name, color="red")))
+            self.logger.error(str(region))
+            if region_added:
+                self.regions.pop(name, None)
+            raise SoCError()
         try:
             if strip_origin:
                 slave = self.add_offset(name, slave, self.regions[name].origin)

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -140,8 +140,13 @@ class SoCRegion:
             raise SoCError()
         if (not self.decode) or ((origin == 0) and (size == 2**bus.address_width)):
             return lambda a: True
-        origin >>= int(math.log2(bus.data_width//8)) # bytes to words aligned.
-        size   >>= int(math.log2(bus.data_width//8)) # bytes to words aligned.
+        # Convert Origin/Size from bytes to words when the decoded address is word-aligned: AXI/AXI-
+        # Lite interconnects pre-shift addresses to words before calling the decoder and Wishbone
+        # buses carry word addresses natively with addressing="word". With addressing="byte", the
+        # Wishbone Decoder sees raw byte addresses, so no conversion must be done.
+        if not ((bus.standard == "wishbone") and (bus.addressing == "byte")):
+            origin >>= int(math.log2(bus.data_width//8)) # bytes to words aligned.
+            size   >>= int(math.log2(bus.data_width//8)) # bytes to words aligned.
         return lambda a: (a[log2_int(size):] == (origin >> log2_int(size)))
 
     def __str__(self):

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1896,6 +1896,16 @@ class LiteXSoC(SoC):
         # Imports.
         from litex.soc.cores import uart
 
+        # Checks.
+        if baudrate <= 0:
+            self.logger.error("UART {} {}: must be positive.".format(
+                colorer("baudrate"), colorer(baudrate, color="red")))
+            raise SoCError()
+        if fifo_depth <= 0:
+            self.logger.error("UART {} {}: must be positive.".format(
+                colorer("fifo_depth"), colorer(fifo_depth, color="red")))
+            raise SoCError()
+
         # Core.
         self.check_if_exists(name)
         supported_uarts = uart.get_uart_supported_names()
@@ -1912,10 +1922,8 @@ class LiteXSoC(SoC):
             raise SoCError()
 
         # UARTBone.
-        if uart_name in ["crossover+uartbone"]:
+        if uart_name in ["uartbone", "crossover+uartbone"]:
             self.add_uartbone(baudrate=baudrate, with_dynamic_baudrate=with_dynamic_baudrate)
-        elif uart_name in ["uartbone"]:
-            self.add_uartbone(baudrate=baudrate)
 
         uart_core = uart.get_uart_core(
             uart_name              = uart_name,
@@ -1928,9 +1936,13 @@ class LiteXSoC(SoC):
             rx_fifo_rx_we          = rx_fifo_rx_we,
         )
 
+        # No UART Core (e.g. pure "uartbone"): don't allocate an IRQ/Configs for a UART that does
+        # not exist.
+        if uart_core is None:
+            return
+
         # Add UART.
-        if uart_core is not None:
-            self.add_module(name=name, module=uart_core)
+        self.add_module(name=name, module=uart_core)
 
         if rx_fifo_rx_we:
             self.add_config(f"{name}_RX_FIFO_RX_WE", 1)

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -529,7 +529,14 @@ class SoCBusHandler(LiteXModule):
                     wishbone.Interface   : wishbone.Converter,
                     axi.AXILiteInterface : axi.AXILiteConverter,
                     axi.AXIInterface     : axi.AXIConverter,
-                }[interface_cls]
+                }.get(interface_cls)
+                if converter_cls is None:
+                    self.logger.error("{} {} Data-Width conversion from {}-bit to {}-bit.".format(
+                        colorer(name, color="red"),
+                        colorer("no supported", color="red"),
+                        colorer(interface.data_width),
+                        colorer(self.data_width)))
+                    raise SoCError()
                 adapted_interface = interface_cls(**self._get_interface_args(interface, data_width=self.data_width))
 
                 if direction == "m2s":
@@ -613,7 +620,14 @@ class SoCBusHandler(LiteXModule):
                     (axi.AXIInterface,     axi.AXILiteInterface): axi.AXI2AXILite,
                     (axi.AXIInterface,     wishbone.Interface)  : axi.AXI2Wishbone,
                     (ahb.AHBInterface,     wishbone.Interface)  : ahb.AHB2Wishbone,
-                }[type(master), type(slave)]
+                }.get((type(master), type(slave)))
+                if bridge_cls is None:
+                    self.logger.error("{} {} Bus-Standard conversion from {} to {}.".format(
+                        colorer(name, color="red"),
+                        colorer("no supported", color="red"),
+                        colorer(type(master).__name__),
+                        colorer(type(slave).__name__)))
+                    raise SoCError()
                 bridge = bridge_cls(master, slave)
                 self.submodules += bridge
                 return adapted_interface
@@ -1388,8 +1402,9 @@ class SoC(LiteXModule):
             colorer(f"0x{contents_size:x}")))
         ram.mem.init = contents
 
-        # RAM Auto-Resize (Optional).
-        if auto_size and ram_region.is_rom:
+        # RAM Auto-Resize (Optional). Skip on empty contents: resizing would create a depth-0
+        # Memory that only fails much later, at elaboration, with a cryptic error.
+        if auto_size and contents and ram_region.is_rom:
             self.logger.info("Auto-Resizing {} {} from {} to {}.".format(
                 ram_type,
                 colorer(name),

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -2016,6 +2016,14 @@ class LiteXSoC(SoC):
         l2_cache_full_memory_we = True,
         **kwargs):
 
+        # Checks.
+        if phy is None:
+            self.logger.error("SDRAM requires {}.".format(colorer("phy", color="red")))
+            raise SoCError()
+        if module is None:
+            self.logger.error("SDRAM requires {}.".format(colorer("module", color="red")))
+            raise SoCError()
+
         # Imports.
         from litedram.common import LiteDRAMNativePort
         from litedram.core import LiteDRAMCore
@@ -3059,6 +3067,10 @@ class LiteXSoC(SoC):
 
     # Add Video ColorBars Pattern ------------------------------------------------------------------
     def add_video_colorbars(self, name="video_colorbars", phy=None, timings="800x600@60Hz", clock_domain="sys"):
+        if phy is None:
+            self.logger.error("Video colorbars requires {}.".format(colorer("phy", color="red")))
+            raise SoCError()
+
         # Imports.
         from litex.soc.cores.video import VideoTimingGenerator, ColorBarsPattern
 
@@ -3082,6 +3094,9 @@ class LiteXSoC(SoC):
     # Add Video Terminal ---------------------------------------------------------------------------
     def add_video_terminal(self, name="video_terminal", phy=None, timings="800x600@60Hz", clock_domain="sys",
                            with_extended_csi=False, visible_cols=None):
+        if phy is None:
+            self.logger.error("Video terminal requires {}.".format(colorer("phy", color="red")))
+            raise SoCError()
         if not hasattr(self, "uart"):
             self.logger.error("Video terminal requires {} peripheral.".format(
                 colorer("uart", color="red")))
@@ -3159,6 +3174,9 @@ class LiteXSoC(SoC):
         return self.bus.regions[name].origin
 
     def add_video_framebuffer(self, name="video_framebuffer", phy=None, timings="800x600@60Hz", clock_domain="sys", format="rgb888", fifo_depth=64*KILOBYTE):
+        if phy is None:
+            self.logger.error("Video framebuffer requires {}.".format(colorer("phy", color="red")))
+            raise SoCError()
         if not hasattr(self, "sdram"):
             self.logger.error("Video framebuffer requires {}.".format(
                 colorer("sdram", color="red")))
@@ -3174,11 +3192,13 @@ class LiteXSoC(SoC):
         from litex.soc.cores.video import video_framebuffer_size
 
         # Video Timing Generator.
+        self.check_if_exists(f"{name}_vtg")
         vtg = VideoTimingGenerator(default_video_timings=timings if isinstance(timings, str) else timings[1])
         vtg = ClockDomainsRenamer(clock_domain)(vtg)
         self.add_module(name=f"{name}_vtg", module=vtg)
 
         # Video FrameBuffer.
+        self.check_if_exists(name)
         framebuffer_size = video_framebuffer_size(hres, vres, format)
         base = self._get_video_framebuffer_base(name, framebuffer_size)
         vfb = VideoFrameBuffer(self.sdram.crossbar.get_port(),

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1187,6 +1187,7 @@ class SoC(LiteXModule):
         self.platform     = platform
         self.sys_clk_freq = int(sys_clk_freq) # Do conversion to int here to allow passing float to SoC.
         self.constants    = {}
+        self.config       = {}
         self.csr_regions  = {}
         self.mem_map      = dict(self.mem_map)
 
@@ -1682,6 +1683,7 @@ class SoC(LiteXModule):
 
         # Add Main CSRs to a "main" Sub-Module and delete it from Main Module.
         if main_csrs:
+            self.check_if_exists("main")
             self.main = LiteXModule()
             for name, csr in main_csrs.items():
                 setattr(self.main, name, csr)
@@ -1695,7 +1697,7 @@ class SoC(LiteXModule):
             alignment          = self.csr.alignment,
             paging             = self.csr.paging,
             ordering           = self.csr.ordering)
-        if len(self.csr.masters):
+        if len(self.csr.masters) and len(self.csr_bankarray.get_buses()):
             self.csr_interconnect = csr_bus.InterconnectShared(
                 masters = list(self.csr.masters.values()),
                 slaves  = self.csr_bankarray.get_buses())
@@ -3269,9 +3271,6 @@ class SoCCore(LiteXSoC):
             irq_n_irqs           = irq_n_irqs,
             irq_reserved_irqs    = {},
         )
-
-        # Attributes.
-        self.config = {}
 
         # Parameters management --------------------------------------------------------------------
 

--- a/test/test_soc.py
+++ b/test/test_soc.py
@@ -213,10 +213,12 @@ class TestSoCRegion(unittest.TestCase):
         self.assertFalse(region.is_rom)
 
     def test_invalid_region_size_is_rejected(self):
-        with self.assertRaisesRegex(ValueError, "integer"):
+        with self.assertRaises(SoCError):
             SoCRegion(origin=0, size="0x1000")
-        with self.assertRaisesRegex(ValueError, "positive"):
+        with self.assertRaises(SoCError):
             SoCRegion(origin=0, size=0)
+        with self.assertRaises(SoCError):
+            SoCRegion(origin=0, size=True)
 
 
 class TestSoCBusHandler(unittest.TestCase):


### PR DESCRIPTION
This PR is the result of a systematic review of `litex/soc/integration/` (soc.py, builder.py, export.py, common.py, doc.py) for bugs, robustness issues and usability problems, following the same approach as the BIOS review (#bios-fixes). 12 commits, one fix per commit.

## Bugs

- **Region decoding on byte-addressed Wishbone buses was broken**: `SoCRegion.decoder()` always converted origins to word units, but `wishbone.Decoder` passes raw byte addresses with `--bus-addressing byte` - every non-zero-origin region was undecodable (accesses select no slave and time out). Confirmed and verified by simulation.
- **Plain `SoC`/`LiteXSoC.finalize()` crashed**: `self.config` was only initialized in `SoCCore.__init__` (fallout of the SoCCore-move refactor); a CSR interconnect with zero banks also died with a cryptic migen `TypeError`, and SoC-level CSRs silently clobbered a user module named `main`.
- **Region validation holes**: regions extending beyond the bus address space were accepted silently (producing dead slaves); IO regions added after cached regions (the normal CPU flow: reserved regions exist before `add_cpu` adds the IO regions) skipped overlap re-checking; `add_slave` accepted an `SoCIORegion` and crashed with a bare `KeyError` at finalize; misaligned slave regions now error early *with the slave's name*.
- **Duplicate guards checking the wrong names**: `add_etherbone` checked `{name}_ethcore` but registers `ethcore_{name}`; `add_spi_ram` checked names it never registers; `add_ram` registered the bus slave before its name check.
- **`add_uart` uartbone handling**: `uart_name="uartbone"` dropped `with_dynamic_baudrate` and allocated an IRQ slot + `UART_INTERRUPT` constant for a UART that does not exist.
- **Generated-code correctness (export.py)**: soc.h emitted ill-formed C for >32-bit constants (unsuffixed decimal literals; >64-bit values silently broken) and for strings containing control characters (`\uXXXX` UCNs); csr.json re-exported imported read-only CSRs as `rw`, contradicting csr.h; the fields-only csr.h variant referenced undefined `_read`/`_write` functions (now verified by compiling the generated header with gcc).
- Leftover debug `print()` removed from `LiteXModule.__iadd__` (spammed stdout on every `m += module`).

## Robustness / usability

- SoCCore warns on unknown keyword arguments (typos were silently swallowed by `**kwargs`; `l2_size` stays tolerated for the argdict passthrough - `litex_sim` runs warning-free).
- `add_sdram`/`add_video_*` validate their phy/module arguments like their siblings; `add_video_framebuffer` gets its missing duplicate checks; `add_adapter` raises named `SoCError`s for unsupported conversions; `init_rom` with empty contents no longer creates a depth-0 Memory.
- Builder: export paths get their parent directories created; paths Make cannot represent (spaces/`#`) fail loudly instead of corrupting variables.mak (`$` now escaped); imported JSONs parsed once instead of three times and merged only once (second `build()` no longer raises spurious collisions); `--soc-csv`/`--soc-json` help documents that they are always generated.
- SVD `]]>` CDATA escaping; `add_pcie` warns on ignored `msis` and name-prefixes its DMA constants (legacy unprefixed kept for the default instance); `--uart-with-dynamic-baudrate`/`--uart-rx-fifo-rx-we` exposed on the parser; `--jtagbone-chain` accepts hex; `SoCRegion` raises `SoCError` consistently instead of `ValueError`.

## Verification

- `pytest`: test_soc/test_builder/test_export/test_integration - all tests with available toolchains/dependencies pass (the `test_cpu` failures on this machine are pre-existing environment gaps: missing lm32/or1k/ppc toolchains, pythondata packages, Amaranth, GHDL - verified identical before/after).
- `litex_sim` builds pass (featured ethernet+sdcard+spiflash, and serv); **generated csr.h/soc.h/mem.h are byte-identical to master's output** (the header diff was used as a regression gate during the work).
- End-to-end Verilator run: BIOS boots to the `litex>` prompt.