### PR TITLE
build/openocd: make jtagstream byte construction Jim-Tcl-0.11 compatible

### DIFF
--- a/litex/build/openocd.py
+++ b/litex/build/openocd.py
@@ -140,6 +140,20 @@ class OpenOCD(GenericProgrammer):
         ir       = self.get_ir(chain, config)
         endstate = self.get_endstate(config)
         cfg = """
+if {[catch {binary format c 0x41}]} {
+    # Jim Tcl builds without the binary command (e.g. OpenOCD 0.11): format %c is byte-exact
+    # there (strings have no UTF-8 representation), so it can build the byte stream directly.
+    proc jtagstream_byte {value} {
+        return [format %c $value]
+    }
+} else {
+    # Jim Tcl builds with UTF-8 string representation: format %c would encode bytes >= 0x80
+    # as two bytes, corrupting the stream; use the byte-exact binary command instead.
+    proc jtagstream_byte {value} {
+        return [binary format c $value]
+    }
+}
+
 proc jtagstream_word {word} {
     set word [string trim $word]
     if {[string equal [string range $word 0 1] "0x"] || [string equal [string range $word 0 1] "0X"]} {
@@ -185,7 +199,7 @@ proc jtagstream_poll {tap tx n} {
         set readable [expr { $rxj & 0x200 }]
         set writable [expr { $rxj & $writable }]
         if {$readable} {
-            append rx [binary format c [expr { ($rxj >> 1) & 0xff }]]
+            append rx [jtagstream_byte [expr { ($rxj >> 1) & 0xff }]]
         }
     }
     return [list $rx $readable $writable]

--- a/test/cores/test_jtag.py
+++ b/test/cores/test_jtag.py
@@ -483,21 +483,30 @@ class TestJTAGStreamEncoding(unittest.TestCase):
 
         return inspect.getsource(openocd_mod)
 
-    def test_binary_format_not_format_c(self):
-        """jtagstream must use 'binary format c', not 'format %c'.
+    def test_byte_construction_is_binary_safe(self):
+        """jtagstream must build RX bytes through a binary-safe helper.
 
-        Jim Tcl's 'format %c' creates a Unicode codepoint stored as UTF-8.
-        For values 0x80-0xFF this produces a two-byte sequence, corrupting
-        the binary stream.  'binary format c' produces a raw byte.
+        Jim Tcl builds with UTF-8 string representation encode 'format %c'
+        values 0x80-0xFF as two bytes, corrupting the binary stream: those
+        builds must use 'binary format c'. Jim Tcl builds without the binary
+        command (e.g. OpenOCD 0.11) would abort the poll callback on it, but
+        are byte-exact with 'format %c': a capability probe must select the
+        right implementation at runtime.
         """
         source = self.get_openocd_source()
 
-        self.assertIn("binary format c", source,
-            "jtagstream Tcl does not use 'binary format c' -- "
-            "bytes > 0x7F will be corrupted by UTF-8 encoding")
-        self.assertNotIn("format %c", source,
-            "jtagstream Tcl still uses 'format %c' -- "
-            "this creates UTF-8 codepoints instead of raw bytes")
+        self.assertIn("append rx [jtagstream_byte", source,
+            "jtagstream Tcl must build RX bytes through the jtagstream_byte "
+            "helper, not a direct construction")
+        self.assertIn("catch {binary format c", source,
+            "jtagstream Tcl must probe for the binary command to support "
+            "Jim Tcl builds without it (e.g. OpenOCD 0.11)")
+        self.assertIn("binary format c $value", source,
+            "jtagstream Tcl must use 'binary format c' on Jim Tcl builds "
+            "with UTF-8 strings -- 'format %c' would corrupt bytes > 0x7F")
+        self.assertIn("format %c $value", source,
+            "jtagstream Tcl must fall back to 'format %c' on Jim Tcl builds "
+            "without the binary command (byte-exact there)")
 
     def test_openocd_011_and_012_drscan_word_formats_are_supported(self):
         """jtagstream must accept bare and 0x-prefixed drscan words."""


### PR DESCRIPTION
## Summary

JTAGBone silently returns all-zero reads when the host runs **OpenOCD 0.11**: its embedded Jim Tcl has no `binary` command, so the jtagstream RX decode's `[binary format c ...]` aborts the poll callback with `invalid command name "binary"` on the **first data-carrying word**. The error is swallowed by the Tcl event loop, so everything *looks* healthy (TAP found, server running, TX frames reaching the device — the device's reply is even visible in the raw `drscan` result) while the response bytes are dropped before reaching the TCP client.

## Fix

Probe once for the `binary` command and fall back to `[format %c ...]` on Jim Tcl builds without it. Those builds have no UTF-8 string representation, so `format %c` is byte-exact there. Builds *with* UTF-8 strings — where `format %c` expands bytes ≥ 0x80 into two bytes, the corruption that motivated `binary format` originally — keep using `binary format`.

## Validation

On hardware (Kintex-7, FT4232H, OpenOCD 0.11.0): before the fix, every CSR read over JTAGBone returned zeros; after, `ctrl_scratch` reads back `0x12345678`, writes stick, and values containing bytes ≥ 0x80 (`0xDEADBEEF`) round-trip correctly through `litex_server --jtag` + `RemoteClient`, matching UARTBone results on the same SoC.