### PR TITLE
build/gowin: support Windows Gowin from WSL

### DIFF
--- a/litex/build/gowin/gowin.py
+++ b/litex/build/gowin/gowin.py
@@ -18,6 +18,48 @@ from litex.build.generic_toolchain import GenericToolchain
 from litex.build.generic_platform import *
 from litex.build import tools
 
+# WSL Helpers --------------------------------------------------------------------------------------
+
+def _is_wsl():
+    if sys.platform != "linux":
+        return False
+    release = platform.release().lower()
+    return "microsoft" in release or "wsl" in release
+
+def _find_gowin_shell():
+    gw_sh      = "gw_sh"
+    gw_sh_path = which(gw_sh)
+
+    # On WSL, prefer native Linux Gowin when available but allow falling back to
+    # the Windows Gowin executable exposed through PATH.
+    if gw_sh_path is None and _is_wsl():
+        gw_sh      = "gw_sh.exe"
+        gw_sh_path = which(gw_sh)
+
+    return gw_sh, gw_sh_path
+
+def _gowin_uses_windows_paths():
+    if not _is_wsl():
+        return False
+
+    _, gw_sh_path = _find_gowin_shell()
+    if gw_sh_path is None:
+        return False
+
+    return os.path.basename(os.path.realpath(gw_sh_path)).lower().endswith(".exe")
+
+def _gowin_tcl_path(path, use_windows_paths=False):
+    if use_windows_paths and os.path.isabs(path):
+        path = subprocess.check_output(
+            ["wslpath", "-w", path],
+            universal_newlines=True
+        ).strip()
+
+    if sys.platform == "win32" or use_windows_paths:
+        path = path.replace("\\", "\\\\")
+
+    return path
+
 # Constraints (.cst) -------------------------------------------------------------------------------
 
 def _is_differential_iostandard(iostandard):
@@ -97,7 +139,12 @@ class GowinToolchain(GenericToolchain):
 
     def finalize(self):
         if self.platform.verilog_include_paths:
-            self.options["include_path"] = "{" + ";".join(self.platform.verilog_include_paths) + "}"
+            use_windows_paths = _gowin_uses_windows_paths()
+            include_paths = [
+                _gowin_tcl_path(p, use_windows_paths=use_windows_paths)
+                for p in self.platform.verilog_include_paths
+            ]
+            self.options["include_path"] = "{" + ";".join(include_paths) + "}"
 
         self.apply_hyperram_integration_hack(self._build_name + ".v")
 
@@ -164,11 +211,11 @@ class GowinToolchain(GenericToolchain):
         # Add Timings Constraints.
         tcl.append(f"add_file {self._build_name}.sdc")
 
+        use_windows_paths = _gowin_uses_windows_paths()
+
         # Add Sources.
         for f, typ, lib, *_ in self.platform.sources:
-            # Support windows/powershell
-            if sys.platform == "win32":
-                f = f.replace("\\", "\\\\")
+            f = _gowin_tcl_path(f, use_windows_paths=use_windows_paths)
             tcl.append(f"add_file {f}")
 
         # Set Options.
@@ -191,11 +238,7 @@ class GowinToolchain(GenericToolchain):
         return "" # gw_sh use
 
     def run_script(self, script):
-        # Support Powershell/WSL platform
-        # Some python distros for windows (e.g, oss-cad-suite)
-        # which does not have 'os.uname' support, we should check 'sys.platform' firstly.
-        gw_sh      = "gw_sh"
-        gw_sh_path = which(gw_sh)
+        gw_sh, gw_sh_path = _find_gowin_shell()
 
         if gw_sh_path is None:
             msg = "Unable to find Gowin toolchain, please:\n"

--- a/test/build/test_gowin_toolchain.py
+++ b/test/build/test_gowin_toolchain.py
@@ -1,0 +1,64 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+from unittest import mock
+
+from litex.build.gowin import gowin
+
+
+class TestGowinToolchain(unittest.TestCase):
+    def test_wsl_prefers_native_gowin(self):
+        def which(tool):
+            return {
+                "gw_sh"     : "/opt/gowin/IDE/bin/gw_sh",
+                "gw_sh.exe" : "/mnt/c/Gowin/IDE/bin/gw_sh.exe",
+            }.get(tool)
+
+        with mock.patch.object(gowin, "_is_wsl", return_value=True), \
+             mock.patch.object(gowin, "which", side_effect=which):
+            gw_sh, gw_sh_path = gowin._find_gowin_shell()
+
+            self.assertEqual(gw_sh, "gw_sh")
+            self.assertEqual(gw_sh_path, "/opt/gowin/IDE/bin/gw_sh")
+            self.assertFalse(gowin._gowin_uses_windows_paths())
+
+    def test_wsl_falls_back_to_windows_gowin(self):
+        def which(tool):
+            return {
+                "gw_sh"     : None,
+                "gw_sh.exe" : "/mnt/c/Gowin/IDE/bin/gw_sh.exe",
+            }.get(tool)
+
+        with mock.patch.object(gowin, "_is_wsl", return_value=True), \
+             mock.patch.object(gowin, "which", side_effect=which):
+            gw_sh, gw_sh_path = gowin._find_gowin_shell()
+
+            self.assertEqual(gw_sh, "gw_sh.exe")
+            self.assertEqual(gw_sh_path, "/mnt/c/Gowin/IDE/bin/gw_sh.exe")
+            self.assertTrue(gowin._gowin_uses_windows_paths())
+
+    def test_wsl_windows_paths_use_wslpath_and_escape_backslashes(self):
+        with mock.patch.object(gowin.subprocess, "check_output", return_value="C:\\proj\\top.v\n"):
+            path = gowin._gowin_tcl_path("/mnt/c/proj/top.v", use_windows_paths=True)
+
+        self.assertEqual(path, "C:\\\\proj\\\\top.v")
+
+    def test_wsl_windows_paths_keep_relative_paths(self):
+        with mock.patch.object(gowin.subprocess, "check_output") as check_output:
+            path = gowin._gowin_tcl_path("top.v", use_windows_paths=True)
+
+        self.assertEqual(path, "top.v")
+        check_output.assert_not_called()
+
+    def test_native_wsl_paths_are_not_rewritten(self):
+        path = gowin._gowin_tcl_path("/mnt/c/proj/top.v", use_windows_paths=False)
+
+        self.assertEqual(path, "/mnt/c/proj/top.v")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This adds targeted WSL support for running the Windows Gowin executable from LiteX.

The toolchain now:

- keeps the native Linux `gw_sh` as the preferred executable on WSL;
- falls back to `gw_sh.exe` only when native `gw_sh` is not available;
- converts source/include paths to Windows paths only when the selected Gowin executable is Windows-side;
- leaves native Linux Gowin paths unchanged.

This avoids applying `/mnt/...` to `C:\...` rewriting for every WSL user, while still supporting setups where Windows Gowin is exposed through the WSL `PATH`.

Tests:

- `python3 -m py_compile litex/build/gowin/gowin.py test/build/test_gowin_toolchain.py`
- `pytest -q test/build/test_gowin_toolchain.py`
- `git diff --check`

Follow-up to #1858 and replacement for #2151.
