### PR TITLE
build/openfpgaloader: add serial device selection.

### DIFF
--- a/litex/build/openfpgaloader.py
+++ b/litex/build/openfpgaloader.py
@@ -12,7 +12,7 @@ from litex.build.generic_programmer import GenericProgrammer
 class OpenFPGALoader(GenericProgrammer):
     needs_bitreverse = False
 
-    def __init__(self, board="", cable="", device=None, freq=0, fpga_part="", index_chain=None, ftdi_serial=None):
+    def __init__(self, board="", cable="", freq=0, fpga_part="", index_chain=None, ftdi_serial=None, device=None):
         GenericProgrammer.__init__(self)
 
         # openFPGALoader base command.
@@ -30,7 +30,7 @@ class OpenFPGALoader(GenericProgrammer):
         if cable:
             self.cmd += ["--cable", cable]
 
-        # Specify device to use (/dev/ttyUSBx)
+        # Specify serial device to use (/dev/ttyUSBx).
         if device:
             self.cmd += ["--device", device]
 

--- a/litex/build/openfpgaloader.py
+++ b/litex/build/openfpgaloader.py
@@ -12,7 +12,7 @@ from litex.build.generic_programmer import GenericProgrammer
 class OpenFPGALoader(GenericProgrammer):
     needs_bitreverse = False
 
-    def __init__(self, board="", cable="", freq=0, fpga_part="", index_chain=None, ftdi_serial=None):
+    def __init__(self, board="", cable="", device=None, freq=0, fpga_part="", index_chain=None, ftdi_serial=None):
         GenericProgrammer.__init__(self)
 
         # openFPGALoader base command.
@@ -29,6 +29,10 @@ class OpenFPGALoader(GenericProgrammer):
         # Specify programmation cable.
         if cable:
             self.cmd += ["--cable", cable]
+
+        # Specify device to use (/dev/ttyUSBx)
+        if device:
+            self.cmd += ["--device", device]
 
         # Specify programmation frequency.
         if freq:

--- a/test/build/test_openfpgaloader.py
+++ b/test/build/test_openfpgaloader.py
@@ -1,0 +1,37 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from litex.build.openfpgaloader import OpenFPGALoader
+
+
+class TestOpenFPGALoader(unittest.TestCase):
+    def test_device_option(self):
+        programmer = OpenFPGALoader(device="/dev/ttyUSB2")
+
+        self.assertEqual(programmer.cmd, [
+            "openFPGALoader",
+            "--device", "/dev/ttyUSB2",
+        ])
+
+    def test_legacy_positional_arguments(self):
+        programmer = OpenFPGALoader(
+            "board", "cable", 10e6, "fpga-part", 2, "ftdi-serial")
+
+        self.assertEqual(programmer.cmd, [
+            "openFPGALoader",
+            "--board",       "board",
+            "--fpga-part",   "fpga-part",
+            "--cable",       "cable",
+            "--freq",        "10000000",
+            "--index-chain", "2",
+            "--ftdi-serial", "ftdi-serial",
+        ])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- expose openFPGALoader's `--device /dev/ttyUSBx` selector through `OpenFPGALoader`;
- append the new argument to preserve the existing positional constructor API; and
- test both the new command generation and the complete legacy positional argument order.

This selector is specifically for serial-backed devices. USB probe selection by iSerial remains handled by openFPGALoader's `--usb-serial-num` / deprecated `--ftdi-serial` options.

This supersedes #2532 because maintainer edits are disabled on its source branch. The original implementation commit and @BZab's authorship are preserved here.

## Validation

```
pytest -q test/build
136 passed, 83 subtests passed
```
