### PR TITLE
soc/interconnect/stream: Restore reset-less payloads

### DIFF
--- a/litex/soc/interconnect/stream.py
+++ b/litex/soc/interconnect/stream.py
@@ -72,7 +72,7 @@ class Endpoint(Record):
         Record.__init__(self, self.description.get_full_layout(), name, **kwargs)
         set_reset_less(self.first)
         set_reset_less(self.last)
-        #set_reset_less(self.payload) # FIXME: cause issues with LiteSATA, understand why and uncomment.
+        set_reset_less(self.payload)
         set_reset_less(self.param)
 
     def __getattr__(self, name):

--- a/test/interconnect/test_stream.py
+++ b/test/interconnect/test_stream.py
@@ -13,6 +13,18 @@ from litex.soc.interconnect.stream import *
 
 
 class TestStream(unittest.TestCase):
+    def test_endpoint_datapath_is_resetless(self):
+        endpoint = Endpoint(EndpointDescription(
+            payload_layout = [("data", 8)],
+            param_layout   = [("tag",  4)],
+        ))
+
+        self.assertFalse(endpoint.valid.reset_less)
+        self.assertTrue(endpoint.first.reset_less)
+        self.assertTrue(endpoint.last.reset_less)
+        self.assertTrue(endpoint.data.reset_less)
+        self.assertTrue(endpoint.tag.reset_less)
+
     def test_endpoint_description_duplicate_field(self):
         description = EndpointDescription(
             payload_layout=[("data", 8)],


### PR DESCRIPTION
## Summary

- Restore reset-less stream payload registers.
- Remove the LiteSATA workaround left in `stream.Endpoint` since 2020.
- Add coverage for endpoint reset attributes.

## Background

Stream payload is undefined while `valid` is deasserted and does not need to be part of the reset network. Payload resets were re-enabled globally by `c474272f5` after a LiteSATA RX realignment failure.

The root cause was in LiteSATA: its width-converter reset was derived from payload without checking `valid`. A stale control character could consequently keep a converter with reset-less payload permanently in reset.

[LiteSATA PR #36](https://github.com/enjoy-digital/litesata/pull/36) fixes the consumer and adds a simulation reproducing the deadlock. **That PR must be merged before this one.**

Related issue: [LiteSATA #23](https://github.com/enjoy-digital/litesata/issues/23).

## Validation

- `pytest -q test/interconnect/test_stream.py`: `48 passed`.
- LiteSATA `pytest -q test/test_phy.py` with this branch and LiteSATA PR #36: `5 passed`.
- Generated LiteSATA Verilog retains resets on `valid` and converter control state while removing them from payload-only registers.
