### PR TITLE
tools/litex_server: Use a unique port for JTAGUART instances

### DIFF
--- a/litex/tools/litex_server.py
+++ b/litex/tools/litex_server.py
@@ -248,7 +248,8 @@ def main():
     elif args.jtag:
         from litex.tools.litex_term import JTAGUART
         from litex.tools.remote.comm_uart import CommUART
-        jtag_uart = JTAGUART(config=args.jtag_config, chain=int(args.jtag_chain))
+        jtag_port = int(args.bind_port) + 18766  # server on 1234 -> jtag on 20000
+        jtag_uart = JTAGUART(config=args.jtag_config, chain=int(args.jtag_chain), port=jtag_port)
         jtag_uart.open()
         print("[CommUART] port: JTAG / ", end="")
         comm = CommUART(os.ttyname(jtag_uart.name), debug=args.debug, addr_width=int(args.addr_width))


### PR DESCRIPTION
Allows multiple instances of `litex_server --jtag` to be run concurrently. The OpenOCD jtagstream port is chosen by adding an offset to the server bind port, such that litex_server running on port 1234 uses jtagstream port 2000.