### PR TITLE
gen/fhdl: schedule combinatorial groups by dependency

### DIFF
--- a/litex/gen/fhdl/verilog.py
+++ b/litex/gen/fhdl/verilog.py
@@ -504,45 +504,36 @@ def _normalize_comb_cycle_policy(policy):
             f"{', '.join(sorted(_comb_cycle_policies))}."
         )
 
-def _list_target_inputs(node, target):
+def _collect_target_dependencies(node, deps, active_inputs=None):
+    if active_inputs is None:
+        active_inputs = set()
+
     if isinstance(node, _Assign):
-        if target in list_targets(node):
-            return set(list_inputs(node))
-        return set()
+        inputs = set(list_inputs(node)) | active_inputs
+        for target in list_targets(node):
+            deps[target] |= inputs
 
     elif isinstance(node, collections.abc.Iterable):
-        r = set()
         for statement in node:
-            r |= _list_target_inputs(statement, target)
-        return r
+            _collect_target_dependencies(statement, deps, active_inputs)
 
     elif isinstance(node, If):
-        if target not in list_targets(node):
-            return set()
-        r = set(list_inputs(node.cond))
-        r |= _list_target_inputs(node.t, target)
-        r |= _list_target_inputs(node.f, target)
-        return r
+        inputs = active_inputs | set(list_inputs(node.cond))
+        _collect_target_dependencies(node.t, deps, inputs)
+        _collect_target_dependencies(node.f, deps, inputs)
 
     elif isinstance(node, Case):
-        if target not in list_targets(node):
-            return set()
-        r = set(list_inputs(node.test))
+        inputs = active_inputs | set(list_inputs(node.test))
         for statements in node.cases.values():
-            r |= _list_target_inputs(statements, target)
-        return r
-
-    elif target in list_targets(node):
-        return set(list_inputs(node))
-
-    else:
-        return set()
+            _collect_target_dependencies(statements, deps, inputs)
 
 def _build_target_dependency_graph(statements, targets):
     targets = set(targets)
-    deps = {}
+    deps = collections.defaultdict(set)
+    _collect_target_dependencies(statements, deps)
     for target in targets:
-        deps[target] = _list_target_inputs(statements, target) & targets
+        deps[target] &= targets
+    deps = {target: deps[target] for target in targets}
     return deps
 
 def _topological_sort_targets(targets, deps, ns):

--- a/litex/gen/fhdl/verilog.py
+++ b/litex/gen/fhdl/verilog.py
@@ -17,6 +17,7 @@ import time
 import datetime
 import collections
 import re
+import warnings
 
 from dataclasses import dataclass, field
 from enum import IntEnum
@@ -357,53 +358,6 @@ def _use_wire(stmts):
     return (len(stmts) == 1 and isinstance(stmts[0], _Assign) and
             not isinstance(stmts[0].l, _Slice))
 
-def _has_forward_target_reference(node, later_targets=None):
-    """Return whether a statement tree reads a target assigned later on the same path."""
-    if later_targets is None:
-        later_targets = set()
-
-    if isinstance(node, _Assign):
-        reads   = set(list_inputs(node))
-        targets = set(list_targets(node))
-        return not reads.isdisjoint(later_targets), targets
-
-    elif isinstance(node, If):
-        targets = set(list_targets(node))
-        reads   = set(list_inputs(node.cond))
-        if not reads.isdisjoint(later_targets | targets):
-            return True, targets
-        for statements in [node.t, node.f]:
-            has_forward, _ = _has_forward_target_reference(statements, later_targets)
-            if has_forward:
-                return True, targets
-        return False, targets
-
-    elif isinstance(node, Case):
-        targets = set(list_targets(node))
-        reads   = set(list_inputs(node.test))
-        if not reads.isdisjoint(later_targets | targets):
-            return True, targets
-        for statements in node.cases.values():
-            has_forward, _ = _has_forward_target_reference(statements, later_targets)
-            if has_forward:
-                return True, targets
-        return False, targets
-
-    elif isinstance(node, collections.abc.Iterable):
-        targets = set()
-        for statement in reversed(list(node)):
-            has_forward, statement_targets = _has_forward_target_reference(
-                statement,
-                later_targets | targets,
-            )
-            if has_forward:
-                return True, targets | statement_targets
-            targets |= statement_targets
-        return False, targets
-
-    else:
-        return False, set()
-
 def _list_comb_wires(f):
     r = set()
     groups = group_by_targets(f.comb)
@@ -532,24 +486,157 @@ def _generate_signals(f, ios, name, ns, attr_translate, regs_init, signals_overr
 #                                  COMBINATORIAL LOGIC                                             #
 # ------------------------------------------------------------------------------------------------ #
 
-def _generate_combinatorial_logic(f, ns):
+_comb_cycle_policies = {
+    "ignore"  : "ignore",
+    "warn"    : "warn",
+    "warning" : "warn",
+    "error"   : "error",
+}
+
+def _normalize_comb_cycle_policy(policy):
+    if isinstance(policy, str):
+        policy = policy.lower()
+    try:
+        return _comb_cycle_policies[policy]
+    except (KeyError, TypeError):
+        raise ValueError(
+            f"Invalid comb_cycle_policy {policy!r}, expected one of: "
+            f"{', '.join(sorted(_comb_cycle_policies))}."
+        )
+
+def _list_target_inputs(node, target):
+    if isinstance(node, _Assign):
+        if target in list_targets(node):
+            return set(list_inputs(node))
+        return set()
+
+    elif isinstance(node, collections.abc.Iterable):
+        r = set()
+        for statement in node:
+            r |= _list_target_inputs(statement, target)
+        return r
+
+    elif isinstance(node, If):
+        if target not in list_targets(node):
+            return set()
+        r = set(list_inputs(node.cond))
+        r |= _list_target_inputs(node.t, target)
+        r |= _list_target_inputs(node.f, target)
+        return r
+
+    elif isinstance(node, Case):
+        if target not in list_targets(node):
+            return set()
+        r = set(list_inputs(node.test))
+        for statements in node.cases.values():
+            r |= _list_target_inputs(statements, target)
+        return r
+
+    elif target in list_targets(node):
+        return set(list_inputs(node))
+
+    else:
+        return set()
+
+def _build_target_dependency_graph(statements, targets):
+    targets = set(targets)
+    deps = {}
+    for target in targets:
+        deps[target] = _list_target_inputs(statements, target) & targets
+    return deps
+
+def _topological_sort_targets(targets, deps, ns):
+    remaining = set(targets)
+    ordered   = []
+    while remaining:
+        ready = [
+            target for target in remaining
+            if deps.get(target, set()).isdisjoint(remaining)
+        ]
+        if not ready:
+            return None
+        ready = sorted(ready, key=lambda x: ns.get_name(x))
+        ordered.append(ready[0])
+        remaining.remove(ready[0])
+    return ordered
+
+def _find_target_dependency_cycle(deps, ns):
+    visiting = set()
+    visited  = set()
+    stack    = []
+
+    def visit(target):
+        if target in visited:
+            return None
+        if target in visiting:
+            index = stack.index(target)
+            return stack[index:] + [target]
+        visiting.add(target)
+        stack.append(target)
+        for dep in sorted(deps.get(target, set()), key=lambda x: ns.get_name(x)):
+            cycle = visit(dep)
+            if cycle is not None:
+                return cycle
+        stack.pop()
+        visiting.remove(target)
+        visited.add(target)
+        return None
+
+    for target in sorted(deps, key=lambda x: ns.get_name(x)):
+        cycle = visit(target)
+        if cycle is not None:
+            return cycle
+    return []
+
+def _format_target_cycle(cycle, ns):
+    if cycle:
+        return " -> ".join(ns.get_name(target) for target in cycle)
+    return "unknown cycle"
+
+def _handle_comb_cycles(f, ns, comb_cycle_policy):
+    policy  = _normalize_comb_cycle_policy(comb_cycle_policy)
+    targets = set(list_targets(f.comb))
+    if not targets:
+        return policy
+
+    deps = _build_target_dependency_graph(f.comb, targets)
+    if _topological_sort_targets(targets, deps, ns) is not None:
+        return policy
+
+    cycle = _find_target_dependency_cycle(deps, ns)
+    msg = f"Combinatorial cycle detected: {_format_target_cycle(cycle, ns)}."
+    if policy == "error":
+        raise ValueError(msg)
+    if policy == "warn":
+        warnings.warn(msg, RuntimeWarning)
+    return policy
+
+def _generate_combinatorial_logic(f, ns, comb_cycle_policy="warn"):
     r = ""
     if f.comb:
+        _handle_comb_cycles(f, ns, comb_cycle_policy)
         groups = group_by_targets(f.comb)
 
         for n, g in enumerate(groups):
             if _use_wire(g[1]):
                 r += "assign " + _generate_node(ns, AssignType.BLOCKING, 0, g[1][0])
             else:
-                assign_type = (
-                    AssignType.NON_BLOCKING if _has_forward_target_reference(g[1])[0]
-                    else AssignType.BLOCKING
-                )
-                assignment  = " <= " if assign_type == AssignType.NON_BLOCKING else " = "
+                deps            = _build_target_dependency_graph(g[1], g[0])
+                ordered_targets = _topological_sort_targets(g[0], deps, ns)
+                assign_type     = AssignType.BLOCKING
+                assignment      = " = "
+                if ordered_targets is None:
+                    ordered_targets = sorted(g[0], key=lambda x: ns.get_name(x))
+                    assign_type     = AssignType.NON_BLOCKING
+                    assignment      = " <= "
                 r += "always @(*) begin\n"
                 for t in sorted(g[0], key=lambda x: ns.get_name(x)):
                     r += _tab + ns.get_name(t) + assignment + _generate_expression(ns, t.reset)[0] + ";\n"
-                r += _generate_node(ns, assign_type, 1, g[1])
+                if assign_type == AssignType.BLOCKING and any(deps.values()):
+                    for t in ordered_targets:
+                        r += _generate_node(ns, assign_type, 1, g[1], t)
+                else:
+                    r += _generate_node(ns, assign_type, 1, g[1])
                 r += "end\n"
     r += "\n"
     return r
@@ -822,6 +909,7 @@ class _HierarchicalBuildContext:
     special_overrides: dict
     attr_translate: object
     regs_init: bool
+    comb_cycle_policy: str
     time_unit: str
     time_precision: str
     ios: set
@@ -834,7 +922,7 @@ class _HierarchicalBuildContext:
     ns: object = None
 
 
-def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_translate, regs_init, time_unit, time_precision):
+def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_translate, regs_init, comb_cycle_policy, time_unit, time_precision):
     if LiteXContext.top is None:
         raise ValueError("Hierarchical Verilog generation requires LiteXContext.top to be set.")
 
@@ -850,6 +938,7 @@ def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_transl
         special_overrides = special_overrides,
         attr_translate    = attr_translate,
         regs_init         = regs_init,
+        comb_cycle_policy = comb_cycle_policy,
         time_unit         = time_unit,
         time_precision    = time_precision,
         ios               = _resolve_ios(ios, platform),
@@ -1340,7 +1429,7 @@ def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_transl
         parts.append(_generate_separator("Submodules"))
         parts.append(_generate_submodule_instances(node, ctx.ns))
         parts.append(_generate_separator("Combinatorial Logic"))
-        parts.append(_generate_combinatorial_logic(node.fragment, ctx.ns))
+        parts.append(_generate_combinatorial_logic(node.fragment, ctx.ns, ctx.comb_cycle_policy))
         parts.append(_generate_separator("Synchronous Logic"))
         parts.append(_generate_synchronous_logic(node.fragment, ctx.ns))
         parts.append(_generate_separator("Specialized Logic"))
@@ -1368,6 +1457,7 @@ def convert(f, ios=set(), name="top", platform=None,
     attr_translate    = DummyAttrTranslate(),
     regs_init         = True,
     hierarchical      = False,
+    comb_cycle_policy = "warn",
     # Sim parameters.
     time_unit      = "1ns",
     time_precision = "1ps",
@@ -1379,6 +1469,7 @@ def convert(f, ios=set(), name="top", platform=None,
     # Convert to FHDL fragment if needed (used by both flat and hierarchical paths).
     if not isinstance(f, _Fragment):
         f = f.get_fragment()
+    comb_cycle_policy = _normalize_comb_cycle_policy(comb_cycle_policy)
 
     # Hierarchical Verilog generation (opt-in path).
     if hierarchical:
@@ -1390,6 +1481,7 @@ def convert(f, ios=set(), name="top", platform=None,
             special_overrides = special_overrides,
             attr_translate    = attr_translate,
             regs_init         = regs_init,
+            comb_cycle_policy = comb_cycle_policy,
             time_unit         = time_unit,
             time_precision    = time_precision,
         )
@@ -1453,7 +1545,7 @@ def convert(f, ios=set(), name="top", platform=None,
 
     # Combinatorial Logic.
     verilog += _generate_separator("Combinatorial Logic")
-    verilog += _generate_combinatorial_logic(f, ns)
+    verilog += _generate_combinatorial_logic(f, ns, comb_cycle_policy)
 
     # Synchronous Logic.
     verilog += _generate_separator("Synchronous Logic")

--- a/test/hdl/test_verilog.py
+++ b/test/hdl/test_verilog.py
@@ -44,6 +44,17 @@ class _OrderedCombReference(Module):
         )
 
 
+class _CombCycle(Module):
+    def __init__(self):
+        self.a = Signal(name="a")
+        self.b = Signal(name="b")
+
+        self.comb += [
+            self.a.eq(self.b),
+            self.b.eq(self.a),
+        ]
+
+
 class _SyncOutput(Module):
     def __init__(self):
         self.clock_domains.cd_sys = ClockDomain()
@@ -89,15 +100,16 @@ class TestVerilog(unittest.TestCase):
         self.assertIn("status[0] = flag;", v)
         self.assertIn("status[12:8] = count;", v)
 
-    def test_forward_comb_reference_uses_non_blocking_assignments(self):
+    def test_forward_comb_reference_is_dependency_ordered(self):
         dut = _ForwardCombReference()
         v = convert(dut, ios={dut.sel, dut.a, dut.b}, name="top").main_source
 
-        self.assertIn("a <= 1'd0;", v)
-        self.assertIn("b <= 1'd0;", v)
-        self.assertIn("a <= b;", v)
-        self.assertIn("b <= 1'd1;", v)
-        self.assertNotIn("a = b;", v)
+        self.assertIn("a = 1'd0;", v)
+        self.assertIn("b = 1'd0;", v)
+        self.assertIn("b = 1'd1;", v)
+        self.assertIn("a = b;", v)
+        self.assertLess(v.index("b = 1'd1;"), v.index("a = b;"))
+        self.assertNotIn("a <= b;", v)
 
     def test_ordered_comb_reference_keeps_blocking_assignments(self):
         dut = _OrderedCombReference()
@@ -108,6 +120,16 @@ class TestVerilog(unittest.TestCase):
         self.assertIn("b = 1'd1;", v)
         self.assertIn("a = b;", v)
         self.assertNotIn("a <= b;", v)
+
+    def test_comb_cycle_can_warn(self):
+        dut = _CombCycle()
+        with self.assertWarnsRegex(RuntimeWarning, "a -> b -> a"):
+            convert(dut, ios={dut.a, dut.b}, name="top", comb_cycle_policy="warn")
+
+    def test_comb_cycle_can_error(self):
+        dut = _CombCycle()
+        with self.assertRaisesRegex(ValueError, "a -> b -> a"):
+            convert(dut, ios={dut.a, dut.b}, name="top", comb_cycle_policy="error")
 
     def test_sync_output_port_is_declared_as_reg(self):
         dut = _SyncOutput()


### PR DESCRIPTION
## Summary
- Schedule grouped combinatorial Verilog statements by same-block target dependencies so blocking assignments preserve Migen combinatorial semantics on forward references.
- Add `comb_cycle_policy` with `ignore`/`warn`/`error` handling, keeping non-blocking fallback for cyclic groups unless policy is `error`.
- Collect combinatorial dependencies in a single traversal so large designs can emit Verilog without the first scheduler pass becoming too slow.

## Validation
- `pytest test/hdl/test_verilog.py` (8 passed)
- Checked Verilog generation and Vivado build flow on a large downstream design.