### PR TITLE
RfC full hierarchy generation

### DIFF
--- a/litex/gen/fhdl/verilog.py
+++ b/litex/gen/fhdl/verilog.py
@@ -1140,10 +1140,20 @@ def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_transl
 
     _collect_raw_statements(ctx.root)
 
+    # Initialize inline flags once for the whole tree. Resetting them inside
+    # _mark_inline's recursion would undo _inline_subtree()'s marks: an inlined
+    # node's children would flip back to non-inline and then be silently
+    # dropped from emission (their parent is inline, so _emit never recurses
+    # into its hier_children).
+    def _reset_inline(node):
+        node.inline = False
+        for child in node.children:
+            _reset_inline(child)
+
+    _reset_inline(ctx.root)
+
     def _mark_inline(node):
         parent_path = _normalize_hier_path(node.path)
-        for child in node.children:
-            child.inline = False
         parent_drivers = set(getattr(node, "raw_self_targets", node.raw_targets))
 
         # Policy 1: parent and child both drive same signal object -> inline child.

--- a/litex/gen/fhdl/verilog.py
+++ b/litex/gen/fhdl/verilog.py
@@ -904,6 +904,7 @@ class _HierarchicalBuildContext:
     time_unit: str
     time_precision: str
     ios: set
+    prefer_ports: bool = False
     conv_output: ConvOutput = field(default_factory=ConvOutput)
     root: object = None
     global_clock_domains: object = None
@@ -913,7 +914,7 @@ class _HierarchicalBuildContext:
     ns: object = None
 
 
-def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_translate, regs_init, comb_cycle_policy, time_unit, time_precision):
+def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_translate, regs_init, comb_cycle_policy, time_unit, time_precision, prefer_ports=False):
     if LiteXContext.top is None:
         raise ValueError("Hierarchical Verilog generation requires LiteXContext.top to be set.")
 
@@ -933,6 +934,7 @@ def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_transl
         time_unit         = time_unit,
         time_precision    = time_precision,
         ios               = _resolve_ios(ios, platform),
+        prefer_ports      = prefer_ports,
     )
     _apply_io_name_overrides(ctx.ios)
 
@@ -1162,15 +1164,20 @@ def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_transl
                 child.inline = True
 
         # Policy 2: parent drives a signal owned under a child path -> inline child.
-        for sig in parent_drivers:
-            owner_path = _normalize_hier_path(_signal_owner_path(sig, default_path=parent_path))
-            if owner_path == parent_path:
-                continue
-            for child in node.children:
-                child_path = _normalize_hier_path(child.path)
-                if owner_path[:len(child_path)] == child_path:
-                    child.inline = True
-                    break
+        # With prefer_ports, the child stays a module and the signal becomes
+        # a proper input port instead (used-outside detection in
+        # _compute_external/_compute_ports lifts it to a port), preserving
+        # the internal hierarchy of the child subtree.
+        if not ctx.prefer_ports:
+            for sig in parent_drivers:
+                owner_path = _normalize_hier_path(_signal_owner_path(sig, default_path=parent_path))
+                if owner_path == parent_path:
+                    continue
+                for child in node.children:
+                    child_path = _normalize_hier_path(child.path)
+                    if owner_path[:len(child_path)] == child_path:
+                        child.inline = True
+                        break
 
         # Policy 3: siblings drive same signal object -> inline all conflicting siblings.
         drivers = {}
@@ -1473,6 +1480,14 @@ def convert(f, ios=set(), name="top", platform=None,
     comb_cycle_policy = _normalize_comb_cycle_policy(comb_cycle_policy)
 
     # Hierarchical Verilog generation (opt-in path).
+    # `hierarchical` may also be a dict of options, e.g.
+    # {"enabled": True, "prefer_ports": True}; "prefer_ports" keeps children
+    # as modules by lifting parent-driven child-internal signals to proper
+    # input ports instead of inlining the whole child subtree.
+    prefer_ports = False
+    if isinstance(hierarchical, dict):
+        prefer_ports = bool(hierarchical.get("prefer_ports", False))
+        hierarchical = bool(hierarchical.get("enabled", True))
     if hierarchical:
         return _convert_hierarchical(
             f                 = f,
@@ -1485,6 +1500,7 @@ def convert(f, ios=set(), name="top", platform=None,
             comb_cycle_policy = comb_cycle_policy,
             time_unit         = time_unit,
             time_precision    = time_precision,
+            prefer_ports      = prefer_ports,
         )
 
     # Create ConvOutput for flat path.

--- a/litex/gen/fhdl/verilog.py
+++ b/litex/gen/fhdl/verilog.py
@@ -904,7 +904,7 @@ class _HierarchicalBuildContext:
     time_unit: str
     time_precision: str
     ios: set
-    prefer_ports: bool = False
+    keep_hierarchy: bool = False
     conv_output: ConvOutput = field(default_factory=ConvOutput)
     root: object = None
     global_clock_domains: object = None
@@ -914,7 +914,7 @@ class _HierarchicalBuildContext:
     ns: object = None
 
 
-def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_translate, regs_init, comb_cycle_policy, time_unit, time_precision, prefer_ports=False):
+def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_translate, regs_init, comb_cycle_policy, time_unit, time_precision, keep_hierarchy=False):
     if LiteXContext.top is None:
         raise ValueError("Hierarchical Verilog generation requires LiteXContext.top to be set.")
 
@@ -934,7 +934,7 @@ def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_transl
         time_unit         = time_unit,
         time_precision    = time_precision,
         ios               = _resolve_ios(ios, platform),
-        prefer_ports      = prefer_ports,
+        keep_hierarchy      = keep_hierarchy,
     )
     _apply_io_name_overrides(ctx.ios)
 
@@ -1164,11 +1164,11 @@ def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_transl
                 child.inline = True
 
         # Policy 2: parent drives a signal owned under a child path -> inline child.
-        # With prefer_ports, the child stays a module and the signal becomes
+        # With keep_hierarchy, the child stays a module and the signal becomes
         # a proper input port instead (used-outside detection in
         # _compute_external/_compute_ports lifts it to a port), preserving
         # the internal hierarchy of the child subtree.
-        if not ctx.prefer_ports:
+        if not ctx.keep_hierarchy:
             for sig in parent_drivers:
                 owner_path = _normalize_hier_path(_signal_owner_path(sig, default_path=parent_path))
                 if owner_path == parent_path:
@@ -1481,12 +1481,12 @@ def convert(f, ios=set(), name="top", platform=None,
 
     # Hierarchical Verilog generation (opt-in path).
     # `hierarchical` may also be a dict of options, e.g.
-    # {"enabled": True, "prefer_ports": True}; "prefer_ports" keeps children
+    # {"enabled": True, "keep_hierarchy": True}; "keep_hierarchy" keeps children
     # as modules by lifting parent-driven child-internal signals to proper
     # input ports instead of inlining the whole child subtree.
-    prefer_ports = False
+    keep_hierarchy = False
     if isinstance(hierarchical, dict):
-        prefer_ports = bool(hierarchical.get("prefer_ports", False))
+        keep_hierarchy = bool(hierarchical.get("keep_hierarchy", False))
         hierarchical = bool(hierarchical.get("enabled", True))
     if hierarchical:
         return _convert_hierarchical(
@@ -1500,7 +1500,7 @@ def convert(f, ios=set(), name="top", platform=None,
             comb_cycle_policy = comb_cycle_policy,
             time_unit         = time_unit,
             time_precision    = time_precision,
-            prefer_ports      = prefer_ports,
+            keep_hierarchy      = keep_hierarchy,
         )
 
     # Create ConvOutput for flat path.

--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -111,7 +111,7 @@ class Builder:
 
         # Verilog.
         hierarchical     = False,
-        hierarchical_prefer_ports = False,
+        hierarchical_keep_hierarchy = False,
 
         # Build Bundle.
         build_bundle           = False,
@@ -158,7 +158,7 @@ class Builder:
 
         # Verilog.
         self.hierarchical = hierarchical
-        self.hierarchical_prefer_ports = hierarchical_prefer_ports
+        self.hierarchical_keep_hierarchy = hierarchical_keep_hierarchy
 
         # Build Bundle.
         self.build_bundle           = bool(build_bundle) and (os.getenv("LITEX_BUILD_BUNDLE_REPLAY", "0") != "1")
@@ -606,8 +606,8 @@ class Builder:
             kwargs["run"] = self.compile_gateware
 
         if "hierarchical" not in kwargs:
-            if self.hierarchical_prefer_ports:
-                kwargs["hierarchical"] = {"enabled": True, "prefer_ports": True}
+            if self.hierarchical_keep_hierarchy:
+                kwargs["hierarchical"] = {"enabled": True, "keep_hierarchy": True}
             else:
                 kwargs["hierarchical"] = self.hierarchical
 
@@ -664,7 +664,7 @@ def builder_args(parser):
     builder_group.add_argument("--memory-x",              default=None,        help=f"Write SoC memory regions to the specified Memory-X file. {export_help}")
     builder_group.add_argument("--doc",                   action="store_true", help="Generate SoC documentation.")
     builder_group.add_argument("--hierarchical-verilog",  action="store_true", help="Enable hierarchical Verilog generation.")
-    builder_group.add_argument("--hierarchical-prefer-ports", action="store_true", help="Hierarchical Verilog: lift parent-driven child-internal signals to ports instead of inlining (preserves full hierarchy).")
+    builder_group.add_argument("--keep-hierarchy", dest="hierarchical_keep_hierarchy", action="store_true", help="Hierarchical Verilog: keep internal hierarchy; parent-driven child signals become input ports instead of flattening the child subtree.")
     bundle_group = parser.add_argument_group(title="Build bundle options")
     bundle_group.add_argument("--build-bundle",           default=False, nargs="?", const=True, metavar="PATH", help="Generate build input bundle (optionally to PATH).")
     bundle_group.add_argument("--no-build-bundle",        dest="build_bundle", action="store_false",           help="Disable build input bundle generation.")
@@ -706,7 +706,7 @@ def builder_argdict(args):
         "libc_mode"                : args.libc_mode,
         "integrated_rom_auto_size" : not args.no_integrated_rom_auto_size,
         "hierarchical"             : args.hierarchical_verilog,
-        "hierarchical_prefer_ports": args.hierarchical_prefer_ports,
+        "hierarchical_keep_hierarchy": args.hierarchical_keep_hierarchy,
         "build_bundle"             : args.build_bundle,
         "bundle_root"              : args.bundle_root,
         "bundle_include"           : args.bundle_include,

--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -111,6 +111,7 @@ class Builder:
 
         # Verilog.
         hierarchical     = False,
+        hierarchical_prefer_ports = False,
 
         # Build Bundle.
         build_bundle           = False,
@@ -157,6 +158,7 @@ class Builder:
 
         # Verilog.
         self.hierarchical = hierarchical
+        self.hierarchical_prefer_ports = hierarchical_prefer_ports
 
         # Build Bundle.
         self.build_bundle           = bool(build_bundle) and (os.getenv("LITEX_BUILD_BUNDLE_REPLAY", "0") != "1")
@@ -604,7 +606,10 @@ class Builder:
             kwargs["run"] = self.compile_gateware
 
         if "hierarchical" not in kwargs:
-            kwargs["hierarchical"] = self.hierarchical
+            if self.hierarchical_prefer_ports:
+                kwargs["hierarchical"] = {"enabled": True, "prefer_ports": True}
+            else:
+                kwargs["hierarchical"] = self.hierarchical
 
         kwargs["build_backend"] = self.build_backend
 
@@ -659,6 +664,7 @@ def builder_args(parser):
     builder_group.add_argument("--memory-x",              default=None,        help=f"Write SoC memory regions to the specified Memory-X file. {export_help}")
     builder_group.add_argument("--doc",                   action="store_true", help="Generate SoC documentation.")
     builder_group.add_argument("--hierarchical-verilog",  action="store_true", help="Enable hierarchical Verilog generation.")
+    builder_group.add_argument("--hierarchical-prefer-ports", action="store_true", help="Hierarchical Verilog: lift parent-driven child-internal signals to ports instead of inlining (preserves full hierarchy).")
     bundle_group = parser.add_argument_group(title="Build bundle options")
     bundle_group.add_argument("--build-bundle",           default=False, nargs="?", const=True, metavar="PATH", help="Generate build input bundle (optionally to PATH).")
     bundle_group.add_argument("--no-build-bundle",        dest="build_bundle", action="store_false",           help="Disable build input bundle generation.")
@@ -700,6 +706,7 @@ def builder_argdict(args):
         "libc_mode"                : args.libc_mode,
         "integrated_rom_auto_size" : not args.no_integrated_rom_auto_size,
         "hierarchical"             : args.hierarchical_verilog,
+        "hierarchical_prefer_ports": args.hierarchical_prefer_ports,
         "build_bundle"             : args.build_bundle,
         "bundle_root"              : args.bundle_root,
         "bundle_include"           : args.bundle_include,

--- a/test/hdl/test_hierarchical_verilog.py
+++ b/test/hdl/test_hierarchical_verilog.py
@@ -131,6 +131,30 @@ class _SharedMemoryTop(Module):
         self.comb += self.o.eq(self.reader.dat_r)
 
 
+class _InlineDropLeaf(Module):
+    """Grandchild with real logic and a boundary output."""
+    def __init__(self):
+        self.out = Signal(name="out")
+        self.comb += self.out.eq(1)
+
+
+class _InlineDropChild(Module):
+    def __init__(self):
+        # Owned under this module's path; driven by the parent.
+        self.trigger = Signal(name="trigger")
+        self.submodules.leaf = _InlineDropLeaf()
+
+
+class _InlineDropTop(Module):
+    def __init__(self):
+        self.io = Signal(name="io")
+        self.submodules.child = _InlineDropChild()
+        self.comb += self.io.eq(self.child.leaf.out)
+        # Parent drives a signal owned under the child's path, so the inline
+        # policy inlines the child into the parent.
+        self.comb += self.child.trigger.eq(1)
+
+
 class TestHierarchicalVerilog(unittest.TestCase):
     @staticmethod
     def _module_body(verilog, name):
@@ -277,6 +301,24 @@ class TestHierarchicalVerilog(unittest.TestCase):
         self.assertRegex(leaf_module, r"input\s+wire\s+sys_clk")
         self.assertIn("always @(posedge sys_clk)", leaf_module)
         self.assertIn(".sys_clk(sys_clk)", top_module)
+
+    def test_hierarchical_inlined_child_keeps_grandchild_logic(self):
+        # Regression test for the inline-flag reset bug: _mark_inline reset
+        # every child's inline flag on each recursion, undoing
+        # _inline_subtree()'s marks. A grandchild of an inlined child was
+        # dropped from emission and its output became an undriven register.
+        top = _InlineDropTop()
+
+        old_top = LiteXContext.top
+        try:
+            LiteXContext.top = top
+            verilog = convert(top, ios={top.io}, name="top", hierarchical=True).main_source
+        finally:
+            LiteXContext.top = old_top
+
+        # The grandchild's driver must be emitted somewhere in the netlist;
+        # buggy output left `out` as an undriven register instead.
+        self.assertIn("assign out = 1'd1", verilog)
 
     def test_hierarchical_shared_memory_is_emitted_once(self):
         top = _SharedMemoryTop()

--- a/test/hdl/test_hierarchical_verilog.py
+++ b/test/hdl/test_hierarchical_verilog.py
@@ -134,8 +134,9 @@ class _SharedMemoryTop(Module):
 class _InlineDropLeaf(Module):
     """Grandchild with real logic and a boundary output."""
     def __init__(self):
+        self.inp = Signal(name="inp")
         self.out = Signal(name="out")
-        self.comb += self.out.eq(1)
+        self.comb += self.out.eq(self.inp)
 
 
 class _InlineDropChild(Module):
@@ -143,6 +144,7 @@ class _InlineDropChild(Module):
         # Owned under this module's path; driven by the parent.
         self.trigger = Signal(name="trigger")
         self.submodules.leaf = _InlineDropLeaf()
+        self.comb += self.leaf.inp.eq(self.trigger)
 
 
 class _InlineDropTop(Module):
@@ -318,7 +320,30 @@ class TestHierarchicalVerilog(unittest.TestCase):
 
         # The grandchild's driver must be emitted somewhere in the netlist;
         # buggy output left `out` as an undriven register instead.
-        self.assertIn("assign out = 1'd1", verilog)
+        self.assertIn("assign out = inp", verilog)
+
+    def test_hierarchical_prefer_ports_lifts_child_internal_drive_to_port(self):
+        # With prefer_ports, a parent driving a child-internal signal must
+        # NOT inline the child; the signal becomes a proper input port.
+        top = _InlineDropTop()
+
+        old_top = LiteXContext.top
+        try:
+            LiteXContext.top = top
+            verilog = convert(top, ios={top.io}, name="top",
+                hierarchical={"enabled": True, "prefer_ports": True}).main_source
+        finally:
+            LiteXContext.top = old_top
+
+        # Child stays a module...
+        child_module = self._module_body(verilog, "top__child")
+        top_module   = self._module_body(verilog, "top")
+        # ...with trigger as an input port...
+        self.assertRegex(child_module, r"input\s+wire\s+trigger")
+        # ...and the grandchild logic is still emitted.
+        leaf_module = self._module_body(verilog, "top__child__leaf")
+        self.assertIn("assign out = inp", leaf_module)
+        self.assertIn(".trigger(trigger)", top_module)
 
     def test_hierarchical_shared_memory_is_emitted_once(self):
         top = _SharedMemoryTop()

--- a/test/hdl/test_hierarchical_verilog.py
+++ b/test/hdl/test_hierarchical_verilog.py
@@ -322,8 +322,8 @@ class TestHierarchicalVerilog(unittest.TestCase):
         # buggy output left `out` as an undriven register instead.
         self.assertIn("assign out = inp", verilog)
 
-    def test_hierarchical_prefer_ports_lifts_child_internal_drive_to_port(self):
-        # With prefer_ports, a parent driving a child-internal signal must
+    def test_hierarchical_keep_hierarchy_lifts_child_internal_drive_to_port(self):
+        # With keep_hierarchy, a parent driving a child-internal signal must
         # NOT inline the child; the signal becomes a proper input port.
         top = _InlineDropTop()
 
@@ -331,7 +331,7 @@ class TestHierarchicalVerilog(unittest.TestCase):
         try:
             LiteXContext.top = top
             verilog = convert(top, ios={top.io}, name="top",
-                hierarchical={"enabled": True, "prefer_ports": True}).main_source
+                hierarchical={"enabled": True, "keep_hierarchy": True}).main_source
         finally:
             LiteXContext.top = old_top
 


### PR DESCRIPTION
This PR currently is a request for comment.
Note: As this PR depends on https://github.com/enjoy-digital/litex/pull/2535
its commits are still included.
The current hierarchical verilog generation still flattens a child
module if it drives the internals of a parent.
With this patch there is the option of preserving the full hierarchy.
I am not sure about the naming yet.
prefer_ports is a bit too much focused on implementation details.
maybe full_hierarchy would be a better name.
Possible other choices would be:
- keep_hierarchy
- preserve_hierarchy
- full_hierarchy
- no_flatten
- deep_hierarchy
- strict_hierarchy

I verified this code on a USB controller design with full hierarchy.