### PR TITLE
build/yosys: use built-in slang frontend by default

### DIFF
--- a/litex/build/yosys_nextpnr_toolchain.py
+++ b/litex/build/yosys_nextpnr_toolchain.py
@@ -91,6 +91,7 @@ class YosysNextPNRToolchain(GenericToolchain):
         abc9         = False,
         flow3        = False,
         use_slang    = False,
+        slang_plugin = False,
         timingstrict = False,
         ignoreloops  = False,
         seed         = 1,
@@ -109,6 +110,8 @@ class YosysNextPNRToolchain(GenericToolchain):
             use ABC9 with flow3 (Yosys)
         use_slang : bool
             use Yosys's slang frontend for SystemVerilog sources.
+        slang_plugin : bool
+            load the legacy external slang plugin before using read_slang.
         timingstrict : list
             check timing failures (nextpnr)
         ignoreloops : str
@@ -119,7 +122,8 @@ class YosysNextPNRToolchain(GenericToolchain):
 
         self._nowidelut   = nowidelut
         self._abc9        = abc9 
-        self._use_slang   = use_slang
+        self._use_slang    = use_slang
+        self._slang_plugin = slang_plugin
         if flow3:
             self._abc9 = True
             cmd = "scratchpad -copy abc9.script.flow3 abc9.script"
@@ -144,6 +148,7 @@ class YosysNextPNRToolchain(GenericToolchain):
             yosys_cmds   = self._yosys_cmds,
             yosys_opts   = self._synth_opts,
             use_slang    = self._use_slang,
+            slang_plugin = self._slang_plugin,
             synth_format = self.synth_fmt,
             nowidelut    = self._nowidelut,
             abc9         = self._abc9,

--- a/litex/build/yosys_wrapper.py
+++ b/litex/build/yosys_wrapper.py
@@ -20,6 +20,7 @@ class YosysWrapper():
         yosys_opts   = "",
         yosys_cmds   = [],
         use_slang    = False,
+        slang_plugin = False,
         slang_opts   = "",
         synth_format = "json",
         **kwargs)    :
@@ -42,6 +43,8 @@ class YosysWrapper():
             optionals commands called before synth_xxx
         use_slang : bool
             use Yosys's slang frontend for SystemVerilog sources.
+        slang_plugin : bool
+            load the legacy external slang plugin before using read_slang.
         slang_opts : str
             options to pass to read_slang.
         synth_format : str
@@ -64,7 +67,8 @@ class YosysWrapper():
         self._yosys_opts   = yosys_opts
         self._yosys_cmds   = yosys_cmds
         self._quiet        = "" if not kwargs.pop("quiet", False) else '-Qq'
-        self._use_slang    = use_slang or getattr(platform, "yosys_use_slang", False)
+        self._slang_plugin = slang_plugin or getattr(platform, "yosys_slang_plugin", False)
+        self._use_slang    = use_slang or self._slang_plugin or getattr(platform, "yosys_use_slang", False)
         self._slang_opts   = slang_opts or getattr(platform, "yosys_slang_opts", "")
 
         self._target = target
@@ -100,7 +104,8 @@ class YosysWrapper():
         if slang_files:
             opts  = f" {self._slang_opts}" if self._slang_opts else ""
             files = " ".join(slang_files)
-            reads.insert(0, "plugin -i slang")
+            if self._slang_plugin:
+                reads.insert(0, "plugin -i slang")
             reads.append(f"read_slang{opts}{includes} {files}")
         return "\n".join(reads)
 
@@ -163,6 +168,7 @@ def yosys_args(parser):
     parser.add_argument("--yosys-abc9",      action="store_true", help="Use Yosys's abc9 mode.")
     parser.add_argument("--yosys-flow3",     action="store_true", help="Use Yosys's abc9 mode with the flow3 script.")
     parser.add_argument("--yosys-slang",     action="store_true", help="Use Yosys's slang SystemVerilog frontend.")
+    parser.add_argument("--yosys-slang-plugin", action="store_true", help="Load the legacy external slang plugin (for Yosys < 0.67).")
     parser.add_argument("--yosys-quiet",     action="store_true", help="Use Yosys's '-Qq' to be quiet")
 
 def yosys_argdict(args):
@@ -170,6 +176,7 @@ def yosys_argdict(args):
         "nowidelut": args.yosys_nowidelut,
         "abc9":      args.yosys_abc9,
         "flow3":     args.yosys_flow3,
-        "use_slang": args.yosys_slang,
-        "quiet":     args.yosys_quiet,
+        "use_slang":    args.yosys_slang or args.yosys_slang_plugin,
+        "slang_plugin": args.yosys_slang_plugin,
+        "quiet":        args.yosys_quiet,
     }

--- a/test/build/test_yosys_wrapper.py
+++ b/test/build/test_yosys_wrapper.py
@@ -37,10 +37,18 @@ class TestYosysWrapper(unittest.TestCase):
         wrapper = YosysWrapper(platform, "top", target="gowin")
         read_files = wrapper._import_sources()
 
-        self.assertIn("plugin -i slang", read_files)
+        self.assertNotIn("plugin -i slang", read_files)
         self.assertIn('read_verilog -I/include "/src/top.v"', read_files)
         self.assertIn("read_slang --ignore-initial --top top -I/include /src/pkg.sv /src/include.v", read_files)
         self.assertNotIn("read_verilog -sv", read_files)
+
+    def test_slang_frontend_can_load_legacy_plugin(self):
+        wrapper = YosysWrapper(_Platform(), "top", target="gowin", slang_plugin=True)
+
+        read_files = wrapper._import_sources()
+
+        self.assertIn("plugin -i slang", read_files)
+        self.assertIn("read_slang -I/include /src/pkg.sv /src/include.v", read_files)
 
     def test_yosys_slang_argdict(self):
         parser = argparse.ArgumentParser()
@@ -49,6 +57,17 @@ class TestYosysWrapper(unittest.TestCase):
         args = parser.parse_args(["--yosys-slang"])
 
         self.assertTrue(yosys_argdict(args)["use_slang"])
+        self.assertFalse(yosys_argdict(args)["slang_plugin"])
+
+    def test_yosys_slang_plugin_argdict(self):
+        parser = argparse.ArgumentParser()
+        yosys_args(parser)
+
+        args = parser.parse_args(["--yosys-slang-plugin"])
+        argdict = yosys_argdict(args)
+
+        self.assertTrue(argdict["use_slang"])
+        self.assertTrue(argdict["slang_plugin"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- use Yosys's built-in `read_slang` frontend without loading an external plugin by default
- add `--yosys-slang-plugin` for legacy Yosys installations that still require `plugin -i slang`
- expose the same compatibility choice through `slang_plugin` / `platform.yosys_slang_plugin`
- test both generated Yosys script forms and argument propagation

## Context

This follows up on #2510 and the Yosys 0.67 update reported by @mmicko in https://github.com/enjoy-digital/litex/pull/2510#issuecomment-4935417896.

Yosys 0.67 integrates the slang-based SystemVerilog frontend, so current builds can invoke `read_slang` directly. The compatibility option remains useful for Yosys 0.66 and older, or builds where the integrated frontend is disabled and an external plugin is available. `--yosys-slang-plugin` implies `--yosys-slang`.

Commit: `11c2fb6fd`

## Tests

- `python3 -m pytest -q test/build`: 131 passed, 83 subtests passed
- `python3 -m pytest -q test/build/test_yosys_wrapper.py test/cores/test_cpu_ibex.py`: 8 passed
- Python compilation and `git diff --check`

The local Yosys versions predate 0.67, so the built-in frontend was verified against the Yosys 0.67 release and bundled `sv-elab` frontend sources rather than through a local synthesis run.
