### PR TITLE
Feature/hyperram framebuffer support

### DIFF
--- a/litex/soc/cores/video.py
+++ b/litex/soc/cores/video.py
@@ -16,6 +16,7 @@ from litex.gen import *
 
 from litex.soc.interconnect.csr import *
 from litex.soc.interconnect import stream
+from litex.soc.interconnect import wishbone
 from litex.soc.cores.code_tmds import TMDSEncoder
 
 from litex.build.io import SDROutput, DDROutput
@@ -1030,8 +1031,13 @@ class VideoFrameBuffer(LiteXModule):
         # # #
 
         # Video DMA.
-        from litedram.frontend.dma import LiteDRAMDMAReader
-        self.dma = LiteDRAMDMAReader(dram_port, fifo_depth=fifo_depth//(dram_port.data_width//8), fifo_buffered=True)
+        dma_fifo_depth = fifo_depth//(dram_port.data_width//8)
+        if isinstance(dram_port, wishbone.Interface):
+            from litex.soc.cores.dma import WishboneDMAReader
+            self.dma = WishboneDMAReader(dram_port, endianness="big", fifo_depth=dma_fifo_depth)
+        else:
+            from litedram.frontend.dma import LiteDRAMDMAReader
+            self.dma = LiteDRAMDMAReader(dram_port, fifo_depth=dma_fifo_depth, fifo_buffered=True)
         self.dma.add_csr(
             default_base   = base,
             default_length = video_framebuffer_size(hres, vres, format),

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1633,41 +1633,6 @@ class SoC(LiteXModule):
             self.bus.regions[region_name]))
         return hyperram
 
-    # Add AXI Master ------------------------------------------------------------------------------
-    def add_axi_master(self, name="axi_master", pads=None, origin=None, size=0x10000,
-        bus_standard="axi-lite", data_width=32, address_width=32, id_width=1,
-        clock_domain="sys", mode="rw", **kwargs):
-        if bus_standard not in ["axi-lite", "axi"]:
-            self.logger.error("AXI Master {} {}.".format(
-                colorer("bus_standard", color="red"), colorer(bus_standard, color="red")))
-            raise SoCError()
-        if pads is None:
-            pads = self.platform.request(name)
-        self.check_if_exists(name)
-
-        interface_cls = {
-            "axi-lite": axi.AXILiteInterface,
-            "axi"     : axi.AXIInterface,
-        }[bus_standard]
-        interface_kwargs = dict(
-            data_width    = data_width,
-            address_width = address_width,
-            clock_domain  = clock_domain,
-            mode          = mode,
-            **kwargs,
-        )
-        if interface_cls is axi.AXIInterface:
-            interface_kwargs["id_width"] = id_width
-        interface = interface_cls(**interface_kwargs)
-
-        region = SoCRegion(origin=origin, size=size, cached=False)
-        if not region.cached and region.origin is not None and not self.bus.check_region_is_io(region):
-            self.bus.add_region(f"{name}_io", SoCIORegion(origin=region.origin, size=region.size))
-        self.bus.add_slave(name=name, slave=interface, region=region, clock_domain=clock_domain)
-        self.comb += interface.connect_to_pads(pads, mode="master")
-        setattr(self, name, interface)
-        return interface
-
     # Add CSR Bridge -------------------------------------------------------------------------------
     def add_csr_bridge(self, name="csr", origin=None, with_register=False):
         csr_bridge_cls = {

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -3457,7 +3457,7 @@ class LiteXSoC(SoC):
             return memory_name
         if "main_ram" in self.bus.regions:
             return "main_ram"
-        if hasattr(self, "hyperram") and "hyperram" in self.bus.regions:
+        if "hyperram" in self.bus.regions:
             return "hyperram"
         return "main_ram"
 
@@ -3498,23 +3498,33 @@ class LiteXSoC(SoC):
             name, size, memory_name))
         return self.bus.regions[name].origin
 
-    def _get_video_framebuffer_port(self, port=None):
+    def _get_video_framebuffer_port(self, name, memory_name, port=None):
         if port is not None:
             return port
-        if hasattr(self, "sdram"):
+        if hasattr(self, "sdram") and memory_name == "main_ram":
             return self.sdram.crossbar.get_port()
-        if hasattr(self, "hyperram"):
-            return self.hyperram.bus
-        self.logger.error("Video framebuffer requires {} or {}.".format(
-            colorer("sdram", color="red"), colorer("port", color="red")))
+        if memory_name in self.bus.regions:
+            dma_bus = getattr(self, "dma_bus", self.bus)
+            port = wishbone.Interface(
+                data_width = dma_bus.data_width,
+                adr_width  = dma_bus.get_address_width(standard="wishbone", addressing="word"),
+                addressing = "word",
+                mode       = "r",
+            )
+            dma_bus.add_master(name=f"{name}_dma", master=port)
+            return port
+        self.logger.error("Video framebuffer memory region {} {} and no {} was provided.".format(
+            colorer(memory_name, color="red"),
+            colorer("not found", color="red"),
+            colorer("port", color="red")))
         raise SoCError()
 
     def add_video_framebuffer(self, name="video_framebuffer", phy=None, timings="800x600@60Hz", clock_domain="sys", format="rgb888", fifo_depth=64*KILOBYTE, port=None, memory_name=None):
         if phy is None:
             self.logger.error("Video framebuffer requires {}.".format(colorer("phy", color="red")))
             raise SoCError()
-        port = self._get_video_framebuffer_port(port)
         memory_name = self._get_video_framebuffer_memory_name(memory_name)
+        port = self._get_video_framebuffer_port(name, memory_name, port)
         try:
             _, hres, vres = parse_video_timing_resolution(timings)
         except ValueError as e:

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1633,6 +1633,41 @@ class SoC(LiteXModule):
             self.bus.regions[region_name]))
         return hyperram
 
+    # Add AXI Master ------------------------------------------------------------------------------
+    def add_axi_master(self, name="axi_master", pads=None, origin=None, size=0x10000,
+        bus_standard="axi-lite", data_width=32, address_width=32, id_width=1,
+        clock_domain="sys", mode="rw", **kwargs):
+        if bus_standard not in ["axi-lite", "axi"]:
+            self.logger.error("AXI Master {} {}.".format(
+                colorer("bus_standard", color="red"), colorer(bus_standard, color="red")))
+            raise SoCError()
+        if pads is None:
+            pads = self.platform.request(name)
+        self.check_if_exists(name)
+
+        interface_cls = {
+            "axi-lite": axi.AXILiteInterface,
+            "axi"     : axi.AXIInterface,
+        }[bus_standard]
+        interface_kwargs = dict(
+            data_width    = data_width,
+            address_width = address_width,
+            clock_domain  = clock_domain,
+            mode          = mode,
+            **kwargs,
+        )
+        if interface_cls is axi.AXIInterface:
+            interface_kwargs["id_width"] = id_width
+        interface = interface_cls(**interface_kwargs)
+
+        region = SoCRegion(origin=origin, size=size, cached=False)
+        if not region.cached and region.origin is not None and not self.bus.check_region_is_io(region):
+            self.bus.add_region(f"{name}_io", SoCIORegion(origin=region.origin, size=region.size))
+        self.bus.add_slave(name=name, slave=interface, region=region, clock_domain=clock_domain)
+        self.comb += interface.connect_to_pads(pads, mode="master")
+        setattr(self, name, interface)
+        return interface
+
     # Add CSR Bridge -------------------------------------------------------------------------------
     def add_csr_bridge(self, name="csr", origin=None, with_register=False):
         csr_bridge_cls = {
@@ -3452,22 +3487,36 @@ class LiteXSoC(SoC):
         self.comb += vt.source.connect(phy if isinstance(phy, stream.Endpoint) else phy.sink)
 
     # Add Video Framebuffer ------------------------------------------------------------------------
-    def _get_video_framebuffer_default_region(self, name, size):
-        main_ram = self.bus.regions.get("main_ram", None)
-        if main_ram is None:
-            return SoCRegion(
-                origin = 0x40c00000,
-                size   = size,
-                linker = True)
+    def _get_video_framebuffer_memory_name(self, memory_name=None):
+        if memory_name is not None:
+            return memory_name
+        if "main_ram" in self.bus.regions:
+            return "main_ram"
+        if hasattr(self, "hyperram") and "hyperram" in self.bus.regions:
+            return "hyperram"
+        return "main_ram"
 
-        size_pow2    = 2**log2_int(size, False)
-        main_ram_end = main_ram.origin + main_ram.size
-        origin       = (main_ram_end - size_pow2) & ~(size_pow2 - 1)
-        if origin < main_ram.origin:
-            self.logger.error("{} of size {} does not fit in main_ram:".format(
+    def _get_video_framebuffer_default_region(self, name, size, memory_name="main_ram"):
+        memory = self.bus.regions.get(memory_name, None)
+        if memory is None:
+            if memory_name == "main_ram":
+                return SoCRegion(
+                    origin = 0x40c00000,
+                    size   = size,
+                    linker = True)
+            self.logger.error("Video framebuffer memory region {} {}.".format(
+                colorer(memory_name, color="red"), colorer("not found", color="red")))
+            raise SoCError()
+
+        size_pow2  = 2**log2_int(size, False)
+        memory_end = memory.origin + memory.size
+        origin     = (memory_end - size_pow2) & ~(size_pow2 - 1)
+        if origin < memory.origin:
+            self.logger.error("{} of size {} does not fit in {}:".format(
                 colorer(name, color="red"),
-                colorer("0x{:08x}".format(size))))
-            self.logger.error(str(main_ram))
+                colorer("0x{:08x}".format(size)),
+                colorer(memory_name)))
+            self.logger.error(str(memory))
             raise SoCError()
 
         return SoCRegion(
@@ -3475,22 +3524,32 @@ class LiteXSoC(SoC):
             size   = size,
             linker = True)
 
-    def _get_video_framebuffer_base(self, name, size):
+    def _get_video_framebuffer_base(self, name, size, memory_name="main_ram"):
         base = self.mem_map.get(name, None)
         if base is not None:
             return base
 
-        self.bus.add_region(name, self._get_video_framebuffer_default_region(name, size))
+        self.bus.add_region(name, self._get_video_framebuffer_default_region(
+            name, size, memory_name))
         return self.bus.regions[name].origin
 
-    def add_video_framebuffer(self, name="video_framebuffer", phy=None, timings="800x600@60Hz", clock_domain="sys", format="rgb888", fifo_depth=64*KILOBYTE):
+    def _get_video_framebuffer_port(self, port=None):
+        if port is not None:
+            return port
+        if hasattr(self, "sdram"):
+            return self.sdram.crossbar.get_port()
+        if hasattr(self, "hyperram"):
+            return self.hyperram.bus
+        self.logger.error("Video framebuffer requires {} or {}.".format(
+            colorer("sdram", color="red"), colorer("port", color="red")))
+        raise SoCError()
+
+    def add_video_framebuffer(self, name="video_framebuffer", phy=None, timings="800x600@60Hz", clock_domain="sys", format="rgb888", fifo_depth=64*KILOBYTE, port=None, memory_name=None):
         if phy is None:
             self.logger.error("Video framebuffer requires {}.".format(colorer("phy", color="red")))
             raise SoCError()
-        if not hasattr(self, "sdram"):
-            self.logger.error("Video framebuffer requires {}.".format(
-                colorer("sdram", color="red")))
-            raise SoCError()
+        port = self._get_video_framebuffer_port(port)
+        memory_name = self._get_video_framebuffer_memory_name(memory_name)
         try:
             _, hres, vres = parse_video_timing_resolution(timings)
         except ValueError as e:
@@ -3510,8 +3569,8 @@ class LiteXSoC(SoC):
         # Video FrameBuffer.
         self.check_if_exists(name)
         framebuffer_size = video_framebuffer_size(hres, vres, format)
-        base = self._get_video_framebuffer_base(name, framebuffer_size)
-        vfb = VideoFrameBuffer(self.sdram.crossbar.get_port(),
+        base = self._get_video_framebuffer_base(name, framebuffer_size, memory_name)
+        vfb = VideoFrameBuffer(port,
             hres                  = hres,
             vres                  = vres,
             base                  = base,

--- a/test/cores/test_video.py
+++ b/test/cores/test_video.py
@@ -20,10 +20,13 @@ from litex.soc.cores.video import (
     VideoTimingGenerator,
     ColorBarsPattern,
     VideoGenericPHY,
+    VideoFrameBuffer,
     video_framebuffer_format_depth,
     video_framebuffer_size,
 )
+from litex.soc.cores.dma import WishboneDMAReader
 from litex.soc.cores.code_tmds import TMDSEncoder, control_tokens
+from litex.soc.interconnect import wishbone
 
 
 # Helpers ------------------------------------------------------------------------------------------
@@ -88,6 +91,14 @@ class TestVideoFrameBufferHelpers(unittest.TestCase):
         self.assertEqual(video_framebuffer_size(640, 480, "rgb888"), 640*480*4)
         self.assertEqual(video_framebuffer_size(640, 480, "rgb565"), 640*480*2)
         self.assertEqual(video_framebuffer_size(13,    2, "mono1"),  2*2)
+
+    def test_wishbone_port_uses_wishbone_dma_reader(self):
+        port = wishbone.Interface(data_width=32)
+
+        framebuffer = VideoFrameBuffer(port, hres=8, vres=4, fifo_depth=64)
+
+        self.assertIsInstance(framebuffer.dma, WishboneDMAReader)
+        self.assertIs(framebuffer.dma.bus, port)
 
 
 # VideoTimingGenerator -----------------------------------------------------------------------------

--- a/test/soc/test_soc.py
+++ b/test/soc/test_soc.py
@@ -110,15 +110,6 @@ class _CRGWithEfinityPLL:
 def _make_bus_interface(interface_cls, data_width=32, address_width=32):
     return interface_cls(data_width=data_width, address_width=address_width)
 
-def _make_axi_lite_pads(data_width=32, address_width=32):
-    return Record([
-        ("awvalid", 1), ("awready", 1), ("awaddr", address_width), ("awprot", 3),
-        ("wvalid",  1), ("wready",  1), ("wdata",  data_width),    ("wstrb", data_width//8),
-        ("bvalid",  1), ("bready",  1), ("bresp",  2),
-        ("arvalid", 1), ("arready", 1), ("araddr", address_width), ("arprot", 3),
-        ("rvalid",  1), ("rready",  1), ("rdata",  data_width),    ("rresp", 2),
-    ])
-
 class TestSoCCoreCompatibility(unittest.TestCase):
     def test_soc_core_reexports_canonical_soc_api(self):
         self.assertIs(soc_core.mem_decoder,      mem_decoder)
@@ -1165,44 +1156,6 @@ class TestSoC(unittest.TestCase):
         soc.add_hyperram(number=1, size=0x1000, with_csr=False)
 
         self.assertEqual(platform.request_calls, [("hyperram", 1, False)])
-
-    def test_add_axi_master_maps_requested_axi_lite_pads(self):
-        platform = _FakePlatform()
-        platform.requests["axi_master"] = _make_axi_lite_pads()
-        soc = SoC(platform, sys_clk_freq=100e6, bus_standard="axi-lite")
-
-        interface = soc.add_axi_master(origin=0x20000000, size=0x10000)
-
-        self.assertIs(soc.axi_master, interface)
-        self.assertIs(soc.bus.slaves["axi_master"], interface)
-        self.assertIsInstance(interface, axi.AXILiteInterface)
-        self.assertEqual(soc.bus.regions["axi_master"].origin, 0x20000000)
-        self.assertFalse(soc.bus.regions["axi_master"].cached)
-        self.assertEqual(soc.bus.io_regions["axi_master_io"].origin, 0x20000000)
-        self.assertEqual(platform.request_calls, [("axi_master", None, False)])
-
-    def test_add_axi_master_adapts_to_wishbone_soc_bus(self):
-        soc = SoC(_FakePlatform(), sys_clk_freq=100e6, bus_standard="wishbone")
-
-        interface = soc.add_axi_master(
-            pads   = _make_axi_lite_pads(),
-            origin = 0x20000000,
-            size   = 0x10000,
-        )
-
-        self.assertIs(soc.axi_master, interface)
-        self.assertIsInstance(interface, axi.AXILiteInterface)
-        self.assertIsInstance(soc.bus.slaves["axi_master"], wishbone.Interface)
-        self.assertEqual(soc.bus.regions["axi_master"].origin, 0x20000000)
-
-    def test_add_axi_master_rejects_unknown_bus_standard(self):
-        soc = SoC(_FakePlatform(), sys_clk_freq=100e6)
-
-        with _assert_raises_soc_error(self):
-            soc.add_axi_master(
-                pads         = _make_axi_lite_pads(),
-                bus_standard = "wishbone",
-            )
 
     def test_add_hyperram_rejects_derived_kwargs(self):
         soc = SoC(_FakePlatform(), sys_clk_freq=100e6)

--- a/test/soc/test_soc.py
+++ b/test/soc/test_soc.py
@@ -16,9 +16,10 @@ from types import SimpleNamespace
 from migen import ClockDomain, Record, Signal
 from migen.sim import run_simulation
 
+from litex.soc.cores.dma import WishboneDMAReader
 from litex.soc.cores.hyperbus import HyperRAM
-from litex.soc.cores.video import video_framebuffer_size
-from litex.soc.interconnect import axi, wishbone
+from litex.soc.cores.video import video_data_layout, video_framebuffer_size
+from litex.soc.interconnect import axi, stream, wishbone
 
 from litex.soc.integration.soc import (
     LiteXSoC,
@@ -245,18 +246,68 @@ class TestSoCVideoFrameBuffer(unittest.TestCase):
         soc  = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
         port = wishbone.Interface()
 
-        self.assertIs(soc._get_video_framebuffer_port(port), port)
+        self.assertIs(soc._get_video_framebuffer_port(
+            "video_framebuffer", "main_ram", port), port)
 
-    def test_framebuffer_port_uses_hyperram_when_sdram_is_absent(self):
+    def test_framebuffer_port_uses_soc_bus_when_sdram_is_absent(self):
+        cases = [
+            ("wishbone", wishbone.Interface),
+            ("axi-lite", axi.AXILiteInterface),
+            ("axi",      axi.AXIInterface),
+        ]
+
+        for bus_standard, interface_cls in cases:
+            with self.subTest(bus_standard=bus_standard):
+                soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6, bus_standard=bus_standard)
+                if bus_standard == "axi":
+                    soc.bus.add_master("cpu", axi.AXIInterface(id_width=4))
+                soc.bus.add_region("hyperram", SoCRegion(origin=0x20000000, size=0x00800000))
+
+                port = soc._get_video_framebuffer_port("video_framebuffer", "hyperram")
+
+                self.assertIsInstance(port, wishbone.Interface)
+                self.assertIsInstance(soc.bus.masters["video_framebuffer_dma"], interface_cls)
+                self.assertEqual(port.mode, "r")
+
+    def test_framebuffer_port_requires_mapped_memory(self):
         soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
-        bus = wishbone.Interface()
-        soc.hyperram = SimpleNamespace(bus=bus)
 
-        self.assertIs(soc._get_video_framebuffer_port(), bus)
+        with _assert_raises_soc_error(self):
+            soc._get_video_framebuffer_port("video_framebuffer", "hyperram")
+
+        self.assertNotIn("video_framebuffer_dma", soc.bus.masters)
+
+    def test_explicit_hyperram_does_not_use_sdram_port(self):
+        soc        = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
+        sdram_port = wishbone.Interface()
+        soc.sdram  = SimpleNamespace(crossbar=SimpleNamespace(get_port=lambda: sdram_port))
+        soc.bus.add_region("hyperram", SoCRegion(origin=0x20000000, size=0x00800000))
+
+        port = soc._get_video_framebuffer_port("video_framebuffer", "hyperram")
+
+        self.assertIsNot(port, sdram_port)
+        self.assertIs(soc.bus.masters["video_framebuffer_dma"], port)
+
+    def test_hyperram_framebuffer_uses_routed_wishbone_dma(self):
+        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=100e6)
+        soc.bus.add_region("hyperram", SoCRegion(origin=0x20000000, size=0x00800000))
+
+        soc.add_video_framebuffer(
+            phy         = stream.Endpoint(video_data_layout),
+            timings     = "640x480@60Hz",
+            fifo_depth  = 64,
+            memory_name = "hyperram",
+        )
+
+        self.assertIsInstance(soc.video_framebuffer.dma, WishboneDMAReader)
+        self.assertIs(
+            soc.video_framebuffer.dma.bus,
+            soc.bus.masters["video_framebuffer_dma"],
+        )
+        self.assertEqual(soc.constants["VIDEO_FRAMEBUFFER_BASE"], 0x20600000)
 
     def test_framebuffer_memory_name_defaults_to_hyperram_without_main_ram(self):
         soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
-        soc.hyperram = SimpleNamespace(bus=wishbone.Interface())
         soc.bus.add_region("hyperram", SoCRegion(origin=0x20000000, size=0x00800000))
 
         self.assertEqual(soc._get_video_framebuffer_memory_name(), "hyperram")

--- a/test/soc/test_soc.py
+++ b/test/soc/test_soc.py
@@ -110,6 +110,14 @@ class _CRGWithEfinityPLL:
 def _make_bus_interface(interface_cls, data_width=32, address_width=32):
     return interface_cls(data_width=data_width, address_width=address_width)
 
+def _make_axi_lite_pads(data_width=32, address_width=32):
+    return Record([
+        ("awvalid", 1), ("awready", 1), ("awaddr", address_width), ("awprot", 3),
+        ("wvalid",  1), ("wready",  1), ("wdata",  data_width),    ("wstrb", data_width//8),
+        ("bvalid",  1), ("bready",  1), ("bresp",  2),
+        ("arvalid", 1), ("arready", 1), ("araddr", address_width), ("arprot", 3),
+        ("rvalid",  1), ("rready",  1), ("rdata",  data_width),    ("rresp", 2),
+    ])
 
 class TestSoCCoreCompatibility(unittest.TestCase):
     def test_soc_core_reexports_canonical_soc_api(self):
@@ -242,6 +250,38 @@ class TestSoCVideoFrameBuffer(unittest.TestCase):
         with _assert_raises_soc_error(self):
             soc._get_video_framebuffer_default_region("video_framebuffer", 0x00200000)
 
+    def test_framebuffer_port_can_be_provided_without_sdram(self):
+        soc  = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
+        port = wishbone.Interface()
+
+        self.assertIs(soc._get_video_framebuffer_port(port), port)
+
+    def test_framebuffer_port_uses_hyperram_when_sdram_is_absent(self):
+        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
+        bus = wishbone.Interface()
+        soc.hyperram = SimpleNamespace(bus=bus)
+
+        self.assertIs(soc._get_video_framebuffer_port(), bus)
+
+    def test_framebuffer_memory_name_defaults_to_hyperram_without_main_ram(self):
+        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
+        soc.hyperram = SimpleNamespace(bus=wishbone.Interface())
+        soc.bus.add_region("hyperram", SoCRegion(origin=0x20000000, size=0x00800000))
+
+        self.assertEqual(soc._get_video_framebuffer_memory_name(), "hyperram")
+
+    def test_default_region_can_be_placed_in_hyperram(self):
+        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
+        soc.bus.add_region("hyperram", SoCRegion(origin=0x20000000, size=0x00800000))
+
+        framebuffer_size = video_framebuffer_size(800, 600, "rgb888")
+        region = soc._get_video_framebuffer_default_region(
+            "video_framebuffer", framebuffer_size, memory_name="hyperram")
+
+        self.assertEqual(region.origin, 0x20600000)
+        self.assertEqual(region.size,   framebuffer_size)
+        self.assertLessEqual(region.origin + region.size, 0x20800000)
+        self.assertTrue(region.linker)
 
 class TestSoCResetRequests(unittest.TestCase):
     def test_soc_reset_request_registers_source(self):
@@ -1125,6 +1165,44 @@ class TestSoC(unittest.TestCase):
         soc.add_hyperram(number=1, size=0x1000, with_csr=False)
 
         self.assertEqual(platform.request_calls, [("hyperram", 1, False)])
+
+    def test_add_axi_master_maps_requested_axi_lite_pads(self):
+        platform = _FakePlatform()
+        platform.requests["axi_master"] = _make_axi_lite_pads()
+        soc = SoC(platform, sys_clk_freq=100e6, bus_standard="axi-lite")
+
+        interface = soc.add_axi_master(origin=0x20000000, size=0x10000)
+
+        self.assertIs(soc.axi_master, interface)
+        self.assertIs(soc.bus.slaves["axi_master"], interface)
+        self.assertIsInstance(interface, axi.AXILiteInterface)
+        self.assertEqual(soc.bus.regions["axi_master"].origin, 0x20000000)
+        self.assertFalse(soc.bus.regions["axi_master"].cached)
+        self.assertEqual(soc.bus.io_regions["axi_master_io"].origin, 0x20000000)
+        self.assertEqual(platform.request_calls, [("axi_master", None, False)])
+
+    def test_add_axi_master_adapts_to_wishbone_soc_bus(self):
+        soc = SoC(_FakePlatform(), sys_clk_freq=100e6, bus_standard="wishbone")
+
+        interface = soc.add_axi_master(
+            pads   = _make_axi_lite_pads(),
+            origin = 0x20000000,
+            size   = 0x10000,
+        )
+
+        self.assertIs(soc.axi_master, interface)
+        self.assertIsInstance(interface, axi.AXILiteInterface)
+        self.assertIsInstance(soc.bus.slaves["axi_master"], wishbone.Interface)
+        self.assertEqual(soc.bus.regions["axi_master"].origin, 0x20000000)
+
+    def test_add_axi_master_rejects_unknown_bus_standard(self):
+        soc = SoC(_FakePlatform(), sys_clk_freq=100e6)
+
+        with _assert_raises_soc_error(self):
+            soc.add_axi_master(
+                pads         = _make_axi_lite_pads(),
+                bus_standard = "wishbone",
+            )
 
     def test_add_hyperram_rejects_derived_kwargs(self):
         soc = SoC(_FakePlatform(), sys_clk_freq=100e6)


### PR DESCRIPTION
 ### Wishbone framebuffer DMA

  `VideoFrameBuffer` now selects its DMA reader according to the provided port:

  - `WishboneDMAReader` is used for a Wishbone interface.
  - `LiteDRAMDMAReader` remains the default for native LiteDRAM ports.

  The existing LiteDRAM path and its buffered FIFO behavior are preserved.

  ### HyperRAM framebuffer support

  The framebuffer integration can now:

  - Accept an explicit DMA port.
  - Accept an explicit memory region name.
  - Prefer `main_ram` when available.
  - Fall back to HyperRAM when SDRAM and `main_ram` are unavailable.
  - Reserve the framebuffer region inside the selected memory.
  - Report an error when an explicitly selected memory region does not exist.
  - Report an error when neither SDRAM nor an explicit/HyperRAM port is
    available.

  This allows systems with Wishbone-connected HyperRAM to use the regular LiteX
  video framebuffer path.

### New SoC functionality

  `test/soc/test_soc.py` now verifies:

  - Explicit framebuffer ports without SDRAM.
  - HyperRAM port fallback when SDRAM is absent.
  - Automatic HyperRAM memory selection.
  - Safe framebuffer placement inside a HyperRAM region.

  Validation:
  - `136 passed, 26 subtests passed`

Following up PR #2522 