### PR TITLE
litex_setup: Install packaging>=24.2 alongside setuptools

### DIFF
--- a/litex_setup.py
+++ b/litex_setup.py
@@ -623,6 +623,7 @@ def pip_install_error(
 def pip_install_build_dependencies(user_mode=False, break_system_packages=False):
     build_packages = [
         "setuptools>=65.5",
+        "packaging>=24.2",
         "wheel",
     ]
     print_status("Installing Python build dependencies...")


### PR DESCRIPTION
CI is failing on linux on litex, and probably a few other places, because setuptools has been upgraded here, but packaging has not. This brings packaging in line with setuptool so that the bulid can complete.

https://github.com/litex-hub/linux-on-litex-vexriscv/actions/runs/33004623903/job/98294896871