### PR TITLE
build/efinix: omit feedback mode on Trion V1 PLLs

### DIFF
--- a/litex/build/efinix/ifacewriter.py
+++ b/litex/build/efinix/ifacewriter.py
@@ -250,7 +250,8 @@ design.create("{2}", "{3}", "./", overwrite=True)
         return cmd
 
     def generate_pll(self, block, partnumber, verbose=True):
-        name = block["name"]
+        name      = block["name"]
+        is_pll_v1 = partnumber[0:2] in ["T4", "T8"] and partnumber != "T8Q144"
         cmd = "# ---------- PLL {} ---------\n".format(name)
         cmd += 'design.create_block("{}", block_type="PLL")\n'.format(name)
         cmd += 'pll_config = {{ "REFCLK_FREQ":"{}" }}\n'.format(block["input_freq"] / 1e6)
@@ -268,7 +269,7 @@ design.create("{2}", "{3}", "./", overwrite=True)
 
         elif block["input_clock"] == "EXTERNAL":
             # PLL V1 has a different configuration
-            if partnumber[0:2] in ["T4", "T8"] and partnumber != "T8Q144":
+            if is_pll_v1:
                 cmd += 'design.gen_pll_ref_clock("{}", pll_res="{}", refclk_res="{}", refclk_name="{}", ext_refclk_no="{}")\n\n' \
                     .format(name, block["resource"], block["input_clock_pad"], block["input_clock_name"], block["clock_no"])
             else:
@@ -318,7 +319,8 @@ design.create("{2}", "{3}", "./", overwrite=True)
                     cmd += '    "CLKOUT{}_DYNPHASE_EN": "1",\n'.format(i)
             cmd += "}\n"
 
-            if block["version"] == "V1_V2":
+            # PLL V1 uses fixed internal feedback and does not expose FEEDBACK_MODE.
+            if block["version"] == "V1_V2" and not is_pll_v1:
                 cmd += 'design.set_property("{}","FEEDBACK_MODE","INTERNAL","PLL")\n'.format(name)
 
             cmd += 'calc_result = design.auto_calc_pll_clock("{}", target_freq)\n'.format(name)

--- a/test/build/test_efinix.py
+++ b/test/build/test_efinix.py
@@ -173,6 +173,34 @@ def test_generate_seu_emits_wait_interval_for_auto_mode():
     assert 'WAIT_INTERVAL", "42"' in cmds
 
 
+@pytest.mark.parametrize("partnumber, with_feedback_mode", [
+    ("T4F49",  False),
+    ("T8F81",  False),
+    ("T8Q144",  True),
+    ("T20F256", True),
+])
+def test_generate_pll_handles_trion_v1_feedback_mode(partnumber, with_feedback_mode):
+    writer = InterfaceWriter("/tmp/efinity")
+    block = {
+        "name"         : "pll0",
+        "input_freq"   : 33.333e6,
+        "input_clock"  : "CORE",
+        "input_signal" : "clk",
+        "resource"     : "PLL_0",
+        "locked"       : "locked",
+        "rstn"         : "rstn",
+        "clk_out"      : [["sys_clk", 33.333e6, 0, 0, False]],
+        "feedback"     : -1,
+        "version"      : "V1_V2",
+    }
+
+    cmds = writer.generate_pll(block, partnumber, verbose=False)
+    feedback_mode_cmd = 'design.set_property("pll0","FEEDBACK_MODE","INTERNAL","PLL")'
+
+    assert (feedback_mode_cmd in cmds) is with_feedback_mode
+    assert 'design.auto_calc_pll_clock("pll0", target_freq)' in cmds
+
+
 def test_generate_ddr_emits_controller_interfaces_and_swizzle():
     def signal(name):
         return migen.Signal(name_override=name)


### PR DESCRIPTION
## Summary

- reuse the existing Trion V1 PLL detection in the Efinity interface writer
- omit `FEEDBACK_MODE=INTERNAL` for T4 and non-Q144 T8 devices
- preserve the existing feedback configuration for Trion V2 and Titanium/Topaz PLLs
- add regression coverage for T4, T8 V1, T8 V2, and T20

## Rationale

Trion V1 PLLs use fixed internal feedback and the Efinity API does not expose a `FEEDBACK_MODE` property for them. Efinity 2025.1 rejects the redundant assignment with:

```text
ERROR: Unsupported property FEEDBACK_MODE
```

The backend already distinguishes these V1 PLLs when generating their reference-clock configuration. This change reuses that distinction for the feedback property instead of adding a separate device workaround.

## Validation

- `pytest -q test/build/test_efinix.py test/cores/test_clock.py`: 77 passed, 87 subtests passed
- Efinity 2025.1 no-compile generation for `efinix_t8_f81_dev_kit`
- complete Efinity 2025.1 map, interface, place-and-route, and programming-file flow
- generated `.bit` and `.hex` files
- 33.333 MHz timing met with +1.470 ns setup slack and +0.643 ns hold slack
