### PR TITLE
litex/gen: fix hierarchical Verilog wire classification for memory port slices

### DIFF
--- a/litex/gen/fhdl/verilog.py
+++ b/litex/gen/fhdl/verilog.py
@@ -871,12 +871,18 @@ def _collect_memory_port_signals(specials, clock_domains=None):
                 sig = getattr(port, attr, None)
                 if isinstance(sig, ClockSignal) and (clock_domains is not None):
                     sig = clock_domains[sig.cd].clk
+                if isinstance(sig, _Slice):
+                    sig = sig.value
                 if isinstance(sig, Signal):
                     signals.add(sig)
-            # Memory read data is always driven by the memory.
+            # Memory read data is always driven by the memory.  The port may
+            # drive a slice of a wider aggregate signal (e.g. after a
+            # byte-granular FullMemoryWE split): classify the aggregate itself.
             sig = getattr(port, "dat_r", None)
             if isinstance(sig, ClockSignal) and (clock_domains is not None):
                 sig = clock_domains[sig.cd].clk
+            if isinstance(sig, _Slice):
+                sig = sig.value
             if isinstance(sig, Signal):
                 targets.add(sig)
                 wires.add(sig)

--- a/test/hdl/test_hierarchical_verilog.py
+++ b/test/hdl/test_hierarchical_verilog.py
@@ -3,6 +3,7 @@ import re
 
 from migen import *
 from migen.fhdl.decorators import ClockDomainsRenamer
+from migen.fhdl.simplify import FullMemoryWE
 from migen.fhdl.specials import Tristate
 
 from litex.gen import LiteXContext
@@ -129,6 +130,23 @@ class _SharedMemoryTop(Module):
         self.submodules.owner = _SharedMemoryOwner(mem)
         self.submodules.reader = _SharedMemoryReader(mem, self.adr)
         self.comb += self.o.eq(self.reader.dat_r)
+
+
+class _GrainMemoryTop(Module):
+    def __init__(self):
+        self.adr   = Signal(9)
+        self.dat_w = Signal(128)
+        self.we    = Signal(16)
+        self.dat_r = Signal(128)
+        mem = Memory(128, 512)
+        port = mem.get_port(write_capable=True, we_granularity=8)
+        self.specials += mem, port
+        self.comb += [
+            port.adr.eq(self.adr),
+            port.dat_w.eq(self.dat_w),
+            port.we.eq(self.we),
+            self.dat_r.eq(port.dat_r),
+        ]
 
 
 class _InlineDropLeaf(Module):
@@ -334,3 +352,20 @@ class TestHierarchicalVerilog(unittest.TestCase):
         self.assertNotIn("reg [7:0] mem[0:3];", reader_module)
         self.assertRegex(owner_module, r"output\s+wire\s+\[7:0\]\s+dat_r")
         self.assertRegex(reader_module, r"input\s+wire\s+\[7:0\]\s+dat_r")
+
+    def test_hierarchical_grain_memory_port_dat_r_is_wire(self):
+        # Wide memory with byte-granular write enables: FullMemoryWE splits it
+        # into byte grains whose read-data slices are assembled via continuous
+        # assigns. The aggregate dat_r must be declared wire (like the flat
+        # converter does), never reg, or synthesis rejects it (Synth 8-9315).
+        top = FullMemoryWE()(_GrainMemoryTop())
+
+        old_top = LiteXContext.top
+        try:
+            LiteXContext.top = top
+            verilog = convert(top, ios={top.adr, top.dat_w, top.we, top.dat_r}, name="top", hierarchical=True).main_source
+        finally:
+            LiteXContext.top = old_top
+
+        self.assertRegex(verilog, r"wire\s+\[127:0\]")
+        self.assertNotRegex(verilog, r"reg\s+\[127:0\]")


### PR DESCRIPTION
# litex/gen: fix hierarchical Verilog wire classification for memory port slices

## Problem

`--hierarchical-verilog` generation produces Verilog that Vivado rejects at
synthesis for SoCs whose caches use byte-granular write enables:

```
ERROR: [Synth 8-9315] concurrent assignment to a non-net
       'main_basesoc_data_port_dat_r' is not permitted [...]
```

The L2 cache data memory (128-bit, `we_granularity=8`) is split by
`FullMemoryWE` into 16 byte-grains. Each grain's read-data port drives a
slice of the aggregate read-data signal, e.g.:

```verilog
assign main_basesoc_data_port_dat_r[7:0]  = data_mem_grain0_dat0;
assign main_basesoc_data_port_dat_r[15:8] = data_mem_grain1_dat0;
...
```

The flat converter declares the aggregate as `wire` and everything works.
The hierarchical converter declares it as

```verilog
reg [127:0] main_basesoc_data_port_dat_r = 128'd0;
```

which is illegal: a `reg` driven only by continuous assigns (16 drivers).

## Root cause

Commit a7a9d1c7d ("fix hierarchical memory ownership") deliberately drops
`_MemoryPort` specials when building per-module fragments, so
`list_special_ios()` no longer sees memory port endpoints. That commit
covered read-data signals that become module ports (handled via
`force_wires`), but not the internal case where the aggregate read-data
signal is assembled from grain outputs inside the same module.

`_collect_memory_port_signals()` — the fallback used to classify
memory-driven signals — only accepted plain `Signal` port endpoints and
ignored `_Slice` targets, so the aggregate was never added to the wire set
and fell back to `reg`.

## Fix

Unwrap `_Slice` port endpoints to their base signal in
`_collect_memory_port_signals()`, so memory-driven read-data aggregates
are classified as wires. This is behavior-preserving for the flat path
(which already classified them as wires through the separate
`_MemoryPort` specials) and restores the same classification in the
hierarchical path.

## Test

New regression test `test_hierarchical_grain_memory_port_dat_r_is_wire`:
a 128-bit memory with byte-granular WE is split with `FullMemoryWE`, then
converted hierarchically. Fails before the fix (`reg [127:0]` present),
passes after (`wire [127:0]`).

Full verilog test suites pass: `test_verilog.py`,
`test_verilog_memory.py`, `test_hierarchical_verilog.py` (20 tests).

## Hardware verification

`digilent_arty_s7` (Spartan-7) with `--hierarchical-verilog`:

- 138 modules generated (up to depth 4, e.g. `bus → interconnect → arbiter → rr`)
  with the default automatic partitioning; also verified on the
  `full-hierarchy-refactor` branch with `--no-flatten` (full/deep hierarchy,
  248 modules): the same `dat_r` error is fixed there by this change
- Vivado 2024.1: synthesis 0 errors, 0 critical warnings, bitstream written
- Loaded to board: BIOS boots, CRC passes, VexRiscv @ 100 MHz responds on UART