### PR TITLE
build/gowin/apicula: pass design clock target to nextpnr via --freq.

### DIFF
--- a/litex/build/gowin/apicula.py
+++ b/litex/build/gowin/apicula.py
@@ -52,6 +52,17 @@ class GowinApiculaToolchain(YosysNextPNRToolchain):
             devicename = devicename
         )
 
+        # nextpnr's Gowin arch takes no SDC, so --freq is the only way to pass a
+        # timing target; without it nextpnr defaults to 12 MHz. self.clocks is
+        # already populated at finalize, so the target can be set here directly.
+        max_freq = 0
+        for clk, [period, name] in sorted(self.clocks.items(), key=lambda x: x[0].duid):
+            freq = 1e3 / period # Period in ns -> freq in MHz.
+            if freq > max_freq:
+                max_freq = freq
+        if max_freq > 0:
+            self._pnr_opts += f" --freq {round(max_freq, 3)}"
+
         self._packer_opts += "-d {devicename} -o {top}.fs {top}_routed.json".format(
             devicename = devicename,
             top        = self._build_name

--- a/litex/build/gowin/apicula.py
+++ b/litex/build/gowin/apicula.py
@@ -19,6 +19,17 @@ class GowinApiculaToolchain(YosysNextPNRToolchain):
         super().__init__()
         self.options = {}
         self.additional_cst_commands = []
+        self._sys_clk_freq = None
+
+    def build(self, platform, fragment, *args, **kwargs):
+        self._sys_clk_freq = getattr(fragment, "sys_clk_freq", None)
+        return YosysNextPNRToolchain.build(self, platform, fragment, *args, **kwargs)
+
+    def _get_timing_target(self):
+        frequencies = [1e3/period for period, _ in self.clocks.values()]
+        if self._sys_clk_freq is not None:
+            frequencies.append(self._sys_clk_freq/1e6)
+        return max(frequencies, default=0)
 
     def build_io_constraints(self):
         _build_cst(self.named_sc, self.named_pc, self.additional_cst_commands, self._build_name)
@@ -53,13 +64,9 @@ class GowinApiculaToolchain(YosysNextPNRToolchain):
         )
 
         # nextpnr's Gowin arch takes no SDC, so --freq is the only way to pass a
-        # timing target; without it nextpnr defaults to 12 MHz. self.clocks is
-        # already populated at finalize, so the target can be set here directly.
-        max_freq = 0
-        for clk, [period, name] in sorted(self.clocks.items(), key=lambda x: x[0].duid):
-            freq = 1e3 / period # Period in ns -> freq in MHz.
-            if freq > max_freq:
-                max_freq = freq
+        # timing target; without it nextpnr defaults to 12 MHz. Include the SoC's
+        # system frequency since PLL-generated clocks are not always constrained.
+        max_freq = self._get_timing_target()
         if max_freq > 0:
             self._pnr_opts += f" --freq {round(max_freq, 3)}"
 

--- a/test/build/test_gowin_toolchain.py
+++ b/test/build/test_gowin_toolchain.py
@@ -4,13 +4,57 @@
 # Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
+import os
+import tempfile
 import unittest
 from unittest import mock
 
+from migen import ClockDomain
+
+from litex.gen import LiteXModule
+from litex.build.generic_platform import Pins
 from litex.build.gowin import gowin
+from litex.build.gowin.platform import GowinPlatform
+from litex.soc.cores.clock.gowin_gw1n import GW1NPLL
+
+
+class _ApiculaPlatform(GowinPlatform):
+    def __init__(self):
+        GowinPlatform.__init__(self,
+            device     = "GW1NR-LV9QN88PC6/I5",
+            io         = [("clk27", 0, Pins("52"))],
+            toolchain  = "apicula",
+            devicename = "GW1NR-9C",
+        )
+
+    def do_finalize(self, fragment):
+        self.add_period_constraint(self.lookup_request("clk27"), 1e9/27e6)
+
+
+class _ApiculaSoC(LiteXModule):
+    def __init__(self, platform, sys_clk_freq):
+        self.sys_clk_freq = sys_clk_freq
+        self.cd_sys       = ClockDomain()
+
+        clk27 = platform.request("clk27")
+        self.pll = pll = GW1NPLL(devicename=platform.devicename, device=platform.device)
+        pll.register_clkin(clk27, 27e6)
+        pll.create_clkout(self.cd_sys, sys_clk_freq)
 
 
 class TestGowinToolchain(unittest.TestCase):
+    def test_apicula_uses_generated_system_clock_target(self):
+        platform = _ApiculaPlatform()
+        soc      = _ApiculaSoC(platform, sys_clk_freq=48e6)
+
+        with tempfile.TemporaryDirectory() as build_dir:
+            platform.build(soc, build_dir=build_dir, build_name="top", run=False)
+            with open(os.path.join(build_dir, "build_top.sh")) as f:
+                build_script = f.read()
+
+        self.assertIn("--freq 48.0", build_script)
+        self.assertNotIn("--freq 27.0", build_script)
+
     def test_wsl_prefers_native_gowin(self):
         def which(tool):
             return {


### PR DESCRIPTION
## Problem

Designs built with the open Gowin flow (`--toolchain apicula`) are placed and routed against nextpnr's built-in 12 MHz default instead of the requested `sys_clk_freq`:

1. `litex/build/gowin/apicula.py` invokes nextpnr-himbaechel with `--write / --top / --device / --vopt family / --vopt cst` only. No `--freq` and no SDC ever reach nextpnr, and the himbaechel Gowin arch takes no SDC, so `--freq` is the only channel for a timing target.
2. Without `--freq`, nextpnr targets 12 MHz (`common/kernel/command.cc`).
3. `YosysNextPNRToolchain` defaults to `timingstrict=False`, i.e. `--timing-allow-fail`, so nothing rejects the mis-targeted result.

The fingerprint is in every affected build log:

```
Info: Max frequency for clock 'basesoc_crg_clkout': 25.67 MHz (PASS at 12.00 MHz)
```

The design "passes timing", just not at the clock it will actually run at.

The vendor toolchain (`gowin.py`) is unaffected: it writes a real SDC via `create_clock`, so `add_period_constraint()` has teeth there, presumably why this went unnoticed on the open flow.

## Fix

Pass a `--freq` timing target to nextpnr. The target is the highest frequency found from:

- period constraints collected through `add_period_constraint()`; and
- the top-level SoC's `sys_clk_freq`, captured before the design is lowered to a Migen fragment.

The second source is required because Gowin boards often constrain only the input oscillator while the faster `sys` clock is generated by a PLL. No behavior changes when neither source provides a frequency. With a real target set, `--nextpnr-timingstrict` also becomes meaningful for this backend.

## Validation

An automated no-compile regression uses a constrained 27 MHz input and a 48 MHz PLL-generated system clock, and verifies that the generated nextpnr command contains `--freq 48.0` rather than `--freq 27.0`.

No-compile gateware generation was also checked on the Sipeed Tang Nano 9K and Tang Nano 20K at a 48 MHz system clock. Both generated `--freq 48.0`.

Hardware validation by @yusefkarim on a Sipeed Tang Nano 9K with an Ibex SoC at 27 MHz:

Before:
```
Info: Max frequency for clock 'basesoc_crg_clkout': 36.61 MHz (PASS at 12.00 MHz)
Info: Max frequency for clock 'basesoc_crg_clkout': 25.67 MHz (PASS at 12.00 MHz)
```
After:
```
Info: Max frequency for clock 'basesoc_crg_clkout': 41.30 MHz (PASS at 27.00 MHz)
Info: Max frequency for clock 'basesoc_crg_clkout': 29.37 MHz (PASS at 27.00 MHz)
```

The BIOS now boots at 27 MHz with the open toolchain; previously only ~13.5 MHz produced output.

Scoped to Apicula on purpose; other nextpnr backends may be worth the same audit.
