### PR TITLE
soc/uart: add shared UARTBone mux

### DIFF
--- a/litex/soc/cores/uart.py
+++ b/litex/soc/cores/uart.py
@@ -181,6 +181,33 @@ class RS232PHYMultiplexer(LiteXModule):
         self.comb += Case(self.sel, cases)
 
 
+class UARTSharedPHY(LiteXModule):
+    def __init__(self, phy, uartbone):
+        self.phy          = phy
+        self.uart         = UARTInterface()
+        self.uartbone     = UARTInterface()
+
+        # # #
+
+        self.comb += If(uartbone,
+            # UARTBone Mode: External PHY <-> UARTBone.
+            phy.source.connect(self.uartbone.source),
+            self.uartbone.sink.connect(phy.sink),
+
+            # Regular UART path inactive.
+            self.uart.source.valid.eq(0),
+            self.uart.sink.ready.eq(1),
+        ).Else(
+            # UART Mode: External PHY <-> CPU UART.
+            phy.source.connect(self.uart.source),
+            self.uart.sink.connect(phy.sink),
+
+            # UARTBone PHY path inactive.
+            self.uartbone.source.valid.eq(0),
+            self.uartbone.sink.ready.eq(1),
+        )
+
+
 class RS232PHYModel(LiteXModule):
     def __init__(self, pads):
         self.sink   = stream.Endpoint([("data", 8)])
@@ -496,15 +523,42 @@ class UARTCrossover(UART):
     Creates a fully compatible UART that can be used by the CPU as a regular UART and adds a second
     UART, cross-connected to the main one to allow terminal emulation over a Wishbone bridge.
     """
-    def __init__(self, **kwargs):
-        if kwargs.get("phy", None) is not None:
+    def __init__(self, phy=None, with_uartbone_mux=False, **kwargs):
+        if (phy is not None) and not with_uartbone_mux:
             raise ValueError("UARTCrossover does not support a custom PHY.")
+        if with_uartbone_mux and (phy is None):
+            raise ValueError("UARTCrossover UARTBone mux requires a PHY.")
         UART.__init__(self, **kwargs)
         self.xover = UART(tx_fifo_depth=1, rx_fifo_depth=16, rx_fifo_rx_we=True)
-        self.comb += [
-            self.source.connect(self.xover.sink),
-            self.xover.source.connect(self.sink)
-        ]
+
+        if with_uartbone_mux:
+            self._uartbone = CSRStorage(fields=[
+                CSRField("enable", offset=0, size=1, reset=1,
+                    description="Enable UARTBone mode on shared serial pins.",
+                    values=[
+                        ("``0b0``", "UART mode."),
+                        ("``0b1``", "UARTBone mode."),
+                    ]),
+            ], name="uartbone")
+            self.shared_phy   = UARTSharedPHY(phy, self._uartbone.fields.enable)
+            self.uartbone_phy = self.shared_phy.uartbone
+
+            self.comb += If(self._uartbone.fields.enable,
+                self.source.connect(self.xover.sink),
+                self.xover.source.connect(self.sink),
+            ).Else(
+                self.source.connect(self.shared_phy.uart.sink),
+                self.shared_phy.uart.source.connect(self.sink),
+
+                # Drain inactive UARTBone-side streams to avoid stale data when switching modes.
+                self.xover.source.ready.eq(1),
+                self.xover.sink.valid.eq(0),
+            )
+        else:
+            self.comb += [
+                self.source.connect(self.xover.sink),
+                self.xover.source.connect(self.sink)
+            ]
 
 def get_uart_core(
     uart_name,
@@ -515,6 +569,7 @@ def get_uart_core(
     fifo_depth            = 16,
     with_dynamic_baudrate = False,
     rx_fifo_rx_we         = False,
+    with_uartbone_mux     = False,
 ):
     uart_kwargs = {
         "tx_fifo_depth": fifo_depth,
@@ -524,6 +579,21 @@ def get_uart_core(
 
     # Crossover.
     if uart_name in ["crossover", "crossover+uartbone"]:
+        if with_uartbone_mux:
+            if uart_pads is None:
+                raise ValueError("pads are required for UARTBone UART mux.")
+            if clk_freq is None:
+                raise ValueError("clk_freq is required for UARTBone UART mux.")
+            uart_phy = UARTPHY(
+                uart_pads,
+                clk_freq              = clk_freq,
+                baudrate              = baudrate,
+                with_dynamic_baudrate = with_dynamic_baudrate,
+            )
+            return UARTCrossover(
+                phy               = uart_phy,
+                with_uartbone_mux = True,
+                **uart_kwargs)
         return UARTCrossover(**uart_kwargs)
 
     # JTAG UART.

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -2160,7 +2160,8 @@ class LiteXSoC(SoC):
         return super().__getattr__(name)
 
     # Add UART -------------------------------------------------------------------------------------
-    def add_uart(self, name="uart", uart_name="serial", uart_pads=None, baudrate=115200, fifo_depth=16, with_dynamic_baudrate=False, rx_fifo_rx_we=False):
+    def add_uart(self, name="uart", uart_name="serial", uart_pads=None, baudrate=115200, fifo_depth=16, with_dynamic_baudrate=False, rx_fifo_rx_we=False,
+        with_uartbone_mux=False):
         # Imports.
         from litex.soc.cores import uart
 
@@ -2178,7 +2179,7 @@ class LiteXSoC(SoC):
         self.check_if_exists(name)
         supported_uarts = uart.get_uart_supported_names()
         if uart_pads is None:
-            uart_pads_name = "serial" if uart_name == "sim" else uart_name
+            uart_pads_name = "serial" if (uart_name == "sim") or with_uartbone_mux else uart_name
             uart_pads      = self.platform.request(uart_pads_name, loose=True)
             if (uart_pads is None) and (uart_name == "usb_acm"):
                 uart_pads = self.platform.request("usb")
@@ -2188,6 +2189,15 @@ class LiteXSoC(SoC):
                 colorer("not supported/found on board", color="red"),
                 colorer("- " + "\n- ".join(supported_uarts))))
             raise SoCError()
+        if with_uartbone_mux:
+            if uart_name != "crossover":
+                self.logger.error("UARTBone UART mux requires {} UART.".format(
+                    colorer("crossover", color="red")))
+                raise SoCError()
+            if uart_pads is None:
+                self.logger.error("UARTBone UART mux requires {} pads.".format(
+                    colorer("serial", color="red")))
+                raise SoCError()
 
         # UARTBone.
         if uart_name in ["uartbone", "crossover+uartbone"]:
@@ -2202,6 +2212,7 @@ class LiteXSoC(SoC):
             fifo_depth             = fifo_depth,
             with_dynamic_baudrate  = with_dynamic_baudrate,
             rx_fifo_rx_we          = rx_fifo_rx_we,
+            with_uartbone_mux      = with_uartbone_mux,
         )
 
         # No UART Core (e.g. pure "uartbone"): don't allocate an IRQ/Configs for a UART that does
@@ -2211,6 +2222,11 @@ class LiteXSoC(SoC):
 
         # Add UART.
         self.add_module(name=name, module=uart_core)
+        if with_uartbone_mux:
+            self.add_uartbone(
+                name = "uartbone",
+                phy  = uart_core.uartbone_phy,
+            )
 
         if rx_fifo_rx_we:
             self.add_config(f"{name}_RX_FIFO_RX_WE", 1)
@@ -2222,7 +2238,7 @@ class LiteXSoC(SoC):
             self.add_constant("UART_POLLING", check_duplicate=False)
 
     # Add UARTBone ---------------------------------------------------------------------------------
-    def add_uartbone(self, name="uartbone", uart_name="serial", clk_freq=None, baudrate=115200, cd="sys", with_dynamic_baudrate=False):
+    def add_uartbone(self, name="uartbone", uart_name="serial", clk_freq=None, baudrate=115200, cd="sys", with_dynamic_baudrate=False, phy=None):
         if clk_freq is None:
             clk_freq = self.sys_clk_freq
         if clk_freq <= 0:
@@ -2239,7 +2255,9 @@ class LiteXSoC(SoC):
 
         # Core.
         self.check_if_exists(name)
-        uartbone_phy = uart.UARTPHY(self.platform.request(uart_name), clk_freq, baudrate, with_dynamic_baudrate=with_dynamic_baudrate)
+        uartbone_phy = phy
+        if uartbone_phy is None:
+            uartbone_phy = uart.UARTPHY(self.platform.request(uart_name), clk_freq, baudrate, with_dynamic_baudrate=with_dynamic_baudrate)
         uartbone     = uart.UARTBone(
             phy           = uartbone_phy,
             clk_freq      = clk_freq,
@@ -3735,11 +3753,13 @@ class SoCCore(LiteXSoC):
                 with_build_time = ident_version,
             )
 
+        # Share serial pads when UARTBone and the regular UART are both enabled.
+        with_uartbone_uart_mux = with_uartbone and with_uart and (uart_name in ["serial", "crossover"])
+        if with_uartbone_uart_mux:
+            uart_name = "crossover"
+
         # Add UARTBone.
-        if with_uartbone:
-            if uart_name == "serial":
-                self.logger.error("UARTBone cannot be used with default serial UART.")
-                raise SoCError()
+        if with_uartbone and not with_uartbone_uart_mux:
             self.add_uartbone(name="uartbone",
                 baudrate              = uart_baudrate,
                 with_dynamic_baudrate = uart_with_dynamic_baudrate,
@@ -3753,7 +3773,8 @@ class SoCCore(LiteXSoC):
                 baudrate              = uart_baudrate,
                 fifo_depth            = uart_fifo_depth,
                 with_dynamic_baudrate = uart_with_dynamic_baudrate,
-                rx_fifo_rx_we         = uart_rx_fifo_rx_we,
+                rx_fifo_rx_we          = uart_rx_fifo_rx_we,
+                with_uartbone_mux      = with_uartbone_uart_mux,
             )
 
         # Add JTAGBone.

--- a/litex/soc/software/bios/cmds/cmd_bios.c
+++ b/litex/soc/software/bios/cmds/cmd_bios.c
@@ -5,6 +5,7 @@
 #include <system.h>
 
 #include <libbase/crc.h>
+#include <libbase/uart.h>
 
 #include <generated/csr.h>
 
@@ -187,6 +188,28 @@ static void leds_handler(int nb_params, char **params)
 }
 
 define_command(leds, leds_handler, "Set LEDs value", SYSTEM_CMDS);
+#endif
+
+/**
+ * Command "uartbone"
+ *
+ * Switch shared serial pins back to UARTBone
+ *
+ */
+#ifdef CSR_UART_UARTBONE_ADDR
+static void uartbone_handler(int nb_params, char **params)
+{
+	(void)nb_params;
+	(void)params;
+
+	printf("Switching serial port to UARTBone.\n");
+	/* Let the message leave the UART before disconnecting the console. */
+	uart_sync();
+	while(!uart_txempty_read());
+	uart_uartbone_write(1);
+}
+
+define_command(uartbone, uartbone_handler, "Switch serial port to UARTBone", SYSTEM_CMDS);
 #endif
 
 /**

--- a/test/cores/test_uart.py
+++ b/test/cores/test_uart.py
@@ -13,6 +13,8 @@ from litex.gen import *
 from litex.soc.cores.uart import (
     UART,
     UARTCrossover,
+    UARTInterface,
+    UARTSharedPHY,
     UARTPads,
     RS232PHY,
     get_uart_core,
@@ -43,6 +45,25 @@ class TestUART(unittest.TestCase):
         uart = get_uart_core("crossover", fifo_depth=8, rx_fifo_rx_we=True)
 
         self.assertIsInstance(uart, UARTCrossover)
+
+    def test_get_uart_core_builds_uartbone_mux_crossover(self):
+        uart = get_uart_core(
+            "crossover",
+            uart_pads                 = UARTPads(),
+            clk_freq                  = 1_000_000,
+            fifo_depth                = 8,
+            with_uartbone_mux         = True,
+        )
+
+        self.assertIsInstance(uart, UARTCrossover)
+        self.assertTrue(hasattr(uart, "uartbone_phy"))
+        self.assertTrue(hasattr(uart, "_uartbone"))
+
+    def test_get_uart_core_validates_uartbone_mux_dependencies(self):
+        with self.assertRaisesRegex(ValueError, "pads"):
+            get_uart_core("crossover", clk_freq=1_000_000, with_uartbone_mux=True)
+        with self.assertRaisesRegex(ValueError, "clk_freq"):
+            get_uart_core("crossover", uart_pads=UARTPads(), with_uartbone_mux=True)
 
     def test_get_uart_core_builds_regular_uart(self):
         uart = get_uart_core("serial", uart_pads=UARTPads(), clk_freq=1_000_000)
@@ -108,6 +129,52 @@ class TestUART(unittest.TestCase):
             for _ in range(2_000):
                 yield
                 self.assertEqual((yield dut.phy.source.valid), 0)
+        run_simulation(dut, gen(dut))
+
+    def test_uart_shared_phy_routes_selected_mode(self):
+        class DUT(LiteXModule):
+            def __init__(self):
+                self.uartbone = Signal(reset=1)
+                self.phy      = UARTInterface()
+                self.shared   = UARTSharedPHY(self.phy, self.uartbone)
+
+        dut = DUT()
+
+        def gen(dut):
+            # UARTBone Mode: external PHY <-> UARTBone.
+            yield dut.uartbone.eq(1)
+            yield dut.phy.source.valid.eq(1)
+            yield dut.phy.source.data.eq(0x12)
+            yield dut.shared.uartbone.source.ready.eq(1)
+            yield dut.shared.uartbone.sink.valid.eq(1)
+            yield dut.shared.uartbone.sink.data.eq(0x34)
+            yield dut.phy.sink.ready.eq(1)
+            yield
+            self.assertEqual((yield dut.shared.uartbone.source.valid), 1)
+            self.assertEqual((yield dut.shared.uartbone.source.data),  0x12)
+            self.assertEqual((yield dut.phy.source.ready),             1)
+            self.assertEqual((yield dut.phy.sink.valid),               1)
+            self.assertEqual((yield dut.phy.sink.data),                0x34)
+            self.assertEqual((yield dut.shared.uart.source.valid),     0)
+            self.assertEqual((yield dut.shared.uart.sink.ready),       1)
+
+            # UART Mode: external PHY <-> CPU UART.
+            yield dut.uartbone.eq(0)
+            yield dut.phy.source.valid.eq(1)
+            yield dut.phy.source.data.eq(0x56)
+            yield dut.shared.uart.source.ready.eq(1)
+            yield dut.shared.uart.sink.valid.eq(1)
+            yield dut.shared.uart.sink.data.eq(0x78)
+            yield dut.phy.sink.ready.eq(1)
+            yield
+            self.assertEqual((yield dut.shared.uart.source.valid),     1)
+            self.assertEqual((yield dut.shared.uart.source.data),      0x56)
+            self.assertEqual((yield dut.phy.source.ready),             1)
+            self.assertEqual((yield dut.phy.sink.valid),               1)
+            self.assertEqual((yield dut.phy.sink.data),                0x78)
+            self.assertEqual((yield dut.shared.uartbone.source.valid), 0)
+            self.assertEqual((yield dut.shared.uartbone.sink.ready),   1)
+
         run_simulation(dut, gen(dut))
 
     def test_long_burst_stable(self):

--- a/test/soc/test_soc.py
+++ b/test/soc/test_soc.py
@@ -17,6 +17,7 @@ from migen import ClockDomain, Record, Signal
 from migen.sim import run_simulation
 
 from litex.soc.cores.hyperbus import HyperRAM
+from litex.soc.cores.uart import UARTPads
 from litex.soc.cores.video import video_framebuffer_size
 from litex.soc.interconnect import axi, wishbone
 
@@ -1308,6 +1309,40 @@ class TestSoC(unittest.TestCase):
 
         with _assert_raises_soc_error(self):
             soc.add_uartbone(baudrate=0)
+
+    def test_uartbone_uart_mux_adds_uart_and_uartbone(self):
+        platform = _FakePlatform()
+        platform.requests["serial"] = UARTPads()
+        soc = LiteXSoC(platform, sys_clk_freq=1e6)
+
+        soc.add_uart(uart_name="crossover", with_uartbone_mux=True)
+
+        self.assertTrue(hasattr(soc, "uart"))
+        self.assertTrue(hasattr(soc, "uartbone"))
+        self.assertTrue(hasattr(soc.uart, "uartbone_phy"))
+
+    def test_uartbone_uart_mux_requires_crossover_uart(self):
+        platform = _FakePlatform()
+        platform.requests["serial"] = UARTPads()
+        soc = LiteXSoC(platform, sys_clk_freq=1e6)
+
+        with _assert_raises_soc_error(self):
+            soc.add_uart(uart_name="serial", with_uartbone_mux=True)
+
+    def test_soc_core_uartbone_with_default_uart_uses_mux(self):
+        platform = _FakePlatform()
+        platform.requests["serial"] = UARTPads()
+        soc = SoCCore(platform,
+            clk_freq           = 1e6,
+            cpu_type           = "None",
+            with_ctrl          = False,
+            with_timer         = False,
+            with_uartbone      = True,
+        )
+
+        self.assertTrue(hasattr(soc, "uart"))
+        self.assertTrue(hasattr(soc, "uartbone"))
+        self.assertTrue(hasattr(soc.uart, "uartbone_phy"))
 
     def test_spi_sdcard_rejects_invalid_clock_before_imports(self):
         soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)


### PR DESCRIPTION
This adds a shared serial PHY mux for SoCs that enable UARTBone together with the regular UART.

When UARTBone and the serial/crossover UART are both selected, SoCCore now uses the mux automatically and the selector resets to UARTBone mode. The UART `uartbone` CSR selects whether the shared serial pins are connected to UARTBone or directly to the CPU UART, and the BIOS `uartbone` command switches the pins back to UARTBone from the regular UART console.

This addresses the UARTBone/normal UART sharing use-case from #1959 and is based on the original mux idea proposed by Joshua Wise (@jwise).

Tests:
- `python3 -m py_compile litex/soc/cores/uart.py litex/soc/integration/soc.py test/cores/test_uart.py test/soc/test_soc.py`
- `pytest -q test/cores/test_uart.py test/soc/test_soc.py test/software/test_bios_console.py`
- host `gcc` compile-check for `cmd_bios.c` with UARTBone CSR stubs
