### PR TITLE
Rework libxil (zynq7000 & zynqMP)

### DIFF
--- a/litex/soc/cores/cpu/__init__.py
+++ b/litex/soc/cores/cpu/__init__.py
@@ -45,6 +45,18 @@ class CPU(LiteXModule):
     def bios_map(self, addr, cached):
         return addr
 
+    """
+    Add CPU-specific software packages/libraries to Builder.
+    """
+    def add_software_packages(self, builder):
+        pass
+
+    """
+    Prepare CPU-specific software environment after SoC finalization.
+    """
+    def prepare_software(self, builder):
+        pass
+
     def enable_reset_address_check(self):
         self.reset_address_check = True
 

--- a/litex/soc/cores/cpu/zynq7000/core.py
+++ b/litex/soc/cores/cpu/zynq7000/core.py
@@ -8,6 +8,7 @@
 
 import os
 import re
+import logging
 
 from migen import *
 from migen.genlib.resetsync import AsyncResetSynchronizer
@@ -20,8 +21,11 @@ from litex.soc.interconnect import axi
 from litex.soc.interconnect.csr import CSRStatus, CSRField
 
 from litex.soc.cores.cpu import CPU
+from litex.soc.software.libxil import LibXil
 
 # Zynq 7000 ----------------------------------------------------------------------------------------
+
+logger = logging.getLogger("Zynq7000")
 
 class Zynq7000(CPU):
     variants                 = ["standard"]
@@ -60,6 +64,7 @@ class Zynq7000(CPU):
         self.axi_gp_masters = []    # General Purpose AXI Masters.
         self.axi_gp_slaves  = []    # General Purpose AXI Slaves.
         self.axi_hp_slaves  = []    # High Performance AXI Slaves.
+        self.libxil         = None  # Optional Xilinx libxil software package configuration.
 
         # PS7 peripherals.
         self.can_use        = []
@@ -176,6 +181,38 @@ class Zynq7000(CPU):
         # GP0 as Bus master ------------------------------------------------------------------------
         self.pbus = self.add_axi_gp_master()
         self.periph_buses.append(self.pbus)
+
+    """
+    Configure the Xilinx libxil software package
+    Attributes
+    ==========
+    xparameters: dict
+        xparameters.h defines
+    bspconfig: dict (optional)
+        bspconfig.h contents (defaults: CPU-generic settings)
+    embeddedsw_dir: str (optional)
+        path to an existing Xilinx embeddedsw checkout
+    embeddedsw_git_url: str (optional)
+        embeddedsw git URL, used when no local checkout is provided
+    """
+    def set_libxil(self, xparameters, bspconfig=None, embeddedsw_dir=None, embeddedsw_git_url=None):
+        self.libxil = LibXil(self, xparameters, bspconfig, embeddedsw_dir, embeddedsw_git_url)
+
+    """
+    Add the configured libxil software package/library to Builder.
+    """
+    def add_software_packages(self, builder):
+        if self.libxil is None:
+            logger.warning("libxil software package not enabled, use cpu.set_libxil(...) to enable it.")
+            return
+        self.libxil.add_software_packages(builder)
+
+    """
+    Prepare the configured libxil software environment after SoC finalization.
+    """
+    def prepare_software(self, builder):
+        if self.libxil is not None:
+            self.libxil.prepare_software(builder)
 
     def set_ps7_xci(self, xci):
         # Add .xci as Vivado IP and set ps7_name from .xci filename.

--- a/litex/soc/cores/cpu/zynqmp/core.py
+++ b/litex/soc/cores/cpu/zynqmp/core.py
@@ -5,17 +5,21 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import os
+import logging
 
 from migen import *
 
 from litex.gen                  import *
 
 from litex.soc.cores.cpu        import CPU
+from litex.soc.software.libxil  import LibXil
 from litex.soc.interconnect     import axi
 from litex.soc.interconnect.csr import *
 
 
 # Zynq MP ------------------------------------------------------------------------------------------
+
+logger = logging.getLogger("ZynqMP")
 
 class ZynqMP(CPU):
     variants                 = ["standard"]
@@ -57,6 +61,7 @@ class ZynqMP(CPU):
         self.uart_use       = []          # UART reserved ports.
         self.can_use        = []          # CAN reserved/used ports.
         self.pps            = Signal(4)   # Optional PPS (with gemX and PTP enabled)
+        self.libxil         = None        # Optional Xilinx libxil software package configuration.
 
         # [ 7: 0]: PL_PS_Group0 [128:121]
         # [15: 8]: PL_PS_Group1 [143:136]
@@ -88,6 +93,38 @@ class ZynqMP(CPU):
 
         self.comb += ResetSignal("ps").eq(~rst_n)
         self.ps_tcl.append(f"set ps [create_ip -vendor xilinx.com -name zynq_ultra_ps_e -module_name {self.ps_name}]")
+
+    """
+    Configure the Xilinx libxil software package
+    Attributes
+    ==========
+    xparameters: dict
+        xparameters.h defines
+    bspconfig: dict (optional)
+        bspconfig.h contents (defaults: CPU-generic settings)
+    embeddedsw_dir: str (optional)
+        path to an existing Xilinx embeddedsw checkout
+    embeddedsw_git_url: str (optional)
+        embeddedsw git URL, used when no local checkout is provided
+    """
+    def set_libxil(self, xparameters, bspconfig=None, embeddedsw_dir=None, embeddedsw_git_url=None):
+        self.libxil = LibXil(self, xparameters, bspconfig, embeddedsw_dir, embeddedsw_git_url)
+
+    """
+    Add the configured libxil software package/library to Builder.
+    """
+    def add_software_packages(self, builder):
+        if self.libxil is None:
+            logger.warning("libxil software package not enabled, use cpu.set_libxil(...) to enable it.")
+            return
+        self.libxil.add_software_packages(builder)
+
+    """
+    Prepare the configured libxil software environment after SoC finalization.
+    """
+    def prepare_software(self, builder):
+        if self.libxil is not None:
+            self.libxil.prepare_software(builder)
 
     def set_preset(self, preset):
         preset = os.path.abspath(preset)

--- a/litex/soc/integration/builder.py
+++ b/litex/soc/integration/builder.py
@@ -528,6 +528,8 @@ class Builder:
         with_bios = self.soc.cpu_type is not None
         if with_bios and not self._has_software_package("bios"):
             self.add_software_package("bios")
+        if with_bios:
+            self.soc.cpu.add_software_packages(self)
 
         # Create Gateware directory.
         _create_dir(self.gateware_dir)
@@ -554,6 +556,8 @@ class Builder:
 
         # Finalize the SoC.
         self.soc.finalize()
+        if with_bios:
+            self.soc.cpu.prepare_software(self)
         bundle_platform_sources += [
             source for source in self.soc.platform.sources
             if source not in bundle_platform_sources

--- a/litex/soc/software/__init__.py
+++ b/litex/soc/software/__init__.py
@@ -1,0 +1,5 @@
+#
+# This file is part of LiteX.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+

--- a/litex/soc/software/libxil/__init__.py
+++ b/litex/soc/software/libxil/__init__.py
@@ -1,0 +1,156 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Gwenhael Goavec-Merou <gwenhael.goavec-merou@trabucayre.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import shutil
+import subprocess
+
+from litex.build.tools import write_to_file
+
+# Xilinx libxil ------------------------------------------------------------------------------------
+
+EMBEDDEDSW_GIT_URL = "https://github.com/Xilinx/embeddedsw"
+EMBEDDEDSW_ENV_VAR = "XILINX_EMBEDDEDSW"
+
+HEADERS = {
+    "zynq7000": [
+        "XilinxProcessorIPLib/drivers/uartps/src/xuartps_hw.h",
+        "lib/bsp/standalone/src/common/xil_types.h",
+        "lib/bsp/standalone/src/common/xil_assert.h",
+        "lib/bsp/standalone/src/common/xil_io.h",
+        "lib/bsp/standalone/src/common/xil_printf.h",
+        "lib/bsp/standalone/src/common/xstatus.h",
+        "lib/bsp/standalone/src/common/xdebug.h",
+        "lib/bsp/standalone/src/arm/cortexa9/xpseudo_asm.h",
+        "lib/bsp/standalone/src/arm/cortexa9/xreg_cortexa9.h",
+        "lib/bsp/standalone/src/arm/cortexa9/xil_cache.h",
+        "lib/bsp/standalone/src/arm/cortexa9/xparameters_ps.h",
+        "lib/bsp/standalone/src/arm/cortexa9/xil_errata.h",
+        "lib/bsp/standalone/src/arm/cortexa9/xtime_l.h",
+        "lib/bsp/standalone/src/arm/common/xil_exception.h",
+        "lib/bsp/standalone/src/arm/common/gcc/xpseudo_asm_gcc.h",
+    ],
+    "zynqmp": [
+        "XilinxProcessorIPLib/drivers/uartps/src/xuartps_hw.h",
+        "lib/bsp/standalone/src/common/xil_types.h",
+        "lib/bsp/standalone/src/common/xil_assert.h",
+        "lib/bsp/standalone/src/common/xil_io.h",
+        "lib/bsp/standalone/src/common/xil_printf.h",
+        "lib/bsp/standalone/src/common/xstatus.h",
+        "lib/bsp/standalone/src/common/xdebug.h",
+        "lib/bsp/standalone/src/arm/ARMv8/64bit/xpseudo_asm.h",
+        "lib/bsp/standalone/src/arm/ARMv8/64bit/xreg_cortexa53.h",
+        "lib/bsp/standalone/src/arm/ARMv8/64bit/xil_cache.h",
+        "lib/bsp/standalone/src/arm/ARMv8/64bit/xil_errata.h",
+        "lib/bsp/standalone/src/arm/ARMv8/64bit/platform/ZynqMP/xparameters_ps.h",
+        "lib/bsp/standalone/src/arm/common/xil_exception.h",
+        "lib/bsp/standalone/src/arm/common/gcc/xpseudo_asm_gcc.h",
+    ],
+}
+
+BSPCONFIG = {
+    "zynq7000": "#define FPU_HARD_FLOAT_ABI_ENABLED 1\n",
+    "zynqmp": """\
+#ifndef BSPCONFIG_H
+#define BSPCONFIG_H
+
+#define EL3 1
+#define EL1_NONSECURE 0
+
+#endif
+""",
+}
+
+class LibXil:
+    """
+    Configure the Xilinx libxil software package
+    Attributes
+    ==========
+    cpu: CPU
+        CPU instance using libxil
+    xparameters: dict
+        xparameters.h defines
+    bspconfig: str (optional)
+        bspconfig.h contents (defaults: CPU-generic settings)
+    embeddedsw_dir: str (optional)
+        path to an existing Xilinx embeddedsw checkout
+    embeddedsw_git_url: str (optional)
+        embeddedsw git URL, used when no local checkout is provided
+    """
+
+    def __init__(self, cpu, xparameters, bspconfig=None, embeddedsw_dir=None, embeddedsw_git_url=None):
+        assert cpu is not None, "CPU must be provided"
+        assert cpu.name in HEADERS, f"Unsupported libxil CPU: {cpu.name}"
+
+        self.cpu                = cpu
+        self.xparameters        = xparameters
+        self.bspconfig          = {True: BSPCONFIG[cpu.name], False: bspconfig}[bspconfig is None]
+        self.embeddedsw_dir     = embeddedsw_dir
+        self.embeddedsw_git_url = {True: EMBEDDEDSW_GIT_URL, False: embeddedsw_git_url}[embeddedsw_git_url is None]
+
+    """
+    Add libxil software package/library to Builder.
+    """
+    def add_software_packages(self, builder):
+        assert builder is not None, "Error builder is None"
+
+        if not builder._has_software_package("libxil"):
+            builder.add_software_package("libxil")
+        if "libxil" not in builder.software_libraries:
+            builder.add_software_library("libxil")
+
+    def _prepare_embeddedsw(self, libxil_path):
+        os.makedirs(os.path.realpath(libxil_path), exist_ok=True)
+        dst = os.path.join(libxil_path, "embeddedsw")
+        if os.path.exists(dst):
+            return dst
+
+        src = dst
+        if self.embeddedsw_dir is not None:
+            src = self.embeddedsw_dir
+        elif os.getenv(EMBEDDEDSW_ENV_VAR) is not None:
+            src = os.getenv(EMBEDDEDSW_ENV_VAR)
+        src = os.path.abspath(src)
+
+        if not os.path.exists(src):
+            os.makedirs(os.path.dirname(src), exist_ok=True)
+            subprocess.check_call(["git", "clone", "--depth", "1", self.embeddedsw_git_url, src])
+        if src != dst:
+            os.symlink(src, dst)
+        return dst
+
+    """
+    Prepare embeddedsw headers and generated libxil configuration files.
+    """
+    def prepare_software(self, builder):
+        libxil_path = os.path.join(builder.software_dir, "libxil")
+        lib         = self._prepare_embeddedsw(libxil_path)
+
+        os.makedirs(os.path.realpath(builder.include_dir), exist_ok=True)
+        for header in HEADERS[self.cpu.name]:
+            shutil.copy(os.path.join(lib, header), builder.include_dir)
+
+        write_to_file(os.path.join(builder.include_dir, "bspconfig.h"), self.bspconfig)
+        write_to_file(os.path.join(builder.include_dir, "xparameters.h"), self.xparameters_h())
+
+    def xparameters_h(self):
+        contents = [
+            "#ifndef XPARAMETERS_H",
+            "#define XPARAMETERS_H",
+            "",
+            '#include "xparameters_ps.h"',
+            "",
+        ]
+        for name, value in self.xparameters.items():
+            val = f"0x{value:X}" if isinstance(value, int) else str(value)
+            contents.append(f"#define {name} {val}")
+        contents += [
+            "",
+            "#endif",
+            "",
+        ]
+        return "\n".join(contents)
+

--- a/test/soc/test_builder.py
+++ b/test/soc/test_builder.py
@@ -17,6 +17,7 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+from litex.soc.cores.cpu import CPU
 from litex.soc.integration.builder import Builder, builder_argdict, builder_args
 from litex.soc.integration.soc import SoCRegion
 from litex.build.log import buffer_build_log, start_build_log, stop_build_log
@@ -44,10 +45,14 @@ class _FakeSoC:
         return self.platform.name
 
 
+class _FakeCPU(CPU):
+    use_rom = False
+
+
 class _BuildableFakeSoC(_FakeSoC):
     def __init__(self):
         _FakeSoC.__init__(self, cpu_type="unitcpu")
-        self.cpu         = SimpleNamespace(use_rom=False)
+        self.cpu         = _FakeCPU()
         self.finalized   = 0
         self.build_calls = []
         self.exit_calls  = []


### PR DESCRIPTION
Most of the logic required to integrates the _libxil_ used by **zynq** devices is performed in targets scripts:
- `main` method extends software package/library with this lib
- `BaseSoC.finalize`:
  -  clone `embeddedsw` repository
  - copy headers from the repository
  - creates required board specifics headers.

This imply around 50 lines per boards with a lot of dupplication:
- The `main` part is strictly the same for all zynq based boards.
- The `finalize` part only differs by `xparameters.h` content (and its content is more limited to 3 lines: UART controler id and memory area).

So instead of having these big code dupplicate for all boards:
- the libxil directory is extended to handle clone/copy/header fill
- `CPU` class is extended to adds two dummy helpers to adds and prepare specifics software packages

As the result boards have, only, to provides specifics `#define`, rest of the logic is automatically performed at software build time.

A companion PR will be added for litex-boards