### PR TITLE
builder/gen: add full hierarchical Verilog generation

### DIFF
--- a/litex/gen/fhdl/verilog.py
+++ b/litex/gen/fhdl/verilog.py
@@ -166,26 +166,66 @@ def _build_module_tree(top):
         seen[id(module)] = node
         used_names = set()
         for name, mod in module._submodules:
+            if name is None:
+                name = allocate_generated_name(mod, used_names)
+            elif name in used_names:
+                # Duplicate sibling name: migen's _ModuleSubmodules allows
+                # registering several submodules under the same name (e.g.
+                # liteusb's USBDevice names both of its USBStreamInEndpoint
+                # instances "USBStreamInEndpoint"). Disambiguate or the
+                # path-derived module names and the instance names in the
+                # parent module would collide in the emitted Verilog.
+                base = name
+                idx  = 2
+                name = f"{base}_{idx}"
+                while name in used_names:
+                    idx += 1
+                    name = f"{base}_{idx}"
+            used_names.add(name)
             # Avoid emitting shared submodules multiple times. This mirrors
             # Migen's get_fragment_called behavior for shared instances.
             if id(mod) in seen:
-                if name is None:
-                    name = allocate_generated_name(mod, used_names)
-                used_names.add(name)
                 alias = _ModuleNode(module=mod, parent=node, inst_name=name,
                                     path=(path or []) + [name])
                 alias.shared_alias = True
                 alias.shared_owner = seen[id(mod)]
                 node.children.append(alias)
                 continue
-            if name is None:
-                name = allocate_generated_name(mod, used_names)
-            used_names.add(name)
             child = _walk(mod, parent=node, inst_name=name, path=(path or []) + [name], seen=seen)
             node.children.append(child)
         return node
 
     return _walk(top, parent=None, inst_name=None, path=[], seen={})
+
+
+def _collect_cd_remaps(module):
+    """Recover ClockDomainsRenamer mappings from a (possibly decorated) module.
+
+    ClockDomainsRenamer patches the instance's get_fragment with a closure
+    capturing the renamer object, which stores the old->new domain mapping as
+    cd_remapping. Nested decorators chain such closures, so walk them all.
+    Returns a list of mapping dicts (outermost decorator first).
+    """
+    remaps = []
+    seen   = set()
+
+    def _visit(fn):
+        if id(fn) in seen:
+            return
+        seen.add(id(fn))
+        for cell in getattr(fn, "__closure__", None) or ():
+            try:
+                value = cell.cell_contents
+            except ValueError:
+                continue
+            mapping = getattr(value, "cd_remapping", None)
+            if isinstance(mapping, dict):
+                remaps.append(mapping)
+            if callable(value) and getattr(value, "__closure__", None):
+                _visit(value)
+
+    _visit(getattr(module, "get_fragment", None))
+    return remaps
 
 # ------------------------------------------------------------------------------------------------ #
 #                                    RESERVED KEYWORDS                                             #
@@ -778,11 +818,19 @@ def _prepare_fragment(f, platform, special_overrides, global_clock_domains=None)
     if global_clock_domains is not None:
         # Merge global and local clock domains so submodules can use their
         # locally-defined domains (e.g. renamed/derived CDC domains).
+        # Globals win name collisions (first occurrence): ClockDomainsRenamer
+        # mutates shared ClockDomain objects in place, so local fragments may
+        # carry "phantom" domains that merely share a name with the real
+        # global domain; the global list's first domain with a given name is
+        # authoritative (same first-match semantics as _ClockDomainList
+        # lookups in flat conversion).
         merged = {}
         for cd in global_clock_domains:
-            merged[cd.name] = cd
+            if cd.name not in merged:
+                merged[cd.name] = cd
         for cd in f.clock_domains:
-            merged[cd.name] = cd
+            if cd.name not in merged:
+                merged[cd.name] = cd
         merged_list = _ClockDomainList()
         for cd in merged.values():
             merged_list.append(cd)
@@ -904,6 +952,7 @@ class _HierarchicalBuildContext:
     time_unit: str
     time_precision: str
     ios: set
+    keep_hierarchy: bool = False
     conv_output: ConvOutput = field(default_factory=ConvOutput)
     root: object = None
     global_clock_domains: object = None
@@ -913,7 +962,7 @@ class _HierarchicalBuildContext:
     ns: object = None
 
 
-def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_translate, regs_init, comb_cycle_policy, time_unit, time_precision):
+def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_translate, regs_init, comb_cycle_policy, time_unit, time_precision, keep_hierarchy=False):
     if LiteXContext.top is None:
         raise ValueError("Hierarchical Verilog generation requires LiteXContext.top to be set.")
 
@@ -933,12 +982,26 @@ def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_transl
         time_unit         = time_unit,
         time_precision    = time_precision,
         ios               = _resolve_ios(ios, platform),
+        keep_hierarchy      = keep_hierarchy,
     )
     _apply_io_name_overrides(ctx.ios)
 
     # Prepare global clock domains from the full fragment and build hierarchy.
     ctx.global_clock_domains = f.clock_domains
     ctx.root = _build_module_tree(ctx.top)
+
+    # Clock domain remap chains per node (ClockDomainsRenamer mappings of the
+    # module itself and its ancestors, nearest decorator first). Used to
+    # resolve renamed clock domains when aliasing child clock ports (e.g.
+    # GrayCounter write/read clocks inside an AsyncFIFO wrapped with
+    # {"write": "usb", "read": "sys"}).
+    def _assign_remap_chains(node, inherited):
+        node.own_remaps  = _collect_cd_remaps(node.module)
+        node.remap_chain = node.own_remaps + inherited
+        for child in node.children:
+            _assign_remap_chains(child, node.remap_chain)
+
+    _assign_remap_chains(ctx.root, [])
 
     def _path_component_matches(path_name, trace_name):
         if path_name == trace_name:
@@ -1159,15 +1222,20 @@ def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_transl
                 child.inline = True
 
         # Policy 2: parent drives a signal owned under a child path -> inline child.
-        for sig in parent_drivers:
-            owner_path = _normalize_hier_path(_signal_owner_path(sig, default_path=parent_path))
-            if owner_path == parent_path:
-                continue
-            for child in node.children:
-                child_path = _normalize_hier_path(child.path)
-                if owner_path[:len(child_path)] == child_path:
-                    child.inline = True
-                    break
+        # With keep_hierarchy, the child stays a module and the signal becomes
+        # a proper input port instead (used-outside detection in
+        # _compute_external/_compute_ports lifts it to a port), preserving
+        # the internal hierarchy of the child subtree.
+        if not ctx.keep_hierarchy:
+            for sig in parent_drivers:
+                owner_path = _normalize_hier_path(_signal_owner_path(sig, default_path=parent_path))
+                if owner_path == parent_path:
+                    continue
+                for child in node.children:
+                    child_path = _normalize_hier_path(child.path)
+                    if owner_path[:len(child_path)] == child_path:
+                        child.inline = True
+                        break
 
         # Policy 3: siblings drive same signal object -> inline all conflicting siblings.
         drivers = {}
@@ -1196,7 +1264,13 @@ def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_transl
             _set_hier_children(child)
 
     def _set_inline_children(node):
-        node.filter_children = [c for c in node.children if not getattr(c, "inline", False)]
+        # Shared aliases are excluded from filter_children: they are never
+        # emitted (the owner instance is), and their descendant statement ids
+        # are copies of the owner's. Subtracting those ids in _lower_tree
+        # would wrongly drop the owner's logic when it arrives via an inline
+        # chain from its real registration site.
+        node.filter_children = [c for c in node.children if not getattr(c, "inline", False)
+                                and not getattr(c, "shared_alias", False)]
         node.hier_children = [c for c in node.children if not getattr(c, "inline", False) and not getattr(c, "shared_alias", False)]
         node.inline_children = [c for c in node.children if getattr(c, "inline", False)]
         for child in node.children:
@@ -1314,6 +1388,34 @@ def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_transl
             node.subtree_specials |= child.subtree_specials
 
     _aggregate(ctx.root)
+
+    # Renamed-domain clock/reset signals (fresh domains created locally for
+    # ClockDomainsRenamer-renamed sync keys, e.g. GrayCounter "write"/"read"
+    # clocks) are treated as owned by the nearest ancestor module whose
+    # remap covers the domain name (e.g. the AsyncFIFO wrapped with
+    # {"write": "usb"}). This keeps them as local wires of that ancestor —
+    # driven there by the alias block — instead of lifting them to input
+    # ports all the way up the hierarchy.
+    def _virtual_clock_owner_node(node, cd_name):
+        n = node
+        while n is not None:
+            for remap in getattr(n, "own_remaps", []):
+                if cd_name in remap:
+                    return n
+            n = n.parent
+        return None
+
+    clock_virtual_owner = {}
+    for node in ctx.root.subtree_nodes:
+        for cd in node.fragment.clock_domains:
+            owner = _virtual_clock_owner_node(node, cd.name)
+            if owner is None or owner is node:
+                continue
+            owner_path = _normalize_hier_path(owner.path)
+            clock_virtual_owner[cd.clk] = owner_path
+            if cd.rst is not None:
+                clock_virtual_owner[cd.rst] = owner_path
+
     ctx.all_signals |= set(ctx.ios)
     ctx.ns = build_signal_namespace(
         signals=ctx.all_signals,
@@ -1322,6 +1424,25 @@ def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_transl
     ctx.ns.clock_domains = ctx.global_clock_domains
 
     signal_local_nodes = collections.defaultdict(set)
+
+    # ── Absorb child clock signals into immediate parent ──────────
+    # If a child module has clock signals that the parent doesn't
+    # drive, absorb them as local wires so _compute_external won't
+    # promote them to input ports.  This allows _emit aliases to
+    # drive them (e.g. assign write_clk = usb_clk inside AsyncFIFO).
+    # Only absorb at the DIRECT parent — not recursively upward.
+    def _absorb_child_clock_wires(node):
+        for child in node.hier_children:
+            for sig in child.external_signals:
+                for cd in child.fragment.clock_domains:
+                    if sig is cd.clk or sig is cd.rst:
+                        if sig not in node.local_signals:
+                            node.local_signals.add(sig)
+                            ctx.all_signals.add(sig)
+                        break
+        for child in node.hier_children:
+            _absorb_child_clock_wires(child)
+    _absorb_child_clock_wires(ctx.root)
     for node in ctx.root.subtree_nodes:
         for sig in node.local_signals:
             signal_local_nodes[sig].add(node)
@@ -1336,7 +1457,10 @@ def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_transl
             node.external_signals = set()
             node_path = _normalize_hier_path(node.path)
             for sig in node.subtree_signals:
-                owner_path = _normalize_hier_path(_signal_owner_path(sig, default_path=node_path))
+                if sig in clock_virtual_owner:
+                    owner_path = list(clock_virtual_owner[sig])
+                else:
+                    owner_path = _normalize_hier_path(_signal_owner_path(sig, default_path=node_path))
                 owner_in_subtree = owner_path[:len(node_path)] == node_path
                 used_outside = any(n not in node.subtree_nodes for n in signal_local_nodes[sig])
                 if (not owner_in_subtree) or used_outside:
@@ -1376,6 +1500,124 @@ def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_transl
             _compute_ports(child)
 
     _compute_ports(ctx.root)
+
+    def _generate_clock_reset_aliases(node):
+        """Emit clock/reset alias assignments for child submodule clock ports.
+
+        Children expose their clock domain clk/rst signals as input ports.
+        When such a port is not already tied to the parent's own net by the
+        port connection, emit an alias assign driven by (first match wins):
+
+        1) The parent's domain with the same name, after resolving
+           ClockDomainsRenamer mappings on this module and its ancestors
+           (e.g. write→usb inside an AsyncFIFO wrapped with
+           {"write": "usb", "read": "sys"}).
+        2) The canonical sibling signal for that domain (daisy-chain), when
+           the parent has no domain with that name.
+        3) Any parent clock domain (fallback), only when the parent has no
+           domain with that name at all.
+
+        No alias is emitted when the child's port IS the parent's own
+        clock/reset net (shared ClockDomain object): the port connection
+        already ties them and an alias would add a second driver to a net
+        the parent may already drive (e.g. CRG logic).
+        """
+        if not node.hier_children:
+            return ""
+        clock_assigns = []
+        parent_cd_by_name = {}
+        parent_cd_list = list(node.fragment.clock_domains)
+        for cd in parent_cd_list:
+            parent_cd_by_name[cd.name] = cd
+        canonical_clk = {}
+        canonical_rst = {}
+        for child in node.hier_children:
+            for cd in child.fragment.clock_domains:
+                if cd.name not in canonical_clk:
+                    canonical_clk[cd.name] = cd.clk
+                if cd.rst is not None and cd.name not in canonical_rst:
+                    canonical_rst[cd.name] = cd.rst
+        for child in node.hier_children:
+            for sig in child.external_signals:
+                cd_name = None
+                is_rst  = False
+                for cd in child.fragment.clock_domains:
+                    if sig is cd.clk:
+                        cd_name = cd.name; is_rst = False; break
+                    if sig is cd.rst:
+                        cd_name = cd.name; is_rst = True; break
+                if cd_name is None:
+                    continue
+                if sig not in child.port_directions:
+                    continue
+                if child.port_directions[sig] != "input":
+                    continue
+                if node.port_directions.get(sig) == "input":
+                    # The clock/reset net is also an input of THIS module:
+                    # it is driven from above, a local alias would be
+                    # illegal (assign to an input port) and duplicate the
+                    # driver. Aliases are emitted at the boundary module
+                    # where the net is a local wire (e.g. the renamer
+                    # boundary for renamed domains), not here.
+                    continue
+                source_sig = None
+                # Resolve ClockDomainsRenamer mappings on this module and
+                # its ancestors (e.g. write→usb inside an AsyncFIFO
+                # wrapped with {"write": "usb", "read": "sys"}).
+                mapped_cd_name = cd_name
+                for remap in getattr(node, "remap_chain", []):
+                    if mapped_cd_name in remap:
+                        mapped_cd_name = remap[mapped_cd_name]
+                # 1) Parent domain by (possibly remapped) name.
+                parent_cd = parent_cd_by_name.get(mapped_cd_name)
+                if parent_cd is not None:
+                    source_sig = parent_cd.rst if is_rst else parent_cd.clk
+                    if source_sig is sig:
+                        # The child's clock/reset port IS the parent's own
+                        # net (shared global ClockDomain object): the port
+                        # connection already ties them. Emitting any alias
+                        # here would add a second driver to a net the
+                        # parent may already drive (e.g. CRG logic).
+                        continue
+                # 2) Canonical child signal (sibling daisy-chain).
+                if source_sig is None:
+                    source_sig = (canonical_rst if is_rst
+                                  else canonical_clk).get(cd_name)
+                    if source_sig is sig:
+                        # This child provides the canonical net itself.
+                        if parent_cd is not None:
+                            # Same net as the parent's: nothing to do.
+                            continue
+                        # Parent has no domain with this name (e.g.
+                        # renamed domains write→usb): try the fallback.
+                        source_sig = None
+                # 3) Fallback: any parent clock domain, but only when the
+                #    parent has no domain with this name at all.
+                #    Handles renamed domains (write→usb, read→sys).
+                if source_sig is None and parent_cd is None and parent_cd_list:
+                    for pcd in parent_cd_list:
+                        source_sig = pcd.rst if is_rst else pcd.clk
+                        if source_sig is not None:
+                            break
+                if source_sig is None:
+                    continue
+                # Reject self-aliases (same name both sides).
+                if ctx.ns.get_name(source_sig) == ctx.ns.get_name(sig):
+                    continue
+                child_name  = ctx.ns.get_name(sig)
+                source_name = ctx.ns.get_name(source_sig)
+                # Ensure source signal is declared in this module.
+                if source_sig not in node.local_signals:
+                    node.local_signals.add(source_sig)
+                    ctx.all_signals.add(source_sig)
+                clock_assigns.append(
+                    f"assign {child_name} = {source_name};")
+        r = ""
+        if clock_assigns:
+            for a in sorted(clock_assigns):
+                r += a + "\n"
+            r += "\n"
+        return r
 
     verilog = ""
     verilog += _generate_banner(
@@ -1427,6 +1669,45 @@ def _convert_hierarchical(f, ios, name, platform, special_overrides, attr_transl
         parts.append(_generate_separator("Submodules"))
         parts.append(_generate_submodule_instances(node, ctx.ns))
         parts.append(_generate_separator("Combinatorial Logic"))
+        # ── Clock / Reset aliasing for child submodule ports ────
+        parts.append(_generate_clock_reset_aliases(node))
+        # ── Reset-only constant materialization ─────────────────
+        # Signals that are never assigned anywhere (e.g. Record fields with
+        # reset=1 like USB interface tx_data_pid) keep their reset value in
+        # flat conversion (`reg = <reset>`). Here they would otherwise
+        # become a floating chain of input ports with an undriven net,
+        # delivering GND instead of the reset constant to consumers. The
+        # topmost module passing the signal (not importing it as an input
+        # port itself) drives it with its reset value.
+        constant_assigns = []
+        # Clock/reset domain signals are handled by the alias block above;
+        # never materialize them as constants (a phantom renamed-domain clock
+        # IS never targeted but is driven by its boundary alias).
+        clock_reset_signals = set()
+        for n in [node] + node.hier_children:
+            for cd in n.fragment.clock_domains:
+                clock_reset_signals.add(cd.clk)
+                if cd.rst is not None:
+                    clock_reset_signals.add(cd.rst)
+        for sig in sorted(interconnect_signals, key=lambda x: ctx.ns.get_name(x)):
+            if sig in node.local_targets:
+                continue
+            if sig in child_output_signals:
+                continue
+            if sig in ctx.root.subtree_targets:
+                continue
+            if sig in clock_reset_signals:
+                continue
+            if sig in ctx.ios:
+                continue
+            if sig in node.external_signals and node.port_directions.get(sig) == "input":
+                continue
+            constant_assigns.append(
+                f"assign {ctx.ns.get_name(sig)} = {_generate_expression(ctx.ns, sig.reset)[0]};")
+        if constant_assigns:
+            for a in constant_assigns:
+                parts.append(a + "\n")
+            parts.append("\n")
         parts.append(_generate_combinatorial_logic(node.fragment, ctx.ns, ctx.comb_cycle_policy))
         parts.append(_generate_separator("Synchronous Logic"))
         parts.append(_generate_synchronous_logic(node.fragment, ctx.ns))
@@ -1470,6 +1751,14 @@ def convert(f, ios=set(), name="top", platform=None,
     comb_cycle_policy = _normalize_comb_cycle_policy(comb_cycle_policy)
 
     # Hierarchical Verilog generation (opt-in path).
+    # `hierarchical` may also be a dict of options, e.g.
+    # {"enabled": True, "keep_hierarchy": True}; "keep_hierarchy" keeps children
+    # as modules by lifting parent-driven child-internal signals to proper
+    # input ports instead of inlining the whole child subtree.
+    keep_hierarchy = False
+    if isinstance(hierarchical, dict):
+        keep_hierarchy = bool(hierarchical.get("keep_hierarchy", False))
+        hierarchical = bool(hierarchical.get("enabled", True))
     if hierarchical:
         return _convert_hierarchical(
             f                 = f,
@@ -1482,6 +1771,7 @@ def convert(f, ios=set(), name="top", platform=None,
             comb_cycle_policy = comb_cycle_policy,
             time_unit         = time_unit,
             time_precision    = time_precision,
+            keep_hierarchy      = keep_hierarchy,
         )
 
     # Create ConvOutput for flat path.

--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -111,6 +111,7 @@ class Builder:
 
         # Verilog.
         hierarchical     = False,
+        no_flatten       = False,
 
         # Build Bundle.
         build_bundle           = False,
@@ -157,6 +158,7 @@ class Builder:
 
         # Verilog.
         self.hierarchical = hierarchical
+        self.no_flatten   = no_flatten
 
         # Build Bundle.
         self.build_bundle           = bool(build_bundle) and (os.getenv("LITEX_BUILD_BUNDLE_REPLAY", "0") != "1")
@@ -603,7 +605,9 @@ class Builder:
         if "run" not in kwargs:
             kwargs["run"] = self.compile_gateware
 
-        if "hierarchical" not in kwargs:
+        if self.no_flatten:
+            kwargs["hierarchical"] = {"enabled": True, "keep_hierarchy": True}
+        elif "hierarchical" not in kwargs:
             kwargs["hierarchical"] = self.hierarchical
 
         kwargs["build_backend"] = self.build_backend
@@ -658,7 +662,8 @@ def builder_args(parser):
     builder_group.add_argument("--soc-svd", "--csr-svd",  default=None,        help=f"Write SoC mapping to the specified SVD file. {export_help}")
     builder_group.add_argument("--memory-x",              default=None,        help=f"Write SoC memory regions to the specified Memory-X file. {export_help}")
     builder_group.add_argument("--doc",                   action="store_true", help="Generate SoC documentation.")
-    builder_group.add_argument("--hierarchical-verilog",  action="store_true", help="Enable hierarchical Verilog generation.")
+    builder_group.add_argument("--hierarchical-verilog",  action="store_true", help="Enable hierarchical Verilog generation (one module per SoC submodule; conflicting child subtrees may still be flattened where boundaries cannot be preserved).")
+    builder_group.add_argument("--no-flatten",            action="store_true", help="Hierarchical Verilog: do not flatten child subtrees; parent-driven child-internal signals become proper input ports, preserving the full module hierarchy.")
     bundle_group = parser.add_argument_group(title="Build bundle options")
     bundle_group.add_argument("--build-bundle",           default=False, nargs="?", const=True, metavar="PATH", help="Generate build input bundle (optionally to PATH).")
     bundle_group.add_argument("--no-build-bundle",        dest="build_bundle", action="store_false",           help="Disable build input bundle generation.")
@@ -700,6 +705,7 @@ def builder_argdict(args):
         "libc_mode"                : args.libc_mode,
         "integrated_rom_auto_size" : not args.no_integrated_rom_auto_size,
         "hierarchical"             : args.hierarchical_verilog,
+        "no_flatten"               : args.no_flatten,
         "build_bundle"             : args.build_bundle,
         "bundle_root"              : args.bundle_root,
         "bundle_include"           : args.bundle_include,

--- a/test/hdl/test_hierarchical_verilog.py
+++ b/test/hdl/test_hierarchical_verilog.py
@@ -4,6 +4,7 @@ import re
 from migen import *
 from migen.fhdl.decorators import ClockDomainsRenamer
 from migen.fhdl.specials import Tristate
+from migen.genlib.fifo import AsyncFIFO
 
 from litex.gen import LiteXContext
 from litex.gen.fhdl.hierarchy import LiteXHierarchyExplorer
@@ -152,6 +153,188 @@ class _InlineDropTop(Module):
         self.comb += self.child.trigger.eq(1)
 
 
+class _USBClockLeaf(Module):
+    """Leaf using the 'usb' clock domain; defines no domain itself, so its
+    fragment shares the parent's global 'usb' ClockDomain object."""
+    def __init__(self):
+        self.o = Signal(name="leaf_o")
+        self.sync.usb += self.o.eq(~self.o)
+
+
+class _TwoDomainTop(Module):
+    """Top with a CRG-style 'usb' domain: the top module itself drives the
+    usb clk/rst nets (from a PLL output / POR), and a child leaf uses
+    sync.usb, exposing usb_clk/usb_rst as input ports tied to the very same
+    top-level nets."""
+    def __init__(self, n_leaves=1):
+        # Domain order matters: 'sys' first, mirroring SoC clock domain
+        # lists, so the alias fallback would pick sys_clk/sys_rst.
+        self.clock_domains.cd_sys = ClockDomain("sys")
+        self.clock_domains.cd_usb = ClockDomain("usb")
+        self.por     = Signal(name="por")
+        self.pll_out = Signal(name="pll_out")
+        self.o       = Signal(name="o")
+        # CRG-like: top drives its own usb clock/reset nets.
+        self.comb += [
+            self.cd_usb.clk.eq(self.pll_out),
+            self.cd_usb.rst.eq(self.por),
+        ]
+        leaves = []
+        for i in range(n_leaves):
+            leaf = _USBClockLeaf()
+            setattr(self.submodules, f"leaf{i}" if n_leaves > 1 else "leaf", leaf)
+            leaves.append(leaf)
+        terms = [l.o for l in leaves]
+        x = terms[0]
+        for t in terms[1:]:
+            x = x ^ t
+        self.comb += self.o.eq(x)
+
+
+class _DupNamedLeaf(Module):
+    def __init__(self):
+        self.o = Signal(name="dup_o")
+        self.sync += self.o.eq(~self.o)
+
+
+class _DupNamedSiblingTop(Module):
+    """Two children registered under the SAME submodule name (migen allows
+    it: _ModuleSubmodules.__setattr__ appends to a list; liteusb's USBDevice
+    does this for its two USBStreamInEndpoint instances). Each child has a
+    leaf grandchild so that path-derived module names would collide too."""
+    def __init__(self):
+        self.o = Signal(name="o")
+        for _ in range(2):
+            child = Module()
+            child.submodules.leaf = _DupNamedLeaf()
+            setattr(self.submodules, "endpoint", child)
+        self.comb += self.o.eq(0)
+
+
+class _RenamedFIFOTop(Module):
+    """AsyncFIFO wrapped in ClockDomainsRenamer: GrayCounters keep 'write'/
+    'read' domains while the FIFO parent uses 'usb'/'sys'. Mirrors the
+    liteusb ACM tx_fifo/rx_fifo structure."""
+    def __init__(self):
+        self.i = Signal(8, reset_less=True, name="i")
+        self.o = Signal(8, name="o")
+        self.submodules.fifo = ClockDomainsRenamer(
+            {"write": "usb", "read": "sys"})(AsyncFIFO(width=8, depth=4))
+        self.comb += [
+            self.fifo.din.eq(self.i),
+            self.fifo.we.eq(1),
+            self.fifo.re.eq(1),
+            self.o.eq(self.fifo.dout),
+        ]
+
+
+class _TwiceRegisteredSerializer(Module):
+    """Leaf with real logic, mimics StreamSerializer wrapped in a renamer."""
+    def __init__(self):
+        self.i = Signal(8, name="ser_i")
+        self.o = Signal(8, name="ser_o")
+        self.sync += self.o.eq(self.i)
+
+
+class _TwiceRegisteredHandler(Module):
+    """Handler whose transmitter child is added in do_finalize (like
+    liteusb's UAC2RequestHandlers)."""
+    def __init__(self):
+        self.claim = Signal(name="claim")
+
+    def do_finalize(self):
+        self.submodules.transmitter = ClockDomainsRenamer("usb")(
+            _TwiceRegisteredSerializer())
+        self.comb += self.claim.eq(self.transmitter.o[0])
+
+
+class _TwiceRegisteredControlEp(Module):
+    def __init__(self, handler):
+        self.inner = Signal(name="ctrl_inner")
+        self.submodules.H = handler
+        # Parent drives the same signal as the child: policy-1 inlines H.
+        self.comb += handler.claim.eq(1)
+
+
+class _TwiceRegisteredTop(Module):
+    """The same handler module registered under two parents (like liteusb's
+    add_request_handler + self.submodules.uac2_handlers): the second
+    registration becomes a shared alias. With the whole chain inlined into
+    the top (policy 1 then policy 2), the alias's descendant statement ids
+    must not filter out the handler logic arriving via the inline chain."""
+    def __init__(self):
+        self.o = Signal(name="o")
+        handler = _TwiceRegisteredHandler()
+        self.submodules.ctrl = _TwiceRegisteredControlEp(handler)
+        self.submodules.uac2_handlers = handler
+        # Drive a signal owned under ctrl: policy-2 inlines ctrl into top.
+        self.comb += self.ctrl.inner.eq(1)
+        self.comb += self.o.eq(0)
+
+
+class _StreamerGenLeaf(Module):
+    def __init__(self):
+        self.o = Signal(name="gen_o")
+        self.sync += self.o.eq(~self.o)
+
+
+class _StreamerMid(Module):
+    """Middle module using the 'sys' domain with a child that also uses
+    'sys' (mirrors PacketListStreamer + ConstantStreamGenerator inside the
+    ClockDomainsRenamer("usb")-wrapped AudioInit of the DECA audio design)."""
+    def __init__(self):
+        self.o = Signal(name="strm_o")
+        self.submodules.generator = _StreamerGenLeaf()
+        self.sync += self.o.eq(self.generator.o)
+
+
+class _RenamedInit(Module):
+    def __init__(self):
+        self.submodules.init_streamer = _StreamerMid()
+
+
+class _RenamedInitTop(Module):
+    """Top with a real 'usb' domain; a ClockDomainsRenamer("usb")-wrapped
+    subtree whose middle/leaf levels use 'sys'. The mapped alias must only
+    be emitted at the renamer boundary module — intermediate modules get
+    the net from above, so aliasing there would drive their own input
+    ports (Quartus: "value cannot be assigned to input")."""
+    def __init__(self):
+        self.clock_domains.cd_sys = ClockDomain("sys")
+        self.clock_domains.cd_usb = ClockDomain("usb")
+        self.pll_out = Signal(name="pll_out")
+        self.por     = Signal(name="por")
+        self.o       = Signal(name="o")
+        self.comb += [
+            self.cd_usb.clk.eq(self.pll_out),
+            self.cd_usb.rst.eq(self.por),
+        ]
+        self.submodules.audio_init = ClockDomainsRenamer("usb")(_RenamedInit())
+        self.comb += self.o.eq(self.audio_init.init_streamer.o)
+
+
+class _ConstFieldProducer(Module):
+    """Owns a Record-like field that is never assigned (a reset-only
+    constant), mirroring UAC2RequestHandlers.interface.tx_data_pid."""
+    def __init__(self):
+        self.tx_data_pid = Signal(reset=1, name="tx_data_pid")
+
+
+class _ConstFieldConsumer(Module):
+    def __init__(self, sig):
+        self.o = Signal(name="cons_o")
+        self.comb += self.o.eq(sig)
+
+
+class _ConstFieldTop(Module):
+    def __init__(self):
+        self.o = Signal(name="o")
+        self.submodules.producer = _ConstFieldProducer()
+        self.submodules.consumer = _ConstFieldConsumer(
+            self.producer.tx_data_pid)
+        self.comb += self.o.eq(self.consumer.o)
+
+
 class TestHierarchicalVerilog(unittest.TestCase):
     @staticmethod
     def _module_body(verilog, name):
@@ -159,6 +342,21 @@ class TestHierarchicalVerilog(unittest.TestCase):
         if match is None:
             raise AssertionError(f"module {name} not found")
         return match.group(0)
+
+    def _assert_no_input_port_drivers(self, verilog):
+        # Structural invariant: no module assigns to one of its own input
+        # ports (illegal in Verilog: Quartus "value cannot be assigned to
+        # input ...").
+        for mod in re.finditer(r"module (\S+) \((.*?)\);(.*?)endmodule",
+                               verilog, re.S):
+            header = mod.group(2)
+            body   = mod.group(3)
+            inputs = set(re.findall(r"input\s+wire\s+(?:\[[^\]]*\]\s*)?(\w+)",
+                                    header))
+            for assign in re.finditer(r"assign (\w+) =", body):
+                self.assertNotIn(assign.group(1), inputs,
+                    f"module {mod.group(1)} assigns to its own input port "
+                    f"{assign.group(1)}")
 
     def test_hierarchy_golden_text(self):
         expected = "\n".join([
@@ -316,6 +514,44 @@ class TestHierarchicalVerilog(unittest.TestCase):
         self.assertNotIn("module top__child (", verilog)
         self.assertNotIn("module top__child__leaf (", verilog)
 
+    def test_hierarchical_no_flatten_lifts_child_internal_drive_to_port(self):
+        # With --no-flatten, a parent driving a child-internal signal must
+        # NOT inline the child; the signal becomes a proper input port.
+        # (Dedicated fixture: the driven signal is referenced inside the
+        # child, which is what forces the input-port lifting.)
+        class _NoFlattenChild(Module):
+            def __init__(self):
+                self.trigger = Signal(name="trigger")
+                self.o = Signal(name="nf_o")
+                self.comb += self.o.eq(self.trigger)
+
+        class _NoFlattenTop(Module):
+            def __init__(self):
+                self.o = Signal(name="o")
+                self.submodules.child = _NoFlattenChild()
+                self.comb += self.child.trigger.eq(1)
+                self.comb += self.o.eq(self.child.o)
+
+        top = _NoFlattenTop()
+
+        old_top = LiteXContext.top
+        try:
+            LiteXContext.top = top
+            verilog = convert(top, ios={top.o}, name="top",
+                hierarchical={"enabled": True, "keep_hierarchy": True}).main_source
+        finally:
+            LiteXContext.top = old_top
+
+        # Child stays a module...
+        child_module = self._module_body(verilog, "top__child")
+        top_module   = self._module_body(verilog, "top")
+        # ...with trigger as an input port...
+        self.assertRegex(child_module, r"input\s+wire\s+trigger")
+        self.assertIn(".trigger(trigger)", top_module)
+        # ...and its logic is intact.
+        self.assertIn("assign nf_o = trigger;", child_module)
+        self.assertIn("assign o = nf_o;", top_module)
+
     def test_hierarchical_shared_memory_is_emitted_once(self):
         top = _SharedMemoryTop()
 
@@ -334,3 +570,219 @@ class TestHierarchicalVerilog(unittest.TestCase):
         self.assertNotIn("reg [7:0] mem[0:3];", reader_module)
         self.assertRegex(owner_module, r"output\s+wire\s+\[7:0\]\s+dat_r")
         self.assertRegex(reader_module, r"input\s+wire\s+\[7:0\]\s+dat_r")
+
+    def _convert_hier(self, top, ios):
+        old_top = LiteXContext.top
+        try:
+            LiteXContext.top = top
+            return convert(top, ios=ios, name="top", hierarchical=True).main_source
+        finally:
+            LiteXContext.top = old_top
+
+    def test_hierarchical_parent_driven_clock_not_double_driven(self):
+        # Regression test for the multiple-constant-driver bug (Quartus:
+        # "Can't resolve multiple constant drivers for net usb_rst").
+        # The child's usb_clk/usb_rst input ports ARE the top module's own
+        # nets (shared global ClockDomain object). The clock/reset aliasing
+        # block must NOT emit a fallback alias (assign usb_clk = sys_clk):
+        # the port connection already ties the nets, and an extra assign
+        # creates a second, conflicting driver on a net the top module
+        # already drives from its CRG logic.
+        top = _TwoDomainTop()
+        verilog = self._convert_hier(top, ios={top.por, top.pll_out, top.o})
+        top_module = self._module_body(verilog, "top")
+        leaf_module = self._module_body(verilog, "top__leaf")
+
+        # No cross-domain fallback aliases.
+        self.assertNotIn("assign usb_clk = sys_clk;", top_module)
+        self.assertNotIn("assign usb_rst = sys_rst;", top_module)
+
+        # Each clock/reset net has exactly one continuous-assign driver:
+        # the CRG-like comb logic, nothing else.
+        self.assertEqual(len(re.findall(r"assign usb_clk =", top_module)), 1)
+        self.assertEqual(len(re.findall(r"assign usb_rst =", top_module)), 1)
+        self.assertIn("assign usb_clk = pll_out;", top_module)
+        self.assertIn("assign usb_rst = por;", top_module)
+
+        # The child still gets proper input ports tied to the top nets.
+        self.assertRegex(leaf_module, r"input\s+wire\s+usb_clk")
+        self.assertRegex(leaf_module, r"input\s+wire\s+usb_rst")
+        self.assertIn(".usb_clk(usb_clk)", top_module)
+        self.assertIn(".usb_rst(usb_rst)", top_module)
+
+    def test_hierarchical_sibling_clocks_not_double_driven(self):
+        # Same as above but with two siblings sharing the 'usb' domain
+        # (mirrors the liteusb ACM example, where two USBDevice subtrees
+        # both sit under the top module): no fallback aliases, single
+        # driver per clock/reset net.
+        top = _TwoDomainTop(n_leaves=2)
+        verilog = self._convert_hier(top, ios={top.por, top.pll_out, top.o})
+        top_module = self._module_body(verilog, "top")
+
+        self.assertNotIn("assign usb_clk = sys_clk;", top_module)
+        self.assertNotIn("assign usb_rst = sys_rst;", top_module)
+        self.assertEqual(len(re.findall(r"assign usb_clk =", top_module)), 1)
+        self.assertEqual(len(re.findall(r"assign usb_rst =", top_module)), 1)
+        self.assertEqual(top_module.count(".usb_clk(usb_clk)"), 2)
+        self.assertEqual(top_module.count(".usb_rst(usb_rst)"), 2)
+
+    def test_hierarchical_duplicate_sibling_names_are_disambiguated(self):
+        # Regression test for duplicate module/instance declarations with
+        # --no-flatten: two siblings registered under the same submodule
+        # name (liteusb USBDevice names both of its USBStreamInEndpoint
+        # instances "USBStreamInEndpoint") produced two modules with the same
+        # path-derived name and two instances with the same name in the
+        # parent scope (Quartus: "module ... cannot be declared more than
+        # once", "identifier ... is already declared in the present scope").
+        top = _DupNamedSiblingTop()
+        verilog = self._convert_hier(top, ios={top.o})
+
+        # Every module declaration must be unique.
+        module_names = re.findall(r"^module (\S+) \(", verilog, re.M)
+        self.assertEqual(len(module_names), len(set(module_names)),
+            f"duplicate module declarations: "
+            f"{sorted(n for n in module_names if module_names.count(n) > 1)}")
+
+        # Both siblings emitted, with disambiguated names.
+        self.assertIn("module top__endpoint (", verilog)
+        self.assertIn("module top__endpoint_2 (", verilog)
+        self.assertIn("module top__endpoint__leaf (", verilog)
+        self.assertIn("module top__endpoint_2__leaf (", verilog)
+
+        # Instance names inside the parent must be unique too.
+        top_module = self._module_body(verilog, "top")
+        self.assertIn("top__endpoint endpoint (", top_module)
+        self.assertIn("top__endpoint_2 endpoint_2 (", top_module)
+
+    def test_hierarchical_renamed_domain_aliased_to_mapped_parent_domain(self):
+        # Regression test for Issue 3 (renamed clock domains): the
+        # GrayCounter 'write'/'read' clock ports inside a
+        # ClockDomainsRenamer-wrapped AsyncFIFO must be aliased to the
+        # mapped parent domains (write->usb, read->sys), not to an arbitrary
+        # fallback domain, and the aliased nets must be FIFO-local wires,
+        # not input ports of the FIFO module itself (assigning to an input
+        # port is illegal: Quartus "value cannot be assigned to input").
+        top = _RenamedFIFOTop()
+        old_top = LiteXContext.top
+        try:
+            LiteXContext.top = top
+            verilog = convert(top, ios={top.i, top.o}, name="top",
+                hierarchical={"enabled": True, "keep_hierarchy": True}).main_source
+        finally:
+            LiteXContext.top = old_top
+        fifo_module = self._module_body(verilog, "top__fifo")
+        fifo_header  = fifo_module.split(");", 1)[0]
+
+        # Aliases exist and use the MAPPED parent domains.
+        self.assertIn("assign write_clk = usb_clk;", fifo_module)
+        self.assertIn("assign write_rst = usb_rst;", fifo_module)
+        self.assertIn("assign read_clk = sys_clk;",  fifo_module)
+        self.assertIn("assign read_rst = sys_rst;",  fifo_module)
+
+        # Exactly one driver per phantom clock/reset net (the reset-only
+        # constant materialization must not fire on clock/reset signals:
+        # they are driven by the boundary alias).
+        for net in ("write_clk", "write_rst", "read_clk", "read_rst"):
+            self.assertEqual(
+                len(re.findall(rf"assign {net} =", fifo_module)), 1,
+                f"{net} has != 1 driver in fifo module")
+            self.assertNotIn(f"assign {net} = 1'd0;", fifo_module)
+
+        # The aliased clock/reset nets are local wires, not input ports.
+        self.assertNotRegex(fifo_header, r"input\s+wire\s+write_clk")
+        self.assertNotRegex(fifo_header, r"input\s+wire\s+write_rst")
+        self.assertNotRegex(fifo_header, r"input\s+wire\s+read_clk")
+        self.assertNotRegex(fifo_header, r"input\s+wire\s+read_rst")
+        self.assertRegex(fifo_module, r"wire\s+write_clk;")
+        self.assertRegex(fifo_module, r"wire\s+read_clk;")
+
+        # The GrayCounter instances still get their clock ports connected.
+        self.assertIn(".write_clk(write_clk)", fifo_module)
+        self.assertIn(".read_clk(read_clk)",   fifo_module)
+
+        # Structural invariant: no module assigns to one of its own input
+        # ports anywhere in the output.
+        self._assert_no_input_port_drivers(verilog)
+
+    def test_hierarchical_renamed_subtree_aliases_only_at_boundary(self):
+        # Regression test (DECA audio --no-flatten): inside a
+        # ClockDomainsRenamer("usb")-wrapped subtree, intermediate modules
+        # receive the renamed clock/reset nets via their input ports. The
+        # alias block must NOT fire at those levels: assigning to an input
+        # port is illegal. Aliases belong at the renamer boundary module
+        # only, where the phantom renamed-domain clocks are local wires.
+        top = _RenamedInitTop()
+        old_top = LiteXContext.top
+        try:
+            LiteXContext.top = top
+            verilog = convert(top, ios={top.pll_out, top.por, top.o}, name="top",
+                hierarchical={"enabled": True, "keep_hierarchy": True}).main_source
+        finally:
+            LiteXContext.top = old_top
+
+        # No module anywhere assigns to its own input port.
+        self._assert_no_input_port_drivers(verilog)
+
+        # The middle/leaf modules keep their (phantom-named) clock/reset
+        # input ports and contain no clock aliases at all.
+        for mod_name in ("top__audio_init__init_streamer",
+                         "top__audio_init__init_streamer__generator"):
+            mod = self._module_body(verilog, mod_name)
+            header = mod.split(");", 1)[0]
+            self.assertRegex(header, r"input\s+wire\s+sys_clk")
+            self.assertRegex(header, r"input\s+wire\s+sys_rst")
+            self.assertNotRegex(mod, r"assign \w+_clk = ")
+            self.assertNotRegex(mod, r"assign \w+_rst = ")
+
+        # The renamer boundary module drives the phantom sys-domain nets
+        # from the mapped usb domain.
+        init_module = self._module_body(verilog, "top__audio_init")
+        self.assertIn("assign sys_clk = usb_clk;", init_module)
+        self.assertIn("assign sys_rst = usb_rst;", init_module)
+
+    def test_hierarchical_shared_alias_does_not_drop_inlined_logic(self):
+        # Regression test: a module registered under two parents (shared
+        # alias) whose first registration sits inside a subtree that gets
+        # inlined into the top. The alias is never emitted; its copied
+        # descendant statement ids must not filter the handler logic that
+        # legitimately arrives at the top via the inline chain. (Audio
+        # interface bug: UAC2RequestHandlers' StreamSerializer was dropped,
+        # the device enumerated but could not answer class requests.)
+        top = _TwiceRegisteredTop()
+        verilog = self._convert_hier(top, ios={top.o})
+
+        # The serializer's logic must be emitted somewhere in the netlist.
+        self.assertIn("ser_i", verilog)
+        self.assertIn("ser_o", verilog)
+        self.assertRegex(verilog, r"ser_o <= ser_i")
+
+    def test_hierarchical_never_driven_signal_gets_reset_constant(self):
+        # Regression test (DECA UAC2 --no-flatten): a signal that is
+        # never assigned anywhere (a reset-only constant, e.g.
+        # UAC2RequestHandlers.interface.tx_data_pid with reset=1) but is
+        # referenced across module boundaries became a floating chain of
+        # input ports with an undriven top-level wire (GND at the consumer
+        # instead of the reset constant). The topmost module passing the
+        # signal must materialize the reset value as a constant driver,
+        # matching flat conversion (`reg = <reset>` for untargeted signals).
+        top = _ConstFieldTop()
+        old_top = LiteXContext.top
+        try:
+            LiteXContext.top = top
+            verilog = convert(top, ios={top.o}, name="top",
+                hierarchical={"enabled": True, "keep_hierarchy": True}).main_source
+        finally:
+            LiteXContext.top = old_top
+
+        top_module      = self._module_body(verilog, "top")
+        consumer_module = self._module_body(verilog, "top__consumer")
+
+        # The consumer reads the signal through an input port...
+        self.assertRegex(consumer_module, r"input\s+wire\s+tx_data_pid")
+        self.assertIn(".tx_data_pid(tx_data_pid)", top_module)
+
+        # ...and the top materializes the reset value as a constant driver.
+        self.assertIn("assign tx_data_pid = 1'd1;", top_module)
+
+        # The consumer's logic uses the port.
+        self.assertIn("assign cons_o = tx_data_pid;", consumer_module)


### PR DESCRIPTION
    Add a full hierarchical Verilog output mode to litex.gen.fhdl.verilog,
    enabled via a new builder flag:
    
    - --no-flatten: preserve full internal hierarchy; parent-driven
      child-internal signals are lifted to proper input ports instead of
      inlining the child subtree.
    
    The converter partitions fragments per module, lowers each module
    independently, computes ports from signal ownership/usage analysis, and
    handles shared submodule instances, duplicate sibling names, memories,
    tristates, FSMs, blackbox instances, clock/reset port wiring including
    ClockDomainsRenamer-renamed domains, and reset-only constant signals.
    
    Includes a regression suite in test/hdl/test_hierarchical_verilog.py
    covering module naming/uniqueness, port directions, clock/reset wiring
    (no double drivers, no assigns to input ports, renamed-domain mapping),
    inline-statement preservation, and structural invariants such as "no
    module assigns to one of its own input ports".
    
    Verified with Quartus builds of liteusb acm_serial and the DECA UAC2
    audio interface on Terasic DECA hardware in both modes.
    Also tested on a LiteX soc connected via ACM serial in both modes.