### PR TITLE
liblitespi: Use module erase geometry

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -2857,6 +2857,13 @@ class LiteXSoC(SoC):
             self.add_constant(f"{name}_MODULE_NAME",       module.name)
             self.add_constant(f"{name}_MODULE_TOTAL_SIZE", module.total_size)
             self.add_constant(f"{name}_MODULE_PAGE_SIZE",  module.page_size)
+            erase_opcode    = getattr(module, "erase_opcode", None)
+            erase_size      = getattr(module, "erase_size", None)
+            erase_addr_bits = getattr(module, "erase_addr_bits", None)
+            if None not in [erase_opcode, erase_size, erase_addr_bits]:
+                self.add_constant(f"{name}_MODULE_ERASE_OPCODE",    erase_opcode.code)
+                self.add_constant(f"{name}_MODULE_ERASE_SIZE",      erase_size)
+                self.add_constant(f"{name}_MODULE_ERASE_ADDR_BITS", erase_addr_bits)
             if mode in [ "4x" ]:
                 if module.bus_width >= 4 and SpiNorFlashOpCodes.READ_1_1_4 in module.supported_opcodes:
                     self.add_constant(f"{name}_MODULE_QUAD_CAPABLE")

--- a/litex/soc/software/liblitespi/spiflash.c
+++ b/litex/soc/software/liblitespi/spiflash.c
@@ -295,28 +295,48 @@ static void page_program(uint32_t addr, uint8_t *data, int len)
 	transfer_cmd(w_buf, r_buf, len+4);
 }
 
-static void spiflash_sector_erase(uint32_t addr)
+static void spiflash_erase_command(uint32_t addr, uint8_t opcode, uint8_t addr_bits)
 {
-	w_buf[0] = 0xd8;
-	w_buf[1] = addr>>16;
-	w_buf[2] = addr>>8;
-	w_buf[3] = addr>>0;
-	transfer_cmd(w_buf, r_buf, 4);
+	uint8_t addr_bytes = addr_bits/8;
+
+	w_buf[0] = opcode;
+	for (uint8_t i = 0; i < addr_bytes; i++)
+		w_buf[1+i] = addr >> (8*(addr_bytes - i - 1));
+	transfer_cmd(w_buf, r_buf, 1 + addr_bytes);
 }
 
-/* erase page size in bytes, check flash datasheet */
-#define SPI_FLASH_ERASE_SIZE (64*1024)
+/* Compatibility with LiteSPI module definitions predating erase geometry. */
+#ifndef SPIFLASH_MODULE_ERASE_OPCODE
+#define SPIFLASH_MODULE_ERASE_OPCODE    0xd8
+#define SPIFLASH_MODULE_ERASE_SIZE      (64*1024)
+#define SPIFLASH_MODULE_ERASE_ADDR_BITS 24
+#endif
 
 #define min(x, y) (((x) < (y)) ? (x) : (y))
 
 void spiflash_erase_range(uint32_t addr, uint32_t len)
 {
-	uint32_t i = 0;
+	uint32_t erase_addr;
+	uint32_t last_addr;
 
-	for (i=0; i<len; i+=SPI_FLASH_ERASE_SIZE) {
-		printf("Erase SPI Flash @0x%08lx", ((uint32_t)addr+i));
+	if (len == 0)
+		return;
+	if (addr > UINT32_MAX - (len - 1)) {
+		printf("Error: SPI Flash erase range wraps the address space.\n");
+		return;
+	}
+
+	erase_addr = addr - (addr % SPIFLASH_MODULE_ERASE_SIZE);
+	last_addr  = addr + len - 1;
+	last_addr -= last_addr % SPIFLASH_MODULE_ERASE_SIZE;
+
+	for (;;) {
+		printf("Erase SPI Flash @0x%08lx", erase_addr);
 		spiflash_write_enable();
-		spiflash_sector_erase(addr+i);
+		spiflash_erase_command(
+			erase_addr,
+			SPIFLASH_MODULE_ERASE_OPCODE,
+			SPIFLASH_MODULE_ERASE_ADDR_BITS);
 
 		while (spiflash_read_status_register() & 1) {
 			printf(".");
@@ -325,26 +345,30 @@ void spiflash_erase_range(uint32_t addr, uint32_t len)
 		printf("\n");
 
 #ifdef SPIFLASH_BASE
-		invd_cpu_dcache_range((void *)SPIFLASH_BASE + addr + i, SPI_FLASH_ERASE_SIZE);
+		invd_cpu_dcache_range(
+			(void *)SPIFLASH_BASE + erase_addr,
+			SPIFLASH_MODULE_ERASE_SIZE);
 
 		/* check if region was really erased */
-		for (uint32_t j = 0; j < SPI_FLASH_ERASE_SIZE; j++) {
-			uint8_t* peek = (((uint8_t*)SPIFLASH_BASE)+addr+i+j);
+		for (uint32_t j = 0; j < SPIFLASH_MODULE_ERASE_SIZE; j++) {
+			uint8_t* peek = (((uint8_t*)SPIFLASH_BASE)+erase_addr+j);
 			if (*peek != 0xff) {
-				printf("Error: location 0x%08lx not erased (%0x2x)\n", addr+i+j, *peek);
+				printf("Error: location 0x%08lx not erased (%0x2x)\n", erase_addr+j, *peek);
 			}
 		}
 #endif
+
+		if (erase_addr == last_addr)
+			break;
+		erase_addr += SPIFLASH_MODULE_ERASE_SIZE;
 	}
 }
 
 void spiflash_erase_4k_sector(uint32_t addr)
 {
-	w_buf[0] = 0x20;
-	w_buf[1] = addr>>16;
-	w_buf[2] = addr>>8;
-	w_buf[3] = addr>>0;
-	transfer_cmd(w_buf, r_buf, 4);
+	spiflash_write_enable();
+	spiflash_erase_command(addr, 0x20, 24);
+	while (spiflash_read_status_register() & 1);
 }
 
 /* Returns the number of bytes written and verified, or -1 when the readback

--- a/test/soc/test_soc.py
+++ b/test/soc/test_soc.py
@@ -1268,6 +1268,37 @@ class TestSoC(unittest.TestCase):
         with _assert_raises_soc_error(self):
             soc.add_spi_flash()
 
+    def test_spi_flash_exports_erase_geometry(self):
+        from litespi.ids import SpiNorFlashManufacturerIDs
+        from litespi.opcodes import SpiNorFlashOpCodes as Codes
+        from litespi.phy.model import LiteSPIPHYModel
+        from litespi.spi_nor_flash_module import SpiNorFlashModule
+
+        class EraseGeometryModule(SpiNorFlashModule):
+            manufacturer_id = SpiNorFlashManufacturerIDs.NONJEDEC
+            device_id       = 0x1234
+            name            = "erase-geometry"
+            total_size      = 256
+            page_size       = 256
+            total_pages     = 1
+            supported_opcodes = [Codes.READ_1_1_1, Codes.PP_1_1_1]
+            dummy_bits = 0
+
+        module = EraseGeometryModule(Codes.READ_1_1_1)
+        # Set the attributes directly to keep this test compatible with LiteSPI releases that
+        # predate erase descriptors while exercising LiteX's constant generation.
+        module.erase_opcode    = Codes.BE_4K_4B
+        module.erase_size      = 4 * 1024
+        module.erase_addr_bits = 32
+        phy = LiteSPIPHYModel(module, init=[0])
+        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
+        soc.cpu = SimpleNamespace(endianness="little")
+        soc.add_spi_flash(mode="1x", module=module, phy=phy, with_master=True)
+
+        self.assertEqual(soc.constants["SPIFLASH_MODULE_ERASE_OPCODE"], Codes.BE_4K_4B.code)
+        self.assertEqual(soc.constants["SPIFLASH_MODULE_ERASE_SIZE"], 4 * 1024)
+        self.assertEqual(soc.constants["SPIFLASH_MODULE_ERASE_ADDR_BITS"], 32)
+
     def test_spi_ram_requires_module(self):
         soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
 

--- a/test/software/test_spiflash.py
+++ b/test/software/test_spiflash.py
@@ -184,3 +184,190 @@ def test_is25lp128_quad_enable_preserves_status(tmp_path):
         "-o", str(binary),
     ])
     subprocess.check_call([str(binary)])
+
+
+def test_erase_uses_module_geometry(tmp_path):
+    repo        = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    include_dir = tmp_path / "include"
+    source      = tmp_path / "spiflash_erase_harness.c"
+    binary      = tmp_path / "spiflash_erase_harness"
+
+    _write(include_dir / "generated" / "csr.h", """
+        #ifndef __GENERATED_CSR_H
+        #define __GENERATED_CSR_H
+
+        #define CSR_SPIFLASH_BASE                             1
+        #define CSR_SPIFLASH_MASTER_CS_ADDR                   1
+        #define CSR_SPIFLASH_MASTER_PHYCONFIG_LEN_SIZE        8
+        #define CSR_SPIFLASH_MASTER_PHYCONFIG_LEN_OFFSET      0
+        #define CSR_SPIFLASH_MASTER_PHYCONFIG_WIDTH_SIZE      4
+        #define CSR_SPIFLASH_MASTER_PHYCONFIG_WIDTH_OFFSET    8
+        #define CSR_SPIFLASH_MASTER_PHYCONFIG_MASK_SIZE       8
+        #define CSR_SPIFLASH_MASTER_PHYCONFIG_MASK_OFFSET    16
+        #define CSR_SPIFLASH_MASTER_STATUS_TX_READY_OFFSET    0
+        #define CSR_SPIFLASH_MASTER_STATUS_RX_READY_OFFSET    1
+
+        uint32_t test_spiflash_master_status_read(void);
+        uint32_t test_spiflash_master_rxtx_read(void);
+        void test_spiflash_master_rxtx_write(uint32_t value);
+        void test_spiflash_master_phyconfig_write(uint32_t value);
+        void test_spiflash_master_cs_write(uint32_t value);
+
+        #define spiflash_master_status_read      test_spiflash_master_status_read
+        #define spiflash_master_rxtx_read        test_spiflash_master_rxtx_read
+        #define spiflash_master_rxtx_write       test_spiflash_master_rxtx_write
+        #define spiflash_master_phyconfig_write  test_spiflash_master_phyconfig_write
+        #define spiflash_master_cs_write         test_spiflash_master_cs_write
+
+        #endif
+    """)
+    _write(include_dir / "generated" / "mem.h")
+    _write(include_dir / "libbase" / "crc.h")
+    _write(include_dir / "libbase" / "memtest.h")
+    _write(include_dir / "system.h", """
+        #ifndef __SYSTEM_H
+        #define __SYSTEM_H
+
+        #include <stdbool.h>
+
+        #define CONFIG_CLOCK_FREQUENCY                         1000000
+        #define SPIFLASH_PHY_FREQUENCY                         1000000
+        #define SPIFLASH_MODULE_NAME                         "model"
+        #define SPIFLASH_MODULE_ERASE_OPCODE                  0x21
+        #define SPIFLASH_MODULE_ERASE_SIZE                    4096
+        #define SPIFLASH_MODULE_ERASE_ADDR_BITS                 32
+
+        static inline void cdelay(int cycles) { (void)cycles; }
+
+        #endif
+    """)
+    _write(source, f"""
+        #include <stdbool.h>
+        #include <stdint.h>
+        #include <stdio.h>
+        #include <string.h>
+
+        #define MAX_TRANSACTIONS 16
+        #define MAX_TRANSACTION_BYTES 8
+
+        static uint8_t transactions[MAX_TRANSACTIONS][MAX_TRANSACTION_BYTES];
+        static unsigned int transaction_lengths[MAX_TRANSACTIONS];
+        static unsigned int transaction_count;
+        static bool transaction_active;
+        static bool rx_ready;
+        static uint32_t rx_value;
+
+        uint32_t test_spiflash_master_status_read(void)
+        {{
+            return 1 | (rx_ready << 1);
+        }}
+
+        uint32_t test_spiflash_master_rxtx_read(void)
+        {{
+            rx_ready = false;
+            return rx_value;
+        }}
+
+        void test_spiflash_master_phyconfig_write(uint32_t value)
+        {{
+            (void)value;
+        }}
+
+        void test_spiflash_master_cs_write(uint32_t value)
+        {{
+            if (value) {{
+                transaction_active = true;
+                transaction_lengths[transaction_count] = 0;
+            }} else if (transaction_active) {{
+                transaction_active = false;
+                transaction_count++;
+            }}
+        }}
+
+        void test_spiflash_master_rxtx_write(uint32_t value)
+        {{
+            unsigned int length = transaction_lengths[transaction_count];
+
+            if (transaction_count < MAX_TRANSACTIONS && length < MAX_TRANSACTION_BYTES)
+                transactions[transaction_count][length] = value;
+            transaction_lengths[transaction_count] = length + 1;
+            rx_value = 0;
+            rx_ready = true;
+        }}
+
+        #include "{repo}/litex/soc/software/liblitespi/spiflash.c"
+
+        #define REQUIRE(cond) do {{ \
+            if (!(cond)) {{ \
+                fprintf(stderr, "requirement failed at %s:%d: %s\\n", __FILE__, __LINE__, #cond); \
+                return 1; \
+            }} \
+        }} while (0)
+
+        static void clear_transactions(void)
+        {{
+            memset(transactions, 0, sizeof(transactions));
+            memset(transaction_lengths, 0, sizeof(transaction_lengths));
+            transaction_count  = 0;
+            transaction_active = false;
+            rx_ready            = false;
+            rx_value            = 0;
+        }}
+
+        static int check_erase(unsigned int index, uint32_t address)
+        {{
+            REQUIRE(transaction_lengths[index] == 5);
+            REQUIRE(transactions[index][0] == 0x21);
+            REQUIRE(transactions[index][1] == ((address >> 24) & 0xff));
+            REQUIRE(transactions[index][2] == ((address >> 16) & 0xff));
+            REQUIRE(transactions[index][3] == ((address >>  8) & 0xff));
+            REQUIRE(transactions[index][4] == ((address >>  0) & 0xff));
+            return 0;
+        }}
+
+        int main(void)
+        {{
+            spiflash_erase_range(0x1234, 1);
+            REQUIRE(transaction_count == 3);
+            REQUIRE(transaction_lengths[0] == 1);
+            REQUIRE(transactions[0][0] == 0x06);
+            REQUIRE(check_erase(1, 0x1000) == 0);
+            REQUIRE(transactions[2][0] == 0x05);
+
+            clear_transactions();
+            spiflash_erase_range(0x1fff, 2);
+            REQUIRE(transaction_count == 6);
+            REQUIRE(check_erase(1, 0x1000) == 0);
+            REQUIRE(check_erase(4, 0x2000) == 0);
+
+            clear_transactions();
+            spiflash_erase_range(0xffffffff, 2);
+            REQUIRE(transaction_count == 0);
+
+            clear_transactions();
+            spiflash_erase_4k_sector(0x3456);
+            REQUIRE(transaction_count == 3);
+            REQUIRE(transactions[0][0] == 0x06);
+            REQUIRE(transaction_lengths[1] == 4);
+            REQUIRE(transactions[1][0] == 0x20);
+            REQUIRE(transactions[1][1] == 0x00);
+            REQUIRE(transactions[1][2] == 0x34);
+            REQUIRE(transactions[1][3] == 0x56);
+            REQUIRE(transactions[2][0] == 0x05);
+            return 0;
+        }}
+    """)
+
+    subprocess.check_call([
+        "gcc",
+        "-std=c11",
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        "-Wno-format",
+        "-Wno-unused-function",
+        "-I", str(include_dir),
+        str(source),
+        "-o", str(binary),
+    ])
+    subprocess.check_call([str(binary)])


### PR DESCRIPTION
## Summary

- export the selected LiteSPI module erase opcode, size, and address width as SoC constants
- make `spiflash_erase_range()` align a requested range to the hardware erase geometry and erase every intersecting unit
- support both 24-bit and 32-bit erase commands
- retain the existing 64-KiB/24-bit fallback for older LiteSPI module definitions
- make the explicit 4-KiB erase helper perform write-enable and wait for completion

This is the LiteX half of litex-hub/litespi#35 and is paired with litex-hub/litespi#111.

## Tests

- `pytest -q test/software/test_spiflash.py test/soc/test_soc.py` (128 passed, 21 subtests passed)
