### PR TITLE
Set litedsp branch to main in litex_repos.py

### DIFF
--- a/litex_repos.py
+++ b/litex_repos.py
@@ -43,7 +43,7 @@ git_repos = {
     "litesdcard":   GitRepo(url="https://github.com/enjoy-digital/", tag=True),
     "litescope":    GitRepo(url="https://github.com/enjoy-digital/", tag=True),
     "litejesd204b": GitRepo(url="https://github.com/enjoy-digital/", tag=True),
-    "litedsp":      GitRepo(url="https://github.com/enjoy-digital/"),
+    "litedsp":      GitRepo(url="https://github.com/enjoy-digital/", branch="main"),
     "litespi":      GitRepo(url="https://github.com/litex-hub/",     tag=True),
     "litei2c":      GitRepo(url="https://github.com/litex-hub/",     tag=True, branch="main"),
 


### PR DESCRIPTION
Fixes #2529.

The `litedsp` entry in `litex_repos.py` had no `branch` set, so it defaulted to `branch="master"` (see the `GitRepo` default on line 8). The upstream `enjoy-digital/litedsp` repository no longer has a `master` branch — its default branch is `main` — so fetching `litedsp` fails.

This sets `branch="main"` for the `litedsp` entry, matching how other `main`-based repos are already declared in this file (e.g. `litei2c`, `pythondata-cpu-cdim`).

Single-line change.
