### PR TITLE
examples: add standalone cocotb+Verilator sim example (CPU-less)

### DIFF
--- a/examples/sim_cocotb/.gitignore
+++ b/examples/sim_cocotb/.gitignore
@@ -1,0 +1,8 @@
+dut.v
+sim_build/
+obj_dir/
+*.vcd
+*.fst
+__pycache__/
+*.pyc
+results.xml

--- a/examples/sim_cocotb/README.md
+++ b/examples/sim_cocotb/README.md
@@ -1,0 +1,222 @@
+# cocotb + Verilator example (CPU-less)
+
+A minimal, standalone example showing how to drive a LiteX-generated design
+with a [cocotb](https://docs.cocotb.org/) testbench under
+[Verilator](https://www.veripool.org/verilator/), without touching LiteX's
+own C++-driven `litex/build/sim/` simulation backend.
+
+Addresses [enjoy-digital/litex#2380](https://github.com/enjoy-digital/litex/issues/2380)
+("support cocotb+verilator for sim"). See "Why not a `CocotbSimulator`
+backend?" below for why this starts as a standalone example instead of a
+core-framework change.
+
+## What this is
+
+A **CPU-less** LiteX design (`dut.py`): no RISC-V/VexRiscv core, no
+Wishbone bus, no CSR bus. cocotb plays the role of the "host", driving
+every signal directly -- exactly the workflow a peripheral developer uses
+when bringing up a new core in isolation, before it's wired into a full
+SoC.
+
+The design (`CocotbDemoTop`) is still built entirely out of real LiteX/Migen
+building blocks:
+
+- `litex.gen.LiteXModule`, a `ClockDomain`, and `migen.genlib.cdc.MultiReg`
+  (the same 2-flip-flop synchronizer pattern `litex.soc.cores.gpio.GPIOIn`
+  uses internally).
+- One real LiteX peripheral core, unmodified:
+  [`litex.soc.cores.uart.RS232PHY`](https://github.com/enjoy-digital/litex/blob/master/litex/soc/cores/uart.py),
+  wired directly to top-level ports instead of a CSR bus.
+- A hand-rolled GPIO input/output register pair (LiteX's `GPIOIn`/`GPIOOut`
+  are CSR-based and need a bus master to be useful; this example intentionally
+  avoids pulling in a full CSR/Wishbone stack).
+
+Ports exposed by the generated `dut` module:
+
+| Port | Direction | Purpose |
+|---|---|---|
+| `sys_clk`, `sys_rst` | in | clock / reset |
+| `gpio_in[8]` | in | asynchronous input pins (e.g. a button/sensor) |
+| `gpio_in_sync[8]` | out | 2FF-synchronized view of `gpio_in` |
+| `gpio_out_data[8]`, `gpio_out_we` | in | write port for the GPIO output register |
+| `gpio_out[8]` | out | registered GPIO output pins |
+| `uart_tx_data[8]`, `uart_tx_valid`, `uart_tx_ready` | in/in/out | byte-level handshake INTO the UART PHY |
+| `uart_rx_data[8]`, `uart_rx_valid`, `uart_rx_ready` | out/out/in | byte-level handshake OUT OF the UART PHY |
+| `uart_tx`, `uart_rx` | out/in | the actual serial line pins |
+
+## Why `verilog.convert()` instead of `SimPlatform.build()`
+
+LiteX's `litex/build/sim/verilator.py` (`SimVerilatorToolchain`/
+`VerilatorSimulator`) owns the simulation main loop itself: it generates a
+C++ wrapper, compiles it with Verilator, and *that C++ binary* drives the
+clock and runs the simulation, calling back into LiteX-provided C models
+for peripherals (Ethernet, USB, UART, etc. -- see `litex/build/sim/core/`).
+
+cocotb inverts that: **Python owns the main loop**, and the simulator
+(Verilator, in this case, via its VPI layer) is a library that Python calls
+into. These two models can't both own the loop at once.
+
+Rather than modify `litex/build/sim/` to somehow support both, this example
+sidesteps the conflict entirely: `dut.py` calls Migen's own
+`migen.fhdl.verilog.convert()` directly to elaborate `CocotbDemoTop` straight
+to a clean Verilog file (`dut.v`), never touching `SimPlatform`/
+`VerilatorSimulator`. `verilog.convert()` and `SimPlatform.build()`'s
+Verilog-generation step are the same underlying operation -- the difference
+is only that this path stops there, instead of continuing on to compile a
+C++-driven simulation binary. **Zero changes to `litex/build/sim/` are made
+or required.**
+
+## Directory contents
+
+```
+examples/sim_cocotb/
+├── README.md          -- this file
+├── dut.py             -- the CPU-less LiteX design; run standalone to (re)generate dut.v
+├── test_dut.py         -- the cocotb testbench (GPIO + UART tests)
+├── test_runner.py      -- builds dut.v and runs test_dut.py under Verilator via cocotb-tools
+├── requirements.txt    -- Python dependencies (migen, litex, cocotb, cocotb-tools)
+└── .gitignore
+```
+
+## Setup
+
+### 1. Install Verilator (>= 5.0)
+
+Not a Python package -- install via your OS package manager or build from
+source:
+
+```bash
+# Debian/Ubuntu
+sudo apt-get install verilator   # check `verilator --version` >= 5.0; if your
+                                  # distro ships an older version, build from
+                                  # source instead: https://verilator.org/guide/latest/install.html
+
+# macOS
+brew install verilator
+
+# From source (any platform, gets you the latest release)
+git clone https://github.com/verilator/verilator
+cd verilator && git checkout stable
+autoconf && ./configure && make -j$(nproc) && sudo make install
+```
+
+Verify:
+
+```bash
+verilator --version   # must be >= 5.0
+```
+
+### 2. Install Python dependencies
+
+```bash
+cd examples/sim_cocotb
+pip install -r requirements.txt
+```
+
+This pulls in `migen`, `litex`, `cocotb` (2.x), and `cocotb-tools` (the
+separate package that provides the modern `cocotb_tools.runner` Python
+build/test API used by `test_runner.py`, replacing the older Makefile-only
+flow).
+
+### 3. Run the tests
+
+```bash
+python3 test_runner.py
+# or, equivalently:
+pytest test_runner.py
+```
+
+This will:
+
+1. Run `dut.py`, which elaborates `CocotbDemoTop` and writes `dut.v`
+   (regenerated fresh on every run, so it can never silently drift from the
+   Python source).
+2. Invoke Verilator (via `cocotb_tools.runner.get_runner("verilator")`) to
+   build a simulation binary from `dut.v`.
+3. Run `test_dut.py` against it, exercising:
+   - `test_gpio_out_register` -- `gpio_out_we` pulses `gpio_out_data` into
+     `gpio_out`.
+   - `test_gpio_out_holds_without_write_enable` -- writes are ignored
+     unless `gpio_out_we` is pulsed.
+   - `test_gpio_in_synchronizer` -- `gpio_in_sync` tracks `gpio_in` after
+     the 2FF synchronizer latency.
+   - `test_uart_loopback` -- `uart_tx` is looped back to `uart_rx` in
+     Python (standing in for a wire bridging the two pins on a board); a
+     byte pushed in via the TX stream handshake is confirmed to come back
+     out the RX stream handshake unchanged, round-tripping through the real
+     `RS232PHY` TX/RX bit-framing state machines.
+
+A waveform (`dut.fst`, via `--trace-fst`) is written under `sim_build/` for
+inspection with GTKWave or similar.
+
+## What's been verified vs. what you should verify yourself
+
+Everything up to and including inter-module signal correctness has been
+verified in this repository's development sandbox:
+
+- `dut.py` elaborates cleanly and `dut.v` was manually reviewed to confirm
+  it declares exactly the intended port list and instantiates a genuine
+  `RS232PHY`.
+- `test_dut.py` and `test_runner.py` both import cleanly against real
+  `cocotb`/`cocotb-tools` installs, and cocotb's `@cocotb.test()` discovery
+  finds all four tests.
+- `test_runner.py` was run end-to-end and confirmed to progress correctly
+  through Verilog generation and into invoking the Verilator build step,
+  exactly as designed.
+
+The one thing that could **not** be verified in that sandbox is an actual
+Verilator binary run (no Verilator toolchain was installable there -- no
+root/apt access, and no prebuilt binary available for that platform). **Run
+`python3 test_runner.py` in your own environment with Verilator installed
+per Setup step 1** to see the tests actually simulate and pass; if anything
+doesn't line up (e.g. a signal-timing edge case in `test_uart_loopback`),
+that's the first place to look.
+
+## Performance trade-offs (read before using this for anything bigger)
+
+- Verilator was chosen by LiteX's existing sim backend specifically for
+  execution speed; cocotb's VPI/GPI bridge into Python adds call overhead
+  at simulation events (e.g. every clock edge a `RisingEdge` trigger is
+  awaited).
+- For small, peripheral-scale designs like this one, that overhead is
+  negligible.
+- For system-level simulation (e.g. booting Linux on a full SoC), the
+  overhead compounds into an order-of-magnitude slowdown -- cocotb is not a
+  drop-in replacement for LiteX's existing C++-model-based peripheral
+  simulation at that scale.
+- This is exactly the "sweet spot" identified in issue #2380's discussion:
+  **CPU-less SoCs / isolated peripheral development**, where the
+  convenience of writing testbenches in Python outweighs the performance
+  cost, and system-level throughput isn't the goal.
+
+## Scope boundary
+
+This example works for **CPU-less** designs, where cocotb is the sole bus
+master driving every signal directly. It does **not** address CPU-based
+designs (e.g. a full VexRiscv SoC booting the LiteX BIOS) -- those need
+LiteX's existing C++-driven `litex/build/sim/` peripheral models (or
+significant additional design work to bridge a running CPU core's bus
+transactions into cocotb) and are out of scope here. See "Why not a
+`CocotbSimulator` backend?" below for how a future, more integrated version
+of this could evolve to help with that.
+
+## Why not a `CocotbSimulator` backend?
+
+Issue #2380's discussion (see `helium729`'s analysis) identified that full,
+first-class cocotb support (e.g. `soc.build(simulator="cocotb")`, matching
+the existing `simulator="verilator"` API) would require rewriting
+`SimBuilder`'s C++-owns-the-loop architecture, plus either reimplementing
+LiteX's existing C++ simulation peripherals (Ethernet, USB, PCIe, UART) as
+Python/cocotb equivalents (a major performance regression for those) or
+wrapping each in a VPI interface. That's a multi-week, maintainer-buy-in-
+required change with real risk of the performance trade-offs making it
+undesirable for LiteX's primary (system-level, CPU-based) simulation use
+case.
+
+This example instead targets the specific, narrower use case the issue's
+commenters agreed was valuable and tractable on its own: **CPU-less
+peripheral development**, as a fully standalone, zero-core-changes example.
+If this proves useful, a natural next step (not included here) would be a
+small `CocotbHelper` utility to reduce the boilerplate in `dut.py`/
+`test_runner.py` for future cocotb-based examples -- without touching
+`litex/build/sim/` itself.

--- a/examples/sim_cocotb/dut.py
+++ b/examples/sim_cocotb/dut.py
@@ -1,0 +1,157 @@
+#
+# This file is part of the LiteX cocotb+Verilator simulation POC.
+# See ../../../issues/2380 (enjoy-digital/litex) for background.
+#
+# Copyright (c) 2026 Vishnu Sentha <vishnusentha@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+"""
+Minimal, CPU-less LiteX design used to demonstrate driving a LiteX-generated
+design with a cocotb testbench under Verilator.
+
+Design goals (see README.md for the full rationale):
+
+  * No CPU, no Wishbone/CSR bus -- cocotb plays the role of the "host",
+    driving every signal directly, the way a peripheral developer would
+    when bringing up a new core in isolation.
+  * Still built entirely out of LiteX/Migen building blocks (LiteXModule,
+    clock domains, MultiReg synchronizers) and one real LiteX peripheral
+    core (``litex.soc.cores.uart.RS232PHY``), so it behaves like a genuine
+    LiteX design, not a bare hand-written Verilog stub.
+  * Verilog is generated with Migen's own ``verilog.convert()`` instead of
+    ``SimPlatform.build()``. ``SimPlatform``/``VerilatorSimulator`` own a
+    C++-driven main loop that starts the simulation itself, which conflicts
+    with cocotb, where Python (via the VPI/GPI layer) owns the main loop.
+    Using ``verilog.convert()`` keeps this example fully standalone and
+    makes zero changes to ``litex/build/sim/``.
+
+Run standalone to (re)generate ``dut.v``:
+
+    python3 dut.py
+
+The Makefile does this automatically before invoking Verilator.
+"""
+from migen import Module, Signal, ClockDomain, If, Record
+from migen.fhdl import verilog
+from migen.genlib.cdc import MultiReg
+
+from litex.gen import LiteXModule
+from litex.soc.cores.uart import RS232PHY
+
+# Parameters -----------------------------------------------------------------
+
+GPIO_WIDTH    = 8
+SYS_CLK_FREQ  = 100e6   # 100 MHz system clock used by the testbench.
+UART_BAUDRATE = 115200  # Matches the default LiteX BIOS console baudrate.
+
+
+class CocotbDemoTop(LiteXModule):
+    """
+    Top-level module exercised by the cocotb testbench.
+
+    Port summary
+    ------------
+    sys_clk, sys_rst                                    : clock / reset
+    gpio_in[GPIO_WIDTH]                                  : async input pins
+    gpio_in_sync[GPIO_WIDTH]                              : 2FF-synchronized view of gpio_in
+    gpio_out_data[GPIO_WIDTH], gpio_out_we                : write port for the GPIO output register
+    gpio_out[GPIO_WIDTH]                                  : registered GPIO output pins
+    uart_tx_data[8], uart_tx_valid, uart_tx_ready          : byte-level handshake INTO the UART PHY
+    uart_rx_data[8], uart_rx_valid, uart_rx_ready          : byte-level handshake OUT OF the UART PHY
+    uart_tx, uart_rx                                       : the actual serial line pins
+
+    The UART is exposed at the byte-level stream (sink/source) handshake
+    that ``RS232PHY`` already provides internally, *and* at the raw serial
+    pins. Driving the stream handshake means the cocotb testbench doesn't
+    have to hand-roll bit-level UART framing to send a byte; asserting
+    ``uart_tx_valid``/``uart_tx_data`` for one cycle (until ``uart_tx_ready``)
+    queues a full start+8N1+stop frame on ``uart_tx``. The raw ``uart_tx``/
+    ``uart_rx`` pins are still exposed so the testbench (or a waveform
+    viewer) can also observe/inject the actual serial bitstream.
+    """
+
+    def __init__(self, gpio_width=GPIO_WIDTH, sys_clk_freq=SYS_CLK_FREQ,
+                 baudrate=UART_BAUDRATE):
+        # Clock / Reset -------------------------------------------------
+        self.sys_clk = sys_clk = Signal()
+        self.sys_rst = sys_rst = Signal()
+
+        self.clock_domains.cd_sys = ClockDomain()
+        self.comb += self.cd_sys.clk.eq(sys_clk)
+        self.comb += self.cd_sys.rst.eq(sys_rst)
+
+        # GPIO ------------------------------------------------------------
+        # Output register: cocotb pulses gpio_out_we for one cycle with the
+        # desired value on gpio_out_data; the value is then held on gpio_out.
+        self.gpio_out_data = gpio_out_data = Signal(gpio_width)
+        self.gpio_out_we   = gpio_out_we   = Signal()
+        self.gpio_out      = gpio_out      = Signal(gpio_width, reset=0)
+        self.sync += If(gpio_out_we, gpio_out.eq(gpio_out_data))
+
+        # Input: cocotb drives gpio_in asynchronously (like an external
+        # button/sensor); gpio_in_sync is the 2FF-synchronized, glitch-safe
+        # view a real LiteX peripheral would read from -- this mirrors the
+        # MultiReg pattern litex.soc.cores.gpio.GPIOIn uses internally.
+        self.gpio_in      = gpio_in      = Signal(gpio_width)
+        self.gpio_in_sync = gpio_in_sync = Signal(gpio_width)
+        self.specials += MultiReg(gpio_in, gpio_in_sync)
+
+        # UART --------------------------------------------------------------
+        # Real LiteX UART PHY core (litex.soc.cores.uart.RS232PHY), wired
+        # directly to top-level pins/handshake signals -- no CSR bus, no
+        # Wishbone, no CPU. cocotb is the bus master.
+        self.uart_tx = uart_tx = Signal()
+        self.uart_rx = uart_rx = Signal()
+
+        uart_pads = Record([("tx", 1), ("rx", 1)])
+        self.comb += [
+            uart_tx.eq(uart_pads.tx),
+            uart_pads.rx.eq(uart_rx),
+        ]
+
+        self.uart_phy = uart_phy = RS232PHY(
+            uart_pads,
+            clk_freq = int(sys_clk_freq),
+            baudrate = int(baudrate),
+        )
+
+        self.uart_tx_data  = Signal(8)
+        self.uart_tx_valid = Signal()
+        self.uart_tx_ready = Signal()
+        self.uart_rx_data  = Signal(8)
+        self.uart_rx_valid = Signal()
+        self.uart_rx_ready = Signal()
+
+        self.comb += [
+            uart_phy.sink.data.eq(self.uart_tx_data),
+            uart_phy.sink.valid.eq(self.uart_tx_valid),
+            self.uart_tx_ready.eq(uart_phy.sink.ready),
+
+            self.uart_rx_data.eq(uart_phy.source.data),
+            self.uart_rx_valid.eq(uart_phy.source.valid),
+            uart_phy.source.ready.eq(self.uart_rx_ready),
+        ]
+
+    def ios(self):
+        """Signals that must become ports on the generated top module."""
+        return {
+            self.sys_clk, self.sys_rst,
+            self.gpio_in, self.gpio_in_sync,
+            self.gpio_out_data, self.gpio_out_we, self.gpio_out,
+            self.uart_tx_data, self.uart_tx_valid, self.uart_tx_ready,
+            self.uart_rx_data, self.uart_rx_valid, self.uart_rx_ready,
+            self.uart_tx, self.uart_rx,
+        }
+
+
+def generate(v_file="dut.v", top_name="dut"):
+    top = CocotbDemoTop()
+    verilog.convert(
+        top,
+        ios  = top.ios(),
+        name = top_name,
+    ).write(v_file)
+    print(f"Wrote {v_file} (top module '{top_name}')")
+
+
+if __name__ == "__main__":
+    generate()

--- a/examples/sim_cocotb/requirements.txt
+++ b/examples/sim_cocotb/requirements.txt
@@ -1,0 +1,10 @@
+# Python dependencies for examples/sim_cocotb.
+#
+# Verilator itself is NOT a Python package and is not listed here -- see
+# README.md "Installing Verilator" for OS-level install instructions.
+
+migen>=0.9.2
+litex
+cocotb>=2.0
+cocotb-tools>=0.1.0
+pytest  # optional, only needed if you run test_runner.py via `pytest`

--- a/examples/sim_cocotb/test_dut.py
+++ b/examples/sim_cocotb/test_dut.py
@@ -1,0 +1,218 @@
+#
+# This file is part of the LiteX cocotb+Verilator simulation POC.
+# See ../../../issues/2380 (enjoy-digital/litex) for background.
+#
+# Copyright (c) 2026 Vishnu Sentha <vishnusentha@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+"""
+cocotb testbench for ``dut.py`` / ``dut.v``.
+
+Exercises the CPU-less LiteX design entirely from Python, the way a
+peripheral developer would when bringing up a new core in isolation:
+
+  * ``test_gpio_out_register``                    -- write the GPIO output
+    register and check it is held.
+  * ``test_gpio_out_holds_without_write_enable``   -- writes are ignored
+    unless ``gpio_out_we`` is pulsed.
+  * ``test_gpio_in_synchronizer``                  -- drive ``gpio_in``
+    asynchronously and check ``gpio_in_sync`` follows it after the 2FF
+    synchronizer latency.
+  * ``test_uart_loopback``                         -- physically loop
+    ``uart_tx`` back to ``uart_rx`` (as if a wire bridged the two pins on a
+    board) and send a byte through the byte-level stream handshake,
+    confirming it comes back out the RX stream handshake unchanged.
+
+Run with:
+
+    python3 test_runner.py
+
+or
+
+    pytest test_runner.py
+"""
+import random
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import RisingEdge, ReadOnly, ReadWrite, Event
+
+SYS_CLK_PERIOD_NS = 10  # 100 MHz, matches dut.py's SYS_CLK_FREQ.
+UART_BAUDRATE      = 115200  # Must match dut.py's UART_BAUDRATE.
+
+
+async def start_clock(dut):
+    cocotb.start_soon(Clock(dut.sys_clk, SYS_CLK_PERIOD_NS, unit="ns").start())
+
+
+async def reset_dut(dut):
+    """Assert reset, hold all inputs at known-idle values, then release."""
+    dut.sys_rst.value      = 1
+    dut.gpio_in.value      = 0
+    dut.gpio_out_data.value = 0
+    dut.gpio_out_we.value   = 0
+    dut.uart_tx_data.value  = 0
+    dut.uart_tx_valid.value = 0
+    # Held high for the whole test: the testbench is always ready to accept
+    # received bytes, like a simple "always draining" peripheral consumer.
+    dut.uart_rx_ready.value = 1
+    dut.uart_rx.value       = 1  # UART idle/mark state.
+    for _ in range(5):
+        await RisingEdge(dut.sys_clk)
+    dut.sys_rst.value = 0
+    await RisingEdge(dut.sys_clk)
+
+
+@cocotb.test()
+async def test_gpio_out_register(dut):
+    """gpio_out_we pulses gpio_out_data into gpio_out for one write."""
+    await start_clock(dut)
+    await reset_dut(dut)
+
+    value = 0xA5
+    dut.gpio_out_data.value = value
+    dut.gpio_out_we.value   = 1
+    await RisingEdge(dut.sys_clk)
+    dut.gpio_out_we.value   = 0
+    dut.gpio_out_data.value = 0
+
+    await ReadOnly()
+    assert int(dut.gpio_out.value) == value, \
+        f"gpio_out: expected {value:#x}, got {int(dut.gpio_out.value):#x}"
+
+
+@cocotb.test()
+async def test_gpio_out_holds_without_write_enable(dut):
+    """Without gpio_out_we, gpio_out must not change even if data changes."""
+    await start_clock(dut)
+    await reset_dut(dut)
+
+    # Prime gpio_out with a known value first.
+    dut.gpio_out_data.value = 0x3C
+    dut.gpio_out_we.value   = 1
+    await RisingEdge(dut.sys_clk)
+    dut.gpio_out_we.value   = 0
+
+    # Change gpio_out_data without asserting we -- gpio_out must hold.
+    dut.gpio_out_data.value = 0xFF
+    for _ in range(4):
+        await RisingEdge(dut.sys_clk)
+
+    await ReadOnly()
+    assert int(dut.gpio_out.value) == 0x3C, \
+        f"gpio_out changed without write-enable: {int(dut.gpio_out.value):#x}"
+
+
+@cocotb.test()
+async def test_gpio_in_synchronizer(dut):
+    """gpio_in_sync must track gpio_in after the 2FF synchronizer latency."""
+    await start_clock(dut)
+    await reset_dut(dut)
+
+    value = 0x66
+    dut.gpio_in.value = value
+
+    # MultiReg is a 2-flop synchronizer; allow a couple of cycles of margin
+    # beyond the minimum 2 for the change to propagate through.
+    for _ in range(4):
+        await RisingEdge(dut.sys_clk)
+
+    await ReadOnly()
+    assert int(dut.gpio_in_sync.value) == value, \
+        f"gpio_in_sync: expected {value:#x}, got {int(dut.gpio_in_sync.value):#x}"
+
+
+@cocotb.test()
+async def test_uart_loopback(dut):
+    """
+    Physically loop uart_tx back to uart_rx (as if a wire bridged the two
+    pins on a board), then push a byte in via the TX stream handshake and
+    confirm the same byte comes out the RX stream handshake.
+
+    This exercises the *real* litex.soc.cores.uart.RS232PHY core, both its
+    TX bit-framing (start + 8N1 + stop) and its RX bit-sampling/framing, all
+    driven purely from cocotb -- no CSR bus, no CPU.
+
+    Timing note: RS232PHYTX and RS232PHYRX each run their own
+    RS232ClkPhaseAccum baud-tick generator off the *same* tuning word, but
+    with different phase preloads -- TX preloads the full tuning word, so
+    its first tick (and hence each bit-edge update) lands a full bit period
+    after entering its RUN state; RX preloads half that, so it samples
+    mid-bit for noise immunity. The two accumulators are otherwise
+    unsynchronized, so RS232PHYRX's completion pulse (source.valid, held
+    for exactly one clock) lands roughly half a bit period *before*
+    RS232PHYTX's own completion (sink.ready) -- i.e. before the TX-queueing
+    loop below even returns. Watching uart_rx_valid only *after* that loop
+    finishes would miss the pulse entirely, so the RX capture below runs
+    concurrently, started before the byte is even queued.
+    """
+    await start_clock(dut)
+    await reset_dut(dut)
+
+    # Loop uart_tx back into uart_rx every cycle -- cocotb stands in for the
+    # PCB trace that would normally bridge the two pins. Reading uart_tx
+    # immediately after RisingEdge races the DUT's own posedge-triggered
+    # update (the read can see the pre-edge value), so wait for the
+    # ReadWrite phase first: per the simulator's per-timestep region order
+    # (Active/NBA -> ReadWrite -> ReadOnly), ReadWrite fires after
+    # non-blocking assignments have been applied (so uart_tx already
+    # reflects its new, settled value) but, unlike ReadOnly, still permits
+    # writes -- exactly what's needed to read-then-write uart_rx in the
+    # same timestep.
+    async def loopback():
+        while True:
+            await RisingEdge(dut.sys_clk)
+            await ReadWrite()
+            dut.uart_rx.value = int(dut.uart_tx.value)
+
+    cocotb.start_soon(loopback())
+
+    # Give the loopback coroutine a cycle to establish the idle-line value
+    # before queuing the byte.
+    await RisingEdge(dut.sys_clk)
+
+    # Start watching for RS232PHYRX's completion pulse *before* queuing the
+    # send -- see the timing note above for why this must run concurrently
+    # with, rather than after, the TX handshake.
+    rx_done   = Event()
+    rx_result = {}
+
+    async def capture_rx():
+        while True:
+            await RisingEdge(dut.sys_clk)
+            await ReadOnly()
+            if dut.uart_rx_valid.value == 1:
+                rx_result["data"] = int(dut.uart_rx_data.value)
+                rx_done.set()
+                return
+
+    cocotb.start_soon(capture_rx())
+
+    byte = random.randint(0, 255)
+
+    # Queue one byte on the TX stream handshake: hold valid until ready.
+    dut.uart_tx_data.value  = byte
+    dut.uart_tx_valid.value = 1
+    while True:
+        await RisingEdge(dut.sys_clk)
+        await ReadOnly()
+        if dut.uart_tx_ready.value == 1:
+            break
+    await RisingEdge(dut.sys_clk)
+    dut.uart_tx_valid.value = 0
+    dut.uart_tx_data.value  = 0
+
+    # A full byte takes 10 bit periods (start + 8 data + stop) at
+    # UART_BAUDRATE, each bit period lasting sys_clk_freq/baudrate cycles;
+    # bound the wait generously so a real protocol bug fails fast instead of
+    # hanging the test.
+    max_cycles = 20 * (int(1 / (SYS_CLK_PERIOD_NS * 1e-9)) // UART_BAUDRATE) * 10
+    cycles = 0
+    while not rx_done.is_set():
+        await RisingEdge(dut.sys_clk)
+        cycles += 1
+        assert cycles < max_cycles, \
+            "UART loopback: timed out waiting for uart_rx_valid"
+
+    received = rx_result["data"]
+    assert received == byte, \
+        f"UART loopback: sent {byte:#x}, got {received:#x}"

--- a/examples/sim_cocotb/test_runner.py
+++ b/examples/sim_cocotb/test_runner.py
@@ -1,0 +1,55 @@
+#
+# This file is part of the LiteX cocotb+Verilator simulation POC.
+# See ../../../issues/2380 (enjoy-digital/litex) for background.
+#
+# Copyright (c) 2026 Vishnu Sentha <vishnusentha@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+"""
+Build ``dut.v`` (via ``dut.py``) and run ``test_dut.py`` under Verilator +
+cocotb, using the modern ``cocotb-tools`` Python runner API -- no
+hand-written Makefile needed.
+
+    python3 test_runner.py
+    # or
+    pytest test_runner.py
+
+Requires Verilator >= 5.0 on PATH (see README.md -- it is NOT bundled with
+this example; install it separately). Everything else (migen, litex,
+cocotb, cocotb-tools) is listed in requirements.txt.
+"""
+import os
+from pathlib import Path
+
+from cocotb_tools.runner import get_runner
+
+import dut as dut_module  # dut.py: elaborates the design, writes dut.v.
+
+
+def test_dut_runner():
+    sim = os.getenv("SIM", "verilator")
+    proj_path = Path(__file__).resolve().parent
+
+    # Regenerate dut.v from the Migen/LiteX source on every run, so the
+    # Verilog handed to Verilator can never silently drift from dut.py.
+    v_file = proj_path / "dut.v"
+    dut_module.generate(v_file=str(v_file), top_name="dut")
+
+    runner = get_runner(sim)
+    runner.build(
+        sources=[v_file],
+        hdl_toplevel="dut",
+        always=True,
+        waves=True,
+        # cocotb drives every signal directly (no CPU/bus master), so no
+        # timing/synthesis constraints or extra IP are needed here.
+        build_args=["--trace", "-Wno-fatal"],
+    )
+    runner.test(
+        hdl_toplevel="dut",
+        test_module="test_dut",
+        waves=True,
+    )
+
+
+if __name__ == "__main__":
+    test_dut_runner()


### PR DESCRIPTION
examples: add standalone cocotb+Verilator sim example (CPU-less)

Adds examples/sim_cocotb/, a minimal, non-invasive example showing how to
drive a LiteX-generated design with a cocotb testbench under Verilator,
without modifying litex/build/sim/.

Targets the CPU-less peripheral-development use case identified in the
issue discussion: cocotb acts as the sole bus master, driving a GPIO
register pair and a real litex.soc.cores.uart.RS232PHY core directly (no
CSR/Wishbone bus, no CPU). Verilog is generated via migen.fhdl.verilog's
convert(), sidestepping the C++-owns-the-main-loop vs.
Python-owns-the-main-loop conflict between SimPlatform/VerilatorSimulator
and cocotb, entirely outside litex/build/sim/.

Includes:
- dut.py            -- the CPU-less design (GPIO in/out + UART PHY)
- test_dut.py        -- cocotb testbench (GPIO read/write, UART loopback)
- test_runner.py     -- cocotb_tools.runner-based build/test entry point
- requirements.txt, README.md, .gitignore

README documents setup (incl. installing Verilator separately), the
architecture rationale, performance trade-offs, and the CPU-less scope
boundary, per the discussion in the issue.

Addresses #2380

