### PR TITLE
litex_repos: add LiteDSP (portable RF/DSP building blocks, WIP)

### DIFF
--- a/litex_repos.py
+++ b/litex_repos.py
@@ -43,6 +43,7 @@ git_repos = {
     "litesdcard":   GitRepo(url="https://github.com/enjoy-digital/", tag=True),
     "litescope":    GitRepo(url="https://github.com/enjoy-digital/", tag=True),
     "litejesd204b": GitRepo(url="https://github.com/enjoy-digital/", tag=True),
+    "litedsp":      GitRepo(url="https://github.com/enjoy-digital/"),
     "litespi":      GitRepo(url="https://github.com/litex-hub/",     tag=True),
     "litei2c":      GitRepo(url="https://github.com/litex-hub/",     tag=True, branch="main"),
 


### PR DESCRIPTION
Registers https://github.com/enjoy-digital/litedsp in litex_setup so 'litex_setup init install' clones and develop-installs it alongside the other ecosystem cores (standard + full configs).

LiteDSP provides portable RF/DSP building blocks (NCO/mixing/filters/ rate conversion/AGC/corrections/FEC incl. Viterbi/RS/LDPC/spectral analysis + parallel gigasample variants) with the LiteX stream/CSR conventions, golden-model + Verilator-verified, and standalone Verilog generation via litedsp_gen. Currently Work In Progress: no release tag yet (tag=True will be enabled with the first v-tag), APIs can still move.