### PR TITLE
litex/build/openocd.py: Add CycloneIV to get_ir()

### DIFF
--- a/litex/build/openocd.py
+++ b/litex/build/openocd.py
@@ -78,6 +78,10 @@ class OpenOCD(GenericProgrammer):
         elif "10ax" in cfg_str:
             warn_ignored("Intel Arria10", 0xc)
             return 0xc
+        # Intel CycloneIV.
+        elif "ep4ce" in cfg_str:
+            warn_ignored("Intel CycloneIV", 0xe)
+            return 0xe
         # Xilinx ZynqMP.
         elif "zynqmp" in cfg_str:
             return lookup_ir("Xilinx ZynqMP", {


### PR DESCRIPTION
Added a CycloneIV entry to the get_ir() if/else tree in openocd.py

Value tested as working on a CycloneIV device with jtagbone. 