### PR TITLE
soc: fix CSR alignment, AXI memory IDs, reset wiring and address maps

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -945,15 +945,18 @@ class SoCBusHandler(LiteXModule):
         self.add_slave(name=name, slave=peripheral, region=region)
 
     def get_address_width(self, standard, addressing=None):
+        """Return address-signal bits for an interface spanning this bus's byte address space.
+
+        Use the result as Wishbone ``adr_width`` for word addressing, or as AXI/AXI-Lite
+        ``address_width``. The handler's own ``address_width`` is always measured in bytes.
+        """
         if addressing is None:
             addressing = "word" if standard == "wishbone" else "byte"
 
         address_shift = log2_int(self.data_width//8)
-        source_shift = address_shift if (
-            (self.standard == "wishbone") and (self.addressing == "word")) else 0
         target_shift = address_shift if (
             (standard == "wishbone") and (addressing == "word")) else 0
-        return self.address_width + source_shift - target_shift
+        return self.address_width - target_shift
 
     def do_finalize(self):
         interconnect_p2p_cls = {

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -354,7 +354,8 @@ class SoCBusHandler(LiteXModule):
             # If no Origin specified, allocate Region.
             if region.origin is None:
                 allocated = True
-                region    = self.alloc_region(name, region.size, region.cached, linker=region.linker, mode=region.mode)
+                region    = self.alloc_region(name, region.size, region.cached,
+                    linker=region.linker, mode=region.mode, decode=region.decode)
                 self.regions[name] = region
             # Else add Region.
             else:
@@ -408,7 +409,7 @@ class SoCBusHandler(LiteXModule):
                 colorer(type(region).__name__, color="red")))
             raise SoCError()
 
-    def alloc_region(self, name, size, cached=True, linker=False, mode="rw"):
+    def alloc_region(self, name, size, cached=True, linker=False, mode="rw", decode=True):
         self.logger.info("Allocating {} Region of size {}...".format(
             colorer("Cached" if cached else "IO"),
             colorer("0x{:08x}".format(size))))
@@ -422,15 +423,17 @@ class SoCBusHandler(LiteXModule):
         # Iterate on Search_Regions to find a Candidate.
         size_pow2 = 2**log2_int(size, False)
         for _, search_region in search_regions.items():
-            origin       = search_region.origin
-            search_limit = search_region.origin + search_region.size
+            # CPU IO windows can extend beyond the bus, but decoded slaves cannot.
+            origin       = max(0, search_region.origin)
+            search_limit = min(2**self.address_width, search_region.origin + search_region.size)
             while (origin + size_pow2) <= search_limit:
                 # Align Origin on Size.
                 if (origin%size_pow2):
                     origin += (size_pow2 - origin%size_pow2)
                     continue
                 # Create a Candidate.
-                candidate = SoCRegion(origin=origin, size=size, mode=mode, cached=cached, linker=linker)
+                candidate = SoCRegion(origin=origin, size=size, mode=mode,
+                    cached=cached, linker=linker, decode=decode)
                 overlap   = False
                 if cached and self.io_regions_check and self.check_region_overlap(
                     candidate, self.io_regions, check_linker=True):

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1680,7 +1680,9 @@ class SoC(LiteXModule):
         csr_bridge_name = f"{name}_bridge"
         self.check_if_exists(csr_bridge_name)
         data_width     = self.csr.data_width
-        bus_data_width = self.bus.data_width if self.bus.standard == "wishbone" else data_width
+        # CSR data can be narrower than its address stride. Keep AXI transfers aligned to
+        # that stride: a data-width converter to 8 bits would write four successive CSRs.
+        bus_data_width = self.bus.data_width if self.bus.standard == "wishbone" else self.csr.alignment
         csr_bridge = csr_bridge_cls(
             bus_bridge_cls(
                 address_width = self.bus.address_width,

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1525,10 +1525,14 @@ class SoC(LiteXModule):
             "axi-lite": axi.AXILiteInterface,
             "axi"     : axi.AXIInterface,
         }[self.bus.standard]
+        interface_kwargs = {}
+        if self.bus.standard == "axi":
+            interface_kwargs["id_width"] = self.bus.get_axi_id_width()
         ram_bus = interface_cls(
             data_width    = self.bus.data_width,
             address_width = self.bus.address_width,
-            bursting      = self.bus.bursting
+            bursting      = self.bus.bursting,
+            **interface_kwargs,
         )
         self.check_if_exists(name)
         ram = ram_cls(size, bus=ram_bus, init=contents, read_only=("w" not in mode), name=name)

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -2354,6 +2354,19 @@ class LiteXSoC(SoC):
             self.logger.error("SDRAM requires {}.".format(colorer("module", color="red")))
             raise SoCError()
 
+        # An explicit origin overrides the default SoC map, but not a CPU's fixed mapping.
+        if with_soc_interconnect:
+            from litex.soc.cores.cpu import CPUNone
+            cpu = getattr(self, "cpu", None)
+            cpu_origin = getattr(cpu, "mem_map", {}).get("main_ram", None)
+            if (origin is not None and cpu_origin is not None and
+                not isinstance(cpu, CPUNone) and origin != cpu_origin):
+                self.logger.error("SDRAM origin 0x{:x} conflicts with CPU main_ram mapping 0x{:x}.".format(
+                    origin, cpu_origin))
+                raise SoCError()
+            if origin is None:
+                origin = self.mem_map.get("main_ram", None)
+
         # Imports.
         from litedram.common import LiteDRAMNativePort
         from litedram.core import LiteDRAMCore
@@ -2409,7 +2422,7 @@ class LiteXSoC(SoC):
 
         # Add SDRAM region.
         main_ram_region = SoCRegion(
-            origin = self.mem_map.get("main_ram", origin),
+            origin = origin,
             size   = sdram_size,
             mode   = "rwx")
         self.bus.add_region("main_ram", main_ram_region)

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -1931,14 +1931,17 @@ class SoC(LiteXModule):
     def add_watchdog(self, name="watchdog0", width=32, crg_rst=None, reset_delay=None):
         from litex.soc.cores.watchdog import Watchdog
 
+        # The target can create its CRG after SoCCore.__init__. Generate the watchdog's
+        # reset request now and resolve its default destination during finalization.
+        self.check_if_exists(name)
         if crg_rst is None:
-            crg_rst = getattr(self.crg, "rst", None) if hasattr(self, "crg") else None
+            crg_rst = Signal(name=f"{name}_rst")
+            self.add_soc_reset_request(name, crg_rst)
         if reset_delay is None:
             reset_delay = self.sys_clk_freq
 
         halted = getattr(self.cpu, "o_halted", None) if hasattr(self, "cpu") else None
 
-        self.check_if_exists(name)
         watchdog = Watchdog(width=width, crg_rst=crg_rst, reset_delay=int(reset_delay), halted=halted)
         self.add_module(name=name, module=watchdog)
 

--- a/litex/soc/interconnect/axi/axi_lite_to_csr.py
+++ b/litex/soc/interconnect/axi/axi_lite_to_csr.py
@@ -31,14 +31,21 @@ class AXILite2CSR(LiteXModule):
         self.axi_lite = axi_lite
         self.csr      = bus_csr
 
-        assert axi_lite.data_width == bus_csr.data_width
+        if axi_lite.data_width != bus_csr.alignment:
+            raise ValueError("AXI-Lite data width must match CSR alignment.")
+        if bus_csr.data_width > axi_lite.data_width:
+            raise ValueError("CSR data width must not exceed AXI-Lite data width.")
 
+        csr_we = Signal()
         fsm, comb = axi_lite_to_simple(
             axi_lite   = self.axi_lite,
             port_adr   = self.csr.adr,
             port_re    = self.csr.re,
             port_dat_r = self.csr.dat_r,
             port_dat_w = self.csr.dat_w,
-            port_we    = self.csr.we)
+            port_we    = csr_we)
         self.fsm = fsm
         self.comb += comb
+        # Narrow CSRs occupy the low byte lanes of each aligned bus word. Writes selecting
+        # only padding lanes must not change the register or trigger its write side effects.
+        self.comb += self.csr.we.eq(csr_we & (axi_lite.w.strb[:(bus_csr.data_width + 7)//8] != 0))

--- a/test/interconnect/test_axi_lite.py
+++ b/test/interconnect/test_axi_lite.py
@@ -314,7 +314,7 @@ class TestAXILite(unittest.TestCase):
     def test_axilite2axi2mem_wishbone_low_latency(self):
         return self.test_axilite2axi2mem(low_latency=True)
 
-    def test_axilite2csr(self):
+    def test_axilite2csr(self, csr_width=32):
         @passive
         def csr_mem_handler(csr, mem):
             while True:
@@ -327,7 +327,7 @@ class TestAXILite(unittest.TestCase):
         class DUT(Module):
             def __init__(self):
                 self.axi_lite = AXILiteInterface(data_width=32)
-                self.csr = csr_bus.Interface(data_width=32)
+                self.csr = csr_bus.Interface(data_width=csr_width)
                 self.submodules.axilite2csr = AXILite2CSR(self.axi_lite, self.csr)
                 self.errors = 0
 
@@ -355,10 +355,20 @@ class TestAXILite(unittest.TestCase):
                 if rdata != wdata:
                     dut.errors += 1
 
+            if csr_width == 8:
+                # The upper bytes are CSR alignment padding, not adjacent registers.
+                for strb in [0, 2, 4, 8, 14]:
+                    yield from dut.axi_lite.write(4, 0xffffffff, strb=strb)
+                    rdata, resp = (yield from dut.axi_lite.read(4))
+                    self.assertEqual(rdata, write_data[1])
+
         dut = DUT()
         mem = [v for v in mem_ref]
         run_simulation(dut, [generator(dut), csr_mem_handler(dut.csr, mem)])
         self.assertEqual(dut.errors, 0)
+
+    def test_axilite2csr_dw8(self):
+        self.test_axilite2csr(csr_width=8)
 
     def test_axilite_sram(self):
         class DUT(Module):

--- a/test/soc/test_integration.py
+++ b/test/soc/test_integration.py
@@ -285,8 +285,11 @@ def test_cpu(cpu, request, tmp_path):
     variant = TESTED_CPU_VARIANTS.get(cpu, "standard")
     assert boot_test(cpu_type=cpu, cpu_variant=variant, output_dir=str(tmp_path))
 
-def test_csr_data_width_8(tmp_path):
-    assert boot_test(args="--csr-data-width=8", output_dir=str(tmp_path))
+@pytest.mark.parametrize("bus_standard", ["wishbone", "axi-lite", "axi"])
+def test_csr_data_width_8(tmp_path, bus_standard):
+    assert boot_test(
+        args=f"--csr-data-width=8 --bus-standard={bus_standard} --soc-csv={tmp_path}/csr.csv",
+        output_dir=str(tmp_path))
 
 @pytest.mark.skipif(
     os.environ.get("LITEX_QEMU_COSIM_TEST") != "1",

--- a/test/soc/test_soc.py
+++ b/test/soc/test_soc.py
@@ -565,14 +565,27 @@ class TestSoCBusHandler(unittest.TestCase):
         )
         axi_bus      = SoCBusHandler(standard="axi",      data_width=64, address_width=32)
 
-        self.assertEqual(wishbone_bus.get_address_width("wishbone"), 32)
-        self.assertEqual(wishbone_bus.get_address_width("axi-lite"), 34)
-        self.assertEqual(wishbone_bus.get_address_width("axi"),      34)
+        self.assertEqual(wishbone_bus.get_address_width("wishbone"), 30)
+        self.assertEqual(wishbone_bus.get_address_width("axi-lite"), 32)
+        self.assertEqual(wishbone_bus.get_address_width("axi"),      32)
         self.assertEqual(wishbone_byte_bus.get_address_width("wishbone"), 30)
         self.assertEqual(wishbone_byte_bus.get_address_width("wishbone", addressing="byte"), 32)
         self.assertEqual(wishbone_byte_bus.get_address_width("axi"), 32)
         self.assertEqual(axi_bus.get_address_width("axi"),           32)
         self.assertEqual(axi_bus.get_address_width("wishbone"),      29)
+
+    def test_dma_address_width_matches_bus_byte_address_space(self):
+        for standard in ["wishbone", "axi-lite", "axi"]:
+            for data_width in SoCBusHandler.supported_data_width:
+                for address_width in SoCBusHandler.supported_address_width:
+                    with self.subTest(standard=standard, data_width=data_width, address_width=address_width):
+                        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6,
+                            bus_standard=standard, bus_data_width=data_width,
+                            bus_address_width=address_width)
+                        port, bus = soc._get_video_framebuffer_dma_port()
+                        self.assertIs(bus, soc.bus)
+                        self.assertEqual(port.address_width, address_width)
+                        self.assertEqual(2**len(port.adr)*(data_width//8), 2**address_width)
 
     def test_regions_are_auto_allocated_after_existing_regions(self):
         bus = SoCBusHandler()

--- a/test/soc/test_soc.py
+++ b/test/soc/test_soc.py
@@ -416,6 +416,53 @@ class TestSoCVideoFrameBuffer(unittest.TestCase):
         self.assertNotIn("video_framebuffer", soc.bus.regions)
 
 class TestSoCResetRequests(unittest.TestCase):
+    def test_watchdog_reset_is_connected_when_crg_is_added_late(self):
+        for crg_cls in [_CRGWithReset, _CRGWithSysReset]:
+            with self.subTest(crg=crg_cls.__name__):
+                soc = SoCCore(_FakePlatform(), clk_freq=1e6, cpu_type=None,
+                    integrated_sram_size=0, with_uart=False, with_timer=False,
+                    with_ctrl=False, with_watchdog=True, watchdog_reset_delay=3)
+                soc.crg = crg_cls()
+                reset = soc._get_crg_reset_signal()
+
+                def generator():
+                    yield from soc.watchdog0._cycles.write(4)
+                    # Expiry in interrupt-only mode must not request a reset.
+                    yield from soc.watchdog0._control.write((1 << 8) | 1)
+                    for _ in range(16):
+                        yield
+                        self.assertEqual((yield reset), 0)
+                    self.assertEqual((yield soc.watchdog0.execute), 1)
+                    # Enable reset mode and wait for the configured reset delay.
+                    yield from soc.watchdog0._control.write((1 << 16) | (1 << 8) | 1)
+                    for _ in range(32):
+                        yield
+                        if (yield reset):
+                            return
+                    self.fail("Watchdog expired without resetting the late-created CRG")
+
+                run_simulation(soc, generator())
+
+    def test_watchdog_explicit_reset_target_is_preserved(self):
+        soc = SoCCore(_FakePlatform(), clk_freq=1e6, cpu_type=None,
+            integrated_sram_size=0, with_uart=False, with_timer=False, with_ctrl=False)
+        soc.crg = _CRGWithReset()
+        explicit_reset = Signal()
+        soc.add_watchdog(crg_rst=explicit_reset, reset_delay=2)
+        self.assertNotIn("watchdog0", soc.soc_reset_requests)
+
+        def generator():
+            yield from soc.watchdog0._cycles.write(2)
+            yield from soc.watchdog0._control.write((1 << 16) | (1 << 8) | 1)
+            for _ in range(32):
+                yield
+                self.assertEqual((yield soc.crg.rst), 0)
+                if (yield explicit_reset):
+                    return
+            self.fail("Explicit watchdog reset target was not asserted")
+
+        run_simulation(soc, generator())
+
     def test_soc_reset_request_registers_source(self):
         soc   = SoC(_FakePlatform(), sys_clk_freq=1e6)
         reset = Signal()

--- a/test/soc/test_soc.py
+++ b/test/soc/test_soc.py
@@ -641,6 +641,46 @@ class TestSoCBusHandler(unittest.TestCase):
 
         self.assertNotIn("too_big", bus.regions)
 
+    def test_auto_allocation_clips_io_windows_to_bus_address_space(self):
+        for address_width in [32, 64]:
+            with self.subTest(address_width=address_width):
+                limit = 2**address_width
+                bus = SoCBusHandler(address_width=address_width)
+                bus.add_region("high_io", SoCIORegion(origin=limit, size=0x10000))
+                with _assert_raises_soc_error(self):
+                    bus.add_slave("unreachable", wishbone.Interface(address_width=address_width),
+                        SoCRegion(size=0x1000, cached=False))
+                self.assertNotIn("unreachable", bus.regions)
+                self.assertNotIn("unreachable", bus.slaves)
+
+                bus = SoCBusHandler(address_width=address_width)
+                bus.add_region("io", SoCIORegion(origin=limit-0x1000, size=0x2000))
+                bus.add_region("last_page", SoCRegion(size=0x1000, cached=False))
+                self.assertEqual(bus.regions["last_page"].origin, limit-0x1000)
+                with _assert_raises_soc_error(self):
+                    bus.add_region("overflow", SoCRegion(size=0x1000, cached=False))
+                self.assertNotIn("overflow", bus.regions)
+
+    def test_auto_allocation_checks_rounded_decode_size_at_bus_limit(self):
+        bus = SoCBusHandler()
+        bus.add_region("io", SoCIORegion(origin=2**32-0x1800, size=0x3000))
+        with _assert_raises_soc_error(self):
+            bus.add_region("rounded", SoCRegion(size=0x1800, cached=False))
+        self.assertNotIn("rounded", bus.regions)
+
+    def test_auto_allocation_preserves_region_attributes(self):
+        bus = SoCBusHandler(timeout=None)
+        bus.add_master("cpu", wishbone.Interface())
+        bus.add_slave("ram", wishbone.Interface(),
+            SoCRegion(size=0x1000, mode="rx", linker=True, decode=False))
+        region = bus.regions["ram"]
+        self.assertEqual(region.mode, "rx")
+        self.assertTrue(region.linker)
+        self.assertTrue(region.cached)
+        self.assertFalse(region.decode)
+        bus.finalize()
+        self.assertIsInstance(bus._interconnect, wishbone.InterconnectPointToPoint)
+
     def test_failed_overlapping_io_region_add_does_not_mutate_io_regions(self):
         bus = SoCBusHandler()
         bus.add_region("io0", SoCIORegion(origin=0x80000000, size=0x10000))

--- a/test/soc/test_soc.py
+++ b/test/soc/test_soc.py
@@ -1455,6 +1455,31 @@ class TestSoC(unittest.TestCase):
         with _assert_raises_soc_error(self):
             soc.add_hyperram(pads=_HyperRamPads())
 
+    def test_sdram_origin_uses_explicit_value_before_default_map(self):
+        try:
+            from litedram.modules import IS42S16160
+            from litedram.phy.model import SDRAMPHYModel
+        except ImportError:
+            self.skipTest("LiteDRAM is unavailable")
+
+        for origin, expected in [(None, 0x40000000), (0x60000000, 0x60000000), (0, 0)]:
+            with self.subTest(origin=origin):
+                soc = SoCCore(_FakePlatform(), clk_freq=100e6, cpu_type=None,
+                    integrated_sram_size=0, with_uart=False, with_timer=False, with_ctrl=False)
+                module = IS42S16160(100e6, "1:1")
+                phy = SDRAMPHYModel(module, data_width=16, clk_freq=100e6)
+                soc.add_sdram(phy=phy, module=module, origin=origin,
+                    size=0x100000, l2_cache_size=0)
+                self.assertEqual(soc.bus.regions["main_ram"].origin, expected)
+
+    def test_sdram_origin_rejects_cpu_mapping_conflict_before_core_creation(self):
+        soc = LiteXSoC(_FakePlatform(), sys_clk_freq=100e6)
+        soc.cpu = SimpleNamespace(mem_map={"main_ram": 0x80000000})
+        with _assert_raises_soc_error(self):
+            soc.add_sdram(phy=object(), module=object(), origin=0x60000000)
+        self.assertFalse(hasattr(soc, "sdram"))
+        self.assertNotIn("main_ram", soc.bus.regions)
+
     def test_add_uart_keeps_soc_level_integration(self):
         soc = LiteXSoC(_FakePlatform(), sys_clk_freq=1e6)
 

--- a/test/soc/test_soc.py
+++ b/test/soc/test_soc.py
@@ -13,9 +13,11 @@ import unittest
 from contextlib import contextmanager
 from types import SimpleNamespace
 
-from migen import ClockDomain, Record, Signal
+from migen import ClockDomain, Record, Signal, passive
 from migen.sim import run_simulation
 
+from litex.gen import LiteXModule
+from litex.soc.interconnect.csr import CSRStorage
 from litex.soc.cores.dma import WishboneDMAReader
 from litex.soc.cores.hyperbus import HyperRAM
 from litex.soc.cores.video import video_data_layout, video_framebuffer_size
@@ -1377,6 +1379,41 @@ class TestSoC(unittest.TestCase):
         self.assertTrue(soc.bus.regions["csr"].decode)
         self.assertIn("csr", soc.bus.slaves)
         self.assertIn("csr", soc.csr.masters)
+
+    def test_csr_accesses_keep_alignment_across_bus_standards(self):
+        for standard in ["wishbone", "axi-lite", "axi"]:
+            for csr_width in [8, 32]:
+                for bus_width in [32, 64]:
+                    with self.subTest(standard=standard, csr_width=csr_width, bus_width=bus_width):
+                        soc = SoC(_FakePlatform(), sys_clk_freq=1e6,
+                            bus_standard=standard, bus_data_width=bus_width,
+                            csr_data_width=csr_width)
+                        soc.mem_map["csr"] = 0x10000
+                        soc.bus.add_region("io", SoCIORegion(origin=0x10000, size=0x10000))
+                        soc.regs = LiteXModule()
+                        regs = []
+                        for i in range(8):
+                            reg = CSRStorage(csr_width, reset=0x10+i, name=f"r{i}")
+                            setattr(soc.regs, f"r{i}", reg)
+                            regs.append(reg)
+                        soc.csr.add("regs", 0)
+                        master = wishbone.Interface()
+                        soc.bus.add_master("probe", master)
+
+                        def generator():
+                            yield from master.write((0x10000 + 4)//4, 0xab)
+                            for i, reg in enumerate(regs):
+                                self.assertEqual((yield reg.storage), 0xab if i == 1 else 0x10+i)
+                                self.assertEqual((yield from master.read((0x10000 + 4*i)//4)),
+                                    0xab if i == 1 else 0x10+i)
+
+                        @passive
+                        def timeout():
+                            for _ in range(1000):
+                                yield
+                            self.fail("CSR transaction timed out")
+
+                        run_simulation(soc, [generator(), timeout()])
 
     def test_finalize_bus_requires_csr_origin(self):
         soc = SoC(_FakePlatform(), sys_clk_freq=1e6)

--- a/test/soc/test_soc.py
+++ b/test/soc/test_soc.py
@@ -1518,6 +1518,49 @@ class TestSoC(unittest.TestCase):
         with _assert_raises_soc_error(self):
             soc.init_ram("missing", contents=[0])
 
+    def test_integrated_axi_memories_preserve_master_ids(self):
+        from test.interconnect.test_axi import axi_ar_send, axi_aw_send, axi_w_send
+
+        soc = SoC(_FakePlatform(), sys_clk_freq=1e6, bus_standard="axi")
+        soc.mem_map["csr"] = 0x10000
+        soc.bus.add_region("io", SoCIORegion(origin=0x10000, size=0x10000))
+        master = axi.AXIInterface(id_width=4)
+        soc.bus.add_master("cpu", master)
+        soc.add_ram("ram", origin=0x1000, size=0x1000)
+        soc.add_rom("rom", origin=0x2000, size=0x1000, contents=[0x12345678])
+        self.assertEqual(soc.ram.bus.id_width, 4)
+        self.assertEqual(soc.rom.bus.id_width, 4)
+
+        def generator():
+            yield from axi_aw_send(master, 0x1000, id=0xa)
+            yield from axi_w_send(master, 0xabcdef01, last=True)
+            while not (yield master.b.valid):
+                yield
+            self.assertEqual((yield master.b.id), 0xa)
+            self.assertEqual((yield master.b.resp), axi.RESP_OKAY)
+            yield master.b.ready.eq(1)
+            yield
+            yield master.b.ready.eq(0)
+            for addr, data in [(0x1000, 0xabcdef01), (0x2000, 0x12345678)]:
+                yield from axi_ar_send(master, addr, id=0xd)
+                while not (yield master.r.valid):
+                    yield
+                self.assertEqual((yield master.r.id), 0xd)
+                self.assertEqual((yield master.r.data), data)
+                self.assertEqual((yield master.r.resp), axi.RESP_OKAY)
+                self.assertEqual((yield master.r.last), 1)
+                yield master.r.ready.eq(1)
+                yield
+                yield master.r.ready.eq(0)
+
+        @passive
+        def timeout():
+            for _ in range(300):
+                yield
+            self.fail("AXI memory transaction timed out")
+
+        run_simulation(soc, [generator(), timeout()])
+
     def test_bios_requirements_check_required_csr_and_regions(self):
         soc = SoC(_FakePlatform(), sys_clk_freq=1e6)
 


### PR DESCRIPTION
## Summary

This seven-commit series fixes SoC integration corner cases and adds transaction-level and full-BIOS regressions. It is based directly on master and independent of the BIOS and CPU-performance series.

- Preserve CSR alignment when an 8-bit CSR payload is accessed through AXI/AXI-Lite, including padding-byte strobes.
- Connect watchdog reset after target CRG construction while preserving explicit reset targets.
- Size integrated AXI ROM/RAM IDs for registered masters and check complete read/write responses.
- Bound automatic region allocation to the byte-addressed bus space, preserving decode-disabled regions.
- Derive interface address bits from the byte-address space, including DMA interfaces.
- Honor explicit SDRAM origins while rejecting conflicts with real CPU-fixed memory maps.
- Boot an 8-bit-CSR BIOS over Wishbone, AXI-Lite and AXI in LiteX Sim.

## Validation

In an independent worktree at this branch tip:

```sh
python3 -m pytest -q test/soc/test_soc.py test/soc/test_builder.py \
    test/soc/test_export.py test/cores/test_watchdog.py \
    test/interconnect/test_axi_lite.py test/interconnect/test_axi.py \
    test/interconnect/test_dma.py
```

**295 passed, 121 subtests passed.**

`test/soc/test_integration.py::test_csr_data_width_8`: **3 passed**, including fresh Verilator builds and BIOS boots.
