### PR TITLE
soc: add optional L2 cache to HyperRAM integration

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1591,9 +1591,21 @@ class SoC(LiteXModule):
 
     # Add HyperRAM ---------------------------------------------------------------------------------
     def add_hyperram(self, name="hyperram", pads=None, origin=None, size=None, mode="rwx",
-        region_name=None, number=None, cached=True, linker=False, **kwargs):
+        region_name=None, number=None, cached=True, linker=False,
+        l2_cache_size           = 0,
+        l2_cache_reverse        = True,
+        l2_cache_full_memory_we = True,
+        **kwargs):
         if size is None:
             self.logger.error("HyperRAM requires {}.".format(colorer("size", color="red")))
+            raise SoCError()
+        l2_cache_size_valid = (
+            isinstance(l2_cache_size, int) and l2_cache_size >= 0 and
+            (l2_cache_size == 0 or (
+                l2_cache_size >= 8 and not (l2_cache_size & (l2_cache_size - 1))))
+        )
+        if not l2_cache_size_valid:
+            self.logger.error("HyperRAM L2 cache size must be zero or a power of two of at least 8 bytes.")
             raise SoCError()
         for arg in ["bus_standard", "axi_id_width", "sys_clk_freq"]:
             if arg in kwargs:
@@ -1614,13 +1626,33 @@ class SoC(LiteXModule):
 
         # Core.
         self.check_if_exists(name)
+        bus_kwargs = (
+            {"bus_standard": "wishbone"} if l2_cache_size else
+            self.bus.get_bus_standard_kwargs(with_axi_id_width=True)
+        )
         hyperram = HyperRAM(
             pads         = pads,
             sys_clk_freq = self.sys_clk_freq,
-            **self.bus.get_bus_standard_kwargs(with_axi_id_width=True),
+            **bus_kwargs,
             **kwargs,
         )
-        self.bus.add_slave(name=region_name, slave=hyperram.bus, region=SoCRegion(
+
+        # Optional L2 Cache.
+        bus = hyperram.bus
+        if l2_cache_size:
+            bus = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+            cache = wishbone.Cache(
+                cachesize = l2_cache_size//4,
+                master    = bus,
+                slave     = hyperram.bus,
+                reverse   = l2_cache_reverse,
+            )
+            if l2_cache_full_memory_we:
+                cache = FullMemoryWE()(cache)
+            self.add_module(name="{}_cache".format(name), module=cache)
+            self.add_config("L2_SIZE", l2_cache_size)
+
+        self.bus.add_slave(name=region_name, slave=bus, region=SoCRegion(
             origin = origin,
             size   = size,
             mode   = mode,

--- a/test/soc/test_soc.py
+++ b/test/soc/test_soc.py
@@ -1287,6 +1287,47 @@ class TestSoC(unittest.TestCase):
 
         self.assertEqual(soc.bus.regions["hyperram"].origin, 0x2000_0000)
 
+    def test_add_hyperram_inserts_l2_cache(self):
+        cases = [
+            ("wishbone", wishbone.Interface),
+            ("axi-lite", axi.AXILiteInterface),
+            ("axi",      axi.AXIInterface),
+        ]
+
+        for bus_standard, interface_cls in cases:
+            with self.subTest(bus_standard=bus_standard):
+                soc = SoC(_FakePlatform(), sys_clk_freq=100e6, bus_standard=bus_standard)
+                if bus_standard == "axi":
+                    soc.bus.add_master("cpu", axi.AXIInterface(id_width=4))
+
+                hyperram = soc.add_hyperram(
+                    pads          = _HyperRamPads(),
+                    region_name   = "main_ram",
+                    origin        = 0x4000_0000,
+                    size          = 0x1000,
+                    l2_cache_size = 16*1024,
+                    with_csr      = False,
+                )
+
+                self.assertIsInstance(hyperram.bus, wishbone.Interface)
+                self.assertTrue(hasattr(soc, "hyperram_cache"))
+                self.assertIs(soc.hyperram_cache.slave, hyperram.bus)
+                self.assertIsInstance(soc.bus.slaves["main_ram"], interface_cls)
+                self.assertEqual(soc.constants["CONFIG_L2_SIZE"], 16*1024)
+
+    def test_add_hyperram_rejects_invalid_l2_cache_size(self):
+        soc = SoC(_FakePlatform(), sys_clk_freq=100e6)
+
+        for size in [-1, 4, 12]:
+            with self.subTest(size=size):
+                with _assert_raises_soc_error(self):
+                    soc.add_hyperram(
+                        pads          = _HyperRamPads(),
+                        size          = 0x1000,
+                        l2_cache_size = size,
+                        with_csr      = False,
+                    )
+
     def test_add_hyperram_requests_platform_pads(self):
         platform = _FakePlatform()
         platform.requests[("hyperram", 1)] = _HyperRamPads()


### PR DESCRIPTION
## Summary

- add an opt-in L2 cache to `SoC.add_hyperram()`
- preserve the direct HyperRAM frontend when the cache size is zero
- use the standard bus adapters so the cached path works with Wishbone, AXI-Lite, and AXI SoCs
- validate cache sizes and export the existing `CONFIG_L2_SIZE` software setting

## Validation

- `pytest -q test/soc/test_soc.py test/cores/test_hyperbus.py`
  - 174 passed, 38 subtests passed
- elaborated an existing 32-bit cached HyperRAM design through Efinity interface generation
- compared the direct target implementation with the new helper
  - memory map and CSR map are unchanged
  - Efinity peripheral configuration is unchanged
  - generated hierarchy and cache parameters are unchanged

The corresponding LiteX-Boards migration is kept in a separate PR.
