### PR TITLE
Gowin jtag support

### DIFF
--- a/litex/build/gowin/gowin.py
+++ b/litex/build/gowin/gowin.py
@@ -48,6 +48,14 @@ def _gowin_uses_windows_paths():
 
     return os.path.basename(os.path.realpath(gw_sh_path)).lower().endswith(".exe")
 
+def _gowin_ide_path():
+    _, gw_sh_path = _find_gowin_shell()
+    if gw_sh_path is None:
+        return None
+    gw_bin_path   = os.path.split(gw_sh_path)[0]
+    gw_ide_path   = os.sep.join(gw_bin_path.split(os.sep)[:-1])
+    return gw_ide_path
+
 def _gowin_tcl_path(path, use_windows_paths=False):
     if use_windows_paths and os.path.isabs(path):
         path = subprocess.check_output(
@@ -146,7 +154,22 @@ class GowinToolchain(GenericToolchain):
             ]
             self.options["include_path"] = "{" + ";".join(include_paths) + "}"
 
+        self.apply_gw_jtag_integration(self._build_name + ".v")
         self.apply_hyperram_integration_hack(self._build_name + ".v")
+
+    def apply_gw_jtag_integration(self, v_file):
+        with open(v_file, "r") as f:
+            verilog = f.read()
+
+        # No JTAG? skip
+        if "GW_JTAG" not in verilog:
+            return
+
+        # Integrates gw_jtag.v file from Gowin toolchain.
+        gw_ide_path = _gowin_ide_path()
+        if gw_ide_path is not None:
+            gw_ipcores_path = os.path.join(gw_ide_path, "data", "ipcores")
+            self.platform.add_source(os.path.join(gw_ipcores_path, "gw_jtag.v"))
 
     def apply_hyperram_integration_hack(self, v_file):
         # FIXME: Gowin EDA expects a very specific HypeRAM integration pattern, modify generated verilog to match it.

--- a/litex/build/gowin/platform.py
+++ b/litex/build/gowin/platform.py
@@ -26,7 +26,8 @@ class GowinPlatform(GenericPlatform):
             raise ValueError(f"devicename not provided, maybe {likely_name}?")
         self.devicename = devicename
         if toolchain == "gowin":
-            self.toolchain = gowin.GowinToolchain()
+            self.toolchain     = gowin.GowinToolchain()
+            self._jtag_support = True
         elif toolchain == "apicula":
             self.toolchain = apicula.GowinApiculaToolchain()
         else:

--- a/litex/build/openocd.py
+++ b/litex/build/openocd.py
@@ -54,7 +54,7 @@ class OpenOCD(GenericProgrammer):
         return "$_CHIPNAME.tap"
 
     def get_ir(self, chain, config):
-        cfg_str = open(config).read()
+        cfg_str = open(config).read().lower()
 
         def lookup_ir(family, irs):
             if chain not in irs:
@@ -66,8 +66,16 @@ class OpenOCD(GenericProgrammer):
             if chain != 1:
                 print(f"Warning: chain={chain} ignored on {family} (hardcoded IR 0x{ir:x}).")
 
+        # Gowin GW1N/GW2A.
+        if "gw1n" in cfg_str or "gw2a" in cfg_str:
+            chain = {
+                1: 0x42, # USER1.
+                2: 0x43, # USER2.
+            }[chain]
+            warn_ignored("Gowin GW1N/GW2A", chain)
+            return chain
         # Lattice ECP5.
-        if "ecp5" in cfg_str:
+        elif "ecp5" in cfg_str:
             warn_ignored("Lattice ECP5", 0x32)
             return 0x32
         # Intel Max10.

--- a/litex/soc/cores/jtag.py
+++ b/litex/soc/cores/jtag.py
@@ -395,6 +395,101 @@ class ECP5JTAG(LiteXModule):
             tck = new_tck
         self.comb += self.tck.eq(tck)
 
+# Gowin JTAG ---------------------------------------------------------------------------------------
+
+class GowinJTAG(LiteXModule):
+    def __init__(self, platform=None, chain=1, tck_delay_luts=8):
+        assert chain in [1, 2], "GowinJTAG chain must be 1 or 2."
+        assert platform is not None
+
+        self.reset   = Signal()
+        self.capture = Signal()
+        self.shift   = Signal()
+        self.update  = Signal()
+
+        self.tck     = Signal()
+        self.tms     = Signal()
+        self.tdi     = Signal()
+        self.tdo     = Signal()
+
+        # # #
+
+        tck             = Signal()
+        shift_capture   = Signal()
+        shift_capture_d = Signal()
+        update          = Signal()
+        enable          = Signal()
+
+        # Added fake pins required in .v not in .cst.
+        from litex.build.generic_platform import Pins
+        platform.add_extension([
+            ("tck_pad_i", 0, Pins("X")),
+            ("tms_pad_i", 0, Pins("X")),
+            ("tdi_pad_i", 0, Pins("X")),
+            ("tdo_pad_o", 0, Pins("X")),
+        ])
+        tck_pad_i = platform.request("tck_pad_i")
+        tms_pad_i = platform.request("tms_pad_i")
+        tdi_pad_i = platform.request("tdi_pad_i")
+        tdo_pad_o = platform.request("tdo_pad_o")
+
+        self.specials += Instance("GW_JTAG",
+            # Physical Pads
+            i_tck_pad_i             = tck_pad_i,
+            i_tms_pad_i             = tms_pad_i,
+            i_tdi_pad_i             = tdi_pad_i,
+            o_tdo_pad_o             = tdo_pad_o,
+
+            o_tck_o                 = tck,
+            o_tdi_o                 = self.tdi,
+            o_test_logic_reset_o    = Open(),
+            o_run_test_idle_er1_o   = Open(),
+            o_run_test_idle_er2_o   = Open(),
+            o_shift_dr_capture_dr_o = shift_capture,
+            o_pause_dr_o            = Open(),
+            o_update_dr_o           = update,
+            o_enable_er1_o          = {True: enable,   False: Open()        }[chain==1],
+            o_enable_er2_o          = {True: enable,   False: Open()        }[chain==2],
+            i_tdo_er1_i             = {True: self.tdo, False: Constant(0, 1)}[chain==1],
+            i_tdo_er2_i             = {True: self.tdo, False: Constant(0, 1)}[chain==2],
+        )
+
+        # GW_JTAG provides a combined Capture/Shift indication.
+        # Reconstruct shift/capture by looking at previous and
+        # current state.
+        self.sync.jtag += shift_capture_d.eq(shift_capture),
+        self.comb      += [
+            self.capture.eq(enable & ~shift_capture_d & shift_capture),
+            self.shift.eq(enable & shift_capture_d & shift_capture),
+        ]
+
+        self.comb += [
+            self.reset.eq(0), # test_logic_reset_o is always 1 ...
+            self.update.eq(enable & update),
+        ]
+
+        # TDI/TCK are synchronous on GW_JTAG output (TDI being registered with TCK). Introduce a delay
+        # on TCK with multiple LUT4s to allow its use as the JTAG Clk.
+        for i in range(tck_delay_luts):
+            new_tck = Signal()
+            self.specials += Instance("LUT4",
+                attr   = {"keep"},
+                p_INIT = 2,
+                i_I0   = tck,
+                i_I1   = 0,
+                i_I2   = 0,
+                i_I3   = 0,
+                o_F    = new_tck
+            )
+            tck = new_tck
+        self.comb += self.tck.eq(tck)
+
+        platform.add_period_constraint(tck_pad_i, 30e6)
+
+    @staticmethod
+    def get_tdi_delay(device):
+        return 1
+
 # JTAG PHY -----------------------------------------------------------------------------------------
 
 class JTAGPHY(LiteXModule):
@@ -448,6 +543,9 @@ class JTAGPHY(LiteXModule):
                     primitive = AlteraJTAG.get_primitive(device),
                     pads      = platform.get_reserved_jtag_pads()
                 )
+            # Gowin
+            elif device[:4] in ["GW1N", "GW2A"]:
+                jtag = GowinJTAG(platform)
             else:
                 print(device)
                 raise NotImplementedError


### PR DESCRIPTION
The JTAG primitive is not documented by Gowin, but this is used for goConfig.
[fpgacapZero](https://github.com/lcapossio/fpgacapZero/) also provides a way to access JTAG in GW1N/GW2A.

There is no official primitive but with a simple verilog file (called `gw_jtag.v`) the Gowin toolchain is able to integrates this feature.

This PR adds native support to jtag in LiteX with 3 commits:
- the first commit integrates the logic (mainly based on Lattice ECP5)
- the second commit updates openocd.py to return USER1/USER2 ir code according to chain ID
- the last commit integrates and enables jtag support in `build/gowin` only when the toolchain is fixed to `gowin`.

Note:
- `reset` signal in `GOWINJtag` class is fixed to '0'. With the uses of an Logic Analyzer the `test_logic_reset_o` is always set to '1'
- the `gw_jtag.v` comes from Gowin toolchain. This file is added to the build script at finalize time. If `gw_sh` is not in `PATH` this step is skipped.