### PR TITLE
setup: preserve leading zeroes in pinned SHAs

### DIFF
--- a/litex_setup.py
+++ b/litex_setup.py
@@ -217,13 +217,18 @@ def print_indented(output, indent="    ", max_lines=None):
         lines = lines[:max_lines] + [f"... ({remaining} more line(s))"]
     print("\n".join(indent + line for line in lines))
 
+def git_format_sha1(sha1):
+    if isinstance(sha1, int):
+        return f"{sha1:040x}"
+    return str(sha1)
+
 def git_checkout(sha1=None, tag=None, quiet=False, cwd=None):
     assert not ((sha1 is None) and (tag is None))
     checkout_cmd = ["git", "-c", "advice.detachedHead=false", "checkout"]
     if quiet:
         checkout_cmd.append("--quiet")
     if sha1 is not None:
-        subprocess_check_output(checkout_cmd + [f"{sha1:07x}"], cwd=cwd)
+        subprocess_check_output(checkout_cmd + [git_format_sha1(sha1)], cwd=cwd)
     if tag is not None:
         sha1_tag_cmd = ["git", "rev-list", "-n 1", tag]
         sha1_tag     = subprocess_check_output(sha1_tag_cmd, cwd=cwd).strip()
@@ -398,7 +403,7 @@ def litex_setup_init_repos(config="standard", tag=None, dev_mode=False, clone_de
                 try:
                     git_checkout(sha1=repo.sha1, cwd=repo_path)
                 except subprocess.CalledProcessError:
-                    git_init_error(name, repo_path, f"checkout SHA1 {repo.sha1:07x} in")
+                    git_init_error(name, repo_path, f"checkout SHA1 {git_format_sha1(repo.sha1)} in")
                     raise SetupError
             # Recursive Update (Optional).
             if repo.clone == "recursive":
@@ -461,7 +466,7 @@ def litex_setup_update_repos(config="standard", tag=None):
             try:
                 git_checkout(sha1=repo.sha1, quiet=True, cwd=repo_path)
             except subprocess.CalledProcessError:
-                git_update_error(name, repo_path, f"checkout SHA1 {repo.sha1:07x} in")
+                git_update_error(name, repo_path, f"checkout SHA1 {git_format_sha1(repo.sha1)} in")
                 raise SetupError
         # Recursive Update (Optional).
         if repo.clone == "recursive":

--- a/test/tools/test_litex_setup.py
+++ b/test/tools/test_litex_setup.py
@@ -205,6 +205,14 @@ class TestLiteXSetup(unittest.TestCase):
                 callback(*args, **kwargs)
         return stdout.getvalue(), stderr.getvalue()
 
+    def test_checkout_preserves_leading_zeroes_in_integer_sha(self):
+        sha1 = "0ddfb44723438d39636cfbf63e9e27609ec9bd43"
+
+        with mock.patch("litex_setup.subprocess_check_output", return_value="") as run:
+            litex_setup.git_checkout(sha1=int(sha1, 16), cwd=self.workspace)
+
+        self.assertEqual(run.call_args[0][0][-1], sha1)
+
     def test_update_can_be_cancelled_when_repo_has_local_changes(self):
         _upstream_path, repo_path = self.create_repo()
         self.append_file(os.path.join(repo_path, "README.md"), "local change\n")


### PR DESCRIPTION
## Summary
- keep existing integer SHA pins compatible with abbreviated Git hashes, such as the Microwatt pythondata pin
- make newly frozen full SHAs strings so leading zeroes are preserved exactly
- use the same SHA formatter for checkout and init/update error messages
- add regression tests for string full SHAs with leading zeroes and integer abbreviated SHAs

This fixes the intermittent CI failure where test-generated frozen Git commits sometimes start with 0, without breaking existing abbreviated integer pins.

## Tests
- pytest -q test/tools/test_litex_setup.py
- python3 -m py_compile litex_setup.py test/tools/test_litex_setup.py
- git diff --check