### PR TITLE
soc/uart: add automatic TX/RX swap detection

### DIFF
--- a/litex/soc/cores/uart.py
+++ b/litex/soc/cores/uart.py
@@ -12,6 +12,7 @@ from math import log2
 from migen import *
 from migen.genlib.record import Record
 from migen.genlib.cdc import MultiReg
+from migen.fhdl.specials import Tristate
 
 from litex.gen import *
 from litex.gen.genlib.misc import WaitTimer
@@ -163,6 +164,103 @@ class RS232PHY(LiteXModule):
         self.sink, self.source = self.tx.sink, self.rx.source
 
 
+class RS232PHYAutoSwap(LiteXModule):
+    def __init__(self, pads, clk_freq, baudrate=115200, with_dynamic_baudrate=False):
+        self.sink   = stream.Endpoint([("data", 8)])
+        self.source = stream.Endpoint([("data", 8)])
+
+        self.locked = Signal()
+        self.swap   = Signal()
+
+        # # #
+
+        tuning_word = int((baudrate/clk_freq)*2**32)
+        if with_dynamic_baudrate:
+            self._tuning_word  = CSRStorage(
+                32,
+                reset=tuning_word,
+                name="tuning_word",
+                description="UART baudrate tuning word.",
+            )
+            tuning_word = self._tuning_word.storage
+
+        tx_o  = Signal(reset=RS232_IDLE)
+        tx_oe = Signal()
+        rx_o  = Signal(reset=RS232_IDLE)
+        rx_oe = Signal()
+        tx_i  = self._add_tristate(pads.tx, tx_o, tx_oe)
+        rx_i  = self._add_tristate(pads.rx, rx_o, rx_oe)
+
+        tx_pads = Record([("tx", 1)])
+        self.comb += tx_o.eq(tx_pads.tx)
+        self.tx = RS232PHYTX(tx_pads, tuning_word)
+
+        rx_on_tx_pads = Record([("rx", 1)])
+        rx_on_rx_pads = Record([("rx", 1)])
+        self.comb += [
+            rx_on_tx_pads.rx.eq(tx_i),
+            rx_on_rx_pads.rx.eq(rx_i),
+        ]
+        self.rx_on_tx = RS232PHYRX(rx_on_tx_pads, tuning_word)
+        self.rx_on_rx = RS232PHYRX(rx_on_rx_pads, tuning_word)
+
+        # Lock the direction from the first valid RX frame and drive the opposite pad.
+        self.sync += If(~self.locked,
+            If(self.rx_on_rx.source.valid,
+                self.locked.eq(1),
+                self.swap.eq(0),
+            ).Elif(self.rx_on_tx.source.valid,
+                self.locked.eq(1),
+                self.swap.eq(1),
+            )
+        )
+
+        self.comb += [
+            tx_oe.eq(self.locked & ~self.swap),
+            rx_oe.eq(self.locked &  self.swap),
+            rx_o.eq(tx_o),
+        ]
+
+        # Drop core TX until the direction is known. This avoids firmware stalls and stale boot
+        # output replay after the line locks.
+        self.comb += If(self.locked,
+            self.sink.connect(self.tx.sink),
+        ).Else(
+            self.sink.ready.eq(1),
+            self.tx.sink.valid.eq(0),
+        )
+
+        self.comb += If(self.locked,
+            If(self.swap,
+                self.rx_on_tx.source.connect(self.source),
+                self.rx_on_rx.source.ready.eq(1),
+            ).Else(
+                self.rx_on_rx.source.connect(self.source),
+                self.rx_on_tx.source.ready.eq(1),
+            )
+        ).Else(
+            If(self.rx_on_rx.source.valid,
+                self.rx_on_rx.source.connect(self.source),
+                self.rx_on_tx.source.ready.eq(1),
+            ).Else(
+                self.rx_on_tx.source.connect(self.source),
+                self.rx_on_rx.source.ready.eq(1),
+            )
+        )
+
+    def _add_tristate(self, pad, o, oe):
+        if hasattr(pad, "o") and hasattr(pad, "oe") and hasattr(pad, "i"):
+            self.comb += [
+                pad.o.eq(o),
+                pad.oe.eq(oe),
+            ]
+            return pad.i
+        else:
+            i = Signal(reset=RS232_IDLE)
+            self.specials += Tristate(pad, o=o, oe=oe, i=i)
+            return i
+
+
 class RS232PHYMultiplexer(LiteXModule):
     def __init__(self, phys, phy):
         self.sel = Signal(max=len(phys))
@@ -220,14 +318,17 @@ def _get_uart_fifo(depth, sink_cd="sys", source_cd="sys"):
     else:
         return stream.SyncFIFO([("data", 8)], depth, buffered=True)
 
-def UARTPHY(pads, clk_freq, baudrate, with_dynamic_baudrate=False):
+def UARTPHY(pads, clk_freq, baudrate, with_dynamic_baudrate=False, with_auto_swap=False):
     # FT245 Asynchronous FIFO mode (baudrate ignored)
     if hasattr(pads, "rd_n") and hasattr(pads, "wr_n"):
+        if with_auto_swap:
+            raise ValueError("UART auto-swap requires RS232 pads.")
         from litex.soc.cores.usb_fifo import FT245PHYAsynchronous
         return FT245PHYAsynchronous(pads, clk_freq)
     # RS232
     else:
-        return  RS232PHY(pads, clk_freq, baudrate, with_dynamic_baudrate=with_dynamic_baudrate)
+        phy_cls = RS232PHYAutoSwap if with_auto_swap else RS232PHY
+        return  phy_cls(pads, clk_freq, baudrate, with_dynamic_baudrate=with_dynamic_baudrate)
 
 class UART(LiteXModule, UARTInterface):
     def __init__(self, phy=None,
@@ -515,12 +616,16 @@ def get_uart_core(
     fifo_depth            = 16,
     with_dynamic_baudrate = False,
     rx_fifo_rx_we         = False,
+    with_auto_swap        = False,
 ):
     uart_kwargs = {
         "tx_fifo_depth": fifo_depth,
         "rx_fifo_depth": fifo_depth,
         "rx_fifo_rx_we": rx_fifo_rx_we,
     }
+
+    if with_auto_swap and (uart_name in supported_uarts):
+        raise ValueError("UART auto-swap is only supported on serial UARTs.")
 
     # Crossover.
     if uart_name in ["crossover", "crossover+uartbone"]:
@@ -573,5 +678,6 @@ def get_uart_core(
         clk_freq              = clk_freq,
         baudrate              = baudrate,
         with_dynamic_baudrate = with_dynamic_baudrate,
+        with_auto_swap        = with_auto_swap,
     )
     return UART(uart_phy, **uart_kwargs)

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -2160,7 +2160,8 @@ class LiteXSoC(SoC):
         return super().__getattr__(name)
 
     # Add UART -------------------------------------------------------------------------------------
-    def add_uart(self, name="uart", uart_name="serial", uart_pads=None, baudrate=115200, fifo_depth=16, with_dynamic_baudrate=False, rx_fifo_rx_we=False):
+    def add_uart(self, name="uart", uart_name="serial", uart_pads=None, baudrate=115200, fifo_depth=16, with_dynamic_baudrate=False, rx_fifo_rx_we=False,
+        with_auto_swap=False):
         # Imports.
         from litex.soc.cores import uart
 
@@ -2188,6 +2189,10 @@ class LiteXSoC(SoC):
                 colorer("not supported/found on board", color="red"),
                 colorer("- " + "\n- ".join(supported_uarts))))
             raise SoCError()
+        if with_auto_swap and (uart_name in supported_uarts):
+            self.logger.error("UART auto-swap requires {} UART.".format(
+                colorer("serial", color="red")))
+            raise SoCError()
 
         # UARTBone.
         if uart_name in ["uartbone", "crossover+uartbone"]:
@@ -2202,6 +2207,7 @@ class LiteXSoC(SoC):
             fifo_depth             = fifo_depth,
             with_dynamic_baudrate  = with_dynamic_baudrate,
             rx_fifo_rx_we          = rx_fifo_rx_we,
+            with_auto_swap         = with_auto_swap,
         )
 
         # No UART Core (e.g. pure "uartbone"): don't allocate an IRQ/Configs for a UART that does
@@ -3583,6 +3589,7 @@ class SoCCore(LiteXSoC):
         uart_pads                  = None,
         uart_with_dynamic_baudrate = False,
         uart_rx_fifo_rx_we         = False,
+        uart_auto_swap             = False,
 
         # Timer parameters.
         with_timer                 = True,
@@ -3754,6 +3761,7 @@ class SoCCore(LiteXSoC):
                 fifo_depth            = uart_fifo_depth,
                 with_dynamic_baudrate = uart_with_dynamic_baudrate,
                 rx_fifo_rx_we         = uart_rx_fifo_rx_we,
+                with_auto_swap        = uart_auto_swap,
             )
 
         # Add JTAGBone.
@@ -3857,6 +3865,7 @@ def soc_core_args(parser, cpu_type="vexriscv", cpu_variant=None):
     soc_group.add_argument("--uart-fifo-depth",          default=16,          type=auto_int, help="UART FIFO depth.")
     soc_group.add_argument("--uart-with-dynamic-baudrate", action="store_true",              help="Enable dynamic UART baudrate (tuning CSR).")
     soc_group.add_argument("--uart-rx-fifo-rx-we",       action="store_true",                help="Use FIFO RX We on UART RX path.")
+    soc_group.add_argument("--uart-auto-swap",           action="store_true",                help="Enable automatic UART TX/RX swap detection.")
 
     # UARTBone parameters.
     soc_group.add_argument("--with-uartbone",            action="store_true",                help="Enable UARTBone.")

--- a/test/cores/test_uart.py
+++ b/test/cores/test_uart.py
@@ -15,6 +15,10 @@ from litex.soc.cores.uart import (
     UARTCrossover,
     UARTPads,
     RS232PHY,
+    RS232PHYAutoSwap,
+    RS232_IDLE,
+    RS232_START,
+    RS232_STOP,
     get_uart_core,
     get_uart_supported_names,
 )
@@ -26,6 +30,35 @@ class _LoopbackDUT(LiteXModule):
         self.pads = UARTPads()
         self.phy  = RS232PHY(self.pads, clk_freq=clk_freq, baudrate=baudrate)
         self.comb += self.pads.rx.eq(self.pads.tx)
+
+
+class _TristatePad:
+    def __init__(self):
+        self.o  = Signal(reset=RS232_IDLE)
+        self.oe = Signal()
+        self.i  = Signal(reset=RS232_IDLE)
+
+
+class _AutoSwapPads:
+    def __init__(self):
+        self.tx = _TristatePad()
+        self.rx = _TristatePad()
+
+
+def _drive_uart_byte(line, byte, cycles_per_bit):
+    yield line.eq(RS232_IDLE)
+    for _ in range(cycles_per_bit):
+        yield
+    yield line.eq(RS232_START)
+    for _ in range(cycles_per_bit):
+        yield
+    for bit in range(8):
+        yield line.eq((byte >> bit) & 1)
+        for _ in range(cycles_per_bit):
+            yield
+    yield line.eq(RS232_STOP)
+    for _ in range(2*cycles_per_bit):
+        yield
 
 
 class TestUART(unittest.TestCase):
@@ -50,6 +83,12 @@ class TestUART(unittest.TestCase):
         self.assertIsInstance(uart, UART)
         self.assertTrue(hasattr(uart, "phy"))
 
+    def test_get_uart_core_builds_auto_swap_regular_uart(self):
+        uart = get_uart_core("serial", uart_pads=UARTPads(), clk_freq=1_000_000, with_auto_swap=True)
+
+        self.assertIsInstance(uart, UART)
+        self.assertIsInstance(uart.phy, RS232PHYAutoSwap)
+
     def test_get_uart_core_builds_stub_uart(self):
         uart = get_uart_core("stub")
 
@@ -68,6 +107,10 @@ class TestUART(unittest.TestCase):
             get_uart_core("serial")
         with self.assertRaisesRegex(ValueError, "clk_freq"):
             get_uart_core("serial", uart_pads=UARTPads())
+
+    def test_get_uart_core_rejects_auto_swap_on_soc_uart_modes(self):
+        with self.assertRaisesRegex(ValueError, "serial"):
+            get_uart_core("crossover", with_auto_swap=True)
 
     def test_loopback(self):
         # Use a short "symbol time" so the test runs in tens of ms, not seconds.
@@ -98,6 +141,86 @@ class TestUART(unittest.TestCase):
 
         run_simulation(dut, [tx_driver(dut), rx_driver(dut)])
         self.assertEqual(received, payload)
+
+    def test_auto_swap_idle_keeps_outputs_disabled(self):
+        pads = _AutoSwapPads()
+        dut  = RS232PHYAutoSwap(pads, clk_freq=1_000_000, baudrate=50_000)
+
+        def gen():
+            yield pads.tx.i.eq(RS232_IDLE)
+            yield pads.rx.i.eq(RS232_IDLE)
+            yield dut.source.ready.eq(1)
+            for _ in range(2_000):
+                self.assertEqual((yield dut.locked),       0)
+                self.assertEqual((yield pads.tx.oe),       0)
+                self.assertEqual((yield pads.rx.oe),       0)
+                self.assertEqual((yield dut.source.valid), 0)
+                yield
+
+        run_simulation(dut, gen())
+
+    def _run_auto_swap_receive_test(self, input_name, expected_swap):
+        cycles_per_bit = 20
+        byte           = 0x5a
+        pads           = _AutoSwapPads()
+        dut            = RS232PHYAutoSwap(pads, clk_freq=1_000_000, baudrate=50_000)
+        input_pad      = getattr(pads, input_name)
+        received       = []
+        status         = {}
+
+        def driver():
+            yield pads.tx.i.eq(RS232_IDLE)
+            yield pads.rx.i.eq(RS232_IDLE)
+            for _ in range(cycles_per_bit):
+                yield
+            yield from _drive_uart_byte(input_pad.i, byte, cycles_per_bit)
+
+        def monitor():
+            yield dut.source.ready.eq(1)
+            for _ in range(2_000):
+                if (yield dut.source.valid):
+                    received.append((yield dut.source.data))
+                    yield
+                    status["locked"] = (yield dut.locked)
+                    status["swap"]   = (yield dut.swap)
+                    status["tx_oe"]  = (yield pads.tx.oe)
+                    status["rx_oe"]  = (yield pads.rx.oe)
+                    return
+                yield
+            status["timeout"] = True
+
+        run_simulation(dut, [driver(), monitor()])
+
+        self.assertNotIn("timeout", status)
+        self.assertEqual(received, [byte])
+        self.assertEqual(status["locked"], 1)
+        self.assertEqual(status["swap"],   expected_swap)
+        self.assertEqual(status["tx_oe"],  int(not expected_swap))
+        self.assertEqual(status["rx_oe"],  int(expected_swap))
+
+    def test_auto_swap_detects_normal_wiring(self):
+        self._run_auto_swap_receive_test(input_name="rx", expected_swap=0)
+
+    def test_auto_swap_detects_swapped_wiring(self):
+        self._run_auto_swap_receive_test(input_name="tx", expected_swap=1)
+
+    def test_auto_swap_drops_tx_until_locked(self):
+        pads = _AutoSwapPads()
+        dut  = RS232PHYAutoSwap(pads, clk_freq=1_000_000, baudrate=50_000)
+
+        def gen():
+            yield pads.tx.i.eq(RS232_IDLE)
+            yield pads.rx.i.eq(RS232_IDLE)
+            yield dut.sink.data.eq(0xa5)
+            yield dut.sink.valid.eq(1)
+            for _ in range(100):
+                self.assertEqual((yield dut.locked),     0)
+                self.assertEqual((yield dut.sink.ready), 1)
+                self.assertEqual((yield pads.tx.oe),     0)
+                self.assertEqual((yield pads.rx.oe),     0)
+                yield
+
+        run_simulation(dut, gen())
 
     def test_idle_line_no_spurious_rx(self):
         # With `tx` tied to `rx` and no data ever sent, the RX path must stay idle.

--- a/test/soc/test_soc.py
+++ b/test/soc/test_soc.py
@@ -17,6 +17,7 @@ from migen import ClockDomain, Record, Signal
 from migen.sim import run_simulation
 
 from litex.soc.cores.hyperbus import HyperRAM
+from litex.soc.cores.uart import RS232PHYAutoSwap, UARTPads
 from litex.soc.cores.video import video_framebuffer_size
 from litex.soc.interconnect import axi, wishbone
 
@@ -1058,6 +1059,19 @@ class TestSoC(unittest.TestCase):
 
         self.assertTrue(hasattr(soc, "uart"))
         self.assertIn("UART_POLLING", soc.constants)
+
+    def test_add_uart_auto_swap_builds_serial_phy(self):
+        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
+
+        soc.add_uart(uart_pads=UARTPads(), with_auto_swap=True)
+
+        self.assertIsInstance(soc.uart.phy, RS232PHYAutoSwap)
+
+    def test_add_uart_auto_swap_rejects_soc_uart_modes(self):
+        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
+
+        with _assert_raises_soc_error(self):
+            soc.add_uart(uart_name="stub", with_auto_swap=True)
 
     def test_get_csr_address_returns_main_bus_address(self):
         soc = SoC(_FakePlatform(), sys_clk_freq=1e6)


### PR DESCRIPTION
### Summary

- add an opt-in RS232 PHY that detects which UART pad receives the first valid frame and drives TX on the opposite pad
- wire it through `--uart-auto-swap` for serial UARTs only
- drop pre-lock TX data to avoid boot-time stalls or stale output replay before the direction is known

### Notes

This is intended for direct FPGA UART pads that can be tristated. Fixed-direction external UART/USB/RS232 transceivers should keep this option disabled.

### Tests

- `python3 -m py_compile litex/soc/cores/uart.py litex/soc/integration/soc.py test/cores/test_uart.py test/soc/test_soc.py`
- `pytest -q test/cores/test_uart.py test/soc/test_soc.py`
- minimal Migen Verilog conversion of `RS232PHYAutoSwap`
