### PR TITLE
Vexiiriscv: fix gcc flags and IMSIC parameters

### DIFF
--- a/litex/soc/cores/cpu/vexiiriscv/core.py
+++ b/litex/soc/cores/cpu/vexiiriscv/core.py
@@ -78,7 +78,7 @@ class VexiiRiscv(CPU):
     # Arch.
     @staticmethod
     def get_arch(ignores = []):
-        arch = f"rv{VexiiRiscv.xlen}i2p0_"
+        arch = f"rv{VexiiRiscv.xlen}i"
 
         # s/u is not accepted by the ISA string
         isas = "mafdcvh"
@@ -97,11 +97,15 @@ class VexiiRiscv(CPU):
 
     # Arch for GCC march.
     def get_gcc_arch():
-        # Workaround: add exception for extensions that are not supported
-        # by the GCC in default build.
-        ex = ["zicbom", "zicntr", "zicsr", "zifencei", "zihpm", "sscofpmf"]
+        # Workaround: Assume only allowed supported single letter extension for BIOS
+        arch = f"rv{VexiiRiscv.xlen}i2p0_"
 
-        return VexiiRiscv.get_arch(ex)
+        isas = "mafdcvh"
+        for isa in isas:
+            if isa in VexiiRiscv.isa_map:
+                arch += isa
+
+        return arch + "_zifencei_zicsr"
 
     # Memory Mapping.
     @property

--- a/litex/soc/cores/cpu/vexiiriscv/core.py
+++ b/litex/soc/cores/cpu/vexiiriscv/core.py
@@ -195,7 +195,7 @@ class VexiiRiscv(CPU):
         add_soc_arg("--l2-self-flush", default=None,        help="VexiiRiscv L2 ways will self flush on from,to,cycles")
         # Vexii: interrupts
         add_soc_arg("--with-aplic",                  action="store_true",   help="Enable APLIC.")
-        add_soc_arg("--imsic-interrupts", dest="imsic_interrupt_number", forward=False, default=0, type=int, help="VexiiRiscv IMSIC interrupts, 0 disables this feature.")
+        add_soc_arg("--imsic-interrupts", dest="imsic_interrupt_number", default=0, type=int, help="VexiiRiscv IMSIC interrupts, 0 disables this feature.")
         # Vexii: peripherals
         add_soc_arg("--vexii-video", dest="video",  action="append", default=[], help="Add the memory coherent video controller")
         add_soc_arg("--vexii-macsg", dest="mac_sg", action="append", default=[], help="Add the memory coherent ethernet mac")

--- a/litex/soc/cores/cpu/vexiiriscv/core.py
+++ b/litex/soc/cores/cpu/vexiiriscv/core.py
@@ -78,7 +78,7 @@ class VexiiRiscv(CPU):
     # Arch.
     @staticmethod
     def get_arch(ignores = []):
-        arch = f"rv{VexiiRiscv.xlen}i"
+        arch = f"rv{VexiiRiscv.xlen}i2p0_"
 
         # s/u is not accepted by the ISA string
         isas = "mafdcvh"
@@ -97,15 +97,17 @@ class VexiiRiscv(CPU):
 
     # Arch for GCC march.
     def get_gcc_arch():
-        # Workaround: Assume only allowed supported single letter extension for BIOS
-        arch = f"rv{VexiiRiscv.xlen}i2p0_"
-
-        isas = "mafdcvh"
-        for isa in isas:
+        # Keep BIOS/toolchain flags conservative. Vexii can expose privileged
+        # or recent extensions that the default GCC might not support.
+        arch = f"rv{VexiiRiscv.xlen}i2p0"
+        isas = ""
+        for isa in "mafdc":
             if isa in VexiiRiscv.isa_map:
-                arch += isa
+                isas += isa
 
-        return arch + "_zifencei_zicsr"
+        if isas:
+            arch += "_" + isas
+        return arch
 
     # Memory Mapping.
     @property
@@ -195,7 +197,7 @@ class VexiiRiscv(CPU):
         add_soc_arg("--l2-self-flush", default=None,        help="VexiiRiscv L2 ways will self flush on from,to,cycles")
         # Vexii: interrupts
         add_soc_arg("--with-aplic",                  action="store_true",   help="Enable APLIC.")
-        add_soc_arg("--imsic-interrupts", dest="imsic_interrupt_number", default=0, type=int, help="VexiiRiscv IMSIC interrupts, 0 disables this feature.")
+        add_soc_arg("--imsic-interrupts", dest="imsic_interrupt_number", socgen_name="imsic-interrupt-number", default=0, type=int, help="VexiiRiscv IMSIC interrupts, 0 disables this feature.")
         # Vexii: peripherals
         add_soc_arg("--vexii-video", dest="video",  action="append", default=[], help="Add the memory coherent video controller")
         add_soc_arg("--vexii-macsg", dest="mac_sg", action="append", default=[], help="Add the memory coherent ethernet mac")

--- a/test/test_cpu_vexiiriscv.py
+++ b/test/test_cpu_vexiiriscv.py
@@ -1,0 +1,83 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import argparse
+import unittest
+from types import SimpleNamespace
+
+from litex.soc.cores.cpu.vexiiriscv.core import VexiiRiscv
+
+
+_UNSET = object()
+
+
+class TestVexiiRiscvGCCArch(unittest.TestCase):
+    def setUp(self):
+        self.xlen    = VexiiRiscv.xlen
+        self.isa_map = VexiiRiscv.isa_map
+
+    def tearDown(self):
+        VexiiRiscv.xlen    = self.xlen
+        VexiiRiscv.isa_map = self.isa_map
+
+    def test_gcc_arch_keeps_bios_isa_conservative(self):
+        VexiiRiscv.xlen = 64
+        VexiiRiscv.isa_map = {
+            "i", "m", "a", "f", "d", "c",
+            "b", "e", "g", "h", "v",
+            "zba", "zbb", "zbc", "zbs",
+            "zicbom", "zicntr", "zicsr", "zifencei", "zihpm", "zmmul",
+            "zknd", "zkne",
+            "shlcofideleg",
+            "smaia", "smcntrpmf", "smcsrind",
+            "ssaia", "sscofpmf", "sscsrind", "sstc",
+        }
+
+        self.assertEqual(VexiiRiscv.get_gcc_arch(), "rv64i2p0_mafdc")
+
+    def test_gcc_arch_matches_float_abi_extensions(self):
+        VexiiRiscv.xlen = 32
+        VexiiRiscv.isa_map = {"i", "m", "f", "c"}
+
+        self.assertEqual(VexiiRiscv.get_gcc_arch(), "rv32i2p0_mfc")
+
+
+class TestVexiiRiscvSocArgs(unittest.TestCase):
+    def setUp(self):
+        self.soc_keys      = getattr(VexiiRiscv, "soc_keys",      _UNSET)
+        self.soc_arg_names = getattr(VexiiRiscv, "soc_arg_names", _UNSET)
+        self.soc_args      = getattr(VexiiRiscv, "soc_args",      _UNSET)
+
+    def tearDown(self):
+        if self.soc_keys is _UNSET and hasattr(VexiiRiscv, "soc_keys"):
+            delattr(VexiiRiscv, "soc_keys")
+        elif self.soc_keys is not _UNSET:
+            VexiiRiscv.soc_keys = self.soc_keys
+        if self.soc_arg_names is _UNSET and hasattr(VexiiRiscv, "soc_arg_names"):
+            delattr(VexiiRiscv, "soc_arg_names")
+        elif self.soc_arg_names is not _UNSET:
+            VexiiRiscv.soc_arg_names = self.soc_arg_names
+        if self.soc_args is _UNSET and hasattr(VexiiRiscv, "soc_args"):
+            delattr(VexiiRiscv, "soc_args")
+        elif self.soc_args is not _UNSET:
+            VexiiRiscv.soc_args = self.soc_args
+
+    def test_imsic_interrupts_forwards_vexii_socgen_name(self):
+        parser = argparse.ArgumentParser()
+        VexiiRiscv.args_fill(parser)
+        args = parser.parse_args(["--imsic-interrupts=64"])
+        VexiiRiscv.soc_args = SimpleNamespace(**{
+            key: getattr(args, key) for key in VexiiRiscv.soc_keys
+        })
+
+        soc_args = VexiiRiscv._get_soc_args()
+
+        self.assertIn("--imsic-interrupt-number=64", soc_args)
+        self.assertNotIn("--imsic-interrupts=64", soc_args)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fix unsupported gcc flags for VexiiRiscv, only use at most rv64gc when building BIOS
Also, forward the `--imsic-interrupt` parameter to the VexiiRiscv core, otherwise the build with AIA support will failed.