### PR TITLE
cpu/coreblocks: fix missing PLIC init in crt0

### DIFF
--- a/litex/soc/cores/cpu/coreblocks/crt0.S
+++ b/litex/soc/cores/cpu/coreblocks/crt0.S
@@ -28,8 +28,15 @@ reset_vector:
 	j 1b
 3:
 
+#ifdef __riscv_plic__
+    call plic_init
+    li t0, 0x800
+    csrw mie,t0
+#endif
+
 	call litex_startup_init
-	call main
+
+    call main
 
 1:	j 1b
 

--- a/litex/soc/cores/cpu/coreblocks/irq.h
+++ b/litex/soc/cores/cpu/coreblocks/irq.h
@@ -24,10 +24,10 @@ static inline void irq_setie(unsigned int ie)
 #ifdef __riscv_plic__
 
 #define PLIC_BASE    0xe2000000L // Base address and per-pin priority array
-#define PLIC_PENDING 0xe2001000L // Bit field matching currently pending pins
-#define PLIC_ENABLED 0xe2002000L // Bit field corresponding to the current mask
-#define PLIC_THRSHLD 0xe2200000L // Per-pin priority must be >= this to trigger
-#define PLIC_CLAIM   0xe2200004L // Claim & completion register address
+#define PLIC_PENDING (PLIC_BASE + 0x001000L) // Bit field matching currently pending pins
+#define PLIC_ENABLED (PLIC_BASE + 0x002000L) // Bit field corresponding to the current mask
+#define PLIC_THRSHLD (PLIC_BASE + 0x200000L) // Per-pin priority must be >= this to trigger
+#define PLIC_CLAIM   (PLIC_BASE + 0x200004L) // Claim & completion register address
 
 #define PLIC_EXT_IRQ_BASE 0
 


### PR DESCRIPTION
PLIC in coreblocks was not initialized, i missed one place when adding support for it.

Thought for other change - maybe it would be good to add a common `irq_init` common interface C function in `irq.h`? I'm not sure how useful that would be other CPUs.