### PR TITLE
software: Capture SDCard switch status

### DIFF
--- a/litex/soc/software/liblitesdcard/sdcard.c
+++ b/litex/soc/software/liblitesdcard/sdcard.c
@@ -53,6 +53,10 @@ static unsigned int support_cmd23;
    ver2.00+ standard capacity cards (byte addressing). */
 static unsigned int sdcard_ccs = 1;
 
+#ifdef CSR_SDCARD_BLOCK2MEM_DMA_BASE_ADDR
+static uint8_t sdcard_switch_status[64] __attribute__((aligned(4)));
+#endif
+
 static inline uint32_t sdcard_block_to_addr(uint32_t block) {
 	return sdcard_ccs ? block : block * 512;
 }
@@ -248,11 +252,60 @@ int sdcard_switch(unsigned int mode, unsigned int group, unsigned int value) {
 #endif
 	sdcard_core_block_length_write(64);
 	sdcard_core_block_count_write(1);
+
+#ifdef CSR_SDCARD_BLOCK2MEM_DMA_BASE_ADDR
+	memset(sdcard_switch_status, 0, sizeof(sdcard_switch_status));
+	sdcard_block2mem_dma_enable_write(0);
+	sdcard_block2mem_dma_base_write((uint64_t)(uintptr_t)sdcard_switch_status);
+	sdcard_block2mem_dma_length_write(sizeof(sdcard_switch_status));
+	sdcard_block2mem_dma_enable_write(1);
+#endif
+
 	if (sdcard_send_command_retry(arg, 6,
 		(SDCARD_CTRL_DATA_TRANSFER_READ << 5) |
-		SDCARD_CTRL_RESPONSE_SHORT | SDCARD_CTRL_RESPONSE_CRC) != SD_OK)
+		SDCARD_CTRL_RESPONSE_SHORT | SDCARD_CTRL_RESPONSE_CRC) != SD_OK) {
+#ifdef CSR_SDCARD_BLOCK2MEM_DMA_BASE_ADDR
+		sdcard_block2mem_dma_enable_write(0);
+#endif
 		return SD_TIMEOUT;
-	return sdcard_wait_data_done();
+	}
+
+	int status = sdcard_wait_data_done();
+	if (status != SD_OK) {
+#ifdef CSR_SDCARD_BLOCK2MEM_DMA_BASE_ADDR
+		sdcard_block2mem_dma_enable_write(0);
+#endif
+		return status;
+	}
+
+#ifdef CSR_SDCARD_BLOCK2MEM_DMA_BASE_ADDR
+	unsigned int timeout = SDCARD_DMA_TIMEOUT_US;
+	while ((sdcard_block2mem_dma_done_read() & 0x1) == 0) {
+		if (timeout-- == 0) {
+			sdcard_block2mem_dma_enable_write(0);
+			return SD_TIMEOUT;
+		}
+		busy_wait_us(1);
+	}
+	sdcard_block2mem_dma_enable_write(0);
+
+#ifndef CONFIG_CPU_HAS_DMA_BUS
+	/* Flush caches */
+	flush_cpu_dcache();
+	flush_l2_cache();
+#endif
+
+	/* Compiler barrier */
+	__asm__ __volatile__("" ::: "memory");
+
+	if ((mode == SD_SWITCH_SWITCH) && (group < 6)) {
+		unsigned int selected = (sdcard_switch_status[16 + group/2] >> (4*(group & 1))) & 0xf;
+		if (selected != value)
+			return SD_SWITCHERROR;
+	}
+#endif
+
+	return SD_OK;
 }
 
 int sdcard_app_send_scr(void) {

--- a/litex/soc/software/liblitesdcard/sdcard.h
+++ b/litex/soc/software/liblitesdcard/sdcard.h
@@ -22,6 +22,7 @@ extern "C" {
 #define SD_CRCERROR   1
 #define SD_TIMEOUT    2
 #define SD_WRITEERROR 3
+#define SD_SWITCHERROR 4
 
 #define SD_SWITCH_CHECK  0
 #define SD_SWITCH_SWITCH 1


### PR DESCRIPTION
## Summary
- capture the mandatory 64-byte CMD6 switch-status data block through the SDCard block-to-memory DMA
- wait for the internal DMA completion before returning from `sdcard_switch()`
- validate that the requested function was selected and report `SD_SWITCHERROR` otherwise

## Root Cause
CMD6 is a data-read command: the card returns a 64-byte switch-status block. The LiteX SDCard software driver was issuing the command and waiting for the data event, but it did not provide a DMA destination for the returned block. On hardware this left the following data transfer exposed to stale/misaligned stream/DMA state.

A temporary matrix test showed:
- 1-bit at 400 kHz: stable sector 0 CRC `1165eddc`
- 1-bit at 25 MHz without CMD6: stable CRC `1165eddc`
- 4-bit at 25 MHz without CMD6: stable CRC `1165eddc`
- CMD6 without capture: next sector read could be corrupted
- CMD6 with a real 64-byte DMA buffer: switch-status block was valid and following reads were stable

So this was not a pin-drive/pullup issue; DAT0/CMD/CLK and 4-bit data worked when CMD6's status transfer was handled correctly.

## Testing
- rebuilt an SDCard-enabled LiteX bitstream successfully
- post-route timing met: WNS `0.254 ns`, WHS `0.064 ns`
- loaded the bitstream on hardware
- BIOS `sdcard_detect`: SDCard inserted
- BIOS `sdcard_init`: OK, `sdcard_phy_settings = 0x01` (4-bit mode)
- repeated BIOS `sdcard_read 0 ... 1` reads returned CRC `1165eddc` and ended with `55 aa`
- `sdcard_core_data_event = 0x1` after reads

Related LiteSDCard read-status fix: https://github.com/enjoy-digital/litesdcard/pull/57
