### PR TITLE
gen: Format generated integer constants

### DIFF
--- a/litex/gen/fhdl/expression.py
+++ b/litex/gen/fhdl/expression.py
@@ -10,6 +10,8 @@ from enum import IntEnum
 from migen.fhdl.structure import *
 from migen.fhdl.structure import _Operator, _Slice, _Assign, _Fragment
 
+from litex.gen.format import format_verilog_int
+
 # ------------------------------------------------------------------------------------------------ #
 #                                       EXPRESSIONS                                                #
 # ------------------------------------------------------------------------------------------------ #
@@ -17,10 +19,10 @@ from migen.fhdl.structure import _Operator, _Slice, _Assign, _Fragment
 # Print Constant -----------------------------------------------------------------------------------
 
 def _generate_constant(node):
-    return "{sign}{bits}'d{value}".format(
+    return "{sign}{bits}'{value}".format(
         sign  = "" if node.value >= 0 else "-",
         bits  = str(node.nbits),
-        value = abs(node.value),
+        value = format_verilog_int(abs(node.value)),
     ), node.signed
 
 # Print Signal -------------------------------------------------------------------------------------

--- a/litex/gen/format.py
+++ b/litex/gen/format.py
@@ -1,0 +1,57 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Int Formatting -----------------------------------------------------------------------------------
+
+def _is_power_of_two(value):
+    return (value != 0) and ((value & (value - 1)) == 0)
+
+def _is_bit_mask(value):
+    return (value != 0) and _is_power_of_two(value + 1)
+
+def _format_int_as_hex(value):
+    value = abs(value)
+
+    # Keep small values/counts readable.
+    if value < 100:
+        return False
+
+    # Keep exact powers of 10 in decimal.
+    decimal = str(value)
+    if decimal[0] == "1" and set(decimal[1:]) <= {"0"}:
+        return False
+
+    # Powers/masks are more naturally read in hex once they are not tiny.
+    if value >= 0x100 and _is_power_of_two(value):
+        return True
+    if value >= 0xff and _is_bit_mask(value):
+        return True
+
+    # Aligned values are usually addresses/sizes/register values.
+    if value >= 0x1000 and (value & 0xff) == 0:
+        return True
+
+    # For larger unstructured values, use hex when it is visibly simpler.
+    hexadecimal = f"{value:x}"
+    if value >= 0x10000 and len(set(hexadecimal)) < len(set(decimal)):
+        return True
+
+    return False
+
+def format_int(value, prefix="0x", suffix="", base="auto"):
+    if base not in ["auto", "dec", "hex"]:
+        raise ValueError("base must be auto, dec or hex")
+    if value < 0:
+        return f"-{format_int(-value, prefix=prefix, suffix=suffix, base=base)}"
+    if base == "hex" or (base == "auto" and _format_int_as_hex(value)):
+        return f"{prefix}{value:x}{suffix}"
+    return f"{value:d}{suffix}"
+
+def format_verilog_int(value, base="auto"):
+    if value < 0:
+        return f"-{format_verilog_int(-value, base=base)}"
+    value = format_int(value, prefix="h", base=base)
+    return value if value.startswith("h") else f"d{value}"

--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -31,6 +31,7 @@ from xml.sax.saxutils import quoteattr
 
 from migen import *
 
+from litex.gen.format import format_int
 from litex.soc.interconnect.csr import CSRStatus
 from litex.soc.integration.soc import SoCRegion
 
@@ -230,6 +231,7 @@ def get_soc_header(constants, with_access_functions=True):
                 value = int(value)
             ctype = "int32_t"
             if isinstance(value, int):
+                suffix = ""
                 if value >= 0:
                     if value > 0xffffffffffffffff:
                         raise ValueError(f"Constant {name} value {value} does not fit in a 64-bit C type.")
@@ -237,7 +239,7 @@ def get_soc_header(constants, with_access_functions=True):
                     # INT64_MAX is ill-formed C and values above UINT32_MAX must not be truncated.
                     if value > 0xffffffff:
                         ctype = "uint64_t"
-                        value = f"0x{value:x}ULL"
+                        suffix = "ULL"
                     else:
                         ctype = "uint32_t"
                 else:
@@ -245,8 +247,10 @@ def get_soc_header(constants, with_access_functions=True):
                         raise ValueError(f"Constant {name} value {value} does not fit in a 64-bit C type.")
                     if value < -0x80000000:
                         ctype = "int64_t"
-                        value = f"{value}LL"
-            value = str(value)
+                        suffix = "LL"
+                value = format_int(value, suffix=suffix)
+            else:
+                value = str(value)
         r += "#define "+name+" "+value+"\n"
         if with_access_functions:
             funcs += "static inline "+ctype+" "+name.lower()+"_read(void) {\n"

--- a/test/hdl/test_verilog.py
+++ b/test/hdl/test_verilog.py
@@ -41,6 +41,19 @@ class _DisplayTime(Module):
         self.sync += Display("time=%t value=%d", VerilogTime(), self.value)
 
 
+class _Constants(Module):
+    def __init__(self):
+        self.count   = Signal(8,  name="count")
+        self.address = Signal(32, name="address")
+        self.mask    = Signal(16, name="mask")
+
+        self.comb += [
+            self.count.eq(Constant(42, 8)),
+            self.address.eq(Constant(0x80000000, 32)),
+            self.mask.eq(Constant(0xffff, 16)),
+        ]
+
+
 class TestVerilog(unittest.TestCase):
     def test_sliced_comb_target_is_declared_as_reg(self):
         dut = _SlicedCombTarget()
@@ -67,6 +80,14 @@ class TestVerilog(unittest.TestCase):
 
         self.assertIn('$display("time=%t value=%d", $time, value);', v)
         self.assertNotIn('"$time"', v)
+
+    def test_constants_use_readable_bases(self):
+        dut = _Constants()
+        v = convert(dut, ios={dut.count, dut.address, dut.mask}, name="top").main_source
+
+        self.assertIn("assign count = 8'd42;", v)
+        self.assertIn("assign address = 32'h80000000;", v)
+        self.assertIn("assign mask = 16'hffff;", v)
 
 
 if __name__ == "__main__":

--- a/test/soc/test_export.py
+++ b/test/soc/test_export.py
@@ -8,7 +8,13 @@ import unittest
 import xml.etree.ElementTree as ET
 from types import SimpleNamespace
 
-from litex.soc.integration.export import get_csr_header, get_csr_svd, get_linker_regions, get_mem_header
+from litex.soc.integration.export import (
+    get_csr_header,
+    get_csr_svd,
+    get_linker_regions,
+    get_mem_header,
+    get_soc_header,
+)
 from litex.soc.integration.soc import SoCCSRRegion, SoCRegion
 from litex.soc.interconnect.csr import CSRField, CSRStatus, CSRStorage
 
@@ -57,6 +63,25 @@ def _get_svd_registers(svd):
 
 
 class TestCSRExport(unittest.TestCase):
+    def test_soc_header_formats_int_constants(self):
+        header = get_soc_header({
+            "CONFIG_SMALL":           42,
+            "CONFIG_CLOCK_FREQUENCY": 100000000,
+            "CONFIG_RESET_ADDR":      0x80000000,
+            "CONFIG_MASK":            0xffff,
+            "CONFIG_64BIT":           0x100000000,
+            "CONFIG_NEGATIVE_64BIT": -0x80000001,
+        })
+
+        self.assertIn("#define CONFIG_SMALL 42\n", header)
+        self.assertIn("#define CONFIG_CLOCK_FREQUENCY 100000000\n", header)
+        self.assertIn("#define CONFIG_RESET_ADDR 0x80000000\n", header)
+        self.assertIn("#define CONFIG_MASK 0xffff\n", header)
+        self.assertIn("#define CONFIG_64BIT 0x100000000ULL\n", header)
+        self.assertIn("#define CONFIG_NEGATIVE_64BIT -0x80000001LL\n", header)
+        self.assertIn("static inline uint64_t config_64bit_read(void)", header)
+        self.assertIn("static inline int64_t config_negative_64bit_read(void)", header)
+
     def test_csr_field_accessors_use_uint64_for_wide_csr(self):
         csr = CSRStorage(name="wide", fields=[
             CSRField("low",  size=32, offset=0),


### PR DESCRIPTION
This reworks the idea from #1913 on top of current `master`.

The goal is to keep generated constants readable without changing their value,
width, signedness or C type. Small/count-like values remain decimal, while
addresses, masks, powers of two and aligned register-like values are emitted in
hexadecimal.

Examples:

```verilog
// Before.
assign count   = 8'd42;
assign address = 32'd2147483648;
assign mask    = 16'd65535;

// After.
assign count   = 8'd42;
assign address = 32'h80000000;
assign mask    = 16'hffff;
```

```c
// Before.
#define CONFIG_CLOCK_FREQUENCY 100000000
#define CONFIG_CPU_RESET_ADDR 2147483648
#define CONFIG_MASK 65535
#define CONFIG_64BIT 0x100000000ULL

// After.
#define CONFIG_CLOCK_FREQUENCY 100000000
#define CONFIG_CPU_RESET_ADDR 0x80000000
#define CONFIG_MASK 0xffff
#define CONFIG_64BIT 0x100000000ULL
```

The implementation is intentionally conservative:

- small values stay decimal;
- exact powers of ten stay decimal;
- masks, powers of two and aligned/address-like values use hex;
- existing `soc.h` 64-bit `ULL`/`LL` suffix handling is preserved.

Tests added:

- Verilog constant formatting coverage;
- `soc.h` integer constant formatting coverage, including 64-bit signed and
  unsigned accessors.

Validated with:

```sh
pytest -q test/hdl/test_verilog.py test/soc/test_export.py
pytest -q test/hdl test/soc/test_export.py
pytest -q test/soc/test_builder.py test/soc/test_soc.py test/soc/test_export.py test/hdl
```

The last run passed with `221 passed, 21 subtests passed`.
