### PR TITLE
software: Add common IRQ initialization hook

### DIFF
--- a/litex/soc/cores/cpu/coreblocks/crt0.S
+++ b/litex/soc/cores/cpu/coreblocks/crt0.S
@@ -29,14 +29,12 @@ reset_vector:
 3:
 
 #ifdef __riscv_plic__
-    call plic_init
-    li t0, 0x800
-    csrw mie,t0
+	call irq_init // initialize interrupt controller
 #endif
 
 	call litex_startup_init
 
-    call main
+	call main
 
 1:	j 1b
 

--- a/litex/soc/cores/cpu/coreblocks/crt0.S
+++ b/litex/soc/cores/cpu/coreblocks/crt0.S
@@ -28,10 +28,6 @@ reset_vector:
 	j 1b
 3:
 
-#ifdef __riscv_plic__
-	call irq_init // initialize interrupt controller
-#endif
-
 	call litex_startup_init
 
 	call main

--- a/litex/soc/cores/cpu/cva5/crt0.S
+++ b/litex/soc/cores/cpu/cva5/crt0.S
@@ -102,8 +102,6 @@ bss_loop:
   j bss_loop
 bss_done:
 
-  call irq_init // initialize interrupt controller
-
   call litex_startup_init
   call main
 infinit_loop:

--- a/litex/soc/cores/cpu/cva5/crt0.S
+++ b/litex/soc/cores/cpu/cva5/crt0.S
@@ -102,10 +102,7 @@ bss_loop:
   j bss_loop
 bss_done:
 
-  call plic_init // initialize external interrupt controller
-  li t0, 0x800   // external interrupt sources only (using LiteX timer);
-                 // NOTE: must still enable mstatus.MIE!
-  csrw mie,t0
+  call irq_init // initialize interrupt controller
 
   call litex_startup_init
   call main

--- a/litex/soc/cores/cpu/cva6/crt0.S
+++ b/litex/soc/cores/cpu/cva6/crt0.S
@@ -104,10 +104,7 @@ bss_loop:
   j bss_loop
 bss_done:
 
-  call plic_init // initialize external interrupt controller
-  li t0, 0x800   // external interrupt sources only (using LiteX timer);
-                 // NOTE: must still enable mstatus.MIE!
-  csrw mie,t0
+  call irq_init // initialize interrupt controller
 
   call litex_startup_init
   call main
@@ -225,10 +222,7 @@ bss_loop:
   j bss_loop
 bss_done:
 
-  call plic_init // initialize external interrupt controller
-  li t0, 0x800   // external interrupt sources only (using LiteX timer);
-                 // NOTE: must still enable mstatus.MIE!
-  csrw mie,t0
+  call irq_init // initialize interrupt controller
 
   call litex_startup_init
   call main

--- a/litex/soc/cores/cpu/cva6/crt0.S
+++ b/litex/soc/cores/cpu/cva6/crt0.S
@@ -104,8 +104,6 @@ bss_loop:
   j bss_loop
 bss_done:
 
-  call irq_init // initialize interrupt controller
-
   call litex_startup_init
   call main
 inf_loop:
@@ -221,8 +219,6 @@ bss_loop:
   add t0,t0,8
   j bss_loop
 bss_done:
-
-  call irq_init // initialize interrupt controller
 
   call litex_startup_init
   call main

--- a/litex/soc/cores/cpu/naxriscv/crt0.S
+++ b/litex/soc/cores/cpu/naxriscv/crt0.S
@@ -123,10 +123,7 @@ bss_loop:
   j bss_loop
 bss_done:
 
-  call plic_init // initialize external interrupt controller
-  li t0, 0x800   // external interrupt sources only (using LiteX timer);
-                 // NOTE: must still enable mstatus.MIE!
-  csrw mie,t0
+  call irq_init // initialize interrupt controller
 
   call litex_startup_init
   call main
@@ -138,4 +135,3 @@ infinit_loop:
   smp_lottery_target: .word 0
   smp_lottery_args:   .word 0; .word 0; .word 0
   smp_lottery_lock:   .word 0
-

--- a/litex/soc/cores/cpu/naxriscv/crt0.S
+++ b/litex/soc/cores/cpu/naxriscv/crt0.S
@@ -123,8 +123,6 @@ bss_loop:
   j bss_loop
 bss_done:
 
-  call irq_init // initialize interrupt controller
-
   call litex_startup_init
   call main
 infinit_loop:

--- a/litex/soc/cores/cpu/openc906/crt0.S
+++ b/litex/soc/cores/cpu/openc906/crt0.S
@@ -95,8 +95,6 @@ bss_loop:
   j bss_loop
 bss_done:
 
-  call irq_init // initialize interrupt controller
-
   call litex_startup_init
   call main
 inf_loop:

--- a/litex/soc/cores/cpu/openc906/crt0.S
+++ b/litex/soc/cores/cpu/openc906/crt0.S
@@ -95,10 +95,7 @@ bss_loop:
   j bss_loop
 bss_done:
 
-  call plic_init // initialize external interrupt controller
-  li t0, 0x800   // external interrupt sources only (using LiteX timer);
-                 // NOTE: must still enable mstatus.MIE!
-  csrw mie,t0
+  call irq_init // initialize interrupt controller
 
   call litex_startup_init
   call main

--- a/litex/soc/cores/cpu/rocket/crt0.S
+++ b/litex/soc/cores/cpu/rocket/crt0.S
@@ -102,8 +102,6 @@ bss_loop:
   j bss_loop
 bss_done:
 
-  call irq_init // initialize interrupt controller
-
   call litex_startup_init
   call main
 inf_loop:

--- a/litex/soc/cores/cpu/rocket/crt0.S
+++ b/litex/soc/cores/cpu/rocket/crt0.S
@@ -102,10 +102,7 @@ bss_loop:
   j bss_loop
 bss_done:
 
-  call plic_init // initialize external interrupt controller
-  li t0, 0x800   // external interrupt sources only (using LiteX timer);
-                 // NOTE: must still enable mstatus.MIE!
-  csrw mie,t0
+  call irq_init // initialize interrupt controller
 
   call litex_startup_init
   call main

--- a/litex/soc/cores/cpu/vexiiriscv/crt0.S
+++ b/litex/soc/cores/cpu/vexiiriscv/crt0.S
@@ -126,8 +126,6 @@ bss_loop:
   j bss_loop
 bss_done:
 
-  call irq_init // initialize interrupt controller
-
   call litex_startup_init
   call main
 infinit_loop:

--- a/litex/soc/cores/cpu/vexiiriscv/crt0.S
+++ b/litex/soc/cores/cpu/vexiiriscv/crt0.S
@@ -126,14 +126,7 @@ bss_loop:
   j bss_loop
 bss_done:
 
-  #if defined(__riscv_plic__)
-    call plic_init // initialize external interrupt controller
-  #else
-    call aplic_init // initialize external advanced i nterrupt controller
-  #endif
-  li t0, 0x800   // external interrupt sources only (using LiteX timer);
-                 // NOTE: must still enable mstatus.MIE!
-  csrw mie,t0
+  call irq_init // initialize interrupt controller
 
   call litex_startup_init
   call main

--- a/litex/soc/cores/cpu/vexriscv_smp/crt0.S
+++ b/litex/soc/cores/cpu/vexriscv_smp/crt0.S
@@ -102,10 +102,7 @@ bss_loop:
   j bss_loop
 bss_done:
 
-  call plic_init // initialize external interrupt controller
-  li t0, 0x800   // external interrupt sources only (using LiteX timer);
-                 // NOTE: must still enable mstatus.MIE!
-  csrw mie,t0
+  call irq_init // initialize interrupt controller
 
   call litex_startup_init
   call main
@@ -119,4 +116,3 @@ infinit_loop:
   smp_lottery_target: .word 0
   smp_lottery_args:   .word 0; .word 0; .word 0
   smp_lottery_lock:   .word 0
-

--- a/litex/soc/cores/cpu/vexriscv_smp/crt0.S
+++ b/litex/soc/cores/cpu/vexriscv_smp/crt0.S
@@ -102,8 +102,6 @@ bss_loop:
   j bss_loop
 bss_done:
 
-  call irq_init // initialize interrupt controller
-
   call litex_startup_init
   call main
 infinit_loop:

--- a/litex/soc/software/include/irq.h
+++ b/litex/soc/software/include/irq.h
@@ -7,6 +7,7 @@ typedef void (*isr_t)(void);
 extern "C" {
 #endif
 
+extern void irq_init(void);
 extern int irq_attach(unsigned int irq, isr_t isr) __attribute__((weak));
 extern int irq_detach(unsigned int irq) __attribute__((weak));
 

--- a/litex/soc/software/libbase/isr.c
+++ b/litex/soc/software/libbase/isr.c
@@ -33,10 +33,10 @@ void irq_init(void)
 {
 #if defined(CONFIG_CPU_HAS_INTERRUPT) && (defined(__riscv_plic__) || defined(__cva5__))
     plic_init();
-    csrw(mie, 0x800);
+    csrs(mie, 0x800);
 #elif defined(CONFIG_CPU_HAS_INTERRUPT) && defined(__riscv_aplic__)
     aplic_init();
-    csrw(mie, 0x800);
+    csrs(mie, 0x800);
 #endif
 }
 

--- a/litex/soc/software/libbase/isr.c
+++ b/litex/soc/software/libbase/isr.c
@@ -16,6 +16,30 @@ void isr_dec(void);
 void isr(void);
 #endif
 
+#if defined(CONFIG_CPU_HAS_INTERRUPT)
+#if defined(__riscv_plic__) || defined(__cva5__)
+void plic_init(void);
+#endif
+#if defined(__riscv_aplic__)
+void aplic_init(void);
+#endif
+#endif
+
+/*
+ * Initialize interrupt controllers/sources.
+ * Global interrupt enable remains controlled by irq_setie().
+ */
+void irq_init(void)
+{
+#if defined(CONFIG_CPU_HAS_INTERRUPT) && (defined(__riscv_plic__) || defined(__cva5__))
+    plic_init();
+    csrw(mie, 0x800);
+#elif defined(CONFIG_CPU_HAS_INTERRUPT) && defined(__riscv_aplic__)
+    aplic_init();
+    csrw(mie, 0x800);
+#endif
+}
+
 #ifdef CONFIG_CPU_HAS_INTERRUPT
 
 /*******************************************************/
@@ -49,8 +73,6 @@ int irq_detach(unsigned int irq)
 /* ISR and PLIC Initialization for RISC-V PLIC-based CPUs. */
 /***********************************************************/
 #if defined(__riscv_plic__)
-
-void plic_init(void);
 
 /* PLIC initialization. */
 void plic_init(void)
@@ -262,33 +284,8 @@ void isr_dec(void)
 /***********************************/
 #elif defined(__cva5__)
 
-void plic_init(void);
-
 void plic_init(void)
 {
-}
-struct irq_table
-{
-	isr_t isr;
-} irq_table[CONFIG_CPU_INTERRUPTS];
-
-int irq_attach(unsigned int irq, isr_t isr)
-{
-	if (irq >= CONFIG_CPU_INTERRUPTS) {
-		printf("Inv irq %d\n", irq);
-		return -1;
-	}
-
-	unsigned int ie = irq_getie();
-	irq_setie(0);
-	irq_table[irq].isr = isr;
-	irq_setie(ie);
-	return irq;
-}
-
-int irq_detach(unsigned int irq)
-{
-	return irq_attach(irq, NULL);
 }
 
 void isr(void)

--- a/litex/soc/software/libbase/startup.c
+++ b/litex/soc/software/libbase/startup.c
@@ -1,4 +1,5 @@
 #include <startup.h>
+#include <irq.h>
 
 typedef void (*init_func)(void);
 
@@ -15,6 +16,8 @@ static void call_init_array(init_func const *start, init_func const *end)
 
 void litex_startup_init(void)
 {
+	irq_init();
+
 	call_init_array(__preinit_array_start, __preinit_array_end);
 	call_init_array(__init_array_start, __init_array_end);
 }


### PR DESCRIPTION
This adds a common `irq_init()` libbase entry point for CPU startup code that needs to initialize interrupt-controller state.

Changes:
- Declare `irq_init()` in the shared `irq.h` wrapper.
- Move the RISC-V PLIC/APLIC startup setup behind `irq_init()`.
- Keep global interrupt enable controlled by `irq_setie()`.
- Drop CVA5's duplicate IRQ table/attach/detach definitions so it uses the common libbase table.

Validation:
- `git diff --check`
- `riscv64-unknown-elf-gcc` compiled `isr.c` for the touched PLIC paths.
- `riscv64-unknown-elf-gcc` compiled `isr.c` for VexiiRiscv APLIC and CVA5 non-PLIC.
- `riscv64-unknown-elf-gcc` assembled the touched `crt0.S` files.
