### PR TITLE
soc/interconnect/axi: AXIDownConverter — hold narrow single-beat commands until the width converter drained

### DIFF
--- a/litex/soc/interconnect/axi/axi_full.py
+++ b/litex/soc/interconnect/axi/axi_full.py
@@ -543,6 +543,19 @@ class AXIDownConverter(LiteXModule):
         is_aw_slow = ((axi_from.aw.burst == BURST_FIXED) & (axi_from.aw.len != 0)) | \
                      (axi_from.aw.len > max_fast_len)
 
+        # Outstanding-write counter: the narrow single-beat path detaches the W StrideConverter
+        # (its sink is de-validated and the W mux is switched to the lane path), so a narrow AW
+        # may only be accepted once every previously accepted write has fully drained: a B
+        # response is only generated after the converter emitted (and the slave accepted) all of
+        # the write's W beats. Accepting it earlier would swallow the wide beat currently held
+        # mid-conversion: silent write-data loss, one write's data delivered under another
+        # write's address and an extra W beat after a len=0 burst for beat-counting slaves.
+        self.aw_counter = _AXIRequestCounter(
+            request  = axi_from.aw.valid & axi_from.aw.ready,
+            response = axi_from.b.valid  & axi_from.b.ready,
+        )
+        aw_drained = self.aw_counter.empty
+
         aw_fsm = FSM(reset_state="IDLE")
         self.aw_fsm = aw_fsm
 
@@ -550,8 +563,10 @@ class AXIDownConverter(LiteXModule):
             If(narrow_aw_active,
                 axi_from.aw.ready.eq(0),
             ).Elif(is_aw_narrow,
-                aw_narrow_pending.eq(axi_from.aw.valid),
-                axi_to.aw.valid.eq(axi_from.aw.valid),
+                # Hold the narrow AW (and do not present it to the slave) until the W stream of
+                # all previously accepted writes has fully drained through the converter.
+                aw_narrow_pending.eq(axi_from.aw.valid & aw_drained),
+                axi_to.aw.valid.eq(axi_from.aw.valid & aw_drained),
                 axi_to.aw.addr.eq(axi_from.aw.addr),
                 axi_to.aw.len.eq(0),
                 axi_to.aw.size.eq(axi_from.aw.size),
@@ -564,8 +579,8 @@ class AXIDownConverter(LiteXModule):
                 axi_to.aw.region.eq(axi_from.aw.region),
                 axi_to.aw.dest.eq(axi_from.aw.dest),
                 axi_to.aw.user.eq(axi_from.aw.user),
-                axi_from.aw.ready.eq(axi_to.aw.ready),
-                If(axi_from.aw.valid & axi_to.aw.ready,
+                axi_from.aw.ready.eq(aw_drained & axi_to.aw.ready),
+                If(axi_from.aw.valid & axi_from.aw.ready,
                     NextValue(cap_aw_lane, axi_from.aw.addr[narrow_size_log2:wide_size_log2]),
                     NextValue(narrow_aw_active, 1),
                 ),
@@ -778,6 +793,19 @@ class AXIDownConverter(LiteXModule):
         is_ar_slow = ((axi_from.ar.burst == BURST_FIXED) & (axi_from.ar.len != 0)) | \
                      (axi_from.ar.len > max_fast_len)
 
+        # Outstanding-read counter: the narrow single-beat path detaches the R StrideConverter
+        # (its sink is de-validated and the returning sub-beats are captured into narrow_r_*), so
+        # a narrow AR may only be accepted once every previously accepted read has fully drained
+        # (its final wide R beat handed to the master). Accepting it earlier would capture the
+        # sub-beat completing the wide read as the narrow read's response: the merged wide word
+        # is destroyed (wrong read data) and the narrow response is never delivered (permanent
+        # read-channel deadlock).
+        self.ar_counter = _AXIRequestCounter(
+            request  = axi_from.ar.valid & axi_from.ar.ready,
+            response = axi_from.r.valid  & axi_from.r.ready  & axi_from.r.last,
+        )
+        ar_drained = self.ar_counter.empty
+
         ar_fsm = FSM(reset_state="IDLE")
         self.ar_fsm = ar_fsm
 
@@ -785,7 +813,9 @@ class AXIDownConverter(LiteXModule):
             If(narrow_ar_active,
                 axi_from.ar.ready.eq(0),
             ).Elif(is_ar_narrow,
-                axi_to.ar.valid.eq(axi_from.ar.valid),
+                # Hold the narrow AR (and do not present it to the slave) until the R stream of
+                # all previously accepted reads has fully drained through the converter.
+                axi_to.ar.valid.eq(axi_from.ar.valid & ar_drained),
                 axi_to.ar.addr.eq(axi_from.ar.addr),
                 axi_to.ar.len.eq(0),
                 axi_to.ar.size.eq(axi_from.ar.size),
@@ -798,8 +828,8 @@ class AXIDownConverter(LiteXModule):
                 axi_to.ar.region.eq(axi_from.ar.region),
                 axi_to.ar.dest.eq(axi_from.ar.dest),
                 axi_to.ar.user.eq(axi_from.ar.user),
-                axi_from.ar.ready.eq(axi_to.ar.ready),
-                If(axi_from.ar.valid & axi_to.ar.ready,
+                axi_from.ar.ready.eq(ar_drained & axi_to.ar.ready),
+                If(axi_from.ar.valid & axi_from.ar.ready,
                     NextValue(cap_ar_lane, axi_from.ar.addr[narrow_size_log2:wide_size_log2]),
                     NextValue(narrow_ar_active, 1),
                 ),

--- a/test/interconnect/test_axi.py
+++ b/test/interconnect/test_axi.py
@@ -971,6 +971,205 @@ class TestAXI(unittest.TestCase):
         run_simulation(dut, [gen(dut)])
         self.assertEqual(dut.errors, 0)
 
+    def test_axi_down_converter_narrow_interleave_write(self):
+        # A narrow single-beat write must not be accepted while the W StrideConverter is still
+        # converting a previously accepted wide write: the narrow path detaches the converter,
+        # so the wide beat held mid-conversion would be swallowed (silent write-data loss) and
+        # its data delivered under the narrow write's address. The converter must hold the
+        # narrow AW until the wide write fully drained (B received).
+        dw_wide, dw_narrow = 64, 32
+        aw_log, w_log, b_count = [], [], [0]
+        ar2_held = [None]
+
+        class DUT(LiteXModule):
+            def __init__(self):
+                self.axi_wide   = AXIInterface(data_width=dw_wide,   address_width=32, id_width=4)
+                self.axi_narrow = AXIInterface(data_width=dw_narrow, address_width=32, id_width=4)
+                self.converter  = AXIDownConverter(self.axi_wide, self.axi_narrow)
+
+        @passive
+        def monitor(dut):
+            while True:
+                if (yield dut.axi_narrow.aw.valid) and (yield dut.axi_narrow.aw.ready):
+                    aw_log.append((
+                        (yield dut.axi_narrow.aw.addr),
+                        (yield dut.axi_narrow.aw.len),
+                        (yield dut.axi_narrow.aw.size),
+                    ))
+                if (yield dut.axi_narrow.w.valid) and (yield dut.axi_narrow.w.ready):
+                    w_log.append((
+                        (yield dut.axi_narrow.w.data),
+                        (yield dut.axi_narrow.w.strb),
+                        (yield dut.axi_narrow.w.last),
+                    ))
+                if (yield dut.axi_wide.b.valid) and (yield dut.axi_wide.b.ready):
+                    b_count[0] += 1
+                yield
+
+        @passive
+        def b_slave(dut):
+            # Narrow slave B responses: one B after each completed narrow write burst.
+            narrow = dut.axi_narrow
+            yield narrow.b.valid.eq(0)
+            yield narrow.b.resp.eq(RESP_OKAY)
+            while True:
+                w_valid, w_ready, w_last = (yield [narrow.w.valid, narrow.w.ready, narrow.w.last])
+                if w_valid and w_ready and w_last:
+                    yield narrow.b.valid.eq(1)
+                    yield
+                    while (yield narrow.b.ready) == 0:
+                        yield
+                    yield narrow.b.valid.eq(0)
+                    yield
+                else:
+                    yield
+
+        def gen(dut):
+            wide, narrow = dut.axi_wide, dut.axi_narrow
+            # Narrow slave: accept AWs, stall W until released (B responses from b_slave).
+            yield narrow.aw.ready.eq(1)
+            yield narrow.w.ready.eq(0)
+            yield wide.b.ready.eq(1)
+            # Wide write @0x100 (len=0, size=3): AW accepted, W beat presented but stalled
+            # mid-conversion by the narrow slave (0 of its 2 sub-beats emitted).
+            yield from axi_aw_send(wide, 0x100, size=3)
+            yield wide.w.data.eq(0x1111222233334444)
+            yield wide.w.strb.eq(0xff)
+            yield wide.w.last.eq(1)
+            yield wide.w.valid.eq(1)
+            for _ in range(4):
+                yield
+            # Present the narrow write @0x200 (len=0, size=2) while W1 is still held: it must
+            # not be accepted (no B for the wide write yet).
+            yield wide.aw.valid.eq(1)
+            yield wide.aw.addr.eq(0x200)
+            yield wide.aw.len.eq(0)
+            yield wide.aw.size.eq(2)
+            yield wide.aw.burst.eq(BURST_INCR)
+            ar2_held[0] = True
+            for _ in range(10):
+                yield
+                if (yield wide.aw.ready):
+                    ar2_held[0] = False
+                    break
+            # Release the narrow W path: the wide write must now drain completely (both of its
+            # narrow sub-beats, then its B) before the pending narrow write goes through.
+            yield narrow.w.ready.eq(1)
+            for _ in range(20):
+                if (yield wide.w.valid) and (yield wide.w.ready):
+                    break
+                yield
+            yield wide.w.valid.eq(0)  # Well-behaved master: drop valid once the beat is accepted.
+            for _ in range(20):
+                if (yield wide.aw.ready):
+                    break
+                yield
+            yield wide.aw.valid.eq(0)
+            # Data beat of the narrow write (lane 0 of the wide word).
+            yield from axi_w_send(wide, 0xcafebabe, last=True, strb=0xf)
+            for _ in range(20):
+                yield
+
+        dut = DUT()
+        run_simulation(dut, [gen(dut), monitor(dut), b_slave(dut)])
+
+        self.assertTrue(ar2_held[0])
+        self.assertEqual(aw_log, [(0x100, 1, 2), (0x200, 0, 2)])
+        self.assertEqual(w_log, [
+            (0x33334444, 0xf, 0),  # Wide write, sub-beat 0.
+            (0x11112222, 0xf, 1),  # Wide write, sub-beat 1.
+            (0xcafebabe, 0xf, 1),  # Narrow write, selected lane.
+        ])
+        self.assertEqual(b_count[0], 2)
+
+    def test_axi_down_converter_narrow_interleave_read(self):
+        # Mirror of the write test: a narrow single-beat read must not be accepted while the R
+        # StrideConverter is still merging a previously accepted wide read. Accepting it early
+        # would capture the sub-beat completing the wide read as the narrow read's response
+        # (merged word destroyed -> wrong read data) and never deliver the narrow response
+        # (read-channel deadlock).
+        dw_wide, dw_narrow = 64, 32
+        r_log, ar_log = [], []
+        ar2_held = [None]
+        ar2_accepted = [False]
+
+        class DUT(LiteXModule):
+            def __init__(self):
+                self.axi_wide   = AXIInterface(data_width=dw_wide,   address_width=32, id_width=4)
+                self.axi_narrow = AXIInterface(data_width=dw_narrow, address_width=32, id_width=4)
+                self.converter  = AXIDownConverter(self.axi_wide, self.axi_narrow)
+
+        @passive
+        def monitor(dut):
+            ar_count = 0
+            while True:
+                if (yield dut.axi_wide.ar.valid) and (yield dut.axi_wide.ar.ready):
+                    ar_count += 1
+                    ar_log.append(ar_count)
+                    if ar_count == 2:
+                        ar2_accepted[0] = True
+                if (yield dut.axi_wide.r.valid) and (yield dut.axi_wide.r.ready):
+                    r_log.append((
+                        (yield dut.axi_wide.r.data),
+                        (yield dut.axi_wide.r.last),
+                    ))
+                yield
+
+        def send_r(narrow, data, last):
+            # Scripted narrow slave read beat: hold payload until the handshake, then drop valid.
+            yield narrow.r.valid.eq(1)
+            yield narrow.r.data.eq(data)
+            yield narrow.r.last.eq(int(last))
+            yield narrow.r.resp.eq(RESP_OKAY)
+            while (yield narrow.r.ready) == 0:
+                yield
+            yield
+            yield narrow.r.valid.eq(0)
+
+        def gen(dut):
+            wide, narrow = dut.axi_wide, dut.axi_narrow
+            yield narrow.ar.ready.eq(1)
+            yield wide.r.ready.eq(1)
+            # Wide read @0x100 (len=0, size=3) -> narrow burst of 2; slave returns the first
+            # sub-beat then stalls (the converter now holds a partially merged wide word).
+            yield from axi_ar_send(wide, 0x100, size=3)
+            yield from send_r(narrow, 0x11110000, last=False)
+            # Present the narrow read @0x200 (len=0, size=2) while the merge is in flight: it
+            # must not be accepted before the wide read's R beat has been delivered.
+            yield wide.ar.valid.eq(1)
+            yield wide.ar.addr.eq(0x200)
+            yield wide.ar.len.eq(0)
+            yield wide.ar.size.eq(2)
+            yield wide.ar.burst.eq(BURST_INCR)
+            ar2_held[0] = True
+            for _ in range(10):
+                yield
+                if (yield wide.ar.ready):
+                    ar2_held[0] = False
+                    break
+            # Slave completes the wide read.
+            yield from send_r(narrow, 0x22220000, last=True)
+            # The narrow read can now be accepted.
+            for _ in range(30):
+                if ar2_accepted[0]:
+                    break
+                yield
+            yield wide.ar.valid.eq(0)
+            # Slave returns the narrow read's data.
+            yield from send_r(narrow, 0x33330000, last=True)
+            for _ in range(10):
+                yield
+
+        dut = DUT()
+        run_simulation(dut, [gen(dut), monitor(dut)])
+
+        self.assertTrue(ar2_held[0])
+        self.assertEqual(len(ar_log), 2)
+        self.assertEqual(r_log, [
+            (0x2222000011110000, 1),  # Wide read: correctly merged sub-beats.
+            (0x0000000033330000, 1),  # Narrow read: data on the selected lane.
+        ])
+
     def test_axi_down_converter_id_and_last(self):
         # Verify that the wide-side r.id matches what was issued on ar.id, and that r.last
         # is asserted *only* on the final reassembled wide beat of each burst.


### PR DESCRIPTION

## Summary

`AXIDownConverter` accepts a narrow single-beat AW/AR (the `is_aw_narrow`/`is_ar_narrow`
fast path added for sub-word accesses, issue #2000) **without checking that the previous
full-width transaction has fully drained through the W/R `StrideConverter`**. Because the
narrow path *detaches* the converter (`w_converter.sink.valid` is de-validated,
`w_converter.source.ready` is forced to 0, and the W/R mux is switched to the lane path),
accepting a narrow command while a wide beat is held mid-conversion corrupts the stream:

* **Write side** — the wide W beat currently held by the converter is swallowed: its
  remaining sub-beats are never emitted (silent write-data loss; the master is acked via
  `axi_from.w.ready`), one write's data is delivered under the other write's address
  (the pending wide beat is routed through the lane slice selected by the *narrow* AW's
  `cap_aw_lane`), and an extra W beat arrives after a `len=0` burst, desyncing
  beat-counting bridges (AXI2AXILite, Wishbone adapters).
* **Read side** — the sub-beat that completes the wide read is captured into `narrow_r_*`
  and presented to the master as the *narrow* read's response: the merged wide word is
  destroyed (wrong read data, zero-fill in its place) and the narrow response is never
  delivered (`axi_to.r.ready` stuck low — permanent read-channel deadlock).

The trigger is protocol-legal and routine: any sub-width single-beat access (e.g. a CPU
byte/word store) issued while a full-width access' W/R stream is still in flight on a
pipelined or slave-stalled fabric. The converter is auto-inserted by
`SoCBusHandler.add_adapter` on every master/slave whose data width differs from the bus
width, so any wide-bus SoC with a narrow region (or a wide DMA port on a narrower bus) is
exposed.

## Fix

Serialize the narrow path against the converter, mirroring what `AXIUpConverter` achieves
structurally with its per-beat lane FIFOs (no preemptible shared conversion state): reuse
the existing `_AXIRequestCounter` idiom (as `AXIArbiter` does for grant locking) to track
outstanding commands:

```python
self.aw_counter = _AXIRequestCounter(
    request  = axi_from.aw.valid & axi_from.aw.ready,
    response = axi_from.b.valid  & axi_from.b.ready,
)
aw_drained = self.aw_counter.empty
```

and gate the narrow AW/AR branch on `aw_drained`/`ar_drained` (read side: request = AR
handshake, response = final wide R beat). A B response is only produced after the slave
accepted all W beats of a write, and the last wide R beat is only produced after the
converter merged all narrow sub-beats of a read — so `empty` is an exact "converter
drained" indication:

* `axi_to.aw/ar.valid` is held low (the command is not presented to the slave) and
  `axi_from.aw/ar.ready` stays low until drained;
* the handshake condition uses the (now gated) master-side ready, so a slave-side
  `aw/ar.ready` asserted while we are holding the command can no longer latch
  `narrow_*_active` spuriously.

Full-width fast-path and FIXED slow-path commands are unaffected: they share the
converter consistently and never detach it, so no additional serialization is needed
there. The counter saturates at 256 outstanding commands (same default as the arbiter's
request counters).

## Tests

Two regression tests in `test/interconnect/test_axi.py` (TestAXI), both failing on the
unfixed tree and passing with this change:

* `test_axi_down_converter_narrow_interleave_write` — wide write stalled mid-conversion
  (0 of 2 sub-beats emitted) on the narrow bus; narrow write presented while held.
  Asserts the narrow AW is not accepted until the wide write fully drained, and that the
  narrow bus sees exactly `[W1_sub0, W1_sub1, W2_lane]` with correct strobes/last and two
  B responses.
* `test_axi_down_converter_narrow_interleave_read` — wide read mid-merge (first sub-beat
  delivered, second stalled); narrow read presented while held. Asserts the narrow AR is
  not accepted before the wide read's R beat is delivered, and that the master receives
  the correctly merged wide word followed by the lane-placed narrow word (no deadlock).

Full results with this change applied:

* `test/interconnect/test_axi.py`, `test_axi_lite.py`, `test_axi_stream.py`: 74/74 ok.
* entire `test/interconnect/` suite: 231/231 ok.
* `test/soc/`: 205 tests, 5 pre-existing environment errors (missing optional `litespi`,
  `litedram`, picolibc data module; identical on the unmodified tree).

## Notes for reviewers

* No new primitives are introduced — the change reuses `_AXIRequestCounter` and only
  gates existing handshakes, so the fast path keeps its zero-latency behaviour whenever
  the converter is idle (the common case for non-interleaved traffic).
* The existing narrow/slow-path serialization via `narrow_*_active` + B is unchanged;
  this change extends the same serialization to "any previous command still draining".

---

*Reproduction scripts (migen sim, no external dependencies) used to demonstrate the
failure before the fix are included alongside this PR body: `poc_axi_downconv_write.py`
and `poc_axi_downconv_read2.py`, with red (unfixed) and green (fixed) logs.*
