### PR TITLE
build/lattice: Add native iCE40 DDR tristate

### DIFF
--- a/litex/build/lattice/common.py
+++ b/litex/build/lattice/common.py
@@ -537,6 +537,58 @@ class LatticeiCE40DDRInput:
     def lower(dr):
         return LatticeiCE40DDRInputImpl(dr.i, dr.o1, dr.o2, dr.clk)
 
+# iCE40 DDR Tristate -------------------------------------------------------------------------------
+
+class LatticeiCE40DDRTristateImpl(Module):
+    def __init__(self, io, o1, o2, oe1, oe2, i1, i2, clk, i_async):
+        if oe2 is not None:
+            raise ValueError("iCE40 DDRTristate does not support DDR output enable")
+
+        for j in range(len(io)):
+            parameters = dict(
+                p_PIN_TYPE      = C(0b110000, 6), # PIN_OUTPUT_DDR_REGISTERED_ENABLE + PIN_INPUT_DDR
+                p_IO_STANDARD   = "SB_LVCMOS",
+                io_PACKAGE_PIN  = io[j],
+                i_CLOCK_ENABLE  = 1,
+                i_INPUT_CLK     = clk,
+                i_OUTPUT_CLK    = clk,
+                i_OUTPUT_ENABLE = oe1[j],
+                i_D_OUT_0       = o1[j],
+                i_D_OUT_1       = o2[j],
+            )
+
+            if i_async is not None:
+                # SB_IO cannot expose its registered posedge input and asynchronous input at the
+                # same time. Select the asynchronous input and recreate the posedge register in a
+                # fabric flip-flop; the negedge input remains in the I/O cell.
+                pin_i = Signal()
+                parameters.update(
+                    p_PIN_TYPE = C(0b110001, 6),
+                    o_D_IN_0   = pin_i,
+                )
+                self.comb += i_async[j].eq(pin_i)
+                if i1 is not None:
+                    parameters.update(o_D_IN_1=i2[j])
+                    self.specials += Instance("SB_DFF",
+                        i_C = clk,
+                        i_D = pin_i,
+                        o_Q = i1[j],
+                    )
+            elif i1 is not None:
+                parameters.update(
+                    o_D_IN_0 = i1[j],
+                    o_D_IN_1 = i2[j],
+                )
+
+            self.specials += Instance("SB_IO", **parameters)
+
+
+class LatticeiCE40DDRTristate:
+    @staticmethod
+    def lower(dr):
+        return LatticeiCE40DDRTristateImpl(
+            dr.io, dr.o1, dr.o2, dr.oe1, dr.oe2, dr.i1, dr.i2, dr.clk, dr.i_async)
+
 # iCE40 SDR Output ---------------------------------------------------------------------------------
 
 class LatticeiCE40SDROutputImpl(Module):
@@ -599,6 +651,7 @@ lattice_ice40_special_overrides = {
     DifferentialInput:      LatticeiCE40DifferentialInput,
     DDROutput:              LatticeiCE40DDROutput,
     DDRInput:               LatticeiCE40DDRInput,
+    DDRTristate:            LatticeiCE40DDRTristate,
     SDROutput:              LatticeiCE40SDROutput,
     SDRInput:               LatticeiCE40SDRInput,
     SDRTristate:            LatticeiCE40SDRTristate,

--- a/test/build/test_build_io.py
+++ b/test/build/test_build_io.py
@@ -263,6 +263,69 @@ class TestBuildIO(unittest.TestCase):
         self.assertIn("output wire    [1:0] i_async", v)
         self.assertIn("assign i_async =", v)
 
+    def test_lattice_ice40_ddr_tristate_uses_physical_io_cells(self):
+        io  = Signal(4)
+        o1  = Signal(4)
+        o2  = Signal(4)
+        oe  = Signal(4)
+        i1  = Signal(4)
+        i2  = Signal(4)
+        clk = Signal()
+
+        v = _convert_special(
+            DDRTristate(io, o1, o2, oe, i1=i1, i2=i2, clk=clk),
+            {io, o1, o2, oe, i1, i2, clk},
+            lattice_ice40_special_overrides,
+        )
+
+        self.assertEqual(v.count(" of SB_IO Module."), 4)
+        self.assertEqual(v.count(".PIN_TYPE    (6'd48)"), 4)
+        self.assertIn(".PACKAGE_PIN   (io[0])", v)
+        self.assertIn(".PACKAGE_PIN   (io[3])", v)
+        self.assertNotIn("inferredddrtristate", v)
+
+    def test_lattice_ice40_ddr_tristate_preserves_i_async(self):
+        io      = Signal(2)
+        o1      = Signal(2)
+        o2      = Signal(2)
+        oe      = Signal(2)
+        i1      = Signal(2)
+        i2      = Signal(2)
+        i_async = Signal(2)
+        clk     = Signal()
+
+        v = _convert_special(
+            DDRTristate(io, o1, o2, oe, i1=i1, i2=i2, clk=clk, i_async=i_async),
+            {io, o1, o2, oe, i1, i2, i_async, clk},
+            lattice_ice40_special_overrides,
+        )
+
+        self.assertEqual(v.count(" of SB_IO Module."), 2)
+        self.assertEqual(v.count(".PIN_TYPE    (6'd49)"), 2)
+        self.assertEqual(v.count(" of SB_DFF Module."), 2)
+        self.assertNotIn("inferredddrtristate", v)
+
+    def test_lattice_ice40_ddr_tristate_rejects_ddr_output_enable(self):
+        io  = Signal()
+        o1  = Signal()
+        o2  = Signal()
+        oe1 = Signal()
+        oe2 = Signal()
+        clk = Signal()
+        with self.assertRaisesRegex(ValueError, "DDR output enable"):
+            _convert_special(
+                DDRTristate(
+                    io  = io,
+                    o1  = o1,
+                    o2  = o2,
+                    oe1 = oe1,
+                    oe2 = oe2,
+                    clk = clk,
+                ),
+                {io, o1, o2, oe1, oe2, clk},
+                lattice_ice40_special_overrides,
+            )
+
     def test_efinix_ddr_tristate_rejects_i_async_with_registered_inputs(self):
         with self.assertRaisesRegex(ValueError, "i_async"):
             EfinixTrionDDRTristateImpl(


### PR DESCRIPTION
## Summary

- add a native iCE40 lowering for the generic `DDRTristate` primitive
- combine DDR output, DDR input, and registered output enable in one physical `SB_IO` per bit
- preserve `i_async` by using the asynchronous `D_IN_0` path and a fabric posedge register while keeping the negedge sample in the I/O cell
- reject DDR output-enable data, which the iCE40 `SB_IO` cannot implement directly
- cover physical-pin lowering, asynchronous input, and the unsupported output-enable mode

## Background

The generic fallback decomposes `DDRTristate` into separate DDR output, output-enable, DDR input,
and tristate cells. On iCE40 these each lower to an `SB_IO`, leaving several `PACKAGE_PIN` ports
connected to internal nets. nextpnr cannot place those cells.

The native lowering uses `PIN_TYPE=6'b110000` for the normal synchronous-input case, so every
bidirectional DDR signal is represented by exactly one `SB_IO` attached to the real package pin.

This fixes the LiteSPI Fomu DDR placement failure reported in litex-hub/litespi#62.

## Validation

- `pytest -q test/build` — 132 passed, 83 subtests passed
- full LiteSPI suite with this LiteX branch — 34 passed, 639 subtests passed
- quad LiteSPI DDR elaboration — 4 integrated DDR tristates, no generic fallback/internal package pins
- resource-trimmed Fomu iCE40 `rate="1:2"` build (`--no-uart --no-timer --no-ident`) — Yosys and nextpnr placement/routing completed, timing passed at 12 MHz, and a bitstream was generated
