### PR TITLE
Fix broken inlining in hierarchical verilog

### DIFF
--- a/litex/gen/fhdl/verilog.py
+++ b/litex/gen/fhdl/verilog.py
@@ -1140,10 +1140,20 @@ def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_transl
 
     _collect_raw_statements(ctx.root)
 
+    # Initialize inline flags once for the whole tree. Resetting them inside
+    # _mark_inline's recursion would undo _inline_subtree()'s marks: an inlined
+    # node's children would flip back to non-inline and then be silently
+    # dropped from emission (their parent is inline, so _emit never recurses
+    # into its hier_children).
+    def _reset_inline(node):
+        node.inline = False
+        for child in node.children:
+            _reset_inline(child)
+
+    _reset_inline(ctx.root)
+
     def _mark_inline(node):
         parent_path = _normalize_hier_path(node.path)
-        for child in node.children:
-            child.inline = False
         parent_drivers = set(getattr(node, "raw_self_targets", node.raw_targets))
 
         # Policy 1: parent and child both drive same signal object -> inline child.

--- a/litex/gen/fhdl/verilog.py
+++ b/litex/gen/fhdl/verilog.py
@@ -1140,11 +1140,8 @@ def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_transl
 
     _collect_raw_statements(ctx.root)
 
-    # Initialize inline flags once for the whole tree. Resetting them inside
-    # _mark_inline's recursion would undo _inline_subtree()'s marks: an inlined
-    # node's children would flip back to non-inline and then be silently
-    # dropped from emission (their parent is inline, so _emit never recurses
-    # into its hier_children).
+    # Initialize inline flags before applying policies so recursive visits do
+    # not undo an ancestor's decision to inline a complete subtree.
     def _reset_inline(node):
         node.inline = False
         for child in node.children:

--- a/test/hdl/test_hierarchical_verilog.py
+++ b/test/hdl/test_hierarchical_verilog.py
@@ -132,7 +132,6 @@ class _SharedMemoryTop(Module):
 
 
 class _InlineDropLeaf(Module):
-    """Grandchild with real logic and a boundary output."""
     def __init__(self):
         self.out = Signal(name="out")
         self.comb += self.out.eq(1)
@@ -140,7 +139,6 @@ class _InlineDropLeaf(Module):
 
 class _InlineDropChild(Module):
     def __init__(self):
-        # Owned under this module's path; driven by the parent.
         self.trigger = Signal(name="trigger")
         self.submodules.leaf = _InlineDropLeaf()
 
@@ -150,8 +148,7 @@ class _InlineDropTop(Module):
         self.io = Signal(name="io")
         self.submodules.child = _InlineDropChild()
         self.comb += self.io.eq(self.child.leaf.out)
-        # Parent drives a signal owned under the child's path, so the inline
-        # policy inlines the child into the parent.
+        # Force the child and its subtree to be inlined.
         self.comb += self.child.trigger.eq(1)
 
 
@@ -303,10 +300,6 @@ class TestHierarchicalVerilog(unittest.TestCase):
         self.assertIn(".sys_clk(sys_clk)", top_module)
 
     def test_hierarchical_inlined_child_keeps_grandchild_logic(self):
-        # Regression test for the inline-flag reset bug: _mark_inline reset
-        # every child's inline flag on each recursion, undoing
-        # _inline_subtree()'s marks. A grandchild of an inlined child was
-        # dropped from emission and its output became an undriven register.
         top = _InlineDropTop()
 
         old_top = LiteXContext.top
@@ -316,9 +309,12 @@ class TestHierarchicalVerilog(unittest.TestCase):
         finally:
             LiteXContext.top = old_top
 
-        # The grandchild's driver must be emitted somewhere in the netlist;
-        # buggy output left `out` as an undriven register instead.
-        self.assertIn("assign out = 1'd1", verilog)
+        top_module = self._module_body(verilog, "top")
+
+        self.assertEqual(verilog.count("assign out = 1'd1"), 1)
+        self.assertIn("assign out = 1'd1", top_module)
+        self.assertNotIn("module top__child (", verilog)
+        self.assertNotIn("module top__child__leaf (", verilog)
 
     def test_hierarchical_shared_memory_is_emitted_once(self):
         top = _SharedMemoryTop()

--- a/test/hdl/test_hierarchical_verilog.py
+++ b/test/hdl/test_hierarchical_verilog.py
@@ -131,6 +131,30 @@ class _SharedMemoryTop(Module):
         self.comb += self.o.eq(self.reader.dat_r)
 
 
+class _InlineDropLeaf(Module):
+    """Grandchild with real logic and a boundary output."""
+    def __init__(self):
+        self.out = Signal(name="out")
+        self.comb += self.out.eq(1)
+
+
+class _InlineDropChild(Module):
+    def __init__(self):
+        # Owned under this module's path; driven by the parent.
+        self.trigger = Signal(name="trigger")
+        self.submodules.leaf = _InlineDropLeaf()
+
+
+class _InlineDropTop(Module):
+    def __init__(self):
+        self.io = Signal(name="io")
+        self.submodules.child = _InlineDropChild()
+        self.comb += self.io.eq(self.child.leaf.out)
+        # Parent drives a signal owned under the child's path, so the inline
+        # policy inlines the child into the parent.
+        self.comb += self.child.trigger.eq(1)
+
+
 class TestHierarchicalVerilog(unittest.TestCase):
     @staticmethod
     def _module_body(verilog, name):
@@ -277,6 +301,24 @@ class TestHierarchicalVerilog(unittest.TestCase):
         self.assertRegex(leaf_module, r"input\s+wire\s+sys_clk")
         self.assertIn("always @(posedge sys_clk)", leaf_module)
         self.assertIn(".sys_clk(sys_clk)", top_module)
+
+    def test_hierarchical_inlined_child_keeps_grandchild_logic(self):
+        # Regression test for the inline-flag reset bug: _mark_inline reset
+        # every child's inline flag on each recursion, undoing
+        # _inline_subtree()'s marks. A grandchild of an inlined child was
+        # dropped from emission and its output became an undriven register.
+        top = _InlineDropTop()
+
+        old_top = LiteXContext.top
+        try:
+            LiteXContext.top = top
+            verilog = convert(top, ios={top.io}, name="top", hierarchical=True).main_source
+        finally:
+            LiteXContext.top = old_top
+
+        # The grandchild's driver must be emitted somewhere in the netlist;
+        # buggy output left `out` as an undriven register instead.
+        self.assertIn("assign out = 1'd1", verilog)
 
     def test_hierarchical_shared_memory_is_emitted_once(self):
         top = _SharedMemoryTop()


### PR DESCRIPTION
I had the issue that a USB design worked as a flat build, but did not as a hierarchical build.
After this fix also the hierarchical USB design works. 
A minimal example to reproduce the bug has been added to the unit tests.