### PR TITLE
soc/interconnect/axi: Serialize narrow down-converter accesses

### DIFF
--- a/litex/soc/interconnect/axi/axi_full.py
+++ b/litex/soc/interconnect/axi/axi_full.py
@@ -543,6 +543,14 @@ class AXIDownConverter(LiteXModule):
         is_aw_slow = ((axi_from.aw.burst == BURST_FIXED) & (axi_from.aw.len != 0)) | \
                      (axi_from.aw.len > max_fast_len)
 
+        # The narrow path must not take over the W/B channels while an earlier write is pending.
+        self.aw_counter = aw_counter = _AXIRequestCounter(
+            request  = axi_from.aw.valid & axi_from.aw.ready,
+            response = axi_from.b.valid  & axi_from.b.ready,
+        )
+        aw_drained   = aw_counter.empty
+        aw_available = ~aw_counter.full
+
         aw_fsm = FSM(reset_state="IDLE")
         self.aw_fsm = aw_fsm
 
@@ -550,8 +558,8 @@ class AXIDownConverter(LiteXModule):
             If(narrow_aw_active,
                 axi_from.aw.ready.eq(0),
             ).Elif(is_aw_narrow,
-                aw_narrow_pending.eq(axi_from.aw.valid),
-                axi_to.aw.valid.eq(axi_from.aw.valid),
+                aw_narrow_pending.eq(axi_from.aw.valid & aw_drained),
+                axi_to.aw.valid.eq(axi_from.aw.valid & aw_drained),
                 axi_to.aw.addr.eq(axi_from.aw.addr),
                 axi_to.aw.len.eq(0),
                 axi_to.aw.size.eq(axi_from.aw.size),
@@ -564,8 +572,8 @@ class AXIDownConverter(LiteXModule):
                 axi_to.aw.region.eq(axi_from.aw.region),
                 axi_to.aw.dest.eq(axi_from.aw.dest),
                 axi_to.aw.user.eq(axi_from.aw.user),
-                axi_from.aw.ready.eq(axi_to.aw.ready),
-                If(axi_from.aw.valid & axi_to.aw.ready,
+                axi_from.aw.ready.eq(axi_to.aw.ready & aw_drained),
+                If(axi_from.aw.valid & axi_from.aw.ready,
                     NextValue(cap_aw_lane, axi_from.aw.addr[narrow_size_log2:wide_size_log2]),
                     NextValue(narrow_aw_active, 1),
                 ),
@@ -574,7 +582,7 @@ class AXIDownConverter(LiteXModule):
                 # always runs full-width beats: each wide beat maps to exactly ratio narrow beats
                 # (sub-width transfers are handled through the byte strobes; passing a sub-width
                 # size through with a ratio-multiplied len generated mismatched narrow addresses).
-                axi_to.aw.valid.eq(axi_from.aw.valid),
+                axi_to.aw.valid.eq(axi_from.aw.valid & aw_available),
                 axi_to.aw.addr.eq(axi_from.aw.addr),
                 axi_to.aw.addr[:wide_size_log2].eq(0),
                 axi_to.aw.len.eq(((axi_from.aw.len + 1) << log2_int(ratio)) - 1),
@@ -593,11 +601,11 @@ class AXIDownConverter(LiteXModule):
                 axi_to.aw.region.eq(axi_from.aw.region),
                 axi_to.aw.dest.eq(axi_from.aw.dest),
                 axi_to.aw.user.eq(axi_from.aw.user),
-                axi_from.aw.ready.eq(axi_to.aw.ready),
+                axi_from.aw.ready.eq(axi_to.aw.ready & aw_available),
             ).Else(
                 # Slow path: capture wide AW and switch to FIXED handling.
-                axi_from.aw.ready.eq(1),
-                If(axi_from.aw.valid,
+                axi_from.aw.ready.eq(aw_available),
+                If(axi_from.aw.valid & axi_from.aw.ready,
                     NextValue(cap_aw_addr,   axi_from.aw.addr),
                     NextValue(cap_aw_len,    axi_from.aw.len),
                     NextValue(cap_aw_size,   axi_from.aw.size),
@@ -778,6 +786,14 @@ class AXIDownConverter(LiteXModule):
         is_ar_slow = ((axi_from.ar.burst == BURST_FIXED) & (axi_from.ar.len != 0)) | \
                      (axi_from.ar.len > max_fast_len)
 
+        # The narrow path must not take over the R channel while an earlier read is pending.
+        self.ar_counter = ar_counter = _AXIRequestCounter(
+            request  = axi_from.ar.valid & axi_from.ar.ready,
+            response = axi_from.r.valid  & axi_from.r.ready & axi_from.r.last,
+        )
+        ar_drained   = ar_counter.empty
+        ar_available = ~ar_counter.full
+
         ar_fsm = FSM(reset_state="IDLE")
         self.ar_fsm = ar_fsm
 
@@ -785,7 +801,7 @@ class AXIDownConverter(LiteXModule):
             If(narrow_ar_active,
                 axi_from.ar.ready.eq(0),
             ).Elif(is_ar_narrow,
-                axi_to.ar.valid.eq(axi_from.ar.valid),
+                axi_to.ar.valid.eq(axi_from.ar.valid & ar_drained),
                 axi_to.ar.addr.eq(axi_from.ar.addr),
                 axi_to.ar.len.eq(0),
                 axi_to.ar.size.eq(axi_from.ar.size),
@@ -798,14 +814,14 @@ class AXIDownConverter(LiteXModule):
                 axi_to.ar.region.eq(axi_from.ar.region),
                 axi_to.ar.dest.eq(axi_from.ar.dest),
                 axi_to.ar.user.eq(axi_from.ar.user),
-                axi_from.ar.ready.eq(axi_to.ar.ready),
-                If(axi_from.ar.valid & axi_to.ar.ready,
+                axi_from.ar.ready.eq(axi_to.ar.ready & ar_drained),
+                If(axi_from.ar.valid & axi_from.ar.ready,
                     NextValue(cap_ar_lane, axi_from.ar.addr[narrow_size_log2:wide_size_log2]),
                     NextValue(narrow_ar_active, 1),
                 ),
             ).Elif(~is_ar_slow,
                 # Fast path (see AW fast path: full-width narrow beats).
-                axi_to.ar.valid.eq(axi_from.ar.valid),
+                axi_to.ar.valid.eq(axi_from.ar.valid & ar_available),
                 axi_to.ar.addr.eq(axi_from.ar.addr),
                 axi_to.ar.addr[:wide_size_log2].eq(0),
                 axi_to.ar.len.eq(((axi_from.ar.len + 1) << log2_int(ratio)) - 1),
@@ -824,10 +840,10 @@ class AXIDownConverter(LiteXModule):
                 axi_to.ar.region.eq(axi_from.ar.region),
                 axi_to.ar.dest.eq(axi_from.ar.dest),
                 axi_to.ar.user.eq(axi_from.ar.user),
-                axi_from.ar.ready.eq(axi_to.ar.ready),
+                axi_from.ar.ready.eq(axi_to.ar.ready & ar_available),
             ).Else(
-                axi_from.ar.ready.eq(1),
-                If(axi_from.ar.valid,
+                axi_from.ar.ready.eq(ar_available),
+                If(axi_from.ar.valid & axi_from.ar.ready,
                     NextValue(cap_ar_addr,   axi_from.ar.addr),
                     NextValue(cap_ar_len,    axi_from.ar.len),
                     NextValue(cap_ar_size,   axi_from.ar.size),

--- a/test/interconnect/test_axi.py
+++ b/test/interconnect/test_axi.py
@@ -797,6 +797,12 @@ class TestAXI(unittest.TestCase):
             self.sram       = AXISRAM(mem_bytes, bus=self.axi_narrow, init=init or [0]*mem_words)
             self.errors     = 0
 
+    class _DownConvRawDUT(LiteXModule):
+        def __init__(self):
+            self.axi_wide   = AXIInterface(data_width=64, address_width=32, id_width=4)
+            self.axi_narrow = AXIInterface(data_width=32, address_width=32, id_width=4)
+            self.converter  = AXIDownConverter(self.axi_wide, self.axi_narrow)
+
     def test_axi_down_converter_narrow_single_read(self):
         # A narrow read on a wide master port must stay a single downstream access. Expanding it
         # to a full wide-word burst can be destructive with MMIO/CSR/FIFO-like slaves.
@@ -885,6 +891,153 @@ class TestAXI(unittest.TestCase):
         self.assertEqual(w_log, [(value, (1 << narrow_bytes) - 1, 1)])
         self.assertEqual(results["resp"], RESP_OKAY)
         self.assertEqual(results["mem"], value)
+
+    def test_axi_down_converter_narrow_interleave_write(self):
+        aw_log, w_log, b_count = [], [], [0]
+
+        @passive
+        def monitor(dut):
+            while True:
+                if (yield dut.axi_narrow.aw.valid) and (yield dut.axi_narrow.aw.ready):
+                    aw_log.append((yield dut.axi_narrow.aw.addr))
+                if (yield dut.axi_narrow.w.valid) and (yield dut.axi_narrow.w.ready):
+                    w_log.append(((yield dut.axi_narrow.w.data), (yield dut.axi_narrow.w.last)))
+                if (yield dut.axi_wide.b.valid) and (yield dut.axi_wide.b.ready):
+                    b_count[0] += 1
+                yield
+
+        @passive
+        def b_responder(dut):
+            narrow = dut.axi_narrow
+            while True:
+                if (yield narrow.w.valid) and (yield narrow.w.ready) and (yield narrow.w.last):
+                    yield narrow.b.valid.eq(1)
+                    yield
+                    while not (yield narrow.b.ready):
+                        yield
+                    yield narrow.b.valid.eq(0)
+                yield
+
+        def gen(dut):
+            wide, narrow = dut.axi_wide, dut.axi_narrow
+            yield narrow.aw.ready.eq(1)
+            yield narrow.w.ready.eq(0)
+            yield wide.b.ready.eq(1)
+
+            yield from axi_aw_send(wide, 0x100, size=3)
+            yield wide.w.valid.eq(1)
+            yield wide.w.data.eq(0x1111222233334444)
+            yield wide.w.strb.eq(0xff)
+            yield wide.w.last.eq(1)
+            yield
+
+            yield wide.aw.valid.eq(1)
+            yield wide.aw.addr.eq(0x200)
+            yield wide.aw.len.eq(0)
+            yield wide.aw.size.eq(2)
+            yield wide.aw.burst.eq(BURST_INCR)
+            for _ in range(4):
+                yield
+                self.assertEqual((yield wide.aw.ready), 0)
+
+            yield narrow.w.ready.eq(1)
+            while not ((yield wide.w.valid) and (yield wide.w.ready)):
+                yield
+            yield wide.w.valid.eq(0)
+            while not (yield wide.aw.ready):
+                yield
+            yield wide.aw.valid.eq(0)
+            yield from axi_w_send(wide, 0xcafebabe, last=True, strb=0xf)
+            for _ in range(4):
+                yield
+
+        dut = self._DownConvRawDUT()
+        run_simulation(dut, [gen(dut), monitor(dut), b_responder(dut)])
+
+        self.assertEqual(aw_log, [0x100, 0x200])
+        self.assertEqual(w_log, [
+            (0x33334444, 0),
+            (0x11112222, 1),
+            (0xcafebabe, 1),
+        ])
+        self.assertEqual(b_count[0], 2)
+
+    def test_axi_down_converter_narrow_interleave_read(self):
+        ar_log, r_log = [], []
+
+        @passive
+        def monitor(dut):
+            while True:
+                if (yield dut.axi_wide.ar.valid) and (yield dut.axi_wide.ar.ready):
+                    ar_log.append((yield dut.axi_wide.ar.addr))
+                if (yield dut.axi_wide.r.valid) and (yield dut.axi_wide.r.ready):
+                    r_log.append((yield dut.axi_wide.r.data))
+                yield
+
+        def send_r(axi, data, last):
+            yield axi.r.valid.eq(1)
+            yield axi.r.data.eq(data)
+            yield axi.r.last.eq(last)
+            while not (yield axi.r.ready):
+                yield
+            yield
+            yield axi.r.valid.eq(0)
+
+        def gen(dut):
+            wide, narrow = dut.axi_wide, dut.axi_narrow
+            yield narrow.ar.ready.eq(1)
+            yield wide.r.ready.eq(1)
+
+            yield from axi_ar_send(wide, 0x100, size=3)
+            yield from send_r(narrow, 0x11110000, last=0)
+
+            yield wide.ar.valid.eq(1)
+            yield wide.ar.addr.eq(0x204)
+            yield wide.ar.len.eq(0)
+            yield wide.ar.size.eq(2)
+            yield wide.ar.burst.eq(BURST_INCR)
+            for _ in range(4):
+                yield
+                self.assertEqual((yield wide.ar.ready), 0)
+
+            yield from send_r(narrow, 0x22220000, last=1)
+            while not (yield wide.ar.ready):
+                yield
+            yield wide.ar.valid.eq(0)
+            yield from send_r(narrow, 0x33330000, last=1)
+            for _ in range(4):
+                yield
+
+        dut = self._DownConvRawDUT()
+        run_simulation(dut, [gen(dut), monitor(dut)])
+
+        self.assertEqual(ar_log, [0x100, 0x204])
+        self.assertEqual(r_log, [
+            0x2222000011110000,
+            0x3333000000000000,
+        ])
+
+    def test_axi_down_converter_request_limit(self):
+        accepted = {"aw": 0, "ar": 0}
+
+        def gen(dut):
+            wide, narrow = dut.axi_wide, dut.axi_narrow
+            yield narrow.aw.ready.eq(1)
+            yield narrow.ar.ready.eq(1)
+            yield wide.aw.valid.eq(1)
+            yield wide.aw.size.eq(3)
+            yield wide.ar.valid.eq(1)
+            yield wide.ar.size.eq(3)
+            yield
+            for _ in range(300):
+                accepted["aw"] += (yield wide.aw.ready)
+                accepted["ar"] += (yield wide.ar.ready)
+                yield
+
+        dut = self._DownConvRawDUT()
+        run_simulation(dut, gen(dut))
+
+        self.assertEqual(accepted, {"aw": 255, "ar": 255})
 
     def test_axi_down_converter_wrap(self):
         # WRAP bursts must wrap inside the wide-side wrap window even after data-width reduction:


### PR DESCRIPTION
## Summary

This is a minimal alternative to https://github.com/enjoy-digital/litex/pull/2560, which correctly identified that `AXIDownConverter` can switch its shared W/R data path to the narrow single-beat bypass while an earlier full-width transaction is still in flight.

Track accepted write and read commands until their B or final R response is consumed, and only enter the narrow path when the corresponding channel is drained.

## Bounded implementation

The request counters are finite. In #2560, normal AW/AR commands remain accepted after `_AXIRequestCounter` reaches its limit, so those commands are not counted. Once the counted responses drain, a narrow command can again be accepted while an older transaction remains outstanding.

This version also backpressures all AW/AR command paths when their counter is full. This keeps every accepted transaction accounted for while leaving the normal fast path unchanged below the limit.

## Tests

- Wide write stalled before width conversion, followed by a narrow write.
- Wide read stalled halfway through merging, followed by a narrow read.
- AW/AR request-counter capacity and backpressure.
- Full `test/interconnect` suite: 232 passed, 37 subtests passed.

The three new regressions fail on current `master` and pass with this change.
