### PR TITLE
soc: Add explicit CSR region aliases

### DIFF
--- a/litex/soc/integration/export.py
+++ b/litex/soc/integration/export.py
@@ -350,6 +350,52 @@ def _generate_csr_region_definitions_c(cpu, name, region, origin, alignment, csr
 
     return region_defs
 
+def _generate_csr_define_alias_c(dst, src):
+    alias = f"#define {dst} {src}\n"
+    return alias
+
+def _generate_csr_optional_define_alias_c(dst, src):
+    alias = f"#ifdef {src}\n"
+    alias += f"#define {dst} {src}\n"
+    alias += "#endif\n"
+    return alias
+
+def _generate_csr_region_alias_definitions_c(name, alias, region):
+    region_defs = f"\n/* {alias.upper()} Aliases */\n"
+    region_defs += _generate_csr_define_alias_c(
+        f"CSR_{alias.upper()}_BASE",
+        f"CSR_{name.upper()}_BASE")
+    region_defs += _generate_csr_optional_define_alias_c(
+        f"CSR_{alias.upper()}_BASE_VA",
+        f"CSR_{name.upper()}_BASE_VA")
+
+    if not isinstance(region.obj, Memory):
+        for csr in region.obj:
+            reg_name       = f"{name}_{csr.name}"
+            alias_reg_name = f"{alias}_{csr.name}"
+            region_defs += _generate_csr_define_alias_c(
+                f"CSR_{alias_reg_name.upper()}_ADDR",
+                f"CSR_{reg_name.upper()}_ADDR")
+            region_defs += _generate_csr_optional_define_alias_c(
+                f"CSR_{alias_reg_name.upper()}_ADDR_VA",
+                f"CSR_{reg_name.upper()}_ADDR_VA")
+            region_defs += _generate_csr_define_alias_c(
+                f"CSR_{alias_reg_name.upper()}_SIZE",
+                f"CSR_{reg_name.upper()}_SIZE")
+
+            if hasattr(csr, "fields"):
+                for field in csr.fields.fields:
+                    field_name       = f"{reg_name}_{field.name}"
+                    alias_field_name = f"{alias_reg_name}_{field.name}"
+                    region_defs += _generate_csr_define_alias_c(
+                        f"CSR_{alias_field_name.upper()}_OFFSET",
+                        f"CSR_{field_name.upper()}_OFFSET")
+                    region_defs += _generate_csr_define_alias_c(
+                        f"CSR_{alias_field_name.upper()}_SIZE",
+                        f"CSR_{field_name.upper()}_SIZE")
+
+    return region_defs
+
 # CSR Read/Write Access Functions.
 
 def _determine_ctype_and_stride_c(size, alignment):
@@ -428,6 +474,22 @@ def _generate_csr_region_access_functions_c(cpu, name, region, origin, alignment
             origin = csr_origin + alignment // 8 * nr
     return region_defs
 
+def _generate_csr_region_alias_access_functions_c(name, alias, region):
+    region_defs = f"\n/* {alias.upper()} Access Function Aliases */\n"
+
+    if not isinstance(region.obj, Memory):
+        for csr in region.obj:
+            reg_name       = f"{name}_{csr.name}"
+            alias_reg_name = f"{alias}_{csr.name}"
+            region_defs += _generate_csr_define_alias_c(
+                f"{alias_reg_name}_read",
+                f"{reg_name}_read")
+            if not getattr(csr, "read_only", False):
+                region_defs += _generate_csr_define_alias_c(
+                    f"{alias_reg_name}_write",
+                    f"{reg_name}_write")
+    return region_defs
+
 # CSR Fields.
 
 def _generate_csr_field_definitions_c(csr, name):
@@ -487,6 +549,33 @@ def _generate_csr_fields_access_functions_c(name, region, origin, alignment, csr
                 region_defs += _generate_csr_field_functions_c(csr, name, with_access_functions)
     return region_defs
 
+def _generate_csr_region_alias_field_access_functions_c(name, alias, region, with_access_functions=True):
+    region_defs = f"\n/* {alias.upper()} Fields Access Function Aliases */\n"
+
+    if not isinstance(region.obj, Memory):
+        for csr in region.obj:
+            if not hasattr(csr, "fields"):
+                continue
+            for field in csr.fields.fields:
+                field_name       = f"{name}_{csr.name}_{field.name}"
+                alias_field_name = f"{alias}_{csr.name}_{field.name}"
+                region_defs += _generate_csr_define_alias_c(
+                    f"{alias_field_name}_extract",
+                    f"{field_name}_extract")
+                if with_access_functions:
+                    region_defs += _generate_csr_define_alias_c(
+                        f"{alias_field_name}_read",
+                        f"{field_name}_read")
+                if not getattr(csr, "read_only", False):
+                    region_defs += _generate_csr_define_alias_c(
+                        f"{alias_field_name}_replace",
+                        f"{field_name}_replace")
+                    if with_access_functions:
+                        region_defs += _generate_csr_define_alias_c(
+                            f"{alias_field_name}_write",
+                            f"{field_name}_write")
+    return region_defs
+
 # CSR Header.
 
 def _get_csr_region_origin(region, csr_base):
@@ -519,6 +608,9 @@ def get_csr_header(regions, constants, csr_ordering="big", csr_base=None, with_c
     for name, region in regions.items():
         origin = _get_csr_region_origin(region, _csr_base)
         r += _generate_csr_region_definitions_c(cpu, name, region, origin, alignment, csr_base, with_csr_base_define)
+    for name, region in regions.items():
+        for alias in getattr(region, "aliases", []):
+            r += _generate_csr_region_alias_definitions_c(name, alias, region)
 
     # CSR Registers Access Functions.
     if with_access_functions:
@@ -535,6 +627,9 @@ def get_csr_header(regions, constants, csr_ordering="big", csr_base=None, with_c
             region_ordering = getattr(region, "ordering", None) or csr_ordering
             r += _generate_csr_region_access_functions_c(
                 cpu, name, region, origin, alignment, region_ordering, csr_base, with_csr_base_define)
+        for name, region in regions.items():
+            for alias in getattr(region, "aliases", []):
+                r += _generate_csr_region_alias_access_functions_c(name, alias, region)
         r += "#endif /* LITEX_CSR_ACCESS_FUNCTIONS */\n"
 
     # CSR Registers Field Access Functions.
@@ -550,6 +645,9 @@ def get_csr_header(regions, constants, csr_ordering="big", csr_base=None, with_c
         for name, region in regions.items():
             origin = _get_csr_region_origin(region, _csr_base)
             r += _generate_csr_fields_access_functions_c(name, region, origin, alignment, csr_base, with_csr_base_define, with_access_functions)
+        for name, region in regions.items():
+            for alias in getattr(region, "aliases", []):
+                r += _generate_csr_region_alias_field_access_functions_c(name, alias, region, with_access_functions)
         r += "#endif /* LITEX_CSR_FIELDS_ACCESS_FUNCTIONS */\n"
 
     r += "\n#endif /* ! __GENERATED_CSR_H */\n"

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -171,10 +171,11 @@ class SoCIORegion(SoCRegion):
 # SoCCSRRegion -------------------------------------------------------------------------------------
 
 class SoCCSRRegion:
-    def __init__(self, origin, busword, obj):
+    def __init__(self, origin, busword, obj, aliases=None):
         self.origin  = origin
         self.busword = busword
         self.obj     = obj
+        self.aliases = [] if aliases is None else list(aliases)
 
 # SoCBusHandler ------------------------------------------------------------------------------------
 
@@ -1166,6 +1167,7 @@ class SoCCSRHandler(SoCLocHandler):
         self.ordering      = ordering
         self.masters       = {}
         self.regions       = {}
+        self.aliases       = {}
         self.logger.info("{}-bit CSR Bus, {}-bit Aligned, {}KiB Address Space, {}B Paging, {} Ordering (Up to {} Locations).".format(
             colorer(self.data_width),
             colorer(self.alignment),
@@ -1217,6 +1219,30 @@ class SoCCSRHandler(SoCLocHandler):
                 colorer(name, color="red"),
                 colorer("already declared")))
             raise SoCError()
+        region_aliases = []
+        for alias in region.aliases + self.aliases.get(name, []):
+            if alias not in region_aliases:
+                region_aliases.append(alias)
+        for region_name, aliases in self.aliases.items():
+            if name in aliases:
+                self.logger.error("CSR Region {} conflicts with alias of {}.".format(
+                    colorer(name, color="red"),
+                    colorer(region_name)))
+                raise SoCError()
+        for alias in region_aliases:
+            if alias in self.regions:
+                self.logger.error("CSR Alias {} conflicts with an existing CSR Region.".format(
+                    colorer(alias, color="red")))
+                raise SoCError()
+            for region_name, aliases in self.aliases.items():
+                if (region_name != name) and (alias in aliases):
+                    self.logger.error("CSR Alias {} already targets {}.".format(
+                        colorer(alias, color="red"),
+                        colorer(region_name)))
+                    raise SoCError()
+        region.aliases = region_aliases
+        if region_aliases:
+            self.aliases[name] = region_aliases
         # Origin alignment check (origin must land on a paging boundary).
         if (region.origin % self.paging) != 0:
             self.logger.error("CSR Region {} origin 0x{:08x} {} CSR paging 0x{:x}.".format(
@@ -1226,6 +1252,27 @@ class SoCCSRHandler(SoCLocHandler):
                 self.paging))
             raise SoCError()
         self.regions[name] = region
+
+    # Add Alias ------------------------------------------------------------------------------------
+    def add_alias(self, name, alias):
+        if name == alias:
+            self.logger.error("CSR Alias {} cannot target itself.".format(colorer(name, color="red")))
+            raise SoCError()
+        if alias in self.regions:
+            self.logger.error("CSR Alias {} conflicts with an existing CSR Region.".format(
+                colorer(alias, color="red")))
+            raise SoCError()
+        for region_name, aliases in self.aliases.items():
+            if alias in aliases:
+                self.logger.error("CSR Alias {} already targets {}.".format(
+                    colorer(alias, color="red"),
+                    colorer(region_name)))
+                raise SoCError()
+
+        aliases = self.aliases.setdefault(name, [])
+        aliases.append(alias)
+        if name in self.regions:
+            self.regions[name].aliases.append(alias)
 
     # Address map ----------------------------------------------------------------------------------
     def address_map(self, name, memory=None, origin=False):
@@ -1458,6 +1505,9 @@ class SoC(LiteXModule):
     def add_config(self, name, value=None, check_duplicate=True):
         name = "CONFIG_" + name
         self.add_constant(name, value, check_duplicate=check_duplicate)
+
+    def add_csr_alias(self, name, alias):
+        self.csr.add_alias(name, alias)
 
     def add_soc_reset_request(self, name, reset, hold_reset=None):
         if name in self.soc_reset_requests.keys():
@@ -2079,6 +2129,8 @@ class SoC(LiteXModule):
                         colorer(name),
                         colorer("unconnected", color="yellow")))
                 self.add_constant(name + "_INTERRUPT", loc)
+                for alias in self.csr.aliases.get(name, []):
+                    self.add_constant(alias + "_INTERRUPT", loc)
 
     def _log_finalized(self):
         self.logger.info(colorer("-"*80, color="bright"))
@@ -2160,7 +2212,7 @@ class LiteXSoC(SoC):
         return super().__getattr__(name)
 
     # Add UART -------------------------------------------------------------------------------------
-    def add_uart(self, name="uart", uart_name="serial", uart_pads=None, baudrate=115200, fifo_depth=16, with_dynamic_baudrate=False, rx_fifo_rx_we=False):
+    def add_uart(self, name="uart", uart_name="serial", uart_pads=None, baudrate=115200, fifo_depth=16, with_dynamic_baudrate=False, rx_fifo_rx_we=False, csr_aliases=None):
         # Imports.
         from litex.soc.cores import uart
 
@@ -2211,9 +2263,15 @@ class LiteXSoC(SoC):
 
         # Add UART.
         self.add_module(name=name, module=uart_core)
+        if csr_aliases is None:
+            csr_aliases = ["uart"] if name == "uart0" else []
+        for alias in csr_aliases:
+            self.add_csr_alias(name, alias)
 
         if rx_fifo_rx_we:
             self.add_config(f"{name}_RX_FIFO_RX_WE", 1)
+            for alias in csr_aliases:
+                self.add_config(f"{alias}_RX_FIFO_RX_WE", 1)
 
         # IRQ.
         if self.irq.enabled:

--- a/test/soc/test_export.py
+++ b/test/soc/test_export.py
@@ -83,6 +83,28 @@ class TestCSRExport(unittest.TestCase):
         self.assertIn("uint32_t word = ctrl_narrow_read();", header)
         self.assertIn("static inline void ctrl_narrow_field_write(uint32_t plain_value)", header)
 
+    def test_csr_header_exports_explicit_region_aliases(self):
+        csr = CSRStorage(name="rxtx", fields=[
+            CSRField("data", size=8, offset=0),
+        ])
+        header = get_csr_header(
+            regions = {
+                "uart0": SoCCSRRegion(origin=0xf0000000, busword=32, obj=[csr], aliases=["uart"]),
+            },
+            constants                    = {},
+            csr_base                     = 0xf0000000,
+            with_fields_access_functions = True,
+        )
+
+        self.assertIn("#define CSR_UART_BASE CSR_UART0_BASE", header)
+        self.assertIn("#define CSR_UART_RXTX_ADDR CSR_UART0_RXTX_ADDR", header)
+        self.assertIn("#define CSR_UART_RXTX_SIZE CSR_UART0_RXTX_SIZE", header)
+        self.assertIn("#define CSR_UART_RXTX_DATA_OFFSET CSR_UART0_RXTX_DATA_OFFSET", header)
+        self.assertIn("#define uart_rxtx_read uart0_rxtx_read", header)
+        self.assertIn("#define uart_rxtx_write uart0_rxtx_write", header)
+        self.assertIn("#define uart_rxtx_data_extract uart0_rxtx_data_extract", header)
+        self.assertIn("#define uart_rxtx_data_write uart0_rxtx_data_write", header)
+
     def test_csr_field_accessors_skip_csr_wider_than_uint64(self):
         csr = CSRStorage(name="too_wide", fields=[
             CSRField("field", size=8, offset=64),

--- a/test/soc/test_soc.py
+++ b/test/soc/test_soc.py
@@ -867,6 +867,35 @@ class TestSoCCSRHandler(unittest.TestCase):
 
         self.assertIs(csr.regions["timer0"], region)
 
+    def test_csr_alias_is_explicit_and_attached_to_target_region(self):
+        csr = SoCCSRHandler()
+        csr.add_alias("uart0", "uart")
+        csr.add_region("uart0", SoCCSRRegion(origin=csr.paging, busword=32, obj=object()))
+
+        self.assertEqual(csr.regions["uart0"].aliases, ["uart"])
+        with _assert_raises_soc_error(self):
+            csr.add_region("uart", SoCCSRRegion(origin=2*csr.paging, busword=32, obj=object()))
+
+    def test_csr_region_direct_alias_is_tracked_by_handler(self):
+        csr = SoCCSRHandler()
+        csr.add_region("uart0", SoCCSRRegion(
+            origin  = csr.paging,
+            busword = 32,
+            obj     = object(),
+            aliases = ["uart"],
+        ))
+
+        self.assertEqual(csr.aliases["uart0"], ["uart"])
+        with _assert_raises_soc_error(self):
+            csr.add_region("uart", SoCCSRRegion(origin=2*csr.paging, busword=32, obj=object()))
+
+    def test_csr_alias_duplicate_is_rejected(self):
+        csr = SoCCSRHandler()
+        csr.add_alias("uart0", "uart")
+
+        with _assert_raises_soc_error(self):
+            csr.add_alias("uart1", "uart")
+
     def test_csr_master_checks_data_width_and_duplicates(self):
         csr    = SoCCSRHandler(data_width=32)
         master = SimpleNamespace(data_width=32)
@@ -1045,6 +1074,41 @@ class TestSoC(unittest.TestCase):
 
         self.assertTrue(hasattr(soc, "uart"))
         self.assertIn("UART_POLLING", soc.constants)
+
+    def test_add_uart0_adds_legacy_uart_csr_alias(self):
+        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
+
+        soc.add_uart(name="uart0", uart_name="stub")
+
+        self.assertEqual(soc.csr.aliases["uart0"], ["uart"])
+
+    def test_add_uart0_aliases_rx_fifo_config(self):
+        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
+
+        soc.add_uart(name="uart0", uart_name="stub", rx_fifo_rx_we=True)
+
+        self.assertIn("CONFIG_UART0_RX_FIFO_RX_WE", soc.constants)
+        self.assertIn("CONFIG_UART_RX_FIFO_RX_WE",  soc.constants)
+
+    def test_add_csr_alias_forwards_to_csr_handler(self):
+        soc = SoC(_FakePlatform(), sys_clk_freq=1e6)
+
+        soc.add_csr_alias("uart0", "uart")
+
+        self.assertEqual(soc.csr.aliases["uart0"], ["uart"])
+
+    def test_csr_alias_exports_irq_constant_alias(self):
+        soc            = SoC(_FakePlatform(), sys_clk_freq=1e6)
+        soc.cpu        = SimpleNamespace(interrupts={}, interrupt=[Signal()])
+        soc.uart0      = SimpleNamespace(irq=Signal())
+        soc.irq.enable()
+        soc.irq.add("uart0", 0)
+        soc.add_csr_alias("uart0", "uart")
+
+        soc._finalize_irq()
+
+        self.assertEqual(soc.constants["UART0_INTERRUPT"], 0)
+        self.assertEqual(soc.constants["UART_INTERRUPT"],  0)
 
     def test_get_csr_address_returns_main_bus_address(self):
         soc = SoC(_FakePlatform(), sys_clk_freq=1e6)


### PR DESCRIPTION
This adds an explicit CSR region alias mechanism as a cleaner replacement for the implicit/default-name work discussed in #777 and #1641.

Summary:
- add explicit CSR aliases on SoCCSRRegion / SoCCSRHandler / SoC;
- generate C CSR aliases for base definitions, register definitions, field definitions and access helpers;
- mirror IRQ constants for aliased CSR regions;
- make add_uart(name="uart0") expose the historical uart CSR/config names for BIOS/libbase compatibility;
- keep the default uart behavior unchanged and avoid automatic suffix-based aliases for unrelated regions such as timer0.

Related:
- #777
- #1641

Tested with:
- pytest test/soc/test_export.py test/soc/test_soc.py