### PR TITLE
video: clean up framebuffer memory integration

### DIFF
--- a/litex/soc/cores/video.py
+++ b/litex/soc/cores/video.py
@@ -1020,8 +1020,14 @@ def video_framebuffer_size(hres, vres, format):
     return stride*vres
 
 class VideoFrameBuffer(LiteXModule):
-    """Video FrameBuffer"""
-    def __init__(self, dram_port, hres=800, vres=600, base=0x00000000, fifo_depth=64*KILOBYTE, clock_domain="sys", clock_faster_than_sys=False, format="rgb888"):
+    """Video framebuffer with Wishbone or LiteDRAM DMA.
+
+    ``fifo_depth`` is expressed in bytes and rounded up to a whole DMA-port
+    word. The port must provide read access to the framebuffer memory.
+    """
+    def __init__(self, port, hres=800, vres=600, base=0x00000000,
+        fifo_depth=64*KILOBYTE, clock_domain="sys", clock_faster_than_sys=False,
+        format="rgb888"):
         self.vtg_sink  = vtg_sink = stream.Endpoint(video_timing_layout)
         self.source    = source   = stream.Endpoint(video_data_layout)
         self.underflow = Signal()
@@ -1031,13 +1037,26 @@ class VideoFrameBuffer(LiteXModule):
         # # #
 
         # Video DMA.
-        dma_fifo_depth = fifo_depth//(dram_port.data_width//8)
-        if isinstance(dram_port, wishbone.Interface):
+        is_wishbone = isinstance(port, wishbone.Interface)
+        if not is_wishbone:
+            from litedram.common import LiteDRAMNativePort
+            from litedram.frontend.axi import LiteDRAMAXIPort
+            if not isinstance(port, (LiteDRAMNativePort, LiteDRAMAXIPort)):
+                raise TypeError("Video framebuffer DMA port must be Wishbone or LiteDRAM Native/AXI.")
+        if port.mode not in ["r", "rw", "read", "both"]:
+            raise ValueError("Video framebuffer DMA port must provide read access.")
+        if (not isinstance(fifo_depth, int)) or isinstance(fifo_depth, bool) or (fifo_depth <= 0):
+            raise ValueError("Video framebuffer FIFO depth must be a positive integer.")
+        if (port.data_width < 8) or (port.data_width % 8):
+            raise ValueError("Video framebuffer DMA port data width must be a multiple of 8.")
+        bytes_per_word = port.data_width//8
+        dma_fifo_depth = max(1, (fifo_depth + bytes_per_word - 1)//bytes_per_word)
+        if is_wishbone:
             from litex.soc.cores.dma import WishboneDMAReader
-            self.dma = WishboneDMAReader(dram_port, endianness="big", fifo_depth=dma_fifo_depth)
+            self.dma = WishboneDMAReader(port, with_byteswap=False, fifo_depth=dma_fifo_depth)
         else:
             from litedram.frontend.dma import LiteDRAMDMAReader
-            self.dma = LiteDRAMDMAReader(dram_port, fifo_depth=dma_fifo_depth, fifo_buffered=True)
+            self.dma = LiteDRAMDMAReader(port, fifo_depth=dma_fifo_depth, fifo_buffered=True)
         self.dma.add_csr(
             default_base   = base,
             default_length = video_framebuffer_size(hres, vres, format),
@@ -1046,23 +1065,23 @@ class VideoFrameBuffer(LiteXModule):
         )
 
         # If DRAM Data Width > depth and Video clock is faster than sys_clk:
-        if (dram_port.data_width > depth) and clock_faster_than_sys:
+        if (port.data_width > depth) and clock_faster_than_sys:
             # Do Clock Domain Crossing first...
-            self.cdc = stream.ClockDomainCrossing([("data", dram_port.data_width)], cd_from="sys", cd_to=clock_domain)
+            self.cdc = stream.ClockDomainCrossing([("data", port.data_width)], cd_from="sys", cd_to=clock_domain)
             self.comb += self.dma.source.connect(self.cdc.sink)
             # ... and then Data-Width Conversion.
-            self.conv = ClockDomainsRenamer(clock_domain)(stream.Converter(dram_port.data_width, depth))
+            self.conv = ClockDomainsRenamer(clock_domain)(stream.Converter(port.data_width, depth))
             self.comb += self.cdc.source.connect(self.conv.sink)
             video_pipe_source = self.conv.source
-        # Elsif DRAM Data Width <= depth or Video clock is slower than sys_clk:
+        # Elsif DMA Data Width <= depth or Video clock is slower than sys_clk:
         else:
             # Do Data-Width Conversion first...
-            self.conv = stream.Converter(dram_port.data_width, depth)
+            self.conv = stream.Converter(port.data_width, depth)
             self.comb += self.dma.source.connect(self.conv.sink)
             # ... and then Clock Domain Crossing.
             self.cdc = stream.ClockDomainCrossing([("data", depth)], cd_from="sys", cd_to=clock_domain)
             self.comb += self.conv.source.connect(self.cdc.sink)
-            if (dram_port.data_width < depth) and (depth == 32): # FIXME.
+            if (port.data_width < depth) and (depth == 32): # FIXME.
                 self.comb += [
                     self.cdc.sink.data[ 0: 8].eq(self.conv.source.data[16:24]),
                     self.cdc.sink.data[16:24].eq(self.conv.source.data[ 0: 8]),

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -3452,79 +3452,70 @@ class LiteXSoC(SoC):
         self.comb += vt.source.connect(phy if isinstance(phy, stream.Endpoint) else phy.sink)
 
     # Add Video Framebuffer ------------------------------------------------------------------------
-    def _get_video_framebuffer_memory_name(self, memory_name=None):
-        if memory_name is not None:
-            return memory_name
-        if "main_ram" in self.bus.regions:
-            return "main_ram"
-        if "hyperram" in self.bus.regions:
-            return "hyperram"
-        return "main_ram"
-
-    def _get_video_framebuffer_default_region(self, name, size, memory_name="main_ram"):
-        memory = self.bus.regions.get(memory_name, None)
+    def _get_video_framebuffer_region(self, name, size, region_name="main_ram", base=None):
+        memory = self.bus.regions.get(region_name, None)
         if memory is None:
-            if memory_name == "main_ram":
-                return SoCRegion(
-                    origin = 0x40c00000,
-                    size   = size,
-                    linker = True)
             self.logger.error("Video framebuffer memory region {} {}.".format(
-                colorer(memory_name, color="red"), colorer("not found", color="red")))
+                colorer(region_name, color="red"), colorer("not found", color="red")))
+            raise SoCError()
+        if "r" not in memory.mode:
+            self.logger.error("Video framebuffer memory region {} is not {}.".format(
+                colorer(region_name, color="red"), colorer("readable", color="red")))
             raise SoCError()
 
-        size_pow2  = 2**log2_int(size, False)
-        memory_end = memory.origin + memory.size
-        origin     = (memory_end - size_pow2) & ~(size_pow2 - 1)
-        if origin < memory.origin:
+        size_pow2 = 2**log2_int(size, False)
+        if base is None:
+            base = self.mem_map.get(name, None)
+        if base is None:
+            memory_end = memory.origin + memory.size
+            base       = (memory_end - size_pow2) & ~(size_pow2 - 1)
+        if (not isinstance(base, int)) or isinstance(base, bool):
+            self.logger.error("Video framebuffer base must be an {}.".format(
+                colorer("integer", color="red")))
+            raise SoCError()
+        if (base < memory.origin) or ((base + size_pow2) > (memory.origin + memory.size)):
             self.logger.error("{} of size {} does not fit in {}:".format(
                 colorer(name, color="red"),
                 colorer("0x{:08x}".format(size)),
-                colorer(memory_name)))
+                colorer(region_name)))
             self.logger.error(str(memory))
             raise SoCError()
 
         return SoCRegion(
-            origin = origin,
+            origin = base,
             size   = size,
-            linker = True)
+            mode   = memory.mode,
+            cached = memory.cached,
+            linker = True,
+        )
 
-    def _get_video_framebuffer_base(self, name, size, memory_name="main_ram"):
-        base = self.mem_map.get(name, None)
-        if base is not None:
-            return base
+    def _get_video_framebuffer_dma_port(self, region_name="main_ram", dma_port=None):
+        if dma_port is None and hasattr(self, "sdram") and region_name == "main_ram":
+            return self.sdram.crossbar.get_port(mode="read"), None
 
-        self.bus.add_region(name, self._get_video_framebuffer_default_region(
-            name, size, memory_name))
-        return self.bus.regions[name].origin
-
-    def _get_video_framebuffer_port(self, name, memory_name, port=None):
-        if port is not None:
-            return port
-        if hasattr(self, "sdram") and memory_name == "main_ram":
-            return self.sdram.crossbar.get_port()
-        if memory_name in self.bus.regions:
-            dma_bus = getattr(self, "dma_bus", self.bus)
-            port = wishbone.Interface(
+        dma_bus = getattr(self, "dma_bus", self.bus)
+        if dma_port is None:
+            dma_port = wishbone.Interface(
                 data_width = dma_bus.data_width,
                 adr_width  = dma_bus.get_address_width(standard="wishbone", addressing="word"),
                 addressing = "word",
                 mode       = "r",
             )
-            dma_bus.add_master(name=f"{name}_dma", master=port)
-            return port
-        self.logger.error("Video framebuffer memory region {} {} and no {} was provided.".format(
-            colorer(memory_name, color="red"),
-            colorer("not found", color="red"),
-            colorer("port", color="red")))
-        raise SoCError()
+        return dma_port, dma_bus if isinstance(dma_port, wishbone.Interface) else None
 
-    def add_video_framebuffer(self, name="video_framebuffer", phy=None, timings="800x600@60Hz", clock_domain="sys", format="rgb888", fifo_depth=64*KILOBYTE, port=None, memory_name=None):
+    def add_video_framebuffer(self, name="video_framebuffer", phy=None,
+        timings="800x600@60Hz", clock_domain="sys", format="rgb888",
+        fifo_depth=64*KILOBYTE, region_name="main_ram", base=None, dma_port=None):
+        """Add a memory-backed video framebuffer.
+
+        ``region_name`` selects the readable memory region containing the
+        framebuffer. Main RAM uses a native LiteDRAM read port when available;
+        other regions use a read-only Wishbone master on the SoC DMA/system bus.
+        ``dma_port`` can override the automatically selected port.
+        """
         if phy is None:
             self.logger.error("Video framebuffer requires {}.".format(colorer("phy", color="red")))
             raise SoCError()
-        memory_name = self._get_video_framebuffer_memory_name(memory_name)
-        port = self._get_video_framebuffer_port(name, memory_name, port)
         try:
             _, hres, vres = parse_video_timing_resolution(timings)
         except ValueError as e:
@@ -3535,25 +3526,64 @@ class LiteXSoC(SoC):
         from litex.soc.cores.video import VideoTimingGenerator, VideoFrameBuffer
         from litex.soc.cores.video import video_framebuffer_size
 
-        # Video Timing Generator.
+        # Video Timing Generator / FrameBuffer Checks.
         self.check_if_exists(f"{name}_vtg")
+        self.check_if_exists(name)
+        if name in self.bus.regions or name in self.bus.io_regions:
+            self.logger.error("{} already declared as video framebuffer Region.".format(
+                colorer(name, color="red")))
+            raise SoCError()
+        try:
+            framebuffer_size = video_framebuffer_size(hres, vres, format)
+        except KeyError as e:
+            self.logger.error("Unsupported video framebuffer format {}.".format(
+                colorer(format, color="red")))
+            raise SoCError() from e
+        if (not isinstance(fifo_depth, int)) or isinstance(fifo_depth, bool) or (fifo_depth <= 0):
+            self.logger.error("Video framebuffer FIFO depth must be a {}.".format(
+                colorer("positive integer", color="red")))
+            raise SoCError()
+        framebuffer_region = self._get_video_framebuffer_region(
+            name        = name,
+            size        = framebuffer_size,
+            region_name = region_name,
+            base        = base,
+        )
+        dma_port, dma_bus = self._get_video_framebuffer_dma_port(
+            region_name = region_name,
+            dma_port    = dma_port,
+        )
+        if dma_bus is not None and f"{name}_dma" in dma_bus.masters:
+            self.logger.error("{} already declared as video framebuffer DMA Bus Master.".format(
+                colorer(f"{name}_dma", color="red")))
+            raise SoCError()
+
+        # Video Timing Generator.
         vtg = VideoTimingGenerator(default_video_timings=timings if isinstance(timings, str) else timings[1])
         vtg = ClockDomainsRenamer(clock_domain)(vtg)
-        self.add_module(name=f"{name}_vtg", module=vtg)
 
         # Video FrameBuffer.
-        self.check_if_exists(name)
-        framebuffer_size = video_framebuffer_size(hres, vres, format)
-        base = self._get_video_framebuffer_base(name, framebuffer_size, memory_name)
-        vfb = VideoFrameBuffer(port,
+        vfb = VideoFrameBuffer(dma_port,
             hres                  = hres,
             vres                  = vres,
-            base                  = base,
+            base                  = framebuffer_region.origin,
             fifo_depth            = fifo_depth,
             format                = format,
             clock_domain          = clock_domain,
             clock_faster_than_sys = vtg.video_timings["pix_clk"] >= self.sys_clk_freq,
         )
+        bytes_per_word = dma_port.data_width//8
+        if framebuffer_region.origin % bytes_per_word:
+            self.logger.error("Video framebuffer base {} is not aligned to the DMA port's {}-byte data width.".format(
+                colorer("0x{:08x}".format(framebuffer_region.origin), color="red"),
+                colorer(bytes_per_word)))
+            raise SoCError()
+
+        # Bus / Modules.
+        self.bus.add_region(name, framebuffer_region)
+        if dma_bus is not None:
+            dma_bus.add_master(name=f"{name}_dma", master=dma_port)
+        self.add_module(name=f"{name}_vtg", module=vtg)
         self.add_module(name=name, module=vfb)
 
         # Connect Video Timing Generator to Video FrameBuffer.
@@ -3563,7 +3593,7 @@ class LiteXSoC(SoC):
         self.comb += vfb.source.connect(phy if isinstance(phy, stream.Endpoint) else phy.sink)
 
         # Constants.
-        self.add_constant("VIDEO_FRAMEBUFFER_BASE", base)
+        self.add_constant("VIDEO_FRAMEBUFFER_BASE", framebuffer_region.origin)
         self.add_constant("VIDEO_FRAMEBUFFER_HRES", hres)
         self.add_constant("VIDEO_FRAMEBUFFER_VRES", vres)
         self.add_constant("VIDEO_FRAMEBUFFER_DEPTH", vfb.depth)

--- a/test/cores/test_video.py
+++ b/test/cores/test_video.py
@@ -100,6 +100,145 @@ class TestVideoFrameBufferHelpers(unittest.TestCase):
         self.assertIsInstance(framebuffer.dma, WishboneDMAReader)
         self.assertIs(framebuffer.dma.bus, port)
 
+    def test_fifo_depth_is_rounded_up_to_one_port_word(self):
+        framebuffer = VideoFrameBuffer(
+            wishbone.Interface(data_width=64),
+            hres       = 1,
+            vres       = 1,
+            fifo_depth = 1,
+        )
+
+        self.assertEqual(framebuffer.dma.fifo.depth, 1)
+
+    def test_fifo_depth_must_be_positive(self):
+        for fifo_depth in [0, -1, None, True]:
+            with self.subTest(fifo_depth=fifo_depth):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    VideoFrameBuffer(
+                        wishbone.Interface(data_width=32),
+                        hres       = 1,
+                        vres       = 1,
+                        fifo_depth = fifo_depth,
+                    )
+
+    def test_unsupported_dma_port_is_rejected(self):
+        with self.assertRaisesRegex(TypeError, "Wishbone or LiteDRAM"):
+            VideoFrameBuffer(object(), hres=1, vres=1, fifo_depth=4)
+
+    def test_dma_port_must_be_readable(self):
+        with self.assertRaisesRegex(ValueError, "read access"):
+            VideoFrameBuffer(
+                wishbone.Interface(data_width=32, mode="w"),
+                hres       = 1,
+                vres       = 1,
+                fifo_depth = 4,
+            )
+
+
+class TestVideoFrameBufferData(unittest.TestCase):
+    @staticmethod
+    def _timings(hres):
+        return {
+            "pix_clk"       : 1e6,
+            "h_active"      : hres,
+            "h_blanking"    : 4,
+            "h_sync_offset" : 1,
+            "h_sync_width"  : 1,
+            "v_active"      : 1,
+            "v_blanking"    : 4,
+            "v_sync_offset" : 1,
+            "v_sync_width"  : 1,
+        }
+
+    def _capture_pixels(self, backend, format, hres, words):
+        if backend == "wishbone":
+            port = wishbone.Interface(data_width=32)
+        else:
+            from litedram.common import LiteDRAMNativePort
+            port = LiteDRAMNativePort(mode="read", address_width=24, data_width=32)
+
+        class DUT(Module):
+            def __init__(self):
+                self.submodules.vtg = VideoTimingGenerator(
+                    default_video_timings=TestVideoFrameBufferData._timings(hres))
+                self.submodules.framebuffer = VideoFrameBuffer(
+                    port,
+                    hres       = hres,
+                    vres       = 1,
+                    fifo_depth = 16,
+                    format     = format,
+                )
+                self.comb += self.vtg.source.connect(self.framebuffer.vtg_sink)
+
+        dut      = DUT()
+        captured = []
+
+        @passive
+        def wishbone_memory():
+            while True:
+                if (yield port.cyc) and (yield port.stb):
+                    address = (yield port.adr)
+                    yield port.dat_r.eq(words[address % len(words)])
+                    yield port.ack.eq(1)
+                    yield
+                    yield port.ack.eq(0)
+                yield
+
+        @passive
+        def litedram_memory():
+            pending = None
+            while True:
+                yield port.cmd.ready.eq(pending is None)
+                if (yield port.cmd.valid) and (yield port.cmd.ready):
+                    pending = words[(yield port.cmd.addr) % len(words)]
+                yield port.rdata.valid.eq(pending is not None)
+                if pending is not None:
+                    yield port.rdata.data.eq(pending)
+                    if (yield port.rdata.ready):
+                        pending = None
+                yield
+
+        def capture():
+            yield dut.framebuffer.dma._enable.storage.eq(1)
+            yield dut.framebuffer.source.ready.eq(1)
+            for _ in range(2000):
+                if ((yield dut.framebuffer.source.valid) and
+                    (yield dut.framebuffer.source.ready) and
+                    (yield dut.framebuffer.source.de)):
+                    captured.append((
+                        (yield dut.framebuffer.source.r),
+                        (yield dut.framebuffer.source.g),
+                        (yield dut.framebuffer.source.b),
+                    ))
+                    if len(captured) == hres:
+                        return
+                yield
+            self.fail("Timed out waiting for framebuffer pixels.")
+
+        memory = wishbone_memory if backend == "wishbone" else litedram_memory
+        _run(dut, [memory(), capture()])
+        return captured
+
+    def test_pixel_order_matches_across_dma_backends(self):
+        mono_bits = 0xa5a55aa5
+        cases = [
+            ("rgb888", 1, [0x00332211], [(0x11, 0x22, 0x33)]),
+            ("rgb565", 2, [0x07e0f800], [(0xf8, 0x00, 0x00), (0x00, 0xfc, 0x00)]),
+            ("rgb332", 4, [0xff031ce0], [(0xe0, 0x00, 0x00), (0x00, 0xe0, 0x00),
+                                                   (0x00, 0x00, 0xc0), (0xe0, 0xe0, 0xc0)]),
+            ("mono8",  4, [0xffaa5511], [(value, value, value) for value in [0x11, 0x55, 0xaa, 0xff]]),
+            ("mono1", 32, [mono_bits],  [(0x80, 0x80, 0x80) if (mono_bits >> i) & 1 else (0, 0, 0)
+                                         for i in range(32)]),
+        ]
+
+        for format, hres, words, expected in cases:
+            for backend in ["wishbone", "litedram"]:
+                with self.subTest(format=format, backend=backend):
+                    self.assertEqual(
+                        self._capture_pixels(backend, format, hres, words),
+                        expected,
+                    )
+
 
 # VideoTimingGenerator -----------------------------------------------------------------------------
 

--- a/test/soc/test_soc.py
+++ b/test/soc/test_soc.py
@@ -190,66 +190,86 @@ class TestSoCVideoFrameBuffer(unittest.TestCase):
         soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
         soc.bus.add_region("main_ram", SoCRegion(origin=0x40000000, size=0x04000000))
 
-        region = soc._get_video_framebuffer_default_region("video_framebuffer", 0x0012c000)
+        region = soc._get_video_framebuffer_region("video_framebuffer", 0x0012c000)
 
         self.assertEqual(region.origin, 0x43e00000)
         self.assertEqual(region.size,   0x0012c000)
         self.assertTrue(region.linker)
+        self.assertTrue(region.decode)
 
     def test_default_region_fits_small_main_ram(self):
         soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
         soc.bus.add_region("main_ram", SoCRegion(origin=0x40000000, size=0x00800000))
 
         framebuffer_size = video_framebuffer_size(800, 600, "rgb888")
-        region = soc._get_video_framebuffer_default_region("video_framebuffer", framebuffer_size)
+        region = soc._get_video_framebuffer_region("video_framebuffer", framebuffer_size)
 
         self.assertEqual(region.origin, 0x40600000)
         self.assertEqual(region.size,   framebuffer_size)
         self.assertLessEqual(region.origin + region.size, 0x40800000)
         self.assertTrue(region.linker)
 
-    def test_default_region_falls_back_when_main_ram_is_unknown(self):
+    def test_default_region_requires_main_ram(self):
         soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
 
-        region = soc._get_video_framebuffer_default_region("video_framebuffer", 0x0012c000)
+        with _assert_raises_soc_error(self):
+            soc._get_video_framebuffer_region("video_framebuffer", 0x0012c000)
 
-        self.assertEqual(region.origin, 0x40c00000)
-        self.assertEqual(region.size,   0x0012c000)
-        self.assertTrue(region.linker)
-
-    def test_default_base_adds_region_at_end_of_main_ram(self):
+    def test_explicit_base_overrides_mem_map(self):
         soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
-        soc.bus.add_region("main_ram", SoCRegion(origin=0x40000000, size=0x04000000))
-
-        base = soc._get_video_framebuffer_base("video_framebuffer", 0x0012c000)
-
-        self.assertEqual(base, 0x43e00000)
-        self.assertEqual(soc.bus.regions["video_framebuffer"].origin, 0x43e00000)
-
-    def test_explicit_mem_map_override_is_preserved(self):
-        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
+        soc.bus.add_region("main_ram", SoCRegion(origin=0x50000000, size=0x04000000))
         soc.mem_map["video_framebuffer"] = 0x50c00000
 
-        base = soc._get_video_framebuffer_base("video_framebuffer", 0x0012c000)
+        region = soc._get_video_framebuffer_region(
+            "video_framebuffer", 0x0012c000, base=0x51000000)
 
-        self.assertEqual(base, 0x50c00000)
-        self.assertNotIn("video_framebuffer", soc.bus.regions)
+        self.assertEqual(region.origin, 0x51000000)
+
+    def test_mem_map_base_is_used_when_explicit_base_is_absent(self):
+        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
+        soc.bus.add_region("main_ram", SoCRegion(origin=0x50000000, size=0x04000000))
+        soc.mem_map["video_framebuffer"] = 0x50c00000
+
+        region = soc._get_video_framebuffer_region("video_framebuffer", 0x0012c000)
+
+        self.assertEqual(region.origin, 0x50c00000)
 
     def test_default_region_rejects_framebuffer_larger_than_main_ram(self):
         soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
         soc.bus.add_region("main_ram", SoCRegion(origin=0x40000000, size=0x00100000))
 
         with _assert_raises_soc_error(self):
-            soc._get_video_framebuffer_default_region("video_framebuffer", 0x00200000)
+            soc._get_video_framebuffer_region("video_framebuffer", 0x00200000)
 
-    def test_framebuffer_port_can_be_provided_without_sdram(self):
-        soc  = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
-        port = wishbone.Interface()
+    def test_region_must_be_readable(self):
+        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
+        soc.bus.add_region("write_only", SoCRegion(
+            origin = 0x20000000,
+            size   = 0x00800000,
+            mode   = "w",
+        ))
 
-        self.assertIs(soc._get_video_framebuffer_port(
-            "video_framebuffer", "main_ram", port), port)
+        with _assert_raises_soc_error(self):
+            soc._get_video_framebuffer_region(
+                "video_framebuffer", 0x0012c000, region_name="write_only")
 
-    def test_framebuffer_port_uses_soc_bus_when_sdram_is_absent(self):
+    def test_region_inherits_parent_attributes(self):
+        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
+        soc.bus.io_regions_check = False
+        soc.bus.add_region("framebuffer_ram", SoCRegion(
+            origin = 0x20000000,
+            size   = 0x00800000,
+            mode   = "rx",
+            cached = False,
+        ))
+
+        region = soc._get_video_framebuffer_region(
+            "video_framebuffer", 0x0012c000, region_name="framebuffer_ram")
+
+        self.assertEqual(region.mode, "rx")
+        self.assertFalse(region.cached)
+
+    def test_system_bus_framebuffer_is_adapted_to_soc_bus_standard(self):
         cases = [
             ("wishbone", wishbone.Interface),
             ("axi-lite", axi.AXILiteInterface),
@@ -261,42 +281,63 @@ class TestSoCVideoFrameBuffer(unittest.TestCase):
                 soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6, bus_standard=bus_standard)
                 if bus_standard == "axi":
                     soc.bus.add_master("cpu", axi.AXIInterface(id_width=4))
-                soc.bus.add_region("hyperram", SoCRegion(origin=0x20000000, size=0x00800000))
+                soc.bus.add_region("framebuffer_ram", SoCRegion(
+                    origin = 0x20000000,
+                    size   = 0x00800000,
+                ))
 
-                port = soc._get_video_framebuffer_port("video_framebuffer", "hyperram")
+                soc.add_video_framebuffer(
+                    phy         = stream.Endpoint(video_data_layout),
+                    timings     = "640x480@60Hz",
+                    fifo_depth  = 64,
+                    region_name = "framebuffer_ram",
+                )
 
+                port = soc.video_framebuffer.dma.bus
                 self.assertIsInstance(port, wishbone.Interface)
                 self.assertIsInstance(soc.bus.masters["video_framebuffer_dma"], interface_cls)
                 self.assertEqual(port.mode, "r")
+                self.assertEqual(soc.constants["VIDEO_FRAMEBUFFER_BASE"], 0x20600000)
+                self.assertEqual(soc.bus.regions["video_framebuffer"].origin, 0x20600000)
 
-    def test_framebuffer_port_requires_mapped_memory(self):
+    def test_missing_region_does_not_add_dma_master(self):
         soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
 
         with _assert_raises_soc_error(self):
-            soc._get_video_framebuffer_port("video_framebuffer", "hyperram")
+            soc.add_video_framebuffer(
+                phy         = stream.Endpoint(video_data_layout),
+                timings     = "640x480@60Hz",
+                region_name = "hyperram",
+            )
 
         self.assertNotIn("video_framebuffer_dma", soc.bus.masters)
+        self.assertNotIn("video_framebuffer", soc.bus.regions)
 
-    def test_explicit_hyperram_does_not_use_sdram_port(self):
-        soc        = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
-        sdram_port = wishbone.Interface()
-        soc.sdram  = SimpleNamespace(crossbar=SimpleNamespace(get_port=lambda: sdram_port))
-        soc.bus.add_region("hyperram", SoCRegion(origin=0x20000000, size=0x00800000))
+    def test_invalid_fifo_depth_does_not_add_dma_master(self):
+        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
+        soc.bus.add_region("main_ram", SoCRegion(origin=0x40000000, size=0x00800000))
 
-        port = soc._get_video_framebuffer_port("video_framebuffer", "hyperram")
+        with _assert_raises_soc_error(self):
+            soc.add_video_framebuffer(
+                phy        = stream.Endpoint(video_data_layout),
+                timings    = "640x480@60Hz",
+                fifo_depth = 0,
+            )
 
-        self.assertIsNot(port, sdram_port)
-        self.assertIs(soc.bus.masters["video_framebuffer_dma"], port)
+        self.assertNotIn("video_framebuffer_dma", soc.bus.masters)
+        self.assertNotIn("video_framebuffer", soc.bus.regions)
 
-    def test_hyperram_framebuffer_uses_routed_wishbone_dma(self):
+    def test_secondary_region_does_not_use_native_sdram_port(self):
         soc = LiteXSoC(_FakePlatform(), sys_clk_freq=100e6)
+        soc.sdram = SimpleNamespace(crossbar=SimpleNamespace(
+            get_port=lambda **kwargs: self.fail("Secondary memory used the SDRAM port.")))
         soc.bus.add_region("hyperram", SoCRegion(origin=0x20000000, size=0x00800000))
 
         soc.add_video_framebuffer(
             phy         = stream.Endpoint(video_data_layout),
             timings     = "640x480@60Hz",
             fifo_depth  = 64,
-            memory_name = "hyperram",
+            region_name = "hyperram",
         )
 
         self.assertIsInstance(soc.video_framebuffer.dma, WishboneDMAReader)
@@ -306,24 +347,71 @@ class TestSoCVideoFrameBuffer(unittest.TestCase):
         )
         self.assertEqual(soc.constants["VIDEO_FRAMEBUFFER_BASE"], 0x20600000)
 
-    def test_framebuffer_memory_name_defaults_to_hyperram_without_main_ram(self):
-        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
-        soc.bus.add_region("hyperram", SoCRegion(origin=0x20000000, size=0x00800000))
+    def test_explicit_wishbone_port_is_registered(self):
+        soc  = LiteXSoC(_FakePlatform(), sys_clk_freq=100e6)
+        port = wishbone.Interface(data_width=64, address_width=32, mode="r")
+        soc.bus.add_region("main_ram", SoCRegion(origin=0x40000000, size=0x00800000))
 
-        self.assertEqual(soc._get_video_framebuffer_memory_name(), "hyperram")
+        soc.add_video_framebuffer(
+            phy        = stream.Endpoint(video_data_layout),
+            timings    = "640x480@60Hz",
+            fifo_depth = 64,
+            dma_port   = port,
+        )
 
-    def test_default_region_can_be_placed_in_hyperram(self):
-        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
-        soc.bus.add_region("hyperram", SoCRegion(origin=0x20000000, size=0x00800000))
+        self.assertIs(soc.video_framebuffer.dma.bus, port)
+        self.assertIsInstance(soc.bus.masters["video_framebuffer_dma"], wishbone.Interface)
+        self.assertEqual(soc.bus.masters["video_framebuffer_dma"].data_width, soc.bus.data_width)
 
-        framebuffer_size = video_framebuffer_size(800, 600, "rgb888")
-        region = soc._get_video_framebuffer_default_region(
-            "video_framebuffer", framebuffer_size, memory_name="hyperram")
+    def test_dedicated_dma_bus_is_preferred(self):
+        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=100e6)
+        soc.dma_bus = SoCBusHandler(standard="wishbone")
+        soc.bus.add_region("main_ram", SoCRegion(origin=0x40000000, size=0x00800000))
 
-        self.assertEqual(region.origin, 0x20600000)
-        self.assertEqual(region.size,   framebuffer_size)
-        self.assertLessEqual(region.origin + region.size, 0x20800000)
-        self.assertTrue(region.linker)
+        soc.add_video_framebuffer(
+            phy        = stream.Endpoint(video_data_layout),
+            timings    = "640x480@60Hz",
+            fifo_depth = 64,
+        )
+
+        self.assertIn("video_framebuffer_dma", soc.dma_bus.masters)
+        self.assertNotIn("video_framebuffer_dma", soc.bus.masters)
+
+    def test_native_sdram_port_is_read_only(self):
+        from litedram.common import LiteDRAMNativePort
+        from litedram.frontend.dma import LiteDRAMDMAReader
+
+        port  = LiteDRAMNativePort(mode="read", address_width=24, data_width=128)
+        modes = []
+        soc   = LiteXSoC(_FakePlatform(), sys_clk_freq=100e6)
+        soc.sdram = SimpleNamespace(crossbar=SimpleNamespace(
+            get_port=lambda mode: modes.append(mode) or port))
+        soc.bus.add_region("main_ram", SoCRegion(origin=0x40000000, size=0x04000000))
+
+        soc.add_video_framebuffer(
+            phy        = stream.Endpoint(video_data_layout),
+            timings    = "640x480@60Hz",
+            fifo_depth = 64,
+        )
+
+        self.assertEqual(modes, ["read"])
+        self.assertIsInstance(soc.video_framebuffer.dma, LiteDRAMDMAReader)
+        self.assertNotIn("video_framebuffer_dma", soc.bus.masters)
+
+    def test_explicit_base_must_be_port_aligned(self):
+        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=100e6)
+        soc.bus.add_region("main_ram", SoCRegion(origin=0x40000000, size=0x00800000))
+
+        with _assert_raises_soc_error(self):
+            soc.add_video_framebuffer(
+                phy        = stream.Endpoint(video_data_layout),
+                timings    = "640x480@60Hz",
+                fifo_depth = 64,
+                base       = 0x40000002,
+            )
+
+        self.assertNotIn("video_framebuffer_dma", soc.bus.masters)
+        self.assertNotIn("video_framebuffer", soc.bus.regions)
 
 class TestSoCResetRequests(unittest.TestCase):
     def test_soc_reset_request_registers_source(self):
@@ -1476,7 +1564,7 @@ class TestSoC(unittest.TestCase):
         with _assert_raises_soc_error(self):
             soc.add_video_terminal(timings="800@60Hz")
 
-    def test_video_framebuffer_requires_sdram(self):
+    def test_video_framebuffer_requires_phy(self):
         soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
 
         with _assert_raises_soc_error(self):
@@ -1484,10 +1572,12 @@ class TestSoC(unittest.TestCase):
 
     def test_video_framebuffer_rejects_bad_timing_before_imports(self):
         soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
-        soc.sdram = SimpleNamespace()
 
         with _assert_raises_soc_error(self):
-            soc.add_video_framebuffer(timings="800@60Hz")
+            soc.add_video_framebuffer(
+                phy     = stream.Endpoint(video_data_layout),
+                timings = "800@60Hz",
+            )
 
     def test_sata_requires_phy_before_imports(self):
         soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)


### PR DESCRIPTION
## Summary

This is a cleanup follow-up to #2527 that separates framebuffer memory placement from the DMA transport:

- reserve the framebuffer in an explicit readable SoC region, defaulting to `main_ram`;
- keep the native LiteDRAM reader for a LiteDRAM-backed `main_ram`;
- use a registered read-only Wishbone master for integrated RAM and other mapped memories, with the existing SoC bus adapters handling Wishbone, AXI-Lite and AXI;
- validate memory bounds, base alignment, FIFO depth and DMA-port capabilities before modifying SoC bus state.

The API now uses `region_name` and `dma_port` at the SoC level, and `port` in `VideoFrameBuffer`. The previous implicit HyperRAM fallback and fixed framebuffer address are removed: designs without `main_ram` must select their memory region explicitly.

Companion board-target regression coverage is in [LiteX-Boards #754](https://github.com/litex-hub/litex-boards/pull/754).

## Validation

- `pytest -q test/cores/test_video.py test/interconnect/test_dma.py test/interconnect/test_axi_lite.py test/soc/test_soc.py` (`211 passed`, `70 subtests passed`)
- behavioral simulation of every pixel format with both Wishbone and native LiteDRAM DMA readers
- no-compile Verilog elaboration with native LiteDRAM
- no-compile Verilog elaboration with integrated main RAM on Wishbone, AXI-Lite and AXI system buses
