### PR TITLE
Add trailing space to synth_opts to fix abc9 and flow3 flags

### DIFF
--- a/litex/build/lattice/icestorm.py
+++ b/litex/build/lattice/icestorm.py
@@ -36,7 +36,7 @@ class LatticeIceStormToolchain(YosysNextPNRToolchain):
 
     def __init__(self):
         super().__init__()
-        self._synth_opts  = "-dsp"
+        self._synth_opts  = "-dsp "
         self._pnr_opts    = ""
         self._packer_opts = "-s"
 


### PR DESCRIPTION
_synth_opts was "-dsp" with no trailing space making YosysWrapper append the abc9 or flow3 flag directly onto it. Generating an invalid "synth_ice40 -dsp-abc9" command. This made --yosys-abc9 and --yosys-flow3 broken on the iceStorm/iCE40 flow.

The fix is matching the other Lattice toolchains (e.g. oxide.py uses "-flatten ") by adding a trailing space making options concatenate correctly as e.g. "-dsp -abc9".
