### PR TITLE
soc: allow wide CPU IO regions

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -303,9 +303,10 @@ class SoCBusHandler(LiteXModule):
             self.logger.error("{} already declared as Region:".format(colorer(name, color="red")))
             self.logger.error(self)
             raise SoCError()
-        # Check Region fits in the Bus Address Space (the decode extent for SoCRegions, since the
-        # decoder matches the full power-of-2 window).
-        if isinstance(region, SoCRegion) and (region.origin is not None):
+        # Check decoded Bus Regions fit in the Bus Address Space. SoCIORegions describe CPU-side
+        # IO/cacheability windows and can be wider than the LiteX bus address width.
+        if (isinstance(region, SoCRegion) and not isinstance(region, SoCIORegion) and
+            (region.origin is not None)):
             if (region.origin < 0) or (self._region_overlap_end(region) > 2**self.address_width):
                 self.logger.error("{} Region {} {}-bit Bus Address Space:".format(
                     colorer(name, color="red"),

--- a/test/soc/test_soc.py
+++ b/test/soc/test_soc.py
@@ -468,6 +468,21 @@ class TestSoCBusHandler(unittest.TestCase):
         bus.add_region("io",       SoCIORegion(origin=0x1200_0000, size=0x6e00_0000))
         bus.add_region("main_ram", SoCRegion(  origin=0x8000_0000, size=0x2000_0000))
 
+    def test_io_region_can_extend_beyond_bus_address_width(self):
+        bus = SoCBusHandler(address_width=32)
+
+        bus.add_region("io", SoCIORegion(origin=0xe000_0000, size=0xff_2000_0000))
+
+        self.assertIn("io", bus.io_regions)
+
+    def test_bus_region_must_fit_bus_address_width(self):
+        bus = SoCBusHandler(address_width=32)
+
+        with _assert_raises_soc_error(self):
+            bus.add_region("too_high", SoCRegion(origin=0xf000_0000, size=0x2000_0000))
+
+        self.assertNotIn("too_high", bus.regions)
+
     def test_partial_io_region_overlap_is_rejected(self):
         bus = SoCBusHandler()
         bus.add_region("io", SoCIORegion(origin=0x1200_0000, size=0x7000_0000))


### PR DESCRIPTION
Fixes a ZynqMP regression where CPU IO/cacheability windows were rejected by the new bus address-width validation.

`SoCIORegion` describes CPU-side IO/cacheability windows, not decoded LiteX bus slave regions. Some CPUs, including ZynqMP, expose high IO windows that can extend beyond the LiteX bus address width. These should remain valid, while normal decoded `SoCRegion` entries should still be checked against the bus address space.

Changes:
- Exclude `SoCIORegion` from the decoded bus region fit check.
- Keep the address-width fit check for normal decoded `SoCRegion` entries.
- Add regression tests for a wide CPU IO region and an out-of-range decoded bus region.

Validated with:
- `pytest -q test/soc/test_soc.py::TestSoCBusHandler`
- `pytest -q test/soc/test_soc.py`
- `python3 -m py_compile litex/soc/integration/soc.py test/soc/test_soc.py`

I also re-ran the reported ZynqMP target locally. It now gets past the CPU IO region registration and reaches SoC finalization; the local run later stops while fetching/copying Xilinx `embeddedsw` assets, which is separate from this bus-region regression.
