### PR TITLE
soc/cores/ram: add async SRAM bridge

### DIFF
--- a/litex/soc/cores/ram/__init__.py
+++ b/litex/soc/cores/ram/__init__.py
@@ -2,6 +2,9 @@
 
 # Intel
 
+# Generic
+from litex.soc.cores.ram.async_sram import AsyncSRAM
+
 # Lattice
 from litex.soc.cores.ram.lattice_ice40 import Up5kSPRAM
 from litex.soc.cores.ram.lattice_nx import NXLRAM

--- a/litex/soc/cores/ram/async_sram.py
+++ b/litex/soc/cores/ram/async_sram.py
@@ -24,18 +24,23 @@ class AsyncSRAM(LiteXModule):
     existing board targets.
     """
     def __init__(self, pads, bus=None, data_width=32, address_width=None,
-        read_cycles=2,
-        write_cycles=3):
+        read_cycles  = 2,
+        write_cycles = 3):
+        # Parameters.
         if read_cycles < 1:
             raise ValueError("AsyncSRAM read_cycles must be >= 1.")
         if write_cycles < 1:
             raise ValueError("AsyncSRAM write_cycles must be >= 1.")
+
+        # Wishbone bus.
         if bus is None:
             bus = wishbone.Interface(data_width=data_width)
         if bus.addressing != "word":
             raise ValueError("AsyncSRAM only supports word-addressed Wishbone buses.")
         if bus.data_width != data_width:
             raise ValueError("AsyncSRAM data_width must match the Wishbone bus data width.")
+
+        # Pads.
         if not hasattr(pads, "adr"):
             raise ValueError("AsyncSRAM pads must provide an adr signal.")
         if not hasattr(pads, "dat"):
@@ -45,6 +50,7 @@ class AsyncSRAM(LiteXModule):
 
         # # #
 
+        # Geometry.
         sram_data_width = len(pads.dat)
         if sram_data_width != 8:
             raise ValueError("AsyncSRAM currently supports 8-bit SRAM data buses only.")
@@ -52,9 +58,11 @@ class AsyncSRAM(LiteXModule):
             raise ValueError("AsyncSRAM data_width must be a multiple of the SRAM data width.")
 
         ratio = data_width//sram_data_width
+        if ratio & (ratio - 1):
+            raise ValueError("AsyncSRAM Wishbone/SRAM width ratio must be a power of two.")
         if len(bus.sel) != ratio:
             raise ValueError("AsyncSRAM Wishbone select width must match the data width ratio.")
-        ratio_bits = log2_int(ratio, need_pow2=True)
+        ratio_bits = log2_int(ratio)
 
         if address_width is None:
             address_width = len(pads.adr)
@@ -67,16 +75,18 @@ class AsyncSRAM(LiteXModule):
         if len(bus.adr) < word_address_width:
             raise ValueError("AsyncSRAM Wishbone address width is too small for the SRAM address bus.")
 
-        def get_control_pad(*names):
+        # Control pads.
+        def _get_control_pad(*names):
             for name in names:
                 if hasattr(pads, name):
                     return getattr(pads, name)
             raise ValueError("AsyncSRAM pads must provide one of: {}.".format(", ".join(names)))
 
-        ce_n_pad = get_control_pad("ce_n", "ce")
-        oe_n_pad = get_control_pad("oe_n", "oe")
-        we_n_pad = get_control_pad("we_n", "we")
+        ce_n_pad = _get_control_pad("ce_n", "ce")
+        oe_n_pad = _get_control_pad("oe_n", "oe")
+        we_n_pad = _get_control_pad("we_n", "we")
 
+        # Signals.
         ce_n  = Signal(reset=1)
         oe_n  = Signal(reset=1)
         we_n  = Signal(reset=1)
@@ -97,29 +107,33 @@ class AsyncSRAM(LiteXModule):
         byte_sel = Signal()
         mem_adr  = Signal(address_width)
 
-        # Tristate data bus.
+        # SRAM data tristate.
         self.specials += Tristate(pads.dat, o=dat_o, oe=dat_oe, i=dat_i)
 
-        # Pads/control.
+        # SRAM controls.
         self.comb += [
             ce_n_pad.eq(ce_n),
             oe_n_pad.eq(oe_n),
             we_n_pad.eq(we_n),
             pads.adr.eq(mem_adr),
         ]
+
+        # SRAM address: Wishbone word address + current byte lane.
         if ratio_bits:
             self.comb += mem_adr.eq(Cat(byte[:ratio_bits], word_adr[:word_address_width]))
         else:
             self.comb += mem_adr.eq(word_adr[:word_address_width])
 
-        dat_o_cases  = {}
+        # Byte lane decoding.
+        dat_o_cases    = {}
         byte_sel_cases = {}
-        read_cases   = {}
+        read_cases     = {}
         for n in range(ratio):
             dat_o_cases[n] = dat_o.eq(data_w[n*sram_data_width:(n + 1)*sram_data_width])
             byte_sel_cases[n] = byte_sel.eq(sel[n])
             read_cases[n] = NextValue(data_r[n*sram_data_width:(n + 1)*sram_data_width], dat_i)
 
+        # Defaults.
         self.comb += [
             bus.dat_r.eq(data_r),
             bus.ack.eq(0),
@@ -138,8 +152,10 @@ class AsyncSRAM(LiteXModule):
         read_done  = wait == (read_cycles - 1)
         write_done = wait == (write_cycles - 1)
 
+        # FSM.
         self.submodules.fsm = fsm = FSM(reset_state="IDLE")
         fsm.act("IDLE",
+            # Latch Wishbone command.
             If(bus.cyc & bus.stb,
                 NextValue(word_adr, bus.adr),
                 NextValue(sel,      bus.sel),
@@ -154,6 +170,7 @@ class AsyncSRAM(LiteXModule):
             )
         )
         fsm.act("READ",
+            # Read byte.
             ce_n.eq(0),
             oe_n.eq(0),
             If(read_done,
@@ -169,6 +186,7 @@ class AsyncSRAM(LiteXModule):
             )
         )
         fsm.act("WRITE",
+            # Write byte.
             ce_n.eq(0),
             If(byte_sel,
                 we_n.eq(0),
@@ -193,6 +211,7 @@ class AsyncSRAM(LiteXModule):
             )
         )
         fsm.act("ACK",
+            # Wishbone ack.
             bus.ack.eq(1),
             NextState("IDLE")
         )

--- a/litex/soc/cores/ram/async_sram.py
+++ b/litex/soc/cores/ram/async_sram.py
@@ -1,0 +1,198 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+from migen.fhdl.specials import Tristate
+
+from litex.gen import *
+
+from litex.soc.interconnect import wishbone
+
+
+# Async SRAM ---------------------------------------------------------------------------------------
+
+class AsyncSRAM(LiteXModule):
+    """Wishbone bridge for 8-bit asynchronous SRAMs.
+
+    The core exposes a word-addressed Wishbone slave and serializes each bus
+    word into byte-wide async SRAM accesses. The external control pads are
+    driven as active-low signals; pad names can either use the explicit
+    ``*_n`` suffix or the shorter ``ce``/``oe``/``we`` names used by some
+    existing board targets.
+    """
+    def __init__(self, pads, bus=None, data_width=32, address_width=None,
+        read_cycles=2,
+        write_cycles=3):
+        if read_cycles < 1:
+            raise ValueError("AsyncSRAM read_cycles must be >= 1.")
+        if write_cycles < 1:
+            raise ValueError("AsyncSRAM write_cycles must be >= 1.")
+        if bus is None:
+            bus = wishbone.Interface(data_width=data_width)
+        if bus.addressing != "word":
+            raise ValueError("AsyncSRAM only supports word-addressed Wishbone buses.")
+        if bus.data_width != data_width:
+            raise ValueError("AsyncSRAM data_width must match the Wishbone bus data width.")
+        if not hasattr(pads, "adr"):
+            raise ValueError("AsyncSRAM pads must provide an adr signal.")
+        if not hasattr(pads, "dat"):
+            raise ValueError("AsyncSRAM pads must provide a dat signal.")
+
+        self.bus = bus
+
+        # # #
+
+        sram_data_width = len(pads.dat)
+        if sram_data_width != 8:
+            raise ValueError("AsyncSRAM currently supports 8-bit SRAM data buses only.")
+        if data_width % sram_data_width:
+            raise ValueError("AsyncSRAM data_width must be a multiple of the SRAM data width.")
+
+        ratio = data_width//sram_data_width
+        if len(bus.sel) != ratio:
+            raise ValueError("AsyncSRAM Wishbone select width must match the data width ratio.")
+        ratio_bits = log2_int(ratio, need_pow2=True)
+
+        if address_width is None:
+            address_width = len(pads.adr)
+        if address_width != len(pads.adr):
+            raise ValueError("AsyncSRAM address_width must match the SRAM address pad width.")
+        if address_width < ratio_bits:
+            raise ValueError("AsyncSRAM address_width is too small for the bus/SRAM width ratio.")
+
+        word_address_width = address_width - ratio_bits
+        if len(bus.adr) < word_address_width:
+            raise ValueError("AsyncSRAM Wishbone address width is too small for the SRAM address bus.")
+
+        def get_control_pad(*names):
+            for name in names:
+                if hasattr(pads, name):
+                    return getattr(pads, name)
+            raise ValueError("AsyncSRAM pads must provide one of: {}.".format(", ".join(names)))
+
+        ce_n_pad = get_control_pad("ce_n", "ce")
+        oe_n_pad = get_control_pad("oe_n", "oe")
+        we_n_pad = get_control_pad("we_n", "we")
+
+        ce_n  = Signal(reset=1)
+        oe_n  = Signal(reset=1)
+        we_n  = Signal(reset=1)
+        dat_i = Signal(sram_data_width)
+        dat_o = Signal(sram_data_width)
+        dat_oe = Signal()
+
+        self.dat_i  = dat_i
+        self.dat_o  = dat_o
+        self.dat_oe = dat_oe
+
+        word_adr = Signal(len(bus.adr))
+        byte     = Signal(max=max(ratio, 2))
+        wait     = Signal(max=max(read_cycles, write_cycles, 2))
+        sel      = Signal(ratio)
+        data_w   = Signal(data_width)
+        data_r   = Signal(data_width)
+        byte_sel = Signal()
+        mem_adr  = Signal(address_width)
+
+        # Tristate data bus.
+        self.specials += Tristate(pads.dat, o=dat_o, oe=dat_oe, i=dat_i)
+
+        # Pads/control.
+        self.comb += [
+            ce_n_pad.eq(ce_n),
+            oe_n_pad.eq(oe_n),
+            we_n_pad.eq(we_n),
+            pads.adr.eq(mem_adr),
+        ]
+        if ratio_bits:
+            self.comb += mem_adr.eq(Cat(byte[:ratio_bits], word_adr[:word_address_width]))
+        else:
+            self.comb += mem_adr.eq(word_adr[:word_address_width])
+
+        dat_o_cases  = {}
+        byte_sel_cases = {}
+        read_cases   = {}
+        for n in range(ratio):
+            dat_o_cases[n] = dat_o.eq(data_w[n*sram_data_width:(n + 1)*sram_data_width])
+            byte_sel_cases[n] = byte_sel.eq(sel[n])
+            read_cases[n] = NextValue(data_r[n*sram_data_width:(n + 1)*sram_data_width], dat_i)
+
+        self.comb += [
+            bus.dat_r.eq(data_r),
+            bus.ack.eq(0),
+            bus.err.eq(0),
+            ce_n.eq(1),
+            oe_n.eq(1),
+            we_n.eq(1),
+            dat_oe.eq(0),
+            dat_o.eq(0),
+            byte_sel.eq(0),
+            Case(byte, dat_o_cases),
+            Case(byte, byte_sel_cases),
+        ]
+
+        byte_last  = byte == (ratio - 1)
+        read_done  = wait == (read_cycles - 1)
+        write_done = wait == (write_cycles - 1)
+
+        self.submodules.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            If(bus.cyc & bus.stb,
+                NextValue(word_adr, bus.adr),
+                NextValue(sel,      bus.sel),
+                NextValue(data_w,   bus.dat_w),
+                NextValue(byte,     0),
+                NextValue(wait,     0),
+                If(bus.we,
+                    NextState("WRITE")
+                ).Else(
+                    NextState("READ")
+                )
+            )
+        )
+        fsm.act("READ",
+            ce_n.eq(0),
+            oe_n.eq(0),
+            If(read_done,
+                Case(byte, read_cases),
+                NextValue(wait, 0),
+                If(byte_last,
+                    NextState("ACK")
+                ).Else(
+                    NextValue(byte, byte + 1)
+                )
+            ).Else(
+                NextValue(wait, wait + 1)
+            )
+        )
+        fsm.act("WRITE",
+            ce_n.eq(0),
+            If(byte_sel,
+                we_n.eq(0),
+                dat_oe.eq(1),
+                If(write_done,
+                    NextValue(wait, 0),
+                    If(byte_last,
+                        NextState("ACK")
+                    ).Else(
+                        NextValue(byte, byte + 1)
+                    )
+                ).Else(
+                    NextValue(wait, wait + 1)
+                )
+            ).Else(
+                NextValue(wait, 0),
+                If(byte_last,
+                    NextState("ACK")
+                ).Else(
+                    NextValue(byte, byte + 1)
+                )
+            )
+        )
+        fsm.act("ACK",
+            bus.ack.eq(1),
+            NextState("IDLE")
+        )

--- a/test/cores/test_async_sram.py
+++ b/test/cores/test_async_sram.py
@@ -1,0 +1,173 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import *
+from migen.fhdl.specials import Tristate
+
+from litex.soc.cores.ram.async_sram import AsyncSRAM
+from litex.soc.interconnect import wishbone
+
+
+# Helpers ------------------------------------------------------------------------------------------
+
+class _AsyncSRAMPads:
+    def __init__(self, address_width=19, data_width=8):
+        self.ce  = Signal(reset=1)
+        self.oe  = Signal(reset=1)
+        self.we  = Signal(reset=1)
+        self.adr = Signal(address_width)
+        self.dat = Signal(data_width)
+
+
+class _IgnoreTristate:
+    @staticmethod
+    def lower(t):
+        return Module()
+
+
+class _DUT(Module):
+    def __init__(self, read_cycles=2, write_cycles=3):
+        self.pads = _AsyncSRAMPads()
+        self.bus  = wishbone.Interface(data_width=32)
+        self.submodules.sram = AsyncSRAM(
+            pads         = self.pads,
+            bus          = self.bus,
+            read_cycles  = read_cycles,
+            write_cycles = write_cycles)
+
+
+def _byte_addr(word_addr, byte):
+    return 4*word_addr + byte
+
+
+def _word_from_memory(memory, word_addr):
+    value = 0
+    for byte in range(4):
+        value |= memory.get(_byte_addr(word_addr, byte), 0) << (8*byte)
+    return value
+
+
+def _async_sram_model(testcase, dut, memory, read_log=None, write_log=None):
+    @passive
+    def model():
+        while True:
+            ce_n = (yield dut.pads.ce)
+            oe_n = (yield dut.pads.oe)
+            we_n = (yield dut.pads.we)
+            adr  = (yield dut.pads.adr)
+
+            if ce_n == 0 and we_n == 0:
+                testcase.assertEqual((yield dut.sram.dat_oe), 1)
+                data = (yield dut.sram.dat_o)
+                memory[adr] = data
+                if write_log is not None:
+                    write_log.append((adr, data))
+
+            if ce_n == 0 and oe_n == 0 and we_n == 1:
+                if read_log is not None:
+                    read_log.append(adr)
+                yield dut.sram.dat_i.eq(memory.get(adr, 0))
+            else:
+                yield dut.sram.dat_i.eq(0)
+
+            yield
+
+    return model()
+
+
+# Tests --------------------------------------------------------------------------------------------
+
+class TestAsyncSRAM(unittest.TestCase):
+    def run_dut(self, dut, generator, memory=None, read_log=None, write_log=None):
+        if memory is None:
+            memory = {}
+        run_simulation(dut, [
+            generator(),
+            _async_sram_model(self, dut, memory, read_log, write_log),
+        ], special_overrides={Tristate: _IgnoreTristate})
+
+    def test_instantiation(self):
+        dut = _DUT()
+        self.assertEqual(dut.bus.data_width, 32)
+        self.assertEqual(len(dut.pads.dat), 8)
+        self.assertEqual(len(dut.pads.adr), 19)
+
+    def test_full_word_write_and_readback(self):
+        dut = _DUT()
+        memory = {}
+        word_addr = 4
+
+        def generator():
+            yield from dut.bus.write(word_addr, 0x78563412)
+            self.assertEqual(memory[_byte_addr(word_addr, 0)], 0x12)
+            self.assertEqual(memory[_byte_addr(word_addr, 1)], 0x34)
+            self.assertEqual(memory[_byte_addr(word_addr, 2)], 0x56)
+            self.assertEqual(memory[_byte_addr(word_addr, 3)], 0x78)
+            self.assertEqual((yield from dut.bus.read(word_addr)), 0x78563412)
+
+        self.run_dut(dut, generator, memory)
+
+    def test_byte_select_write_preserves_unselected_bytes(self):
+        dut = _DUT()
+        memory = {}
+        word_addr = 7
+        for byte, value in enumerate([0xaa, 0xbb, 0xcc, 0xdd]):
+            memory[_byte_addr(word_addr, byte)] = value
+
+        def generator():
+            yield from dut.bus.write(word_addr, 0x11223344, sel=0b1010)
+            self.assertEqual(memory[_byte_addr(word_addr, 0)], 0xaa)
+            self.assertEqual(memory[_byte_addr(word_addr, 1)], 0x33)
+            self.assertEqual(memory[_byte_addr(word_addr, 2)], 0xcc)
+            self.assertEqual(memory[_byte_addr(word_addr, 3)], 0x11)
+            self.assertEqual((yield from dut.bus.read(word_addr)), 0x11cc33aa)
+
+        self.run_dut(dut, generator, memory)
+
+    def test_read_byte_address_sequence(self):
+        dut = _DUT(read_cycles=2)
+        memory = {}
+        read_log = []
+        word_addr = 9
+        for byte, value in enumerate([0xde, 0xad, 0xbe, 0xef]):
+            memory[_byte_addr(word_addr, byte)] = value
+
+        def generator():
+            self.assertEqual((yield from dut.bus.read(word_addr)), 0xefbeadde)
+
+        self.run_dut(dut, generator, memory, read_log=read_log)
+        self.assertEqual(read_log, [
+            _byte_addr(word_addr, 0), _byte_addr(word_addr, 0),
+            _byte_addr(word_addr, 1), _byte_addr(word_addr, 1),
+            _byte_addr(word_addr, 2), _byte_addr(word_addr, 2),
+            _byte_addr(word_addr, 3), _byte_addr(word_addr, 3),
+        ])
+
+    def test_write_select_controls_byte_strobes(self):
+        dut = _DUT(write_cycles=3)
+        memory = {}
+        write_log = []
+        word_addr = 2
+
+        def generator():
+            yield from dut.bus.write(word_addr, 0xa1b2c3d4, sel=0b0101)
+
+        self.run_dut(dut, generator, memory, write_log=write_log)
+        self.assertEqual(write_log, [
+            (_byte_addr(word_addr, 0), 0xd4),
+            (_byte_addr(word_addr, 0), 0xd4),
+            (_byte_addr(word_addr, 0), 0xd4),
+            (_byte_addr(word_addr, 2), 0xb2),
+            (_byte_addr(word_addr, 2), 0xb2),
+            (_byte_addr(word_addr, 2), 0xb2),
+        ])
+        self.assertEqual(_word_from_memory(memory, word_addr), 0x00b200d4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add a generic LiteX/Migen Wishbone bridge for byte-wide asynchronous SRAMs.

The core exposes a word-addressed Wishbone slave and serializes each access into byte-wide external SRAM cycles. It drives active-low CE/OE/WE control pads and the bidirectional data bus, allowing board targets to use a native LiteX core instead of carrying local Verilog SRAM bridges.

Test coverage:
- Full-word write/readback.
- Masked byte writes preserving unselected bytes.
- Read byte address sequencing.
- Selected-byte write strobe timing.

Validated with:

```sh
pytest test/cores/test_async_sram.py -q
pytest test/cores/test_async_sram.py test/cores/test_ram.py -q
python3 -m py_compile litex/soc/cores/ram/async_sram.py test/cores/test_async_sram.py
git diff --check
```

Also checked standalone Verilog conversion of the new core.
