### PR TITLE
cpu/microwatt: boot Linux (RAM@0 / ROM@0xFFFE0000) + ppc64 DTS (litex#2306)

### DIFF
--- a/litex/soc/cores/cpu/microwatt/core.py
+++ b/litex/soc/cores/cpu/microwatt/core.py
@@ -45,6 +45,10 @@ class Microwatt(CPU):
     @property
     def mem_map(self):
         return {
+            # PPC/Microwatt mandates main RAM at 0x0000_0000 (see litex#2306); move ROM/SRAM high.
+            "main_ram": 0x0000_0000,  # DRAM at 0.
+            "rom":      0xFFFE_0000,  # ROM at high address; CPU boots from here via alt_reset.
+            "sram":     0xFFFC_0000,  # SRAM right before ROM (PPC64 TOC addressing).
             # Keep the lower 128MBs for SoC IOs auto-allocation.
             "csr":      0xc800_0000,
             "xicsicp":  0xcbff_0000,
@@ -71,6 +75,10 @@ class Microwatt(CPU):
         self.platform     = platform
         self.variant      = variant
         self.reset        = Signal()
+        # Microwatt samples alt_reset only during reset, so it must be high from power-on for the
+        # CPU to boot from ALT_RESET_ADDRESS (the high ROM). Firmware can clear it via CSR after init.
+        self.alt_reset         = Signal(reset=1)
+        self.alt_reset_address = self.mem_map.get("rom", 0xFFFE_0000)
         self.ibus         = ibus = wishbone.Interface(data_width=64, adr_width=29, addressing="word")
         self.dbus         = dbus = wishbone.Interface(data_width=64, adr_width=29, addressing="word")
         self.periph_buses = [ibus, dbus] # Peripheral buses (Connected to main SoC's bus).
@@ -82,10 +90,16 @@ class Microwatt(CPU):
         # # #
 
         # CPU Instance.
+        # Note: ALT_RESET_ADDRESS (the alt_reset boot address) is baked into the VHDL default
+        # (microwatt_wrapper.vhdl) because ghdl --synth constant-folds vector generics rather than
+        # exposing them as Verilog parameters; it is therefore not passed here.
         self.cpu_params = dict(
             # Clk / Rst.
             i_clk = ClockSignal("sys"),
             i_rst = ResetSignal("sys") | self.reset,
+
+            # Alt Reset (boot from ALT_RESET_ADDRESS / ROM).
+            i_alt_reset = self.alt_reset,
 
             # IBus.
             i_wishbone_insn_dat_r = ibus.dat_r,
@@ -140,11 +154,22 @@ class Microwatt(CPU):
         # Add VHDL sources.
         self.add_sources(platform, use_ghdl_yosys_plugin="ghdl" in self.variant)
 
-    def set_reset_address(self, reset_address):
-        self.reset_address = reset_address
-        assert reset_address == 0x0000_0000
+    def set_reset_address(self, reset_address=None):
+        # Default to the ROM origin (alt_reset boot); the CPU boots from ALT_RESET_ADDRESS.
+        if reset_address is None:
+            reset_address = self.mem_map.get("rom", 0xFFFE_0000)
+        self.reset_address     = reset_address
+        self.alt_reset_address = reset_address
+        # ALT_RESET_ADDRESS is baked into the VHDL default (see __init__); if reset_address differs
+        # from mem_map["rom"] (0xFFFE_0000), update the VHDL default to match.
+        assert reset_address == self.mem_map.get("rom", 0xFFFE_0000), \
+            "Microwatt alt_reset address must match the baked VHDL ALT_RESET_ADDRESS (0xFFFE_0000)"
 
     def add_soc_components(self, soc):
+        # alt_reset starts high (boot from ROM); firmware can clear it via CSR after DRAM init.
+        self._alt_reset_csr = CSRStorage(reset=1,
+            description="Alt reset control (1 = boot from ALT_RESET_ADDRESS / ROM).")
+        soc.comb += self.alt_reset.eq(self._alt_reset_csr.storage)
         if "irq" in self.variant:
             self.xics = XICSSlave(
                 platform     = self.platform,

--- a/litex/soc/cores/cpu/microwatt/crt0.S
+++ b/litex/soc/cores/cpu/microwatt/crt0.S
@@ -267,4 +267,4 @@ __isr:
 	.data
 	.align 8
 __isr_address:
-	.long isr
+	.quad isr

--- a/litex/soc/cores/cpu/microwatt/microwatt_wrapper.vhdl
+++ b/litex/soc/cores/cpu/microwatt/microwatt_wrapper.vhdl
@@ -17,11 +17,17 @@ entity microwatt_wrapper is
     generic (
         SIM             : boolean := false;
         DISABLE_FLATTEN : boolean := false;
-        HAS_FPU         : boolean := false
+        HAS_FPU         : boolean := true;
+        -- CPU boots here when alt_reset = '1'. ghdl --synth constant-folds vector generics to this
+        -- default (it is not exposed as a Verilog parameter), so bake the ROM origin (mem_map["rom"])
+        -- here directly. Keep in sync with Microwatt.mem_map["rom"] in core.py (0xFFFE_0000).
+        ALT_RESET_ADDRESS : std_ulogic_vector(63 downto 0) := x"00000000fffe0000"
     );
     port (
         clk          : in std_logic;
         rst          : in std_logic;
+        -- When '1', CPU boots from ALT_RESET_ADDRESS (the high ROM).
+        alt_reset    : in std_logic := '0';
 
         wishbone_insn_dat_r : in std_ulogic_vector(63 downto 0);
         wishbone_insn_ack   : in std_ulogic;
@@ -111,15 +117,16 @@ begin
 
     microwatt_core : entity work.core
         generic map (
-            SIM             => SIM,
-            DISABLE_FLATTEN => DISABLE_FLATTEN,
-            HAS_FPU         => HAS_FPU
+            SIM               => SIM,
+            DISABLE_FLATTEN   => DISABLE_FLATTEN,
+            HAS_FPU           => HAS_FPU,
+            ALT_RESET_ADDRESS => ALT_RESET_ADDRESS
         )
         port map (
             clk               => clk,
             rst               => rst,
 
-            alt_reset         => '0',
+            alt_reset         => alt_reset,
 
             wishbone_insn_in  => wishbone_insn_in,
             wishbone_insn_out => wishbone_insn_out,

--- a/litex/soc/cores/cpu/microwatt/system.h
+++ b/litex/soc/cores/cpu/microwatt/system.h
@@ -1,5 +1,8 @@
 #ifndef __SYSTEM_H
 #define __SYSTEM_H
+/* IRQ-driven UART stalls in the BIOS: PPC needs IRQ vectors set up first (done by Linux),
+   so use polling UART until then (see litex#2306 / PowerCommons). */
+#define UART_POLLING
 
 #ifdef __cplusplus
 extern "C" {

--- a/litex/soc/cores/cpu/microwatt/xics_wrapper.vhdl
+++ b/litex/soc/cores/cpu/microwatt/xics_wrapper.vhdl
@@ -46,7 +46,7 @@ begin
     wishbone_ack      <= wishbone_out.ack;
     wishbone_stall    <= wishbone_out.stall;
 
-    wishbone_in.adr   <= wishbone_adr(27 downto 0) & "00";
+    wishbone_in.adr   <= wishbone_adr;
     wishbone_in.dat   <= wishbone_dat_w;
     wishbone_in.cyc   <= wishbone_cyc;
     wishbone_in.stb   <= wishbone_stb;
@@ -116,7 +116,7 @@ begin
     wishbone_ack      <= wishbone_out.ack;
     wishbone_stall    <= wishbone_out.stall;
 
-    wishbone_in.adr   <= wishbone_adr(27 downto 0) & "00";
+    wishbone_in.adr   <= wishbone_adr;
     wishbone_in.dat   <= wishbone_dat_w;
     wishbone_in.cyc   <= wishbone_cyc;
     wishbone_in.stb   <= wishbone_stb;

--- a/litex/tools/litex_json2dts_linux.py
+++ b/litex/tools/litex_json2dts_linux.py
@@ -15,16 +15,25 @@ import re
 
 from litex.gen.common import KILOBYTE, MEGABYTE
 
+# XICS (Microwatt/ppc64) interrupt source base: the ICS "interrupt-ranges" starts at HWIRQ 0x10,
+# so a peripheral connected to LiteX IRQ line N appears to Linux as XICS source 0x10 + N.
+XICS_IRQ_BASE = 0x10
+
 def generate_dts_interrupt(d, intr, polling):
     if polling:
         return ""
+    elif d["constants"].get("config_cpu_family") == "ppc64":
+        # XICS sources use 2 interrupt-cells: <hwirq, level> (level = 1).
+        return "interrupts = <{} 0x1>;".format(XICS_IRQ_BASE + intr)
     elif ("aplic_m" in d["memories"]) or ("aplic_s" in d["memories"]):
         return "interrupts = <{} 0x4>;".format(intr)
     else:
         return "interrupts = <{}>;".format(intr)
 
 def generate_dts_intc(d):
-    if "aplic_s" in d["memories"]:
+    if d["constants"].get("config_cpu_family") == "ppc64":
+        return "ICS"
+    elif "aplic_s" in d["memories"]:
         return "intc_s"
     elif "aplic_m" in d["memories"]:
         return "intc_m"
@@ -300,6 +309,7 @@ def generate_dts(d, initrd_start=None, initrd_size=None, initrd=None, root_devic
     default_initrd_start = {
         "or1k":   8 * MEGABYTE,
         "riscv": 16 * MEGABYTE,
+        "ppc64": 16 * MEGABYTE,
     }
     default_initrd_size = 8 * MEGABYTE
 
@@ -576,6 +586,72 @@ def generate_dts(d, initrd_start=None, initrd_size=None, initrd=None, root_devic
         }};
 """.format(sys_clk_freq=d["constants"]["config_clock_frequency"])
 
+    # PowerPC64 (Microwatt)
+    # ---------------------
+    elif cpu_family == "ppc64":
+        # Cache parameters (fall back to Microwatt's upstream device-tree defaults if the SoC does
+        # not export cache constants).
+        dcache_size = d["constants"].get("config_cpu_dcache_size",       0x1000)
+        dcache_sets = d["constants"].get("config_cpu_dcache_ways",       2)
+        dcache_blk  = d["constants"].get("config_cpu_dcache_block_size", 64)
+        icache_size = d["constants"].get("config_cpu_icache_size",       0x1000)
+        icache_sets = d["constants"].get("config_cpu_icache_ways",       2)
+        icache_blk  = d["constants"].get("config_cpu_icache_block_size", 64)
+        dts += """
+        cpus {{
+            #address-cells = <1>;
+            #size-cells    = <0>;
+
+            /* CPU features (used by CONFIG_PPC_DT_CPU_FTRS): advertises radix MMU
+               etc. so the kernel enables the radix MMU on Microwatt. */
+            ibm,powerpc-cpu-features {{
+                display-name = "Microwatt";
+                isa = <3000>;
+                device_type = "cpu-features";
+                compatible = "ibm,powerpc-cpu-features";
+                mmu-radix                  {{ isa = <3000>; usable-privilege = <2>; }};
+                little-endian              {{ isa = <2050>; usable-privilege = <3>; hwcap-bit-nr = <1>; }};
+                cache-inhibited-large-page {{ isa = <2040>; usable-privilege = <2>; }};
+                fixed-point-v3             {{ isa = <3000>; usable-privilege = <3>; }};
+                no-execute                 {{ isa = <2010>; usable-privilege = <2>; }};
+                floating-point             {{ isa = <0>;    usable-privilege = <3>; hwcap-bit-nr = <27>; }};
+            }};
+
+            PowerPC,Microwatt@0 {{
+                device_type = "cpu";
+                reg = <0>;
+                status = "okay";
+                64-bit;
+                general-purpose;
+                cpu-version        = <0x990000>;
+                clock-frequency    = <{sys_clk_freq}>;
+                timebase-frequency = <{sys_clk_freq}>;
+                reservation-granule-size = <64>;
+                i-cache-size       = <0x{icache_size:x}>;
+                i-cache-sets       = <{icache_sets}>;
+                i-cache-block-size = <{icache_blk}>;
+                d-cache-size       = <0x{dcache_size:x}>;
+                d-cache-sets       = <{dcache_sets}>;
+                d-cache-block-size = <{dcache_blk}>;
+                i-tlb-size = <64>;
+                i-tlb-sets = <1>;
+                d-tlb-size = <128>;
+                d-tlb-sets = <2>;
+                tlb-size   = <0>;
+                tlb-sets   = <0>;
+                ibm,dec-bits       = <64>;
+                ibm,chip-id        = <0>;
+                ibm,mmu-lpid-bits  = <12>;
+                ibm,mmu-pid-bits   = <20>;
+                ibm,ppc-interrupt-server#s = <0>;
+                ibm,processor-radix-AP-encodings = <0x0c 0xa0000010 0x20000015 0x4000001e>;
+            }};
+        }};
+""".format(
+    sys_clk_freq = d["constants"]["config_clock_frequency"],
+    icache_size  = icache_size, icache_sets = icache_sets, icache_blk = icache_blk,
+    dcache_size  = dcache_size, dcache_sets = dcache_sets, dcache_blk = dcache_blk)
+
     # Memory ---------------------------------------------------------------------------------------
 
     dts += """
@@ -801,6 +877,29 @@ def generate_dts(d, initrd_start=None, initrd_size=None, initrd=None, root_devic
                 status = "okay";
             };
 """
+
+    # XICS (Microwatt) interrupt controller: ICP (presentation) + ICS (sources).
+    elif cpu_family == "ppc64":
+        dts += """
+            ICP: interrupt-controller@{icp_base:x} {{
+                compatible = "openpower,xics-presentation", "ibm,ppc-xicp";
+                ibm,interrupt-server-ranges = <0x0 0x1>;
+                reg = <0x{icp_base:x} 0x10>;
+            }};
+
+            ICS: interrupt-controller@{ics_base:x} {{
+                compatible = "openpower,xics-sources";
+                interrupt-controller;
+                interrupt-ranges = <0x{irq_base:x} 0x10>;
+                reg = <0x{ics_base:x} 0x{ics_size:x}>;
+                #address-cells = <0>;
+                #interrupt-cells = <2>;
+            }};
+""".format(
+        icp_base = d["memories"]["xicsicp"]["base"],
+        ics_base = d["memories"]["xicsics"]["base"],
+        ics_size = d["memories"]["xicsics"]["size"],
+        irq_base = XICS_IRQ_BASE)
     if (cpu_family == "riscv") and (cpu_name == "rocket"):
         dts += """
             dbg_ctl: debug-controller@0 {{


### PR DESCRIPTION
## Goal

Make the LiteX **Microwatt** (OpenPOWER ppc64le) core able to boot Linux, fixing
the root cause of [#2306](https://github.com/enjoy-digital/litex/issues/2306)
("Can't load Linux on Microwatt and LiteX BIOS"). Approach follows the working
**PowerCommons** reference (VCU118): `codeberg.org/PowerCommons/Litex`
(`microwatt-linux-boot`) + `codeberg.org/PowerCommons/linux-powercommons`.

## Why

Microwatt enters the kernel in **real mode at `KERNELBASE`**, whose accesses land
in low physical memory, so Linux requires **main RAM at physical `0x0`**. LiteX's
default map (BIOS ROM at `0x0`, DRAM at `0x4000_0000`) is the conflict behind #2306.

## Commits

**1. `cpu/microwatt: move RAM to 0x0 and boot from high ROM`**
- `core.py`: `mem_map` → `main_ram=0x0`, `rom=0xFFFE_0000`, `sram=0xFFFC_0000`;
  add the Microwatt `alt_reset` input (`Signal(reset=1)` + CSR) so the CPU boots
  from `ALT_RESET_ADDRESS` (the high ROM); `set_reset_address()` wired to match.
- `microwatt_wrapper.vhdl`: enable `HAS_FPU` (kernel needs it), add the `alt_reset`
  port, and **bake `ALT_RESET_ADDRESS=0xFFFE_0000` as the VHDL generic default**
  (ghdl `--synth` constant-folds vector generics, so it can't be passed as a
  Verilog parameter — Verilator errors "Parameter not found" otherwise).
- `xics_wrapper.vhdl`: drop the spurious `<< 2` on the XICS wishbone address so
  ICP/ICS map correctly.
- `system.h`: `#define UART_POLLING` — the IRQ-driven BIOS UART stalls before the
  XICS/IRQ vectors exist (set up later by Linux).
- `crt0.S`: store the ISR vector as `.quad` (64-bit) instead of `.long`.

**2. `tools/litex_json2dts_linux: add ppc64/Microwatt DTS generation`**
- New `ppc64` branch emitting the `PowerPC,Microwatt@0` CPU node with
  `ibm,powerpc-cpu-features` (`mmu-radix` + `ibm,processor-radix-AP-encodings`) so
  `CONFIG_PPC_DT_CPU_FTRS` **enables the radix MMU** (without it the kernel stays
  in real mode, PTCR=0), plus the XICS ICP/ICS interrupt-controller nodes and a
  ppc64 `default_initrd_start`. Existing riscv/or1k paths preserved.

## Status

- Builds cleanly; the **Arty A7** SoC + BIOS build with the new map and **meet
  timing at 75 MHz with the FPU**.
- Resulting map (build log):
  ```
  CPU microwatt overriding main_ram mapping from 0x40000000 to 0x00000000.
  CPU microwatt overriding rom mapping from 0x00000000 to 0xfffe0000.
  CPU microwatt setting reset address to 0xfffe0000.
  ```
- **Draft:** end-to-end Linux boot is still being brought up. The faithful path is
  the Verilator `--cpu-type=microwatt` sim (real Microwatt radix); the qemu cosim
  models POWER9 radix differently and can't complete the boot. The PowerCommons
  reference also mentions further BIOS C changes still to be reconciled here.

Refs #2306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
