### PR TITLE
build/openfpgaloader: Add --device option

### DIFF
--- a/litex/build/openfpgaloader.py
+++ b/litex/build/openfpgaloader.py
@@ -12,7 +12,7 @@ from litex.build.generic_programmer import GenericProgrammer
 class OpenFPGALoader(GenericProgrammer):
     needs_bitreverse = False
 
-    def __init__(self, board="", cable="", freq=0, fpga_part="", index_chain=None, ftdi_serial=None):
+    def __init__(self, board="", cable="", device=None, freq=0, fpga_part="", index_chain=None, ftdi_serial=None):
         GenericProgrammer.__init__(self)
 
         # openFPGALoader base command.
@@ -29,6 +29,10 @@ class OpenFPGALoader(GenericProgrammer):
         # Specify programmation cable.
         if cable:
             self.cmd += ["--cable", cable]
+
+        # Specify device to use (/dev/ttyUSBx)
+        if device:
+            self.cmd += ["--device", device]
 
         # Specify programmation frequency.
         if freq:


### PR DESCRIPTION
Since [2 months](https://github.com/trabucayre/openFPGALoader/commit/9e548983f99f988778abfcc63b04ccfb8c2594e2) `--ftdi-serial` is marked as deprecated. Furthermore, the openFPGALoader yields an error when there's an attempt to access the device with given iSerial value, while other connected USB devices may have iSerial set to `none`.