### PR TITLE
SoC: add HyperRAM framebuffer and AXI support with extended test coverage

### DIFF
--- a/litex/build/altera/quartus.py
+++ b/litex/build/altera/quartus.py
@@ -172,7 +172,7 @@ class AlteraQuartusToolchain(GenericToolchain):
                 sdc.append(tpl.format(name=name, clk=clk_sig, period=str(period)))
 
         # Enable automatical constraint generation for PLLs
-        if not self.platform.device[:3] in ["A5E", "A3C"]:
+        if self.platform.device[:3] not in ["A5E", "A3C"]:
             sdc.append("derive_pll_clocks -use_net_name")
 
         # Any additional clock constraints like "create_generated_clock" etc.

--- a/litex/build/anlogic/platform.py
+++ b/litex/build/anlogic/platform.py
@@ -25,9 +25,10 @@ class AnlogicPlatform(GenericPlatform):
         else:
             raise ValueError(f"Unknown toolchain {toolchain}")
 
-    def get_verilog(self, *args, special_overrides=dict(), **kwargs):
+    def get_verilog(self, *args, special_overrides=None, **kwargs):
         so = dict(common.anlogic_special_overrides)
-        so.update(special_overrides)
+        if special_overrides is not None:
+            so.update(special_overrides)
         return GenericPlatform.get_verilog(self, *args,
             special_overrides = so,
             attr_translate    = self.toolchain.attr_translate,

--- a/litex/build/efinix/efinity.py
+++ b/litex/build/efinix/efinity.py
@@ -384,7 +384,7 @@ class EfinityToolchain(GenericToolchain):
         et.SubElement(design_info, "efx:top_module", name=self._build_name)
 
         # Add Design Sources.
-        for filename, language, library, *copy in self.platform.sources:
+        for filename, language, library, *_ in self.platform.sources:
             if language is None:
                 continue
             et.SubElement(design_info, "efx:design_file", {

--- a/litex/build/efinix/ifacewriter.py
+++ b/litex/build/efinix/ifacewriter.py
@@ -603,7 +603,6 @@ design.create("{2}", "{3}", "./", overwrite=True)
         return '\n'.join(cmd) + '\n'
 
     def generate_remote_update(self, block, verbose=True):
-        name = block["name"]
         pins = block["pins"]
         clock = block["clock"]
         invert_clk = block["invert_clock"]

--- a/litex/build/io.py
+++ b/litex/build/io.py
@@ -295,8 +295,8 @@ class DDRTristate(Special):
 
 class CRG(Module):
     def __init__(self, clk, rst=0):
-        self.clock_domains.cd_sys = ClockDomain()
-        self.clock_domains.cd_por = ClockDomain(reset_less=True)
+        self.clock_domains.cd_sys = ClockDomain("sys")
+        self.clock_domains.cd_por = ClockDomain("por", reset_less=True)
 
         if hasattr(clk, "p"):
             clk_se = Signal()

--- a/litex/soc/cores/video.py
+++ b/litex/soc/cores/video.py
@@ -16,6 +16,7 @@ from litex.gen import *
 
 from litex.soc.interconnect.csr import *
 from litex.soc.interconnect import stream
+from litex.soc.interconnect import wishbone
 from litex.soc.cores.code_tmds import TMDSEncoder
 
 from litex.build.io import SDROutput, DDROutput
@@ -1030,8 +1031,13 @@ class VideoFrameBuffer(LiteXModule):
         # # #
 
         # Video DMA.
-        from litedram.frontend.dma import LiteDRAMDMAReader
-        self.dma = LiteDRAMDMAReader(dram_port, fifo_depth=fifo_depth//(dram_port.data_width//8), fifo_buffered=True)
+        dma_fifo_depth = fifo_depth//(dram_port.data_width//8)
+        if isinstance(dram_port, wishbone.Interface):
+            from litex.soc.cores.dma import WishboneDMAReader
+            self.dma = WishboneDMAReader(dram_port, endianness="big", fifo_depth=dma_fifo_depth)
+        else:
+            from litedram.frontend.dma import LiteDRAMDMAReader
+            self.dma = LiteDRAMDMAReader(dram_port, fifo_depth=dma_fifo_depth, fifo_buffered=True)
         self.dma.add_csr(
             default_base   = base,
             default_length = video_framebuffer_size(hres, vres, format),

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1633,6 +1633,41 @@ class SoC(LiteXModule):
             self.bus.regions[region_name]))
         return hyperram
 
+    # Add AXI Master ------------------------------------------------------------------------------
+    def add_axi_master(self, name="axi_master", pads=None, origin=None, size=0x10000,
+        bus_standard="axi-lite", data_width=32, address_width=32, id_width=1,
+        clock_domain="sys", mode="rw", **kwargs):
+        if bus_standard not in ["axi-lite", "axi"]:
+            self.logger.error("AXI Master {} {}.".format(
+                colorer("bus_standard", color="red"), colorer(bus_standard, color="red")))
+            raise SoCError()
+        if pads is None:
+            pads = self.platform.request(name)
+        self.check_if_exists(name)
+
+        interface_cls = {
+            "axi-lite": axi.AXILiteInterface,
+            "axi"     : axi.AXIInterface,
+        }[bus_standard]
+        interface_kwargs = dict(
+            data_width    = data_width,
+            address_width = address_width,
+            clock_domain  = clock_domain,
+            mode          = mode,
+            **kwargs,
+        )
+        if interface_cls is axi.AXIInterface:
+            interface_kwargs["id_width"] = id_width
+        interface = interface_cls(**interface_kwargs)
+
+        region = SoCRegion(origin=origin, size=size, cached=False)
+        if not region.cached and region.origin is not None and not self.bus.check_region_is_io(region):
+            self.bus.add_region(f"{name}_io", SoCIORegion(origin=region.origin, size=region.size))
+        self.bus.add_slave(name=name, slave=interface, region=region, clock_domain=clock_domain)
+        self.comb += interface.connect_to_pads(pads, mode="master")
+        setattr(self, name, interface)
+        return interface
+
     # Add CSR Bridge -------------------------------------------------------------------------------
     def add_csr_bridge(self, name="csr", origin=None, with_register=False):
         csr_bridge_cls = {
@@ -3452,22 +3487,36 @@ class LiteXSoC(SoC):
         self.comb += vt.source.connect(phy if isinstance(phy, stream.Endpoint) else phy.sink)
 
     # Add Video Framebuffer ------------------------------------------------------------------------
-    def _get_video_framebuffer_default_region(self, name, size):
-        main_ram = self.bus.regions.get("main_ram", None)
-        if main_ram is None:
-            return SoCRegion(
-                origin = 0x40c00000,
-                size   = size,
-                linker = True)
+    def _get_video_framebuffer_memory_name(self, memory_name=None):
+        if memory_name is not None:
+            return memory_name
+        if "main_ram" in self.bus.regions:
+            return "main_ram"
+        if hasattr(self, "hyperram") and "hyperram" in self.bus.regions:
+            return "hyperram"
+        return "main_ram"
 
-        size_pow2    = 2**log2_int(size, False)
-        main_ram_end = main_ram.origin + main_ram.size
-        origin       = (main_ram_end - size_pow2) & ~(size_pow2 - 1)
-        if origin < main_ram.origin:
-            self.logger.error("{} of size {} does not fit in main_ram:".format(
+    def _get_video_framebuffer_default_region(self, name, size, memory_name="main_ram"):
+        memory = self.bus.regions.get(memory_name, None)
+        if memory is None:
+            if memory_name == "main_ram":
+                return SoCRegion(
+                    origin = 0x40c00000,
+                    size   = size,
+                    linker = True)
+            self.logger.error("Video framebuffer memory region {} {}.".format(
+                colorer(memory_name, color="red"), colorer("not found", color="red")))
+            raise SoCError()
+
+        size_pow2  = 2**log2_int(size, False)
+        memory_end = memory.origin + memory.size
+        origin     = (memory_end - size_pow2) & ~(size_pow2 - 1)
+        if origin < memory.origin:
+            self.logger.error("{} of size {} does not fit in {}:".format(
                 colorer(name, color="red"),
-                colorer("0x{:08x}".format(size))))
-            self.logger.error(str(main_ram))
+                colorer("0x{:08x}".format(size)),
+                colorer(memory_name)))
+            self.logger.error(str(memory))
             raise SoCError()
 
         return SoCRegion(
@@ -3475,22 +3524,32 @@ class LiteXSoC(SoC):
             size   = size,
             linker = True)
 
-    def _get_video_framebuffer_base(self, name, size):
+    def _get_video_framebuffer_base(self, name, size, memory_name="main_ram"):
         base = self.mem_map.get(name, None)
         if base is not None:
             return base
 
-        self.bus.add_region(name, self._get_video_framebuffer_default_region(name, size))
+        self.bus.add_region(name, self._get_video_framebuffer_default_region(
+            name, size, memory_name))
         return self.bus.regions[name].origin
 
-    def add_video_framebuffer(self, name="video_framebuffer", phy=None, timings="800x600@60Hz", clock_domain="sys", format="rgb888", fifo_depth=64*KILOBYTE):
+    def _get_video_framebuffer_port(self, port=None):
+        if port is not None:
+            return port
+        if hasattr(self, "sdram"):
+            return self.sdram.crossbar.get_port()
+        if hasattr(self, "hyperram"):
+            return self.hyperram.bus
+        self.logger.error("Video framebuffer requires {} or {}.".format(
+            colorer("sdram", color="red"), colorer("port", color="red")))
+        raise SoCError()
+
+    def add_video_framebuffer(self, name="video_framebuffer", phy=None, timings="800x600@60Hz", clock_domain="sys", format="rgb888", fifo_depth=64*KILOBYTE, port=None, memory_name=None):
         if phy is None:
             self.logger.error("Video framebuffer requires {}.".format(colorer("phy", color="red")))
             raise SoCError()
-        if not hasattr(self, "sdram"):
-            self.logger.error("Video framebuffer requires {}.".format(
-                colorer("sdram", color="red")))
-            raise SoCError()
+        port = self._get_video_framebuffer_port(port)
+        memory_name = self._get_video_framebuffer_memory_name(memory_name)
         try:
             _, hres, vres = parse_video_timing_resolution(timings)
         except ValueError as e:
@@ -3510,8 +3569,8 @@ class LiteXSoC(SoC):
         # Video FrameBuffer.
         self.check_if_exists(name)
         framebuffer_size = video_framebuffer_size(hres, vres, format)
-        base = self._get_video_framebuffer_base(name, framebuffer_size)
-        vfb = VideoFrameBuffer(self.sdram.crossbar.get_port(),
+        base = self._get_video_framebuffer_base(name, framebuffer_size, memory_name)
+        vfb = VideoFrameBuffer(port,
             hres                  = hres,
             vres                  = vres,
             base                  = base,

--- a/test/soc/test_soc.py
+++ b/test/soc/test_soc.py
@@ -110,6 +110,14 @@ class _CRGWithEfinityPLL:
 def _make_bus_interface(interface_cls, data_width=32, address_width=32):
     return interface_cls(data_width=data_width, address_width=address_width)
 
+def _make_axi_lite_pads(data_width=32, address_width=32):
+    return Record([
+        ("awvalid", 1), ("awready", 1), ("awaddr", address_width), ("awprot", 3),
+        ("wvalid",  1), ("wready",  1), ("wdata",  data_width),    ("wstrb", data_width//8),
+        ("bvalid",  1), ("bready",  1), ("bresp",  2),
+        ("arvalid", 1), ("arready", 1), ("araddr", address_width), ("arprot", 3),
+        ("rvalid",  1), ("rready",  1), ("rdata",  data_width),    ("rresp", 2),
+    ])
 
 class TestSoCCoreCompatibility(unittest.TestCase):
     def test_soc_core_reexports_canonical_soc_api(self):
@@ -242,6 +250,38 @@ class TestSoCVideoFrameBuffer(unittest.TestCase):
         with _assert_raises_soc_error(self):
             soc._get_video_framebuffer_default_region("video_framebuffer", 0x00200000)
 
+    def test_framebuffer_port_can_be_provided_without_sdram(self):
+        soc  = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
+        port = wishbone.Interface()
+
+        self.assertIs(soc._get_video_framebuffer_port(port), port)
+
+    def test_framebuffer_port_uses_hyperram_when_sdram_is_absent(self):
+        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
+        bus = wishbone.Interface()
+        soc.hyperram = SimpleNamespace(bus=bus)
+
+        self.assertIs(soc._get_video_framebuffer_port(), bus)
+
+    def test_framebuffer_memory_name_defaults_to_hyperram_without_main_ram(self):
+        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
+        soc.hyperram = SimpleNamespace(bus=wishbone.Interface())
+        soc.bus.add_region("hyperram", SoCRegion(origin=0x20000000, size=0x00800000))
+
+        self.assertEqual(soc._get_video_framebuffer_memory_name(), "hyperram")
+
+    def test_default_region_can_be_placed_in_hyperram(self):
+        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
+        soc.bus.add_region("hyperram", SoCRegion(origin=0x20000000, size=0x00800000))
+
+        framebuffer_size = video_framebuffer_size(800, 600, "rgb888")
+        region = soc._get_video_framebuffer_default_region(
+            "video_framebuffer", framebuffer_size, memory_name="hyperram")
+
+        self.assertEqual(region.origin, 0x20600000)
+        self.assertEqual(region.size,   framebuffer_size)
+        self.assertLessEqual(region.origin + region.size, 0x20800000)
+        self.assertTrue(region.linker)
 
 class TestSoCResetRequests(unittest.TestCase):
     def test_soc_reset_request_registers_source(self):
@@ -1125,6 +1165,44 @@ class TestSoC(unittest.TestCase):
         soc.add_hyperram(number=1, size=0x1000, with_csr=False)
 
         self.assertEqual(platform.request_calls, [("hyperram", 1, False)])
+
+    def test_add_axi_master_maps_requested_axi_lite_pads(self):
+        platform = _FakePlatform()
+        platform.requests["axi_master"] = _make_axi_lite_pads()
+        soc = SoC(platform, sys_clk_freq=100e6, bus_standard="axi-lite")
+
+        interface = soc.add_axi_master(origin=0x20000000, size=0x10000)
+
+        self.assertIs(soc.axi_master, interface)
+        self.assertIs(soc.bus.slaves["axi_master"], interface)
+        self.assertIsInstance(interface, axi.AXILiteInterface)
+        self.assertEqual(soc.bus.regions["axi_master"].origin, 0x20000000)
+        self.assertFalse(soc.bus.regions["axi_master"].cached)
+        self.assertEqual(soc.bus.io_regions["axi_master_io"].origin, 0x20000000)
+        self.assertEqual(platform.request_calls, [("axi_master", None, False)])
+
+    def test_add_axi_master_adapts_to_wishbone_soc_bus(self):
+        soc = SoC(_FakePlatform(), sys_clk_freq=100e6, bus_standard="wishbone")
+
+        interface = soc.add_axi_master(
+            pads   = _make_axi_lite_pads(),
+            origin = 0x20000000,
+            size   = 0x10000,
+        )
+
+        self.assertIs(soc.axi_master, interface)
+        self.assertIsInstance(interface, axi.AXILiteInterface)
+        self.assertIsInstance(soc.bus.slaves["axi_master"], wishbone.Interface)
+        self.assertEqual(soc.bus.regions["axi_master"].origin, 0x20000000)
+
+    def test_add_axi_master_rejects_unknown_bus_standard(self):
+        soc = SoC(_FakePlatform(), sys_clk_freq=100e6)
+
+        with _assert_raises_soc_error(self):
+            soc.add_axi_master(
+                pads         = _make_axi_lite_pads(),
+                bus_standard = "wishbone",
+            )
 
     def test_add_hyperram_rejects_derived_kwargs(self):
         soc = SoC(_FakePlatform(), sys_clk_freq=100e6)

--- a/test/tools/test_litex_json2renode.py
+++ b/test/tools/test_litex_json2renode.py
@@ -1,0 +1,102 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import io
+import unittest
+from contextlib import redirect_stdout
+
+from litex.tools.litex_json2renode import (
+    filter_memory_regions,
+    generate_cpu,
+    generate_memory_region,
+    generate_sysbus_registration,
+    generate_video_framebuffer,
+)
+
+
+class TestLiteXJson2Renode(unittest.TestCase):
+    def test_sysbus_registration_can_emit_named_shadow_region(self):
+        registration = generate_sysbus_registration({
+            "base":             0x1000,
+            "shadowed_address": 0x2000,
+            "size":             0x100,
+        }, skip_braces=True, region="csr")
+
+        self.assertIn('address: 0x1000', registration)
+        self.assertIn('address: 0x2000', registration)
+        self.assertIn('size: 0x100', registration)
+        self.assertEqual(registration.count('region: "csr"'), 2)
+
+    def test_memory_region_reports_autoaligned_metadata(self):
+        repl = generate_memory_region({
+            "name":             "rom",
+            "base":             0x00000000,
+            "size":             0x1000,
+            "original_address": 0x00000010,
+            "original_size":    0x0f00,
+        })
+
+        self.assertIn("rom: Memory.MappedMemory", repl)
+        self.assertIn("original base address", repl)
+        self.assertIn("0x10", repl)
+        self.assertIn("original size", repl)
+        self.assertIn("0xf00", repl)
+
+    def test_filter_memory_regions_autoaligns_base_and_size(self):
+        with redirect_stdout(io.StringIO()):
+            regions = list(filter_memory_regions([{
+                "name": "sram",
+                "base": 0x1004,
+                "size": 0x1800,
+                "type": "cached",
+            }], alignment=0x1000, autoalign=["sram"]))
+
+        self.assertEqual(len(regions), 1)
+        self.assertEqual(regions[0]["base"], 0x1000)
+        self.assertEqual(regions[0]["size"], 0x2000)
+        self.assertEqual(regions[0]["original_address"], 0x1004)
+        self.assertEqual(regions[0]["original_size"], 0x1800)
+
+    def test_generate_cpu_uses_variant_and_time_provider_for_each_core(self):
+        repl = generate_cpu({
+            "constants": {
+                "config_cpu_type_vexriscv":    None,
+                "config_cpu_variant_standard": None,
+            },
+        }, time_provider="clint", number_of_cores=2)
+
+        self.assertIn("cpu0: CPU.VexRiscv", repl)
+        self.assertIn("cpu1: CPU.VexRiscv", repl)
+        self.assertEqual(repl.count('cpuType: "rv32im_zicsr_zifencei"'), 2)
+        self.assertEqual(repl.count("timeProvider: clint"), 2)
+
+    def test_generate_video_framebuffer_uses_containing_memory_region(self):
+        repl = generate_video_framebuffer({
+            "csr_bases": {
+                "video_framebuffer":     0xf0005000,
+                "video_framebuffer_vtg": 0xf0006000,
+            },
+            "constants": {
+                "video_framebuffer_hres": 640,
+                "video_framebuffer_vres": 480,
+                "video_framebuffer_base": 0x40002000,
+            },
+            "filtered_memories": [{
+                "name": "main_ram",
+                "base": 0x40000000,
+                "size": 0x01000000,
+            }],
+        }, "video_framebuffer")
+
+        self.assertIn("litex_video: Video.LiteX_Framebuffer_CSR32", repl)
+        self.assertIn("memory: main_ram", repl)
+        self.assertIn("offset: 0x00002000", repl)
+        self.assertIn("hres: 640", repl)
+        self.assertIn("vres: 480", repl)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/tools/test_litex_periph_gen.py
+++ b/test/tools/test_litex_periph_gen.py
@@ -1,0 +1,61 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from litex.soc.interconnect import axi, wishbone
+from litex.tools.litex_periph_gen import LiteXSoCGenerator, get_common_ios, get_uart_ios
+
+
+def make_soc(bus_standard):
+    return LiteXSoCGenerator(
+        name                 = "unit_soc",
+        cpu_type             = "None",
+        bus_standard         = bus_standard,
+        uart_name            = "serial",
+        integrated_rom_size  = 0,
+        integrated_sram_size = 0,
+        with_ctrl            = False,
+        with_timer           = False,
+        with_uart            = False,
+    )
+
+
+class TestLiteXPeriphGen(unittest.TestCase):
+    def test_common_ios_expose_clock_and_reset(self):
+        ios = get_common_ios()
+
+        self.assertEqual(ios[0][0], "clk")
+        self.assertEqual(ios[1][0], "rst")
+
+    def test_uart_ios_expose_tx_and_rx(self):
+        uart = get_uart_ios()[0]
+
+        self.assertEqual(uart[0], "uart")
+        self.assertEqual(uart[2].name, "tx")
+        self.assertEqual(uart[3].name, "rx")
+
+    def test_generator_adds_wishbone_mmap_interfaces(self):
+        soc = make_soc("wishbone")
+
+        self.assertEqual(soc.platform.name, "unit_soc")
+        self.assertIsInstance(soc.bus.masters["mmap_s"], wishbone.Interface)
+        self.assertIsInstance(soc.bus.slaves["mmap_m"],  wishbone.Interface)
+        self.assertEqual(soc.bus.regions["mmap_m"].origin, 0x20000000)
+        self.assertEqual(soc.bus.regions["mmap_m"].size,   0x10000000)
+
+    def test_generator_adds_axi_lite_mmap_interfaces(self):
+        soc = make_soc("axi-lite")
+
+        self.assertIsInstance(soc.bus.masters["mmap_s"], axi.AXILiteInterface)
+        self.assertIsInstance(soc.bus.slaves["mmap_m"],  axi.AXILiteInterface)
+        self.assertEqual(soc.bus.regions["mmap_m"].origin, 0x20000000)
+        self.assertEqual(soc.bus.regions["mmap_m"].size,   0x10000000)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary

  This PR extends LiteX framebuffer and SoC integration, adds dedicated tests for
  existing command-line tools, covers the newly introduced functionality, and
  includes a small set of behavior-preserving cleanups identified with SonarQube
  Cloud.

  The main additions are:

  - Wishbone DMA support for video framebuffers.
  - HyperRAM-backed framebuffer support.
  - Explicit framebuffer port and memory selection.
  - A new external AXI/AXI-Lite master integration API.
  - Explicit CRG clock domain names.
  - Dedicated tests for `litex_periph_gen` and `litex_json2renode`.
  - Unit tests for the new framebuffer, HyperRAM, and AXI behavior.
  - Small readability and maintainability improvements reported by SonarQube.

  ## Motivation

  `VideoFrameBuffer` previously assumed that its DMA port was provided by
  LiteDRAM. This prevented the framebuffer from directly using memories exposed
  through Wishbone, including HyperRAM integrations.

  The SoC framebuffer helper also required SDRAM and always reserved its memory
  inside `main_ram`. This made it difficult to use the framebuffer in systems
  where HyperRAM is the primary external memory or where the caller already has a
  suitable memory port.

  In addition, `litex_periph_gen` and `litex_json2renode` had important existing
  behavior without dedicated unit test modules.

  ## SoC and video changes

  ### Wishbone framebuffer DMA

  `VideoFrameBuffer` now selects its DMA reader according to the provided port:

  - `WishboneDMAReader` is used for a Wishbone interface.
  - `LiteDRAMDMAReader` remains the default for native LiteDRAM ports.

  The existing LiteDRAM path and its buffered FIFO behavior are preserved.

  ### HyperRAM framebuffer support

  The framebuffer integration can now:

  - Accept an explicit DMA port.
  - Accept an explicit memory region name.
  - Prefer `main_ram` when available.
  - Fall back to HyperRAM when SDRAM and `main_ram` are unavailable.
  - Reserve the framebuffer region inside the selected memory.
  - Report an error when an explicitly selected memory region does not exist.
  - Report an error when neither SDRAM nor an explicit/HyperRAM port is
    available.

  This allows systems with Wishbone-connected HyperRAM to use the regular LiteX
  video framebuffer path.

  ### External AXI master integration

  A new `SoC.add_axi_master()` helper creates and exposes an AXI-Lite or full AXI
  interface.

  The helper:

  - Supports AXI-Lite and full AXI.
  - Configures data, address, ID, clock-domain, and access-mode parameters.
  - Registers a non-cacheable bus region.
  - Creates the corresponding I/O region when required.
  - Connects the interface to platform pads in master mode.
  - Allows the existing LiteX bus infrastructure to adapt the interface to an
    internal Wishbone bus.
  - Rejects unsupported bus standards with `SoCError`.

  ### Explicit CRG clock domains

  The standard CRG now explicitly names its clock domains `sys` and `por`.

  This avoids relying on Migen's implicit name inference while preserving the
  existing clock and reset behavior.

  ## Test coverage

  ### `litex_periph_gen`

  A new `test/tools/test_litex_periph_gen.py` module verifies:

  - Common clock and reset I/Os.
  - UART TX and RX I/Os.
  - Wishbone `mmap_s` and `mmap_m` interfaces.
  - AXI-Lite `mmap_s` and `mmap_m` interfaces.
  - The expected external memory region origin and size.

  ### `litex_json2renode`

  A new `test/tools/test_litex_json2renode.py` module verifies:

  - Named normal and shadow system-bus registrations.
  - Preservation of original memory metadata after alignment.
  - Automatic memory-region alignment.
  - VexRiscv variant and time-provider generation for multiple cores.
  - Framebuffer association with its containing memory and the correct offset.

  ### New SoC functionality

  `test/soc/test_soc.py` now verifies:

  - Explicit framebuffer ports without SDRAM.
  - HyperRAM port fallback when SDRAM is absent.
  - Automatic HyperRAM memory selection.
  - Safe framebuffer placement inside a HyperRAM region.
  - AXI-Lite pad mapping and bus registration.
  - AXI-Lite adaptation to an internal Wishbone bus.
  - Rejection of unsupported AXI bus standards.

  ## SonarQube-guided cleanups

  SonarQube Cloud was used to identify a few small maintainability issues. This PR
  includes the following behavior-preserving cleanups:

  - Use `not in` for the Altera device-family condition.
  - Avoid a mutable default argument in the Anlogic `get_verilog()` helper by
    using `None`.
  - Rename an intentionally ignored Efinity source metadata capture to `*_`.
  - Remove an unused local `name` assignment from Efinity remote update
    generation.

  The cleanups were documented in the fork before implementation:

  - [CauaBF1/litex#1](https://github.com/CauaBF1/litex/issues/1)
  - [CauaBF1/litex#2](https://github.com/CauaBF1/litex/issues/2)
  - [CauaBF1/litex#3](https://github.com/CauaBF1/litex/issues/3)
  - [CauaBF1/litex#4](https://github.com/CauaBF1/litex/issues/4)
  
  ## Backward compatibility

  - Existing LiteDRAM framebuffer users continue to use `LiteDRAMDMAReader`.
  - `main_ram` remains the preferred default framebuffer memory.
  - The legacy framebuffer address fallback is preserved when `main_ram` has not
    yet been registered.
  - Existing callers do not need to provide the new `port` or `memory_name`
    arguments.
  - The SonarQube cleanups do not intentionally change generated gateware or
    toolchain behavior.

  ## Validation

  The focused unit test suite was executed with:

  ```bash
  python -m pytest -q \
    test/soc/test_soc.py \
    test/tools/test_litex_json2renode.py \
    test/tools/test_litex_periph_gen.py

  Result:

  148 passed, 26 subtests passed

  Coverage reports were also generated with branch coverage enabled:

  python -m pytest -q \
    test/soc/test_soc.py \
    test/tools/test_litex_json2renode.py \
    test/tools/test_litex_periph_gen.py \
    --cov=litex \
    --cov-branch \
    --cov-report=term-missing \
    --cov-report=html:htmlcov \
    --cov-report=xml:coverage.xml

  The HTML and Cobertura XML reports are generated locally and are not committed.

  ## Checklist

  - [x] Existing LiteDRAM framebuffer behavior is preserved.
  - [x] New Wishbone/HyperRAM paths have unit tests.
  - [x] AXI-Lite integration and Wishbone adaptation have unit tests.
  - [x] Existing tool behavior has dedicated unit coverage.
  - [x] Focused pytest suite passes locally.
  - [x] Coverage reports can be generated locally.
  - [x] Final GitHub Actions run completes successfully.