### PR TITLE
build: explicitly name CRG clock domains

### DIFF
--- a/litex/build/io.py
+++ b/litex/build/io.py
@@ -295,8 +295,8 @@ class DDRTristate(Special):
 
 class CRG(Module):
     def __init__(self, clk, rst=0):
-        self.clock_domains.cd_sys = ClockDomain()
-        self.clock_domains.cd_por = ClockDomain(reset_less=True)
+        self.clock_domains.cd_sys = ClockDomain("sys")
+        self.clock_domains.cd_por = ClockDomain("por", reset_less=True)
 
         if hasattr(clk, "p"):
             clk_se = Signal()


### PR DESCRIPTION
Explicitly name the system and power-on-reset clock domains to avoid implicit clock domain naming issues.

Following up PR #2522 