### PR TITLE
Vhd2v converter fix missing params

### DIFF
--- a/litex/build/converter_common.py
+++ b/litex/build/converter_common.py
@@ -134,5 +134,7 @@ def normalize_instance_ports(params, *, top_entity, target="converter", generic_
     return ip_params
 
 
-def extract_prefixed_generics(params, *, prefix="p_"):
+def extract_prefixed_generics(params, *, prefix="p_", target="GHDL"):
+    if target != "GHDL":
+        return {k: v for k, v in params.items() if k.startswith(prefix)}
     return ["-g" + k[len(prefix):] + "=" + str(v) for k, v in params.items() if k.startswith(prefix)]

--- a/litex/build/vhd2v_converter.py
+++ b/litex/build/vhd2v_converter.py
@@ -244,6 +244,7 @@ class VHD2VConverter(Module):
         if self._platform.support_mixed_language and not self._force_convert:
             if (self._params is not None) and self._add_instance:
                 ip_params = self._normalize_instance_ports(self._params)
+                ip_params.update(self._extract_generics(self._params, target="native"))
             elif self._instance is not None:
                 ip_params = self._instance.items
             for file in sources:

--- a/litex/build/vhd2v_converter.py
+++ b/litex/build/vhd2v_converter.py
@@ -185,8 +185,8 @@ class VHD2VConverter(Module):
         return normalize_instance_ports(params, top_entity=self._top_entity, target="VHD2V")
 
     @staticmethod
-    def _extract_generics(params):
-        return extract_prefixed_generics(params, prefix="p_")
+    def _extract_generics(params, target="GHDL"):
+        return extract_prefixed_generics(params, prefix="p_", target=target)
 
     @staticmethod
     def _sanitize_ghdl_escaped_identifiers(content):


### PR DESCRIPTION
When `support_mixed_language` is True at platform level and conversion is not forced by user, the `self._normalize_instance_ports` is used to extract ports for `_instance`.
But parameters (`p_`) are skipped/ignored.
As a result, the instance is written with all parameters omitted and the synthesis tool uses default instead of valid value.
This situation imply some build failure hard to understand because the `p_` are correct at LiteXModule level but not seen as synthesis level.

This PR modify `extract_generics` to introduces an additional parameter called `target`. Values may be:
- `GHDL` to built a list of parameters as required by `ghdl`
- any others values to simply build a new dict with only `p_` entries in original dict

the `do_finalyze` method is also updated to update ip_params with generic since `normalize_instance_ports` skip these entries