### PR TITLE
setup: keep abbreviated integer SHA pins

### DIFF
--- a/litex_setup.py
+++ b/litex_setup.py
@@ -219,7 +219,7 @@ def print_indented(output, indent="    ", max_lines=None):
 
 def git_format_sha1(sha1):
     if isinstance(sha1, int):
-        return f"{sha1:040x}"
+        return f"{sha1:07x}"
     return str(sha1)
 
 def git_checkout(sha1=None, tag=None, quiet=False, cwd=None):
@@ -734,7 +734,7 @@ def litex_setup_format_frozen_repo(name, repo, git_url, git_sha1):
         args.append(f"develop={repo.develop}")
     if repo.editable is not True:
         args.append(f"editable={repo.editable}")
-    args.append(f"sha1=0x{git_sha1}")
+    args.append(f'sha1="{git_sha1}"')
     if repo.branch != "master":
         args.append(f'branch="{repo.branch}"')
     if repo.tag is not None:

--- a/test/tools/test_litex_setup.py
+++ b/test/tools/test_litex_setup.py
@@ -181,7 +181,7 @@ class TestLiteXSetup(unittest.TestCase):
                 branch="master",
                 clone="recursive",
                 tag=True,
-                sha1=int(main_v1, 16),
+                sha1=main_v1,
                 develop=True,
                 editable=True,
             ),
@@ -205,13 +205,37 @@ class TestLiteXSetup(unittest.TestCase):
                 callback(*args, **kwargs)
         return stdout.getvalue(), stderr.getvalue()
 
-    def test_checkout_preserves_leading_zeroes_in_integer_sha(self):
+    def test_checkout_preserves_leading_zeroes_in_string_sha(self):
         sha1 = "0ddfb44723438d39636cfbf63e9e27609ec9bd43"
 
         with mock.patch("litex_setup.subprocess_check_output", return_value="") as run:
-            litex_setup.git_checkout(sha1=int(sha1, 16), cwd=self.workspace)
+            litex_setup.git_checkout(sha1=sha1, cwd=self.workspace)
 
         self.assertEqual(run.call_args[0][0][-1], sha1)
+
+    def test_checkout_keeps_integer_sha_abbreviated(self):
+        with mock.patch("litex_setup.subprocess_check_output", return_value="") as run:
+            litex_setup.git_checkout(sha1=0xc69953aff92, cwd=self.workspace)
+
+        self.assertEqual(run.call_args[0][0][-1], "c69953aff92")
+
+    def test_format_frozen_repo_keeps_full_sha_as_string(self):
+        repo = SimpleNamespace(
+            url="https://github.com/enjoy-digital/",
+            branch="master",
+            clone="regular",
+            tag=None,
+            develop=True,
+            editable=True,
+        )
+        formatted = litex_setup.litex_setup_format_frozen_repo(
+            "litex",
+            repo,
+            "https://github.com/enjoy-digital/",
+            "0ddfb44723438d39636cfbf63e9e27609ec9bd43",
+        )
+
+        self.assertIn('sha1="0ddfb44723438d39636cfbf63e9e27609ec9bd43"', formatted)
 
     def test_update_can_be_cancelled_when_repo_has_local_changes(self):
         _upstream_path, repo_path = self.create_repo()
@@ -253,7 +277,7 @@ class TestLiteXSetup(unittest.TestCase):
 
     def test_init_clone_depth_uses_full_clone_for_pinned_sha(self):
         _upstream_path, _remote_path, commits = self.create_remote_only_repo()
-        litex_setup.git_repos["litex"].sha1 = int(commits[0], 16)
+        litex_setup.git_repos["litex"].sha1 = commits[0]
 
         litex_setup.litex_setup_init_repos(config="minimal", clone_depth=1)
 


### PR DESCRIPTION
## Summary
- restore integer SHA formatting to the previous abbreviated form, fixing existing pins such as pythondata-cpu-microwatt's c69953aff92
- emit newly frozen full SHAs as strings so leading zeroes are preserved exactly
- update setup tests to cover both string full SHAs and abbreviated integer SHAs

This fixes the regression introduced by #2511 while preserving the original leading-zero CI fix for newly frozen repositories.

## Tests
- pytest -q test/tools/test_litex_setup.py
- python3 -m py_compile litex_setup.py test/tools/test_litex_setup.py
- git diff --check