### PR TITLE
setup: add -y/--yes for repository updates.

### DIFF
--- a/litex_setup.py
+++ b/litex_setup.py
@@ -287,7 +287,7 @@ def git_status_has_tracked_changes(status):
             return True
     return False
 
-def git_confirm_update_with_local_changes(name, repo_path):
+def git_confirm_update_with_local_changes(name, repo_path, always_update_repo):
     status = git_status(repo_path, short=True)
     if not git_status_has_tracked_changes(status) or not sys.stdin.isatty():
         return
@@ -295,10 +295,11 @@ def git_confirm_update_with_local_changes(name, repo_path):
     print_status("Updating can fail if these changes overlap with upstream changes.")
     print_status("Local changes:")
     print_indented(status, max_lines=12)
-    confirm = input("Continue updating this repository? [y/N]: ")
-    if confirm.strip().lower() not in ["y", "yes"]:
-        print_status("Update cancelled.")
-        raise SetupError
+    if not always_update_repo:
+        confirm = input("Continue updating this repository? [y/N]: ")
+        if confirm.strip().lower() not in ["y", "yes"]:
+            print_status("Update cancelled.")
+            raise SetupError
 
 def git_update_error(name, repo_path, action):
     print_error(f"Could not {action} {name} Git repository.")
@@ -418,7 +419,7 @@ def litex_setup_init_repos(config="standard", tag=None, dev_mode=False, clone_de
 
 # Git repositories update --------------------------------------------------------------------------
 
-def litex_setup_update_repos(config="standard", tag=None):
+def litex_setup_update_repos(config="standard", tag=None, always_update_repo=False):
     print_status("Updating Git repositories...", underline=True)
     for name in install_configs[config]:
         repo = git_repos[name]
@@ -431,7 +432,7 @@ def litex_setup_update_repos(config="standard", tag=None):
         print_status(f"Updating {name} Git repository...")
         os.chdir(os.path.join(current_path, name))
         repo_path = os.path.join(current_path, name)
-        git_confirm_update_with_local_changes(name, repo_path)
+        git_confirm_update_with_local_changes(name, repo_path, always_update_repo)
         try:
             subprocess_check_output(["git", "checkout", "--quiet", repo.branch], cwd=repo_path)
         except subprocess.CalledProcessError:
@@ -993,6 +994,8 @@ def main():
         help="Pass pip's --break-system-packages option when installing outside a virtual environment.")
     parser.add_argument("--config",    default="standard",  help="Install config (minimal, standard, full).")
     parser.add_argument("--tag",       default=None,        help="Use version from release tag.")
+    parser.add_argument("--always-update-repo", action="store_true",
+        help="Bypass the confirmation prompt before updating modified repositories.")
     parser.add_argument("--clone-depth", type=int, default=None,
         help="Use shallow Git clones with this depth during --init when compatible.")
 
@@ -1041,7 +1044,7 @@ def main():
 
     # Update.
     if args.update:
-        litex_setup_update_repos(config=args.config, tag=args.tag)
+        litex_setup_update_repos(config=args.config, tag=args.tag, always_update_repo=args.always_update_repo)
 
     # Install.
     if args.install:

--- a/litex_setup.py
+++ b/litex_setup.py
@@ -287,7 +287,7 @@ def git_status_has_tracked_changes(status):
             return True
     return False
 
-def git_confirm_update_with_local_changes(name, repo_path, always_update_repo):
+def git_confirm_update_with_local_changes(name, repo_path, assume_yes=False):
     status = git_status(repo_path, short=True)
     if not git_status_has_tracked_changes(status) or not sys.stdin.isatty():
         return
@@ -295,7 +295,7 @@ def git_confirm_update_with_local_changes(name, repo_path, always_update_repo):
     print_status("Updating can fail if these changes overlap with upstream changes.")
     print_status("Local changes:")
     print_indented(status, max_lines=12)
-    if not always_update_repo:
+    if not assume_yes:
         confirm = input("Continue updating this repository? [y/N]: ")
         if confirm.strip().lower() not in ["y", "yes"]:
             print_status("Update cancelled.")
@@ -419,7 +419,7 @@ def litex_setup_init_repos(config="standard", tag=None, dev_mode=False, clone_de
 
 # Git repositories update --------------------------------------------------------------------------
 
-def litex_setup_update_repos(config="standard", tag=None, always_update_repo=False):
+def litex_setup_update_repos(config="standard", tag=None, assume_yes=False):
     print_status("Updating Git repositories...", underline=True)
     for name in install_configs[config]:
         repo = git_repos[name]
@@ -432,7 +432,7 @@ def litex_setup_update_repos(config="standard", tag=None, always_update_repo=Fal
         print_status(f"Updating {name} Git repository...")
         os.chdir(os.path.join(current_path, name))
         repo_path = os.path.join(current_path, name)
-        git_confirm_update_with_local_changes(name, repo_path, always_update_repo)
+        git_confirm_update_with_local_changes(name, repo_path, assume_yes=assume_yes)
         try:
             subprocess_check_output(["git", "checkout", "--quiet", repo.branch], cwd=repo_path)
         except subprocess.CalledProcessError:
@@ -994,8 +994,8 @@ def main():
         help="Pass pip's --break-system-packages option when installing outside a virtual environment.")
     parser.add_argument("--config",    default="standard",  help="Install config (minimal, standard, full).")
     parser.add_argument("--tag",       default=None,        help="Use version from release tag.")
-    parser.add_argument("--always-update-repo", action="store_true",
-        help="Bypass the confirmation prompt before updating modified repositories.")
+    parser.add_argument("-y", "--yes", action="store_true",
+        help="Automatically confirm updates for repositories with local changes.")
     parser.add_argument("--clone-depth", type=int, default=None,
         help="Use shallow Git clones with this depth during --init when compatible.")
 
@@ -1044,7 +1044,7 @@ def main():
 
     # Update.
     if args.update:
-        litex_setup_update_repos(config=args.config, tag=args.tag, always_update_repo=args.always_update_repo)
+        litex_setup_update_repos(config=args.config, tag=args.tag, assume_yes=args.yes)
 
     # Install.
     if args.install:

--- a/test/tools/test_litex_setup.py
+++ b/test/tools/test_litex_setup.py
@@ -248,6 +248,17 @@ class TestLiteXSetup(unittest.TestCase):
         self.assertIn("litex Git repository has local changes.", output)
         self.assertIn("Update cancelled.", output)
 
+    def test_update_assume_yes_preserves_local_changes(self):
+        _upstream_path, repo_path = self.create_repo()
+        self.append_file(os.path.join(repo_path, "README.md"), "local change\n")
+
+        with mock.patch("sys.stdin.isatty", return_value=True), \
+             mock.patch("builtins.input") as input_prompt:
+            litex_setup.litex_setup_update_repos(config="minimal", assume_yes=True)
+
+        input_prompt.assert_not_called()
+        self.assertIn("README.md", self.git_output(repo_path, "status", "--short"))
+
     def test_update_fast_forward_failure_has_actionable_error(self):
         upstream_path, repo_path = self.create_repo()
 


### PR DESCRIPTION
## Summary

When repositories contain tracked local changes, `litex_setup.py --update` asks for confirmation before updating each one. Add the conventional `-y` / `--yes` option to accept these confirmations for the complete update operation:

```
./litex_setup.py --update --yes
```

Interactive confirmation remains the default. The option only skips the prompts; it does not merge, rebase, overwrite or discard local work, and Git failures are still reported normally.

## Validation

Added a dirty-repository regression confirming that `--yes` skips `input()` while preserving the local working-tree modification.

```
pytest -q test/tools
124 passed
```
