### PR TITLE
soc/cores/ram: add Efinix hard DDR integration

### DIFF
--- a/litex/build/efinix/ifacewriter.py
+++ b/litex/build/efinix/ifacewriter.py
@@ -564,6 +564,118 @@ design.create("{2}", "{3}", "./", overwrite=True)
 
         return '\n'.join(cmd) + '\n'
 
+    def generate_ddr(self, block, verbose=True):
+        block_type = "DDR"
+        name       = block["name"]
+        location   = block["location"]
+        axi        = block["axi"]
+        cfg        = block["cfg"]
+
+        cmd = []
+        cmd.append('design.create_block("{}", "{}")'.format(name, block_type))
+
+        properties = [
+            ("MEMORY_TYPE",    block["memory_type"]),
+            ("DQ_WIDTH",       block["dq_width"]),
+            ("MEMORY_DENSITY", block["memory_density"]),
+            ("PHYSICAL_RANK",  block["physical_rank"]),
+            ("CLKIN_SEL",      block["clkin_sel"]),
+            ("TARGET0_EN",     "1"),
+            ("TARGET1_EN",     "0"),
+        ]
+        for prop, value in properties:
+            cmd.append('design.set_property("{}", "{}", "{}", "{}")'.format(
+                name, prop, value, block_type))
+
+        axi_properties = [
+            ("AXI0_ARADDR_BUS",     axi.araddr),
+            ("AXI0_ARAPCMD_PIN",    axi.arapcmd),
+            ("AXI0_ARBURST_BUS",    axi.arburst),
+            ("AXI0_ARID_BUS",       axi.arid),
+            ("AXI0_ARLEN_BUS",      axi.arlen),
+            ("AXI0_ARLOCK_PIN",     axi.arlock),
+            ("AXI0_ARQOS_PIN",      axi.arqos),
+            ("AXI0_ARREADY_PIN",    axi.arready),
+            ("AXI0_ARSIZE_BUS",     axi.arsize),
+            ("AXI0_ARSTN_PIN",      axi.resetn),
+            ("AXI0_ARVALID_PIN",    axi.arvalid),
+            ("AXI0_AWADDR_BUS",     axi.awaddr),
+            ("AXI0_AWALLSTRB_PIN",  axi.awallstrb),
+            ("AXI0_AWAPCMD_PIN",    axi.awapcmd),
+            ("AXI0_AWBURST_BUS",    axi.awburst),
+            ("AXI0_AWCACHE_BUS",    axi.awcache),
+            ("AXI0_AWCOBUF_PIN",    axi.awcobuf),
+            ("AXI0_AWID_BUS",       axi.awid),
+            ("AXI0_AWLEN_BUS",      axi.awlen),
+            ("AXI0_AWLOCK_PIN",     axi.awlock),
+            ("AXI0_AWQOS_PIN",      axi.awqos),
+            ("AXI0_AWREADY_PIN",    axi.awready),
+            ("AXI0_AWSIZE_BUS",     axi.awsize),
+            ("AXI0_AWVALID_PIN",    axi.awvalid),
+            ("AXI0_BID_BUS",        axi.bid),
+            ("AXI0_BREADY_PIN",     axi.bready),
+            ("AXI0_BRESP_BUS",      axi.bresp),
+            ("AXI0_BVALID_PIN",     axi.bvalid),
+            ("AXI0_CLK_INPUT_PIN",  block["axi_clk"]),
+            ("AXI0_CLK_INVERT_EN",  "0"),
+            ("AXI0_DATA_WIDTH",     block["axi_data_width"]),
+            ("AXI0_RDATA_BUS",      axi.rdata),
+            ("AXI0_RID_BUS",        axi.rid),
+            ("AXI0_RLAST_PIN",      axi.rlast),
+            ("AXI0_RREADY_PIN",     axi.rready),
+            ("AXI0_RRESP_BUS",      axi.rresp),
+            ("AXI0_RVALID_PIN",     axi.rvalid),
+            ("AXI0_WDATA_BUS",      axi.wdata),
+            ("AXI0_WLAST_PIN",      axi.wlast),
+            ("AXI0_WREADY_PIN",     axi.wready),
+            ("AXI0_WSTRB_BUS",      axi.wstrb),
+            ("AXI0_WVALID_PIN",     axi.wvalid),
+        ]
+        for prop, value in axi_properties:
+            if isinstance(value, Signal):
+                value = value.name_override
+            cmd.append('design.set_property("{}", "{}", "{}", "{}")'.format(
+                name, prop, value, block_type))
+
+        cfg_properties = [
+            ("CFG_DONE_PIN",  cfg.done),
+            ("CFG_RESET_PIN", cfg.reset),
+            ("CFG_SEL_PIN",   cfg.sel),
+            ("CFG_START_PIN", cfg.start),
+        ]
+        for prop, value in cfg_properties:
+            cmd.append('design.set_property("{}", "{}", "{}", "{}")'.format(
+                name, prop, value.name_override, block_type))
+
+        ctrl_properties = [
+            ("CTRL_BUSY_PIN",              ""),
+            ("CTRL_CKE_PIN",               ""),
+            ("CTRL_CLK_INVERT_EN",         "0"),
+            ("CTRL_CLK_PIN",               ""),
+            ("CTRL_CMD_Q_ALMOST_FULL_PIN", ""),
+            ("CTRL_DP_IDLE_PIN",           ""),
+            ("CTRL_INT_PIN",               ""),
+            ("CTRL_MEM_RST_VALID_PIN",     ""),
+            ("CTRL_PORT_BUSY_PIN",          ""),
+            ("CTRL_REFRESH_PIN",            ""),
+        ]
+        for prop, value in ctrl_properties:
+            cmd.append('design.set_property("{}", "{}", "{}", "{}")'.format(
+                name, prop, value, block_type))
+
+        pin_swizzle = block.get("pin_swizzle", {})
+        for group, value in pin_swizzle.items():
+            cmd.append('design.set_property("{}", "PIN_SWIZZLE_{}", "{}", "{}")'.format(
+                name, group, value, block_type))
+        if pin_swizzle:
+            cmd.append('design.set_property("{}", "PIN_SWIZZLE_EN", "1", "{}")'.format(
+                name, block_type))
+
+        cmd.append('design.assign_resource("{}", "{}", "{}")\n'.format(
+            name, location, block_type))
+
+        return '\n'.join(cmd) + '\n'
+
     def generate_spiflash(self, block, verbose=True):
         pads       = block["pads"]
         name       = block["name"]
@@ -671,6 +783,8 @@ design.create("{2}", "{3}", "./", overwrite=True)
                     output += self.generate_lvds(block)
                 if block["type"] == "HYPERRAM":
                     output += self.generate_hyperram(block)
+                if block["type"] == "DDR":
+                    output += self.generate_ddr(block)
                 if block["type"] == "JTAG":
                     output += self.generate_jtag(block)
                 if block["type"] == "SPI_FLASH":

--- a/litex/soc/cores/ram/efinix_ddr.py
+++ b/litex/soc/cores/ram/efinix_ddr.py
@@ -1,0 +1,177 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+
+from litex.gen import *
+
+from litex.build.generic_platform import Pins, Subsignal
+
+from litex.soc.integration.soc import SoCRegion
+from litex.soc.interconnect import axi
+
+
+# Efinix DDR ---------------------------------------------------------------------------------------
+
+class EfinixDDR(LiteXModule):
+    """Efinix Titanium/Topaz hardened DDR controller."""
+    def __init__(self, platform,
+        memory_type,
+        memory_density,
+        clkin_sel,
+        clock_domain   = "sys",
+        location       = "DDR_0",
+        name           = "ddr_inst1",
+        interface_name = "ddr0",
+        cfg_name       = "cfg",
+        dq_width       = 32,
+        physical_rank  = 1,
+        data_width     = 512,
+        address_width  = 33,
+        id_width       = 8,
+        pin_swizzle    = None,
+        init_delay     = 256):
+
+        if clock_domain not in platform.clks:
+            raise ValueError("Efinix DDR clock domain {} has no Efinity clock.".format(clock_domain))
+        if init_delay < 1:
+            raise ValueError("Efinix DDR initialization delay must be positive.")
+
+        self.clock_domain = clock_domain
+        self.awallstrb    = Signal()
+        self.init_done    = Signal()
+        self.bus = axi.AXIInterface(
+            data_width    = data_width,
+            address_width = address_width,
+            id_width      = id_width,
+            clock_domain  = clock_domain,
+        )
+
+        # AXI Interface.
+        # --------------
+        axi_ios = self.bus.get_ios(interface_name)
+        axi_ios[0] += (
+            Subsignal("arapcmd",   Pins(1)),
+            Subsignal("awallstrb", Pins(1)),
+            Subsignal("awapcmd",   Pins(1)),
+            Subsignal("awcobuf",   Pins(1)),
+            Subsignal("resetn",    Pins(1)),
+        )
+        self.axi_pads = axi_pads = platform.add_iface_ios(axi_ios)
+        self.comb += self.bus.connect_to_pads(axi_pads, mode="master")
+        self.comb += [
+            axi_pads.arapcmd.eq(0),
+            axi_pads.awallstrb.eq(self.awallstrb),
+            axi_pads.awapcmd.eq(0),
+            axi_pads.awcobuf.eq(0),
+            axi_pads.resetn.eq(~ResetSignal(clock_domain)),
+        ]
+
+        # Configuration Interface.
+        # ------------------------
+        cfg_ios = [(cfg_name, 0,
+            Subsignal("start", Pins(1)),
+            Subsignal("reset", Pins(1)),
+            Subsignal("sel",   Pins(1)),
+            Subsignal("done",  Pins(1)),
+        )]
+        self.cfg_pads = cfg_pads = platform.add_iface_ios(cfg_ios)
+
+        cfg_count = Signal(max=init_delay)
+        cfg_start = Signal()
+        self.comb += [
+            cfg_pads.sel.eq(0),
+            cfg_pads.reset.eq(~cfg_start),
+            cfg_pads.start.eq(cfg_start),
+            self.init_done.eq(cfg_pads.done),
+        ]
+        self.sync += If(~cfg_start,
+            If(cfg_count == (init_delay - 1),
+                cfg_start.eq(1),
+            ).Else(
+                cfg_count.eq(cfg_count + 1),
+            )
+        )
+
+        # Efinity Interface Designer Block.
+        # ----------------------------------
+        platform.toolchain.ifacewriter.blocks.append({
+            "type"            : "DDR",
+            "name"            : name,
+            "location"        : location,
+            "memory_type"     : memory_type,
+            "memory_density"  : memory_density,
+            "dq_width"        : dq_width,
+            "physical_rank"   : physical_rank,
+            "clkin_sel"       : clkin_sel,
+            "axi"             : axi_pads,
+            "axi_clk"         : platform.clks[clock_domain],
+            "axi_data_width"  : data_width,
+            "cfg"             : cfg_pads,
+            "pin_swizzle"     : {} if pin_swizzle is None else pin_swizzle,
+        })
+
+
+# Efinix DDR SoC Integration -----------------------------------------------------------------------
+
+def add_efinix_ddr(soc, ddr, size, origin=None):
+    if origin is None:
+        origin = soc.mem_map.get("main_ram", None)
+    if origin is None:
+        raise ValueError("Efinix DDR main RAM origin is not defined.")
+
+    region = SoCRegion(
+        origin = origin,
+        size   = size,
+        mode   = "rwx",
+    )
+
+    # Let CPUs with a native memory port create it at the hard controller's data width.
+    if hasattr(soc.cpu, "add_memory_buses"):
+        soc.cpu.add_memory_buses(
+            address_width = min(soc.bus.address_width, ddr.bus.address_width),
+            data_width    = ddr.bus.data_width,
+        )
+
+    memory_buses = getattr(soc.cpu, "memory_buses", [])
+    if memory_buses:
+        if len(memory_buses) != 1:
+            raise ValueError("Efinix DDR requires exactly one CPU memory bus.")
+        memory_bus = memory_buses[0]
+        if not isinstance(memory_bus, axi.AXIInterface):
+            raise TypeError("Efinix DDR CPU memory bus must use AXI.")
+        if memory_bus.data_width != ddr.bus.data_width:
+            raise ValueError(
+                "Efinix DDR CPU memory bus data width must match the controller data width.")
+
+        soc.submodules += axi.AXIRemapper(
+            master = memory_bus,
+            slave  = ddr.bus,
+        )
+        soc.comb += ddr.awallstrb.eq(getattr(soc.cpu, "mBus_awallStrb", 0))
+        soc.bus.add_region("main_ram", region)
+        return memory_bus
+
+    # The SoC bus adapts its native standard/data width to this frontend. A separate 33-bit
+    # interface then extends the address before conversion to the hard controller's AXI port.
+    axi_lite_bus = axi.AXILiteInterface(
+        data_width    = ddr.bus.data_width,
+        address_width = soc.bus.address_width,
+        clock_domain  = ddr.clock_domain,
+    )
+    axi_lite_ddr = axi.AXILiteInterface(
+        data_width    = ddr.bus.data_width,
+        address_width = ddr.bus.address_width,
+        clock_domain  = ddr.clock_domain,
+    )
+    soc.submodules += axi.AXILiteRemapper(
+        master = axi_lite_bus,
+        slave  = axi_lite_ddr,
+    )
+    soc.submodules += axi.AXILite2AXI(axi_lite_ddr, ddr.bus)
+    soc.comb += ddr.awallstrb.eq(0)
+    soc.bus.add_slave("main_ram", axi_lite_bus, region)
+    return axi_lite_bus

--- a/test/build/test_efinix.py
+++ b/test/build/test_efinix.py
@@ -173,6 +173,56 @@ def test_generate_seu_emits_wait_interval_for_auto_mode():
     assert 'WAIT_INTERVAL", "42"' in cmds
 
 
+def test_generate_ddr_emits_controller_interfaces_and_swizzle():
+    def signal(name):
+        return migen.Signal(name_override=name)
+
+    axi_names = [
+        "araddr", "arapcmd", "arburst", "arid", "arlen", "arlock", "arqos", "arready",
+        "arsize", "resetn", "arvalid", "awaddr", "awallstrb", "awapcmd", "awburst",
+        "awcache", "awcobuf", "awid", "awlen", "awlock", "awqos", "awready", "awsize",
+        "awvalid", "bid", "bready", "bresp", "bvalid", "rdata", "rid", "rlast", "rready",
+        "rresp", "rvalid", "wdata", "wlast", "wready", "wstrb", "wvalid",
+    ]
+    writer = InterfaceWriter("/tmp/efinity")
+    writer.blocks.append({
+        "type"            : "DDR",
+        "name"            : "ddr_inst1",
+        "location"        : "DDR_0",
+        "memory_type"     : "LPDDR4x",
+        "memory_density"  : "8G",
+        "dq_width"        : 32,
+        "physical_rank"   : 1,
+        "clkin_sel"       : "CLKIN 0",
+        "axi"             : SimpleNamespace(**{name: signal(f"ddr0_{name}") for name in axi_names}),
+        "axi_clk"         : "sys_pll0_clk",
+        "axi_data_width"  : 512,
+        "cfg"             : SimpleNamespace(
+            done  = signal("cfg_done"),
+            reset = signal("cfg_reset"),
+            sel   = signal("cfg_sel"),
+            start = signal("cfg_start"),
+        ),
+        "pin_swizzle" : {
+            "CA"   : "CA[0],CA[1],CA[2],CA[3],CA[4],CA[5]",
+            "DQM0" : "DQ[3],DQ[6],DQ[4],DQ[5],DQ[0],DQ[1],DQ[7],DQ[2],DM[0]",
+        },
+    })
+
+    cmds = writer.generate(partnumber="Ti375C529")
+
+    assert 'design.create_block("ddr_inst1", "DDR")' in cmds
+    assert '"MEMORY_TYPE", "LPDDR4x", "DDR"' in cmds
+    assert '"AXI0_ARADDR_BUS", "ddr0_araddr", "DDR"' in cmds
+    assert '"AXI0_AWALLSTRB_PIN", "ddr0_awallstrb", "DDR"' in cmds
+    assert '"AXI0_CLK_INPUT_PIN", "sys_pll0_clk", "DDR"' in cmds
+    assert '"CFG_DONE_PIN", "cfg_done", "DDR"' in cmds
+    assert '"CTRL_BUSY_PIN", "", "DDR"' in cmds
+    assert '"PIN_SWIZZLE_DQM0", "DQ[3],DQ[6],DQ[4],DQ[5],DQ[0],DQ[1],DQ[7],DQ[2],DM[0]", "DDR"' in cmds
+    assert '"PIN_SWIZZLE_EN", "1", "DDR"' in cmds
+    assert 'design.assign_resource("ddr_inst1", "DDR_0", "DDR")' in cmds
+
+
 def test_find_efinity_path_prefers_env(monkeypatch, tmp_path):
     efinity_root = tmp_path / "efinity"
     bin_dir = efinity_root / "bin"

--- a/test/cores/test_ram.py
+++ b/test/cores/test_ram.py
@@ -7,12 +7,14 @@
 import unittest
 from types import SimpleNamespace
 
-from migen import Array, If, Module, Signal, run_simulation
+from migen import Array, ClockDomain, If, Module, Signal, run_simulation
 from migen.fhdl.specials import Instance
 
 from litex.build.altera import AlteraPlatform
 from litex.build.efinix import EfinixPlatform
+from litex.build.generic_platform import GenericPlatform
 from litex.soc.cores.ram.common import RAM_CAPABILITIES, get_cpu_ram_filename
+from litex.soc.cores.ram.efinix_ddr import EfinixDDR, add_efinix_ddr
 from litex.soc.cores.ram.efinix_hyperram import (
     EFINIX_HYPERRAM_DYN_PHASE_SEL_WIDTH,
     EFINIX_HYPERRAM_MAX_PHY_CLK_FREQ,
@@ -21,6 +23,7 @@ from litex.soc.cores.ram.efinix_hyperram import (
 from litex.soc.cores.ram.lattice_ice40 import Up5kSPRAM
 from litex.soc.cores.ram.lattice_nx import NXLRAM, initval_parameters
 from litex.soc.cores.ram.xilinx_fifo_sync_macro import FIFOSyncMacro
+from litex.soc.interconnect import axi
 
 kB = 1024
 
@@ -92,6 +95,64 @@ class _FakeEfinixHyperRAMPlatform:
         resource = "PLL{}".format(self.pll_used)
         self.pll_used += 1
         return resource
+
+
+class _FakeEfinixDDRPlatform(GenericPlatform):
+    def __init__(self):
+        GenericPlatform.__init__(self, device="test", io=[])
+        self.clks = {
+            "sys" : "sys_pll0_clk",
+            "cpu" : "cpu_pll0_clk",
+        }
+        self.toolchain = SimpleNamespace(
+            ifacewriter  = _FakeEfinixIfaceWriter(),
+            excluded_ios = [],
+        )
+
+    def add_iface_ios(self, ios):
+        self.add_extension(ios)
+        pads = self.request(ios[0][0])
+        self.toolchain.excluded_ios.extend(pads.flatten())
+        return pads
+
+
+class _FakeSoCBus:
+    address_width = 32
+
+    def __init__(self):
+        self.regions = {}
+        self.slaves  = {}
+
+    def add_region(self, name, region):
+        self.regions[name] = region
+
+    def add_slave(self, name, slave, region):
+        self.slaves[name]  = slave
+        self.regions[name] = region
+
+
+class _FakeNativeMemoryCPU(Module):
+    def __init__(self):
+        self.memory_buses = []
+
+    def add_memory_buses(self, address_width, data_width):
+        self.mBus_awallStrb = Signal()
+        self.memory_buses.append(axi.AXIInterface(
+            data_width    = data_width,
+            address_width = address_width,
+            id_width      = 8,
+            clock_domain  = "cpu",
+        ))
+
+
+class _FakeSoC(Module):
+    mem_map = {"main_ram": 0x4000_0000}
+
+    def __init__(self, cpu):
+        if isinstance(cpu, Module):
+            self.submodules.cpu = cpu
+        self.cpu = cpu
+        self.bus = _FakeSoCBus()
 
 
 class _IgnoreInstance:
@@ -446,6 +507,98 @@ class TestEfinixRAM(unittest.TestCase):
         self.assertIs(hyperram_blocks[0]["pads"], hyperram.io_pads)
         self.assertIn(platform.request("shift_ena"), platform.toolchain.excluded_ios)
         self.assertIn(hyperram.io_pads.csn, platform.toolchain.excluded_ios)
+
+    def test_efinix_ddr_registers_interface_block(self):
+        platform = _FakeEfinixDDRPlatform()
+
+        ddr = EfinixDDR(
+            platform       = platform,
+            memory_type    = "LPDDR4x",
+            memory_density = "8G",
+            clkin_sel      = "CLKIN 0",
+            pin_swizzle    = {"CA": "CA[0],CA[1],CA[2],CA[3],CA[4],CA[5]"},
+        )
+
+        block = platform.toolchain.ifacewriter.get_block("ddr_inst1")
+        self.assertEqual(block["type"], "DDR")
+        self.assertEqual(block["location"], "DDR_0")
+        self.assertEqual(block["axi_clk"], "sys_pll0_clk")
+        self.assertEqual(block["pin_swizzle"]["CA"], "CA[0],CA[1],CA[2],CA[3],CA[4],CA[5]")
+        self.assertEqual(ddr.bus.data_width, 512)
+        self.assertEqual(ddr.bus.address_width, 33)
+        self.assertEqual(ddr.bus.id_width, 8)
+        self.assertIn(ddr.axi_pads.awaddr, platform.toolchain.excluded_ios)
+        self.assertIn(ddr.cfg_pads.done, platform.toolchain.excluded_ios)
+
+    def test_efinix_ddr_preserves_configuration_start_delay(self):
+        platform = _FakeEfinixDDRPlatform()
+        ddr = EfinixDDR(
+            platform       = platform,
+            memory_type    = "LPDDR4x",
+            memory_density = "8G",
+            clkin_sel      = "CLKIN 0",
+            init_delay     = 4,
+        )
+
+        def generator():
+            for _ in range(4):
+                self.assertEqual((yield ddr.cfg_pads.reset), 1)
+                self.assertEqual((yield ddr.cfg_pads.start), 0)
+                yield
+            self.assertEqual((yield ddr.cfg_pads.reset), 0)
+            self.assertEqual((yield ddr.cfg_pads.start), 1)
+            yield ddr.cfg_pads.done.eq(1)
+            yield
+            self.assertEqual((yield ddr.init_done), 1)
+
+        dut = Module()
+        dut.clock_domains.cd_sys = ClockDomain()
+        dut.submodules.ddr = ddr
+        run_simulation(dut, generator())
+
+    def test_add_efinix_ddr_connects_native_cpu_sideband(self):
+        soc = _FakeSoC(_FakeNativeMemoryCPU())
+        ddr = SimpleNamespace(
+            bus = axi.AXIInterface(
+                data_width    = 512,
+                address_width = 33,
+                id_width      = 8,
+                clock_domain  = "cpu",
+            ),
+            awallstrb    = Signal(),
+            clock_domain = "cpu",
+        )
+
+        memory_bus = add_efinix_ddr(soc, ddr, size=0x4000_0000)
+
+        self.assertIs(memory_bus, soc.cpu.memory_buses[0])
+        self.assertEqual(memory_bus.address_width, 32)
+        self.assertEqual(soc.bus.regions["main_ram"].origin, 0x4000_0000)
+
+        def generator():
+            yield soc.cpu.mBus_awallStrb.eq(1)
+            yield
+            self.assertEqual((yield ddr.awallstrb), 1)
+
+        run_simulation(soc, generator())
+
+    def test_add_efinix_ddr_uses_soc_width_for_fallback_frontend(self):
+        cpu = SimpleNamespace(memory_buses=[])
+        soc = _FakeSoC(cpu)
+        ddr = SimpleNamespace(
+            bus = axi.AXIInterface(
+                data_width    = 512,
+                address_width = 33,
+                id_width      = 8,
+            ),
+            awallstrb    = Signal(),
+            clock_domain = "sys",
+        )
+
+        axi_lite_bus = add_efinix_ddr(soc, ddr, size=0x4000_0000)
+
+        self.assertEqual(axi_lite_bus.address_width, soc.bus.address_width)
+        self.assertIs(soc.bus.slaves["main_ram"], axi_lite_bus)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add structured Efinity Interface Designer generation for hardened DDR blocks
- add a reusable `EfinixDDR` core for Titanium and Topaz devices
- support native CPU AXI memory ports and a bus-adapted AXI-Lite fallback
- keep AXI clock/reset domains consistent and expose DDR initialization completion
- connect the VexiiRiscv `AWALLSTRB` sideband after its memory bus is created

## Validation

- `pytest -q test/build/test_efinix.py test/cores/test_ram.py test/interconnect/test_axi_lite.py`
  - 79 passed, 38 subtests passed
- Efinity 2025.1 Interface Designer checks pass for the TI375 and TZ170 board migrations
- old/new Efinity peripheral databases match except for generation timestamps
- full TI375 VexiiRiscv synthesis, place-and-route, timing analysis, and bitstream generation pass
