### PR TITLE
wishbone/cache: add low-cost read fast paths and LiteX Sim benchmarks

### DIFF
--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -2329,6 +2329,7 @@ class LiteXSoC(SoC):
         l2_cache_min_data_width = 128,
         l2_cache_reverse        = False,
         l2_cache_full_memory_we = True,
+        l2_cache_bursting       = False,
         **kwargs):
 
         # Checks.
@@ -2503,10 +2504,11 @@ class LiteXSoC(SoC):
                 l2_cache_size = 2**int(math.log2(l2_cache_size))                  # Round to nearest power of 2
                 l2_cache_data_width = max(port.data_width, l2_cache_min_data_width)
                 l2_cache = wishbone.Cache(
-                    cachesize = l2_cache_size//4,
-                    master    = wb_sdram,
-                    slave     = wishbone.Interface(data_width=l2_cache_data_width, address_width=32, addressing="word"),
-                    reverse   = l2_cache_reverse)
+                    cachesize     = l2_cache_size//4,
+                    master        = wb_sdram,
+                    slave         = wishbone.Interface(data_width=l2_cache_data_width, address_width=32, addressing="word"),
+                    reverse       = l2_cache_reverse,
+                    with_bursting = l2_cache_bursting)
                 if l2_cache_full_memory_we:
                     l2_cache = FullMemoryWE()(l2_cache)
                 self.l2_cache = l2_cache

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -2330,6 +2330,7 @@ class LiteXSoC(SoC):
         l2_cache_reverse        = False,
         l2_cache_full_memory_we = True,
         l2_cache_bursting       = False,
+        l2_cache_refill_bypass  = False,
         **kwargs):
 
         # Checks.
@@ -2504,11 +2505,12 @@ class LiteXSoC(SoC):
                 l2_cache_size = 2**int(math.log2(l2_cache_size))                  # Round to nearest power of 2
                 l2_cache_data_width = max(port.data_width, l2_cache_min_data_width)
                 l2_cache = wishbone.Cache(
-                    cachesize     = l2_cache_size//4,
-                    master        = wb_sdram,
-                    slave         = wishbone.Interface(data_width=l2_cache_data_width, address_width=32, addressing="word"),
-                    reverse       = l2_cache_reverse,
-                    with_bursting = l2_cache_bursting)
+                    cachesize          = l2_cache_size//4,
+                    master             = wb_sdram,
+                    slave              = wishbone.Interface(data_width=l2_cache_data_width, address_width=32, addressing="word"),
+                    reverse            = l2_cache_reverse,
+                    with_bursting      = l2_cache_bursting,
+                    with_refill_bypass = l2_cache_refill_bypass)
                 if l2_cache_full_memory_we:
                     l2_cache = FullMemoryWE()(l2_cache)
                 self.l2_cache = l2_cache

--- a/litex/soc/interconnect/wishbone.py
+++ b/litex/soc/interconnect/wishbone.py
@@ -977,6 +977,22 @@ class Cache(LiteXModule):
             adr_offset_r = Signal(offsetbits, reset_less=True)
             self.sync += adr_offset_r.eq(adr_offset)
 
+        read_offset = adr_offset_r
+        if bursting:
+            # Share the cache-data lane mux between normal and burst hits.
+            # Switching a small lane index costs less than duplicating the
+            # wide-word mux and then selecting between two complete CPU words.
+            read_offset = Signal(offsetbits)
+            self.comb += read_offset.eq(adr_offset_r)
+
+        read_data = data_port.dat_r
+        if with_refill_bypass and dw_to >= dw_from:
+            # Both sources use the same lane selection. Selecting the source
+            # before the lane mux avoids two independent wide-word selectors.
+            read_from_refill = Signal()
+            read_data = Signal.like(data_port.dat_r)
+            self.comb += read_data.eq(Mux(read_from_refill, slave.dat_r, data_port.dat_r))
+
         self.comb += [
             data_port.adr.eq(adr_line),
             If(write_from_slave,
@@ -990,7 +1006,7 @@ class Cache(LiteXModule):
             ),
             chooser(data_port.dat_r, word, slave.dat_w),
             slave.sel.eq(2**(dw_to//8)-1),
-            chooser(data_port.dat_r, adr_offset_r, master.dat_r, reverse=reverse)
+            chooser(read_data, read_offset, master.dat_r, reverse=reverse)
         ]
 
 
@@ -1053,7 +1069,7 @@ class Cache(LiteXModule):
             # Writes still need TEST_HIT to apply byte enables and mark dirty.
             refill_next = [If(master.cyc & master.stb & ~master.we,
                 master.ack.eq(1),
-                chooser(slave.dat_r, adr_offset, master.dat_r, reverse=reverse),
+                read_from_refill.eq(1),
                 *hit_next,
             ).Else(
                 NextState("TEST_HIT")
@@ -1086,6 +1102,9 @@ class Cache(LiteXModule):
 
         if bursting:
             fsm.act("BURST",
+                # Read data is only consumed with ACK, so lane selection need
+                # not depend on the tag/address/enable checks below.
+                read_offset.eq(adr_offset),
                 If(~master.cyc | ~master.stb,
                     NextState("IDLE")
                 ).Elif(master.we | (adr_line != adr_line_r) | (tag_do.tag != adr_tag),
@@ -1094,7 +1113,6 @@ class Cache(LiteXModule):
                     NextState("TEST_HIT")
                 ).Else(
                     master.ack.eq(1),
-                    chooser(data_port.dat_r, adr_offset, master.dat_r, reverse=reverse),
                     If(~read_burst, NextState("IDLE"))
                 )
             )

--- a/litex/soc/interconnect/wishbone.py
+++ b/litex/soc/interconnect/wishbone.py
@@ -910,8 +910,11 @@ class Cache(LiteXModule):
     words) is the size of the data store and must be a power of 2.
     With with_bursting, read bursts can acknowledge consecutive lanes of a wider slave word on
     consecutive cycles. Equal/narrower slave widths retain the normal hit path.
+    With with_refill_bypass, read misses can acknowledge directly from an equal/wider slave's
+    refill response; this adds a combinational path from slave data/ack to the master.
     """
-    def __init__(self, cachesize, master, slave, reverse=True, with_bursting=False):
+    def __init__(self, cachesize, master, slave, reverse=True,
+        with_bursting=False, with_refill_bypass=False):
         self.master = master
         self.slave  = slave
 
@@ -1043,6 +1046,18 @@ class Cache(LiteXModule):
             ).Else(
                 NextState("IDLE")
             )]
+        refill_next = [NextState("TEST_HIT")]
+        if with_refill_bypass and dw_to >= dw_from:
+            # The whole cache line arrives in this beat. Return the requested
+            # lane while filling RAM, avoiding the subsequent TEST_HIT cycle.
+            # Writes still need TEST_HIT to apply byte enables and mark dirty.
+            refill_next = [If(master.cyc & master.stb & ~master.we,
+                master.ack.eq(1),
+                chooser(slave.dat_r, adr_offset, master.dat_r, reverse=reverse),
+                *hit_next,
+            ).Else(
+                NextState("TEST_HIT")
+            )]
         fsm.act("IDLE",
             If(master.cyc & master.stb,
                 NextState("TEST_HIT")
@@ -1106,7 +1121,7 @@ class Cache(LiteXModule):
                 write_from_slave.eq(1),
                 word_inc.eq(1),
                 If(word_is_last(word),
-                    NextState("TEST_HIT"),
+                    *refill_next,
                 ).Else(
                     NextState("REFILL")
                 )

--- a/litex/soc/interconnect/wishbone.py
+++ b/litex/soc/interconnect/wishbone.py
@@ -908,8 +908,10 @@ class Cache(LiteXModule):
 
     This module is a write-back wishbone cache that can be used as a L2 cache. Cachesize (in 32-bit
     words) is the size of the data store and must be a power of 2.
+    With with_bursting, read bursts can acknowledge consecutive lanes of a wider slave word on
+    consecutive cycles. Equal/narrower slave widths retain the normal hit path.
     """
-    def __init__(self, cachesize, master, slave, reverse=True):
+    def __init__(self, cachesize, master, slave, reverse=True, with_bursting=False):
         self.master = master
         self.slave  = slave
 
@@ -948,6 +950,16 @@ class Cache(LiteXModule):
         wordbits                      = log2_int(max(dw_from//dw_to, 1))
         adr_offset, adr_line, adr_tag = split(master.adr, offsetbits, linebits, tagbits)
         word                          = Signal(wordbits) if wordbits else None
+
+        # A wide data-memory word already contains several CPU words. During a
+        # read burst, select the live lane without another synchronous RAM read.
+        # Check the registered RAM index as well as the tag: an address change
+        # must never acknowledge data left over from the previous cache line.
+        bursting = with_bursting and offsetbits != 0
+        read_burst = (master.cti == CTI_BURST_INCREMENTING) | (master.cti == CTI_BURST_CONSTANT)
+        if bursting:
+            adr_line_r = Signal.like(adr_line)
+            self.sync += adr_line_r.eq(adr_line)
 
         # Data Memory.
         # ------------
@@ -1024,6 +1036,13 @@ class Cache(LiteXModule):
         # FSM.
         # ----
         self.fsm = fsm = FSM(reset_state="IDLE")
+        hit_next = [NextState("IDLE")]
+        if bursting:
+            hit_next = [If(~master.we & read_burst,
+                NextState("BURST")
+            ).Else(
+                NextState("IDLE")
+            )]
         fsm.act("IDLE",
             If(master.cyc & master.stb,
                 NextState("TEST_HIT")
@@ -1037,7 +1056,7 @@ class Cache(LiteXModule):
                     tag_di.dirty.eq(1),
                     tag_port.we.eq(1)
                 ),
-                NextState("IDLE")
+                *hit_next,
             ).Else(
                 If(tag_do.dirty,
                     NextState("EVICT")
@@ -1049,6 +1068,21 @@ class Cache(LiteXModule):
                 )
             )
         )
+
+        if bursting:
+            fsm.act("BURST",
+                If(~master.cyc | ~master.stb,
+                    NextState("IDLE")
+                ).Elif(master.we | (adr_line != adr_line_r) | (tag_do.tag != adr_tag),
+                    # Let both synchronous memories catch up before testing the
+                    # next line, or using the normal byte-write/dirty-tag path.
+                    NextState("TEST_HIT")
+                ).Else(
+                    master.ack.eq(1),
+                    chooser(data_port.dat_r, adr_offset, master.dat_r, reverse=reverse),
+                    If(~read_burst, NextState("IDLE"))
+                )
+            )
 
         fsm.act("EVICT",
             slave.stb.eq(1),

--- a/litex/soc/software/bench/Makefile
+++ b/litex/soc/software/bench/Makefile
@@ -1,0 +1,26 @@
+include ../include/generated/variables.mak
+include $(SOC_DIRECTORY)/software/common.mak
+
+OBJECTS = crt0.o main.o
+CFLAGS += -O2
+VPATH = $(BIOS_DIRECTORY):$(CPU_DIRECTORY)
+LSCRIPT = $(SOC_DIRECTORY)/software/bios/linker.ld
+
+all: bios.bin
+
+bios.elf: $(OBJECTS) $(LSCRIPT)
+	$(CC) $(LDFLAGS) -T $(LSCRIPT) -N -o $@ $(OBJECTS) \
+		$(PACKAGES:%=-L../%) -Wl,--start-group $(LIBS:lib%=-l%) -Wl,--end-group \
+		-Wl,--gc-sections -Wl,-Map,$@.map
+
+bios.bin: bios.elf
+	$(OBJCOPY) -O binary $< $@
+
+%.o: %.c
+	$(compile)
+
+%.o: %.S
+	$(assemble)
+
+-include $(OBJECTS:.o=.d)
+.PHONY: all

--- a/litex/soc/software/bench/README.md
+++ b/litex/soc/software/bench/README.md
@@ -26,6 +26,12 @@ with LiteX Sim's SDR SDRAM model and an 8 KiB L2. Use `--help` for CPU variant,
 bus, decoder-register and L2 configuration options. These are experiments:
 a wider bus or a larger CPU variant is not necessarily faster.
 
+`--min-l2-data-width` changes the minimum L2 refill width in bits without
+changing the CPU bus width. For example, `--with-sdram --min-l2-data-width=256`
+tests 32-byte cache lines with this SDR model. The same option is available in
+`litex_sim`; it defaults to the existing 128-bit width. Larger lines can help
+sequential accesses but fetch unused data on sparse accesses.
+
 ## Measurement contract
 
 - Firmware is compiled at `-O2`, executes from ROM and keeps its stack in SRAM.

--- a/litex/soc/software/bench/README.md
+++ b/litex/soc/software/bench/README.md
@@ -36,6 +36,12 @@ tests 32-byte cache lines with this SDR model. The same option is available in
 `litex_sim`; it defaults to the existing 128-bit width. Larger lines can help
 sequential accesses but fetch unused data on sparse accesses.
 
+`--l2-bursting` enables an opt-in read-burst fast path inside the existing L2
+cache. Consecutive hits within a wide cache line select the next CPU word
+without an idle cycle; line changes and writes use the normal cache path.
+This is separate from `--bus-bursting`, which enables burst support in integrated
+RAM. Keep results in the external output directory, not in the source tree.
+
 ## Measurement contract
 
 - Firmware is compiled at `-O2`, executes from ROM and keeps its stack in SRAM.

--- a/litex/soc/software/bench/README.md
+++ b/litex/soc/software/bench/README.md
@@ -1,0 +1,56 @@
+# CPU-cycle benchmarks in LiteX Sim
+
+This bare-metal microbenchmark uses `litex.tools.litex_sim.SimSoC` and its
+Verilator backend. It measures **simulated system-clock cycles**, not host
+simulation speed. The CPU and bus share the system clock.
+
+Run from a LiteX checkout with the usual LiteX Sim dependencies installed
+(including LiteEth, LiteDRAM, Verilator, a RISC-V GCC toolchain and the
+VexRiscv/compiler-rt/picolibc pythondata packages):
+
+```sh
+python3 -m litex.soc.software.bench.sim --output-dir=/tmp/cpu-baseline
+python3 -m litex.soc.software.bench.sim --output-dir=/tmp/cpu-burst --bus-bursting
+python3 -m litex.soc.software.bench.sim --output-dir=/tmp/cpu-sdram --with-sdram
+```
+
+Use a separate output directory per configuration. Each run builds its own
+firmware and simulator, checks the results, and saves `benchmark.json` with all
+three samples and their medians. `benchmark.log` retains serial output;
+`compile.log` retains simulator compilation output. `--timeout` bounds the
+simulation, not the build. `--jobs` controls the Verilator build parallelism.
+
+The default is VexRiscv `standard`, a shared 32-bit Wishbone bus, 64 KiB ROM,
+32 KiB SRAM and 256 KiB integrated main RAM. `--with-sdram` replaces main RAM
+with LiteX Sim's SDR SDRAM model and an 8 KiB L2. Use `--help` for CPU variant,
+bus, decoder-register and L2 configuration options. These are experiments:
+a wider bus or a larger CPU variant is not necessarily faster.
+
+## Measurement contract
+
+- Firmware is compiled at `-O2`, executes from ROM and keeps its stack in SRAM.
+  The last 64 KiB of main RAM holds the test buffer, separate from L2 eviction
+  traffic. Interrupts are disabled; SDRAM initialization is outside measurements.
+- A latched 32-bit hardware counter advances once per system-clock cycle.
+  This works even when a CPU variant does not expose a readable `mcycle` CSR.
+  Fences order timed memory operations. Counts include sampling overhead;
+  `overhead_0` measures a back-to-back sample for each configuration. Individual
+  measurements must finish within one counter wrap.
+- `compute` performs 32,768 dependent integer multiply/add iterations.
+- `write`, `read_cold` and `read_repeat` traverse 1 KiB and 64 KiB buffers using
+  volatile 32-bit accesses, unrolled eight times. The first read follows cache
+  eviction; the repeat immediately follows that read. The larger working set
+  need not fit L1, so **repeat does not imply an L1 hit**.
+- `chase` performs 8,192 dependent loads through a verified pointer ring with
+  one node per 64-byte block. Each run begins after cache eviction and includes
+  both initial misses and subsequent revisits.
+- Checksums, sample counts, completion and positive cycle counts are mandatory.
+  Failed or incomplete runs do not produce a new result file.
+
+These are compute and data-memory microbenchmarks, not CoreMark, an instruction
+cache stress test, an OS workload or proof of maximum application performance.
+Writes measure CPU-visible completion, not forced L2 writeback to SDRAM.
+Simulation does not establish achievable FPGA clock frequency, timing closure,
+resource cost or power. LiteX Sim uses a 1 MHz system clock but SDRAM timing
+parameters derived at 100 MHz; compare cycles under the same model rather than
+interpreting its printed bandwidth as board performance.

--- a/litex/soc/software/bench/README.md
+++ b/litex/soc/software/bench/README.md
@@ -42,6 +42,13 @@ without an idle cycle; line changes and writes use the normal cache path.
 This is separate from `--bus-bursting`, which enables burst support in integrated
 RAM. Keep results in the external output directory, not in the source tree.
 
+`--l2-refill-bypass` forwards the requested read lane directly from an
+equal/wider refill response while updating cache RAM. It avoids the extra
+hit-test cycle on read misses; write allocation still follows the normal path.
+It can be combined with `--l2-bursting`. Both options leave cache capacity
+unchanged and are disabled by default. Refill bypass lengthens the combinational
+return path, so a cycle improvement in simulation also needs FPGA timing checks.
+
 ## Measurement contract
 
 - Firmware is compiled at `-O2`, executes from ROM and keeps its stack in SRAM.

--- a/litex/soc/software/bench/README.md
+++ b/litex/soc/software/bench/README.md
@@ -14,11 +14,15 @@ python3 -m litex.soc.software.bench.sim --output-dir=/tmp/cpu-burst --bus-bursti
 python3 -m litex.soc.software.bench.sim --output-dir=/tmp/cpu-sdram --with-sdram
 ```
 
-Use a separate output directory per configuration. Each run builds its own
+Use a **new** output directory per run; existing directories are rejected to
+avoid stale binaries or results. Each run builds its own
 firmware and simulator, checks the results, and saves `benchmark.json` with all
 three samples and their medians. `benchmark.log` retains serial output;
 `compile.log` retains simulator compilation output. `--timeout` bounds the
 simulation, not the build. `--jobs` controls the Verilator build parallelism.
+JSON build metadata records the compiler, Verilator, LiteX revision, CPU flags,
+clock frequency, firmware hashes and RTL hashes. The revision alone does not
+describe uncommitted source edits; compare the hashes as well.
 
 The default is VexRiscv `standard`, a shared 32-bit Wishbone bus, 64 KiB ROM,
 32 KiB SRAM and 256 KiB integrated main RAM. `--with-sdram` replaces main RAM

--- a/litex/soc/software/bench/__init__.py
+++ b/litex/soc/software/bench/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: BSD-2-Clause

--- a/litex/soc/software/bench/main.c
+++ b/litex/soc/software/bench/main.c
@@ -1,0 +1,144 @@
+/* CPU/memory microbenchmarks for LiteX Sim. SPDX-License-Identifier: BSD-2-Clause */
+#include <stdint.h>
+#include <stdio.h>
+#include <irq.h>
+#include <system.h>
+#include <generated/csr.h>
+#include <generated/mem.h>
+#include <libbase/uart.h>
+#ifdef CSR_SDRAM_BASE
+#include <liblitedram/sdram.h>
+#endif
+
+#define WORDS (64*1024/sizeof(uint32_t))
+#define ROUNDS 3
+/* Keep the test data outside flush_l2_cache()'s eviction buffer at the start
+   of main RAM, including when testing a larger L2. */
+#if MAIN_RAM_SIZE < 128*1024
+#error "The benchmark requires at least 128 KiB of main RAM"
+#endif
+#if defined(CONFIG_L2_SIZE) && 2*CONFIG_L2_SIZE > MAIN_RAM_SIZE - 64*1024
+#error "The L2 eviction buffer overlaps the benchmark data"
+#endif
+static volatile uint32_t * const buffer =
+	(volatile uint32_t *)(MAIN_RAM_BASE + MAIN_RAM_SIZE - 64*1024);
+static volatile uint32_t result;
+
+static inline uint32_t cycles(void)
+{
+	/* Some VexRiscv variants do not expose mcycle. Use the same system-clock
+	   counter for every configuration and report the sampling overhead. */
+	__asm__ volatile("fence iorw, iorw" ::: "memory");
+	bench_latch_write(1);
+	return bench_cycles_read();
+}
+
+static void report(const char *name, unsigned int bytes, unsigned int iterations,
+	uint32_t elapsed, uint32_t checksum)
+{
+	printf("BENCH,%s,%u,%u,%u,%08x\n", name, bytes, iterations,
+		(unsigned int)elapsed, (unsigned int)checksum);
+}
+
+static void sequential(unsigned int words)
+{
+	uint32_t start, elapsed, sum;
+
+	flush_cpu_dcache();
+	flush_l2_cache();
+	start = cycles();
+	for (unsigned int i = 0; i < words; i += 8) {
+		buffer[i+0] = 0x12345678; buffer[i+1] = 0x12345678;
+		buffer[i+2] = 0x12345678; buffer[i+3] = 0x12345678;
+		buffer[i+4] = 0x12345678; buffer[i+5] = 0x12345678;
+		buffer[i+6] = 0x12345678; buffer[i+7] = 0x12345678;
+	}
+	elapsed = cycles() - start;
+	report("write", words*4, words, elapsed, 0);
+	flush_cpu_dcache();
+	flush_l2_cache();
+	for (unsigned int pass = 0; pass < 2; pass++) {
+		sum = 0;
+		start = cycles();
+		for (unsigned int i = 0; i < words; i += 8) {
+			sum += buffer[i+0]; sum += buffer[i+1];
+			sum += buffer[i+2]; sum += buffer[i+3];
+			sum += buffer[i+4]; sum += buffer[i+5];
+			sum += buffer[i+6]; sum += buffer[i+7];
+		}
+		elapsed = cycles() - start;
+		if (sum != (uint32_t)(words*0x12345678u)) {
+			printf("BENCH_ERROR,read_checksum\n");
+			return;
+		}
+		report(pass ? "read_repeat" : "read_cold", words*4, words, elapsed, sum);
+	}
+}
+
+static void chase(unsigned int words)
+{
+	unsigned int nodes = words/16;
+	uint32_t start, elapsed, index = 0;
+
+	/* One dependent load per 64-byte node; odd stride visits every node. */
+	for (unsigned int i = 0; i < nodes; i++)
+		buffer[i*16] = ((i+17) & (nodes-1))*16;
+	for (unsigned int i = 0; i < nodes; i++) {
+		if (buffer[i*16] != ((i+17) & (nodes-1))*16) {
+			printf("BENCH_ERROR,chase_setup\n");
+			return;
+		}
+	}
+	flush_cpu_dcache();
+	flush_l2_cache();
+	start = cycles();
+	for (unsigned int i = 0; i < 8192; i++)
+		index = buffer[index];
+	elapsed = cycles() - start;
+	result = index;
+	if (index != 0)
+		printf("BENCH_ERROR,chase_checksum\n");
+	report("chase", words*4, 8192, elapsed, index);
+}
+
+int main(void)
+{
+	irq_setie(0);
+	irq_setmask(0);
+	uart_init();
+#ifdef CSR_SDRAM_BASE
+	if (!sdram_init()) {
+		printf("BENCH_ERROR,sdram_init\n");
+		goto done;
+	}
+#endif
+	printf("BENCH_BEGIN\n");
+	for (unsigned int round = 0; round < ROUNDS; round++) {
+		uint32_t value = 1;
+		uint32_t start = cycles();
+		uint32_t elapsed = cycles() - start;
+		report("overhead", 0, 0, elapsed, 0);
+		start = cycles();
+		for (unsigned int i = 0; i < 32768; i++) {
+			__asm__ volatile("" : "+r"(value));
+			value = value*1664525u + 1013904223u;
+		}
+		elapsed = cycles() - start;
+		result = value;
+		if (value != 0x1c348001)
+			printf("BENCH_ERROR,compute_checksum\n");
+		report("compute", 0, 32768, elapsed, value);
+		sequential(256);
+		sequential(WORDS);
+		chase(256);
+		chase(WORDS);
+	}
+	printf("BENCH_DONE\n");
+#ifdef CSR_SDRAM_BASE
+done:
+#endif
+	uart_sync();
+	bench_finish_write(1);
+	while (1);
+	return 0;
+}

--- a/litex/soc/software/bench/sim.py
+++ b/litex/soc/software/bench/sim.py
@@ -133,6 +133,7 @@ def main():
     parser.add_argument("--no-interconnect-register", action="store_true")
     parser.add_argument("--with-sdram", action="store_true")
     parser.add_argument("--l2-size", default=8192, type=cache_size)
+    parser.add_argument("--l2-bursting", action="store_true")
     parser.add_argument("--min-l2-data-width", default=128, type=int,
         choices=[32, 64, 128, 256, 512, 1024])
     parser.add_argument("--jobs", default=4, type=positive_int)
@@ -149,6 +150,7 @@ def main():
         integrated_rom_size=0x10000, integrated_sram_size=0x8000,
         integrated_main_ram_size=0 if args.with_sdram else 0x40000,
         with_sdram=args.with_sdram, l2_size=args.l2_size, min_l2_data_width=args.min_l2_data_width,
+        l2_bursting=args.l2_bursting,
         bus_standard=args.bus_standard, bus_data_width=args.bus_data_width,
         bus_interconnect=args.bus_interconnect, bus_bursting=args.bus_bursting,
         bus_low_latency=args.bus_low_latency)

--- a/litex/soc/software/bench/sim.py
+++ b/litex/soc/software/bench/sim.py
@@ -134,6 +134,7 @@ def main():
     parser.add_argument("--with-sdram", action="store_true")
     parser.add_argument("--l2-size", default=8192, type=cache_size)
     parser.add_argument("--l2-bursting", action="store_true")
+    parser.add_argument("--l2-refill-bypass", action="store_true")
     parser.add_argument("--min-l2-data-width", default=128, type=int,
         choices=[32, 64, 128, 256, 512, 1024])
     parser.add_argument("--jobs", default=4, type=positive_int)
@@ -151,6 +152,7 @@ def main():
         integrated_main_ram_size=0 if args.with_sdram else 0x40000,
         with_sdram=args.with_sdram, l2_size=args.l2_size, min_l2_data_width=args.min_l2_data_width,
         l2_bursting=args.l2_bursting,
+        l2_refill_bypass=args.l2_refill_bypass,
         bus_standard=args.bus_standard, bus_data_width=args.bus_data_width,
         bus_interconnect=args.bus_interconnect, bus_bursting=args.bus_bursting,
         bus_low_latency=args.bus_low_latency)

--- a/litex/soc/software/bench/sim.py
+++ b/litex/soc/software/bench/sim.py
@@ -12,15 +12,16 @@ import subprocess
 
 from migen import Finish, If, Signal
 from litex.gen import LiteXModule
+from litex.build.tools import get_litex_git_revision
 from litex.build.sim.config import SimConfig
 from litex.soc.integration.builder import Builder
 from litex.soc.interconnect.csr import CSRStorage, CSRStatus
-from litex.tools.litex_sim import SimSoC
 
 
 def parse_results(output):
     """Reject incomplete, failed or unmeasured runs before comparing their cycle counts."""
-    if "BENCH_ERROR" in output or "BENCH_DONE" not in output:
+    lines = output.splitlines()
+    if "BENCH_ERROR" in output or lines.count("BENCH_BEGIN") != 1 or lines.count("BENCH_DONE") != 1:
         raise ValueError("Benchmark did not complete successfully")
     expected = {"overhead_0": (0, 0), "compute_0": (32768, 0x1c348001)}
     for size in [1024, 65536]:
@@ -29,14 +30,17 @@ def parse_results(output):
             expected[f"{name}_{size}"] = (size//4, ((size//4)*0x12345678) & 0xffffffff)
         expected[f"chase_{size}"] = (8192, 0)
     samples = {}
-    for line in output.splitlines():
+    begin, end = lines.index("BENCH_BEGIN"), lines.index("BENCH_DONE")
+    if begin >= end or any(line.startswith("BENCH,") for line in lines[:begin] + lines[end+1:]):
+        raise ValueError("Benchmark samples outside the measured run")
+    for line in lines[begin+1:end]:
         if not line.startswith("BENCH,"):
             continue
         _, name, size, iterations, cycles, checksum = line.split(",")
         key = f"{name}_{size}"
         if key not in expected or (int(iterations), int(checksum, 16)) != expected[key]:
             raise ValueError(f"Unexpected benchmark result: {line}")
-        if int(cycles) <= 0:
+        if not 0 < int(cycles) <= 0xffffffff:
             raise ValueError("Benchmark cycle counter did not advance")
         samples.setdefault(key, []).append({
             "cycles": int(cycles), "iterations": int(iterations), "checksum": checksum})
@@ -56,7 +60,68 @@ class BenchmarkControl(LiteXModule):
         self.sync += If(self.finish.storage, Finish())
 
 
+def positive_int(value):
+    value = int(value, 0)
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return value
+
+
+def cache_size(value):
+    value = int(value, 0)
+    if value != 0 and (value < 8 or value & (value - 1)):
+        raise argparse.ArgumentTypeError("must be zero or a power of two of at least 8 bytes")
+    return value
+
+
+def prepare_output(output):
+    # Reusing a build can retain objects compiled with another CPU's flags or
+    # leave an old successful benchmark.json behind after a failed attempt.
+    output.mkdir(parents=True, exist_ok=False)
+
+
+def run_benchmark(output, timeout):
+    try:
+        completed = subprocess.run([str(output / "gateware/obj_dir/Vsim")],
+            cwd=output / "gateware", input="", stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired as error:
+        (output / "benchmark.log").write_bytes(error.output or b"")
+        raise RuntimeError(f"Benchmark timed out; see {output / 'benchmark.log'}") from error
+    (output / "benchmark.log").write_text(completed.stdout)
+    if completed.returncode:
+        raise RuntimeError(f"Benchmark failed; see {output / 'benchmark.log'}")
+    return parse_results(completed.stdout)
+
+
+def build_metadata(soc, output):
+    def sha256(path):
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+
+    variables = dict(line.split("=", 1) for line in
+        (output / "software/include/generated/variables.mak").read_text().splitlines() if "=" in line)
+    compiler = "clang" if variables["CLANG"] == "1" else variables["TRIPLE"] + "-gcc"
+    rtl = {}
+    for source in soc.platform.sources:
+        path = Path(source[0])
+        if not path.is_absolute():
+            path = output / "gateware" / path
+        rtl[path.name] = sha256(path)
+    return {
+        "litex_revision": get_litex_git_revision(),
+        "verilator_version": subprocess.check_output(["verilator", "--version"], text=True).strip(),
+        "compiler_version": subprocess.check_output([compiler, "--version"], text=True).splitlines()[0],
+        "cpu_flags": variables["CPUFLAGS"].strip(),
+        "sys_clk_freq": soc.sys_clk_freq,
+        "firmware_source_sha256": sha256(Path(__file__).with_name("main.c")),
+        "firmware_binary_sha256": sha256(output / "software/bios/bios.bin"),
+        "rtl_sha256": rtl,
+    }
+
+
 def main():
+    from litex.tools.litex_sim import SimSoC
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output-dir", required=True, type=Path)
     parser.add_argument("--cpu-variant", default="standard", choices=["standard", "full", "lite"])
@@ -67,14 +132,18 @@ def main():
     parser.add_argument("--bus-low-latency", action="store_true")
     parser.add_argument("--no-interconnect-register", action="store_true")
     parser.add_argument("--with-sdram", action="store_true")
-    parser.add_argument("--l2-size", default=8192, type=lambda v: int(v, 0))
+    parser.add_argument("--l2-size", default=8192, type=cache_size)
     parser.add_argument("--min-l2-data-width", default=128, type=int,
         choices=[32, 64, 128, 256, 512, 1024])
-    parser.add_argument("--jobs", default=4, type=int)
-    parser.add_argument("--timeout", default=120, type=int)
+    parser.add_argument("--jobs", default=4, type=positive_int)
+    parser.add_argument("--timeout", default=120, type=positive_int)
     args = parser.parse_args()
     logging.basicConfig(level=logging.WARNING)
     output = args.output_dir.resolve()
+    try:
+        prepare_output(output)
+    except FileExistsError:
+        parser.error("--output-dir already exists; use a fresh directory for each run")
     soc = SimSoC(
         cpu_type="vexriscv", cpu_variant=args.cpu_variant, uart_name="sim",
         integrated_rom_size=0x10000, integrated_sram_size=0x8000,
@@ -90,23 +159,14 @@ def main():
     builder = Builder(soc, output_dir=str(output), build_bundle=False)
     builder.add_software_package("bios", src_dir=str(Path(__file__).resolve().parent))
     builder.build(sim_config=config, interactive=False, run=False, jobs=args.jobs, opt_level="O3")
+    metadata = build_metadata(soc, output)
     with (output / "compile.log").open("w") as log:
         subprocess.run(["bash", "build_sim.sh"], cwd=output / "gateware",
             stdout=log, stderr=subprocess.STDOUT, check=True)
-    try:
-        completed = subprocess.run([str(output / "gateware/obj_dir/Vsim")],
-            cwd=output / "gateware", input="", stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT, text=True, timeout=args.timeout)
-    except subprocess.TimeoutExpired as error:
-        (output / "benchmark.log").write_bytes(error.output or b"")
-        raise RuntimeError(f"Benchmark timed out; see {output / 'benchmark.log'}") from error
-    (output / "benchmark.log").write_text(completed.stdout)
-    if completed.returncode:
-        raise RuntimeError(f"Benchmark failed; see {output / 'benchmark.log'}")
-    samples = parse_results(completed.stdout)
+    samples = run_benchmark(output, args.timeout)
     result = {
         "configuration": {key: str(value) if isinstance(value, Path) else value for key, value in vars(args).items()},
-        "firmware_source_sha256": hashlib.sha256(Path(__file__).with_name("main.c").read_bytes()).hexdigest(),
+        "build": metadata,
         "samples": samples,
         "median_cycles": {name: statistics.median(sample["cycles"] for sample in values)
                           for name, values in samples.items()},

--- a/litex/soc/software/bench/sim.py
+++ b/litex/soc/software/bench/sim.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-2-Clause
+"""Run CPU-cycle microbenchmarks using LiteX Sim's SoC and Verilator backend."""
+
+import argparse
+import hashlib
+import json
+import logging
+from pathlib import Path
+import statistics
+import subprocess
+
+from migen import Finish, If, Signal
+from litex.gen import LiteXModule
+from litex.build.sim.config import SimConfig
+from litex.soc.integration.builder import Builder
+from litex.soc.interconnect.csr import CSRStorage, CSRStatus
+from litex.tools.litex_sim import SimSoC
+
+
+def parse_results(output):
+    """Reject incomplete, failed or unmeasured runs before comparing their cycle counts."""
+    if "BENCH_ERROR" in output or "BENCH_DONE" not in output:
+        raise ValueError("Benchmark did not complete successfully")
+    expected = {"overhead_0": (0, 0), "compute_0": (32768, 0x1c348001)}
+    for size in [1024, 65536]:
+        expected[f"write_{size}"] = (size//4, 0)
+        for name in ["read_cold", "read_repeat"]:
+            expected[f"{name}_{size}"] = (size//4, ((size//4)*0x12345678) & 0xffffffff)
+        expected[f"chase_{size}"] = (8192, 0)
+    samples = {}
+    for line in output.splitlines():
+        if not line.startswith("BENCH,"):
+            continue
+        _, name, size, iterations, cycles, checksum = line.split(",")
+        key = f"{name}_{size}"
+        if key not in expected or (int(iterations), int(checksum, 16)) != expected[key]:
+            raise ValueError(f"Unexpected benchmark result: {line}")
+        if int(cycles) <= 0:
+            raise ValueError("Benchmark cycle counter did not advance")
+        samples.setdefault(key, []).append({
+            "cycles": int(cycles), "iterations": int(iterations), "checksum": checksum})
+    if set(samples) != set(expected) or any(len(values) != 3 for values in samples.values()):
+        raise ValueError("Missing benchmark samples")
+    return samples
+
+
+class BenchmarkControl(LiteXModule):
+    def __init__(self):
+        self.finish = CSRStorage(name="finish")
+        self.latch = CSRStorage(name="latch")
+        self.cycles = CSRStatus(32, name="cycles")
+        counter = Signal(32)
+        self.sync += [counter.eq(counter + 1),
+            If(self.latch.wr_stb, self.cycles.status.eq(counter))]
+        self.sync += If(self.finish.storage, Finish())
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--cpu-variant", default="standard", choices=["standard", "full", "lite"])
+    parser.add_argument("--bus-standard", default="wishbone", choices=["wishbone", "axi-lite", "axi"])
+    parser.add_argument("--bus-data-width", default=32, type=int, choices=[32, 64, 128])
+    parser.add_argument("--bus-interconnect", default="shared", choices=["shared", "crossbar"])
+    parser.add_argument("--bus-bursting", action="store_true")
+    parser.add_argument("--bus-low-latency", action="store_true")
+    parser.add_argument("--no-interconnect-register", action="store_true")
+    parser.add_argument("--with-sdram", action="store_true")
+    parser.add_argument("--l2-size", default=8192, type=lambda v: int(v, 0))
+    parser.add_argument("--jobs", default=4, type=int)
+    parser.add_argument("--timeout", default=120, type=int)
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.WARNING)
+    output = args.output_dir.resolve()
+    soc = SimSoC(
+        cpu_type="vexriscv", cpu_variant=args.cpu_variant, uart_name="sim",
+        integrated_rom_size=0x10000, integrated_sram_size=0x8000,
+        integrated_main_ram_size=0 if args.with_sdram else 0x40000,
+        with_sdram=args.with_sdram, l2_size=args.l2_size,
+        bus_standard=args.bus_standard, bus_data_width=args.bus_data_width,
+        bus_interconnect=args.bus_interconnect, bus_bursting=args.bus_bursting,
+        bus_low_latency=args.bus_low_latency)
+    soc.bus.interconnect_register = not args.no_interconnect_register
+    soc.bench = BenchmarkControl()
+    config = SimConfig(default_clk="sys_clk")
+    config.add_module("serial2console", "serial")
+    builder = Builder(soc, output_dir=str(output), build_bundle=False)
+    builder.add_software_package("bios", src_dir=str(Path(__file__).resolve().parent))
+    builder.build(sim_config=config, interactive=False, run=False, jobs=args.jobs, opt_level="O3")
+    with (output / "compile.log").open("w") as log:
+        subprocess.run(["bash", "build_sim.sh"], cwd=output / "gateware",
+            stdout=log, stderr=subprocess.STDOUT, check=True)
+    try:
+        completed = subprocess.run([str(output / "gateware/obj_dir/Vsim")],
+            cwd=output / "gateware", input="", stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT, text=True, timeout=args.timeout)
+    except subprocess.TimeoutExpired as error:
+        (output / "benchmark.log").write_bytes(error.output or b"")
+        raise RuntimeError(f"Benchmark timed out; see {output / 'benchmark.log'}") from error
+    (output / "benchmark.log").write_text(completed.stdout)
+    if completed.returncode:
+        raise RuntimeError(f"Benchmark failed; see {output / 'benchmark.log'}")
+    samples = parse_results(completed.stdout)
+    result = {
+        "configuration": {key: str(value) if isinstance(value, Path) else value for key, value in vars(args).items()},
+        "firmware_source_sha256": hashlib.sha256(Path(__file__).with_name("main.c").read_bytes()).hexdigest(),
+        "samples": samples,
+        "median_cycles": {name: statistics.median(sample["cycles"] for sample in values)
+                          for name, values in samples.items()},
+    }
+    (output / "benchmark.json").write_text(json.dumps(result, indent=2) + "\n")
+    print(json.dumps(result["median_cycles"], indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/litex/soc/software/bench/sim.py
+++ b/litex/soc/software/bench/sim.py
@@ -68,6 +68,8 @@ def main():
     parser.add_argument("--no-interconnect-register", action="store_true")
     parser.add_argument("--with-sdram", action="store_true")
     parser.add_argument("--l2-size", default=8192, type=lambda v: int(v, 0))
+    parser.add_argument("--min-l2-data-width", default=128, type=int,
+        choices=[32, 64, 128, 256, 512, 1024])
     parser.add_argument("--jobs", default=4, type=int)
     parser.add_argument("--timeout", default=120, type=int)
     args = parser.parse_args()
@@ -77,7 +79,7 @@ def main():
         cpu_type="vexriscv", cpu_variant=args.cpu_variant, uart_name="sim",
         integrated_rom_size=0x10000, integrated_sram_size=0x8000,
         integrated_main_ram_size=0 if args.with_sdram else 0x40000,
-        with_sdram=args.with_sdram, l2_size=args.l2_size,
+        with_sdram=args.with_sdram, l2_size=args.l2_size, min_l2_data_width=args.min_l2_data_width,
         bus_standard=args.bus_standard, bus_data_width=args.bus_data_width,
         bus_interconnect=args.bus_interconnect, bus_bursting=args.bus_bursting,
         bus_low_latency=args.bus_low_latency)

--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -182,6 +182,7 @@ class SimSoC(SoCCore):
         with_jtag              = False,
         min_l2_data_width      = 128,
         l2_bursting            = False,
+        l2_refill_bypass       = False,
         **kwargs):
 
         if (not isinstance(min_l2_data_width, int) or min_l2_data_width < 32 or
@@ -234,6 +235,7 @@ class SimSoC(SoCCore):
                 l2_cache_size           = kwargs.get("l2_size", 8192),
                 l2_cache_min_data_width = min_l2_data_width,
                 l2_cache_bursting       = l2_bursting,
+                l2_cache_refill_bypass  = l2_refill_bypass,
                 l2_cache_reverse        = False,
                 with_bist               = with_sdram_bist
             )
@@ -455,6 +457,7 @@ def sim_args(parser):
     parser.add_argument("--sdram-verbosity",      default=0,               help="Set SDRAM checker verbosity.")
     parser.add_argument("--min-l2-data-width",    default=128, type=int,   help="Minimum SDRAM L2 refill width in bits (power of two, at least 32).")
     parser.add_argument("--l2-bursting",          action="store_true",     help="Enable the same-line SDRAM L2 read-burst fast path.")
+    parser.add_argument("--l2-refill-bypass",     action="store_true",     help="Acknowledge SDRAM L2 read misses directly from refill data.")
 
     # Ethernet /Etherbone.
     parser.add_argument("--with-ethernet",      action="store_true",                                         help="Enable Ethernet support.")
@@ -581,6 +584,7 @@ def main():
         soc_kwargs["sdram_verbosity"]  = int(args.sdram_verbosity)
         soc_kwargs["min_l2_data_width"] = args.min_l2_data_width
         soc_kwargs["l2_bursting"] = args.l2_bursting
+        soc_kwargs["l2_refill_bypass"] = args.l2_refill_bypass
         if args.sdram_from_spd_dump:
             soc_kwargs["sdram_spd_data"] = parse_spd_hexdump(args.sdram_from_spd_dump)
         if args.sdram_init is not None:

--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -180,7 +180,12 @@ class SimSoC(SoCCore):
         sim_debug              = False,
         trace_reset_on         = False,
         with_jtag              = False,
+        min_l2_data_width      = 128,
         **kwargs):
+
+        if (not isinstance(min_l2_data_width, int) or min_l2_data_width < 32 or
+            min_l2_data_width & (min_l2_data_width - 1)):
+            raise ValueError("min_l2_data_width must be a power of two of at least 32 bits.")
 
         # Platform ---------------------------------------------------------------------------------
         platform = Platform()
@@ -226,7 +231,7 @@ class SimSoC(SoCCore):
                 phy                     = self.sdrphy,
                 module                  = sdram_module,
                 l2_cache_size           = kwargs.get("l2_size", 8192),
-                l2_cache_min_data_width = kwargs.get("min_l2_data_width", 128),
+                l2_cache_min_data_width = min_l2_data_width,
                 l2_cache_reverse        = False,
                 with_bist               = with_sdram_bist
             )
@@ -446,6 +451,7 @@ def sim_args(parser):
     parser.add_argument("--sdram-init",           default=None,            help="SDRAM init file (.bin or .json).")
     parser.add_argument("--sdram-from-spd-dump",  default=None,            help="Generate SDRAM module based on data from SPD EEPROM dump.")
     parser.add_argument("--sdram-verbosity",      default=0,               help="Set SDRAM checker verbosity.")
+    parser.add_argument("--min-l2-data-width",    default=128, type=int,   help="Minimum SDRAM L2 refill width in bits (power of two, at least 32).")
 
     # Ethernet /Etherbone.
     parser.add_argument("--with-ethernet",      action="store_true",                                         help="Enable Ethernet support.")
@@ -570,6 +576,7 @@ def main():
         soc_kwargs["sdram_module"]     = args.sdram_module
         soc_kwargs["sdram_data_width"] = int(args.sdram_data_width)
         soc_kwargs["sdram_verbosity"]  = int(args.sdram_verbosity)
+        soc_kwargs["min_l2_data_width"] = args.min_l2_data_width
         if args.sdram_from_spd_dump:
             soc_kwargs["sdram_spd_data"] = parse_spd_hexdump(args.sdram_from_spd_dump)
         if args.sdram_init is not None:

--- a/litex/tools/litex_sim.py
+++ b/litex/tools/litex_sim.py
@@ -181,6 +181,7 @@ class SimSoC(SoCCore):
         trace_reset_on         = False,
         with_jtag              = False,
         min_l2_data_width      = 128,
+        l2_bursting            = False,
         **kwargs):
 
         if (not isinstance(min_l2_data_width, int) or min_l2_data_width < 32 or
@@ -232,6 +233,7 @@ class SimSoC(SoCCore):
                 module                  = sdram_module,
                 l2_cache_size           = kwargs.get("l2_size", 8192),
                 l2_cache_min_data_width = min_l2_data_width,
+                l2_cache_bursting       = l2_bursting,
                 l2_cache_reverse        = False,
                 with_bist               = with_sdram_bist
             )
@@ -452,6 +454,7 @@ def sim_args(parser):
     parser.add_argument("--sdram-from-spd-dump",  default=None,            help="Generate SDRAM module based on data from SPD EEPROM dump.")
     parser.add_argument("--sdram-verbosity",      default=0,               help="Set SDRAM checker verbosity.")
     parser.add_argument("--min-l2-data-width",    default=128, type=int,   help="Minimum SDRAM L2 refill width in bits (power of two, at least 32).")
+    parser.add_argument("--l2-bursting",          action="store_true",     help="Enable the same-line SDRAM L2 read-burst fast path.")
 
     # Ethernet /Etherbone.
     parser.add_argument("--with-ethernet",      action="store_true",                                         help="Enable Ethernet support.")
@@ -577,6 +580,7 @@ def main():
         soc_kwargs["sdram_data_width"] = int(args.sdram_data_width)
         soc_kwargs["sdram_verbosity"]  = int(args.sdram_verbosity)
         soc_kwargs["min_l2_data_width"] = args.min_l2_data_width
+        soc_kwargs["l2_bursting"] = args.l2_bursting
         if args.sdram_from_spd_dump:
             soc_kwargs["sdram_spd_data"] = parse_spd_hexdump(args.sdram_from_spd_dump)
         if args.sdram_init is not None:

--- a/test/interconnect/test_wishbone_cache.py
+++ b/test/interconnect/test_wishbone_cache.py
@@ -1,0 +1,200 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import random
+
+import pytest
+from migen import If, Memory, Signal
+from migen.fhdl.simplify import FullMemoryWE
+from migen.sim import run_simulation
+
+from litex.gen import LiteXModule
+from litex.soc.interconnect import wishbone
+
+
+def initial_word(address):
+    return (0x12345678 ^ (address*0x01020305)) & 0xffffffff
+
+
+class CacheDUT(LiteXModule):
+    def __init__(self, width=128, reverse=False, bursting=False, latency=1, full_we=False):
+        self.master = master = wishbone.Interface(data_width=32, address_width=16)
+        self.slave = slave = wishbone.Interface(data_width=width, address_width=16)
+        cache = wishbone.Cache(64, master, slave, reverse=reverse, with_bursting=bursting)
+        self.cache = FullMemoryWE()(cache) if full_we else cache
+        ratio = width//32
+        init = [sum(initial_word(index*ratio + lane) << (32*(ratio-1-lane if reverse else lane))
+                    for lane in range(ratio)) for index in range(512)]
+        memory = Memory(width, len(init), init=init)
+        port = memory.get_port(write_capable=True, we_granularity=8)
+        self.specials += memory, port
+        count = Signal(max=latency+1)
+        self.comb += [
+            port.adr.eq(slave.adr),
+            port.dat_w.eq(slave.dat_w),
+            slave.dat_r.eq(port.dat_r),
+            slave.ack.eq(slave.cyc & slave.stb & (count == latency)),
+        ]
+        for byte in range(width//8):
+            self.comb += port.we[byte].eq(slave.ack & slave.we & slave.sel[byte])
+        self.sync += If(~slave.cyc | ~slave.stb | slave.ack,
+            count.eq(0)
+        ).Else(
+            count.eq(count + 1)
+        )
+
+
+def transfer(bus, beats, stalls=None, bte=0):
+    """Each beat is (word address, write data or None, byte select, CTI)."""
+    values, gaps = [], []
+    yield bus.cyc.eq(1)
+    yield bus.bte.eq(bte)
+    for index, (address, data, select, cti) in enumerate(beats):
+        if stalls and index in stalls:
+            yield bus.stb.eq(0)
+            # The address is unspecified while stalled; exercise RAM-index tracking.
+            yield bus.adr.eq(address ^ 32)
+            for _ in range(stalls[index]):
+                yield
+                assert not (yield bus.ack)
+        yield bus.stb.eq(1)
+        yield bus.adr.eq(address)
+        yield bus.we.eq(data is not None)
+        yield bus.dat_w.eq(data or 0)
+        yield bus.sel.eq(select)
+        yield bus.cti.eq(cti)
+        elapsed = 0
+        while True:
+            yield
+            elapsed += 1
+            assert elapsed < 100, "cache transaction timed out"
+            assert not (yield bus.err)
+            if (yield bus.ack):
+                values.append((yield bus.dat_r))
+                gaps.append(elapsed)
+                break
+    yield bus.cyc.eq(0)
+    yield bus.stb.eq(0)
+    yield bus.we.eq(0)
+    yield bus.cti.eq(wishbone.CTI_BURST_NONE)
+    yield
+    assert not (yield bus.ack)
+    return values, gaps
+
+
+def read_beats(addresses, cti=wishbone.CTI_BURST_INCREMENTING):
+    return [(address, None, 15, cti if index != len(addresses)-1 else wishbone.CTI_BURST_END)
+            for index, address in enumerate(addresses)]
+
+
+@pytest.mark.parametrize("width", [32, 64, 128, 256])
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("bursting", [False, True])
+@pytest.mark.parametrize("full_we", [False, True])
+def test_same_line_burst_hits(width, reverse, bursting, full_we):
+    dut = CacheDUT(width, reverse, bursting, full_we=full_we)
+    addresses = list(range(128, 128 + width//32))
+
+    def generator():
+        yield from transfer(dut.master, read_beats([128]))
+        values, gaps = yield from transfer(dut.master, read_beats(addresses))
+        assert values == [initial_word(address) for address in addresses]
+        assert gaps[1:] == [1 if bursting else 2]*(len(addresses)-1)
+
+    run_simulation(dut, generator())
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("latency", [1, 4])
+@pytest.mark.parametrize("bte", [0, 1, 2, 3])
+def test_burst_boundaries_wraps_and_stalls(reverse, latency, bte):
+    dut = CacheDUT(reverse=reverse, bursting=True, latency=latency)
+    # Cross RAM indices and change tag while retaining the same cache index.
+    # The address presented by the master is authoritative, including wrapping.
+    addresses = [130, 131, 128, 129] if bte else [130, 131, 132, 133]
+    addresses += [192, 193, 194, 195, 128, 129]
+
+    def generator():
+        values, _ = yield from transfer(dut.master, read_beats(addresses), stalls={3: 2, 7: 1}, bte=bte)
+        assert values == [initial_word(address) for address in addresses]
+        values, gaps = yield from transfer(dut.master, read_beats([129]*4, wishbone.CTI_BURST_CONSTANT))
+        assert values == [initial_word(129)]*4
+        assert gaps[1:] == [1]*3
+        # A classic cycle after a terminated burst must not reuse a live-lane acknowledgement.
+        values, _ = yield from transfer(dut.master, [(200, None, 15, wishbone.CTI_BURST_NONE)])
+        assert values == [initial_word(200)]
+
+    run_simulation(dut, generator())
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("full_we", [False, True])
+def test_burst_read_write_transition_and_dirty_eviction(reverse, full_we):
+    dut = CacheDUT(reverse=reverse, bursting=True, full_we=full_we)
+    expected = (initial_word(129) & 0xffff00ff) | 0x0000aa00
+    beats = [
+        (128, None, 15, wishbone.CTI_BURST_INCREMENTING),
+        (129, 0x0000aa00, 2, wishbone.CTI_BURST_INCREMENTING),
+        (129, None, 15, wishbone.CTI_BURST_END),
+    ]
+
+    def generator():
+        values, _ = yield from transfer(dut.master, beats)
+        assert values[0] == initial_word(128)
+        assert values[2] == expected
+        # Evict to backing memory, then refill and check every byte/lane.
+        yield from transfer(dut.master, read_beats([192]))
+        values, _ = yield from transfer(dut.master, read_beats([128, 129, 130, 131]))
+        assert values == [initial_word(128), expected, initial_word(130), initial_word(131)]
+
+    run_simulation(dut, generator())
+
+
+def test_cycle_end_terminates_live_burst():
+    dut = CacheDUT(bursting=True)
+
+    def generator():
+        # End CYC after an acknowledged incrementing beat without sending END.
+        yield from transfer(dut.master, [(128, None, 15, wishbone.CTI_BURST_INCREMENTING)])
+        for _ in range(3):
+            yield
+            assert not (yield dut.master.ack)
+        values, _ = yield from transfer(dut.master, read_beats([193, 194, 195]))
+        assert values == [initial_word(address) for address in [193, 194, 195]]
+
+    run_simulation(dut, generator())
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_random_cache_traffic(reverse):
+    dut = CacheDUT(reverse=reverse, bursting=True, latency=3)
+    rng = random.Random(42)
+    expected = {address: initial_word(address) for address in range(128, 320)}
+
+    def generator():
+        for _ in range(80):
+            address = rng.randrange(128, 304)
+            addresses = list(range(address, address + rng.randrange(1, 9)))
+            beats, writes = [], []
+            for index, address in enumerate(addresses):
+                writing = rng.randrange(3) == 0
+                data = rng.getrandbits(32) if writing else None
+                select = rng.randrange(16)
+                cti = wishbone.CTI_BURST_INCREMENTING if index != len(addresses)-1 else wishbone.CTI_BURST_END
+                beats.append((address, data, select, cti))
+                writes.append(writing)
+                if writing:
+                    mask = sum(255 << (8*byte) for byte in range(4) if select & (1 << byte))
+                    expected[address] = (expected[address] & ~mask) | (data & mask)
+            values, _ = yield from transfer(dut.master, beats, stalls={1: 1})
+            for address, value, writing in zip(addresses, values, writes):
+                if not writing:
+                    assert value == expected[address]
+        for address, expected_value in expected.items():
+            values, _ = yield from transfer(dut.master, read_beats([address]))
+            assert values == [expected_value]
+
+    run_simulation(dut, generator())

--- a/test/interconnect/test_wishbone_cache.py
+++ b/test/interconnect/test_wishbone_cache.py
@@ -20,10 +20,12 @@ def initial_word(address):
 
 
 class CacheDUT(LiteXModule):
-    def __init__(self, width=128, reverse=False, bursting=False, latency=1, full_we=False):
+    def __init__(self, width=128, reverse=False, bursting=False, latency=1, full_we=False,
+        refill_bypass=False):
         self.master = master = wishbone.Interface(data_width=32, address_width=16)
         self.slave = slave = wishbone.Interface(data_width=width, address_width=16)
-        cache = wishbone.Cache(64, master, slave, reverse=reverse, with_bursting=bursting)
+        cache = wishbone.Cache(64, master, slave, reverse=reverse,
+            with_bursting=bursting, with_refill_bypass=refill_bypass)
         self.cache = FullMemoryWE()(cache) if full_we else cache
         ratio = width//32
         init = [sum(initial_word(index*ratio + lane) << (32*(ratio-1-lane if reverse else lane))
@@ -132,8 +134,9 @@ def test_burst_boundaries_wraps_and_stalls(reverse, latency, bte):
 
 @pytest.mark.parametrize("reverse", [False, True])
 @pytest.mark.parametrize("full_we", [False, True])
-def test_burst_read_write_transition_and_dirty_eviction(reverse, full_we):
-    dut = CacheDUT(reverse=reverse, bursting=True, full_we=full_we)
+@pytest.mark.parametrize("refill_bypass", [False, True])
+def test_burst_read_write_transition_and_dirty_eviction(reverse, full_we, refill_bypass):
+    dut = CacheDUT(reverse=reverse, bursting=True, full_we=full_we, refill_bypass=refill_bypass)
     expected = (initial_word(129) & 0xffff00ff) | 0x0000aa00
     beats = [
         (128, None, 15, wishbone.CTI_BURST_INCREMENTING),
@@ -169,8 +172,9 @@ def test_cycle_end_terminates_live_burst():
 
 
 @pytest.mark.parametrize("reverse", [False, True])
-def test_random_cache_traffic(reverse):
-    dut = CacheDUT(reverse=reverse, bursting=True, latency=3)
+@pytest.mark.parametrize("refill_bypass", [False, True])
+def test_random_cache_traffic(reverse, refill_bypass):
+    dut = CacheDUT(reverse=reverse, bursting=True, latency=3, refill_bypass=refill_bypass)
     rng = random.Random(42)
     expected = {address: initial_word(address) for address in range(128, 320)}
 
@@ -198,3 +202,62 @@ def test_random_cache_traffic(reverse):
             assert values == [expected_value]
 
     run_simulation(dut, generator())
+
+
+@pytest.mark.parametrize("width", [32, 64, 128, 256])
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("latency", [1, 4])
+@pytest.mark.parametrize("bursting", [False, True])
+def test_refill_bypass_saves_one_cycle(width, reverse, latency, bursting):
+    measurements = []
+    for enabled in [False, True]:
+        dut = CacheDUT(width, reverse, bursting, latency, full_we=True, refill_bypass=enabled)
+        reads, writes = [], []
+
+        def generator():
+            for lane in range(width//32):
+                # Leave one tag between targets so a dirty victim from an
+                # earlier iteration is not part of a later expected clean line.
+                address = 128 + 128*lane + lane
+                # Force a dirty victim in the same index before this read miss.
+                _, gaps = yield from transfer(dut.master,
+                    [(address ^ 64, 0xaabbccdd, 5, wishbone.CTI_BURST_NONE)])
+                writes.append(gaps[0])
+                line = address & ~(width//32 - 1)
+                addresses = [line + ((lane + i) % (width//32)) for i in range(width//32)]
+                values, gaps = yield from transfer(dut.master, read_beats(addresses))
+                assert values == [initial_word(address) for address in addresses]
+                reads.append(gaps[0])
+                # A following same-line beat sees the newly filled RAM contents.
+                assert gaps[1:] == [1 if bursting else 2]*(len(addresses)-1)
+
+        run_simulation(dut, generator())
+        measurements.append((reads, writes))
+    assert measurements[1][0] == [cycles-1 for cycles in measurements[0][0]]
+    assert measurements[1][1] == measurements[0][1]
+
+
+@pytest.mark.parametrize("width", [32, 64, 128])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_wide_master_refill_and_narrow_slave_fallback(width, reverse):
+    first_reads = []
+    for enabled in [False, True]:
+        dut = LiteXModule()
+        dut.master = wishbone.Interface(data_width=64, address_width=16)
+        dut.slave = wishbone.Interface(data_width=width, address_width=16)
+        dut.cache = wishbone.Cache(64, dut.master, dut.slave, reverse=reverse,
+            with_bursting=True, with_refill_bypass=enabled)
+        dut.memory = wishbone.SRAM(8192, bus=dut.slave)
+
+        def generator():
+            values, gaps = yield from transfer(dut.master, read_beats([128]))
+            assert values == [0]
+            first_reads.append(gaps[0])
+            yield from transfer(dut.master, [(128, 0x1122334455667788, 255, wishbone.CTI_BURST_NONE)])
+            yield from transfer(dut.master, [(128, 0xaabbccddeeff0011, 0x18, wishbone.CTI_BURST_NONE)])
+            yield from transfer(dut.master, read_beats([192]))
+            values, _ = yield from transfer(dut.master, read_beats([128]))
+            assert values == [0x112233ddee667788]
+
+        run_simulation(dut, generator())
+    assert first_reads[1] == first_reads[0] - int(width >= 64)

--- a/test/software/test_cpu_bench.py
+++ b/test/software/test_cpu_bench.py
@@ -1,7 +1,13 @@
 # SPDX-License-Identifier: BSD-2-Clause
-import pytest
+import argparse
+import subprocess
 
-from litex.soc.software.bench.sim import parse_results
+import pytest
+from migen.sim import run_simulation
+
+from litex.soc.software.bench.sim import (
+    BenchmarkControl, cache_size, parse_results, positive_int, prepare_output, run_benchmark,
+)
 
 
 def output():
@@ -24,8 +30,11 @@ def test_complete_benchmark_results():
 
 @pytest.mark.parametrize("old,new", [
     ("BENCH_DONE", ""),
+    ("BENCH_BEGIN", ""),
+    ("BENCH_DONE", "BENCH_DONE\nBENCH_DONE"),
     ("BENCH_BEGIN", "BENCH_ERROR,read_checksum"),
     (",196619,", ",0,"),
+    (",196619,", ",4294967296,"),
     (",1c348001", ",00000000"),
     ("BENCH,write,1024,256,1000,00000000", ""),
     ("BENCH,chase,1024", "BENCH,unknown,1024"),
@@ -33,3 +42,80 @@ def test_complete_benchmark_results():
 def test_invalid_benchmark_results(old, new):
     with pytest.raises(ValueError):
         parse_results(output().replace(old, new))
+
+
+def test_latched_system_counter():
+    dut = BenchmarkControl()
+
+    def generator():
+        yield dut.latch.wr_stb.eq(1)
+        yield
+        yield dut.latch.wr_stb.eq(0)
+        yield
+        first = yield dut.cycles.status
+        for _ in range(10):
+            yield
+        assert (yield dut.cycles.status) == first
+        yield dut.latch.wr_stb.eq(1)
+        yield
+        yield dut.latch.wr_stb.eq(0)
+        yield
+        assert (yield dut.cycles.status) - first == 12
+
+    run_simulation(dut, generator())
+
+
+@pytest.mark.parametrize("value", ["0", "-1"])
+def test_invalid_positive_int(value):
+    with pytest.raises(argparse.ArgumentTypeError):
+        positive_int(value)
+
+
+@pytest.mark.parametrize("value", ["-8", "4", "24"])
+def test_invalid_cache_size(value):
+    with pytest.raises(argparse.ArgumentTypeError):
+        cache_size(value)
+
+
+def test_numeric_options():
+    assert positive_int("4") == 4
+    assert cache_size("0") == 0
+    assert cache_size("0x10000") == 65536
+
+
+def test_existing_output_is_preserved(tmp_path):
+    directory = tmp_path / "run"
+    prepare_output(directory)
+    result = directory / "benchmark.json"
+    result.write_text("previous result")
+    with pytest.raises(FileExistsError):
+        prepare_output(directory)
+    assert result.read_text() == "previous result"
+
+
+def test_run_uses_noninteractive_pipe_and_preserves_output(tmp_path, monkeypatch):
+    def run(command, **kwargs):
+        assert command == [str(tmp_path / "gateware/obj_dir/Vsim")]
+        assert kwargs["input"] == "" and "stdin" not in kwargs
+        assert kwargs["timeout"] == 3
+        return subprocess.CompletedProcess(command, 0, output())
+
+    monkeypatch.setattr(subprocess, "run", run)
+    assert len(run_benchmark(tmp_path, 3)) == 10
+    assert (tmp_path / "benchmark.log").read_text() == output()
+
+
+@pytest.mark.parametrize("failure", ["timeout", "exit", "checksum"])
+def test_failed_run_retains_log(tmp_path, monkeypatch, failure):
+    log = b"BENCH_ERROR,read_checksum\n"
+
+    def run(command, **kwargs):
+        if failure == "timeout":
+            raise subprocess.TimeoutExpired(command, kwargs["timeout"], output=log)
+        return subprocess.CompletedProcess(command, int(failure == "exit"), log.decode())
+
+    monkeypatch.setattr(subprocess, "run", run)
+    with pytest.raises(ValueError if failure == "checksum" else RuntimeError):
+        run_benchmark(tmp_path, 3)
+    assert (tmp_path / "benchmark.log").read_bytes() == log
+    assert not (tmp_path / "benchmark.json").exists()

--- a/test/software/test_cpu_bench.py
+++ b/test/software/test_cpu_bench.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: BSD-2-Clause
+import pytest
+
+from litex.soc.software.bench.sim import parse_results
+
+
+def output():
+    rows = ["BENCH,overhead,0,0,7,00000000", "BENCH,compute,0,32768,196619,1c348001"]
+    for size in [1024, 65536]:
+        rows.append(f"BENCH,write,{size},{size//4},1000,00000000")
+        for name in ["read_cold", "read_repeat"]:
+            checksum = ((size//4)*0x12345678) & 0xffffffff
+            rows.append(f"BENCH,{name},{size},{size//4},1000,{checksum:08x}")
+        rows.append(f"BENCH,chase,{size},8192,1000,00000000")
+    return "BENCH_BEGIN\n" + "\n".join(rows*3) + "\nBENCH_DONE\n"
+
+
+def test_complete_benchmark_results():
+    samples = parse_results(output())
+    assert len(samples) == 10
+    assert all(len(values) == 3 for values in samples.values())
+    assert samples["compute_0"][0]["cycles"] == 196619
+
+
+@pytest.mark.parametrize("old,new", [
+    ("BENCH_DONE", ""),
+    ("BENCH_BEGIN", "BENCH_ERROR,read_checksum"),
+    (",196619,", ",0,"),
+    (",1c348001", ",00000000"),
+    ("BENCH,write,1024,256,1000,00000000", ""),
+    ("BENCH,chase,1024", "BENCH,unknown,1024"),
+])
+def test_invalid_benchmark_results(old, new):
+    with pytest.raises(ValueError):
+        parse_results(output().replace(old, new))

--- a/test/tools/test_litex_sim.py
+++ b/test/tools/test_litex_sim.py
@@ -16,6 +16,8 @@ def test_l2_refill_width_argument():
     assert parser.parse_args(["--min-l2-data-width=256"]).min_l2_data_width == 256
     assert not parser.parse_args([]).l2_bursting
     assert parser.parse_args(["--l2-bursting"]).l2_bursting
+    assert not parser.parse_args([]).l2_refill_bypass
+    assert parser.parse_args(["--l2-refill-bypass"]).l2_refill_bypass
 
 
 @pytest.mark.parametrize("enabled", [False, True])

--- a/test/tools/test_litex_sim.py
+++ b/test/tools/test_litex_sim.py
@@ -14,6 +14,15 @@ def test_l2_refill_width_argument():
     sim_args(parser)
     assert parser.parse_args([]).min_l2_data_width == 128
     assert parser.parse_args(["--min-l2-data-width=256"]).min_l2_data_width == 256
+    assert not parser.parse_args([]).l2_bursting
+    assert parser.parse_args(["--l2-bursting"]).l2_bursting
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_l2_bursting_reaches_cache(enabled):
+    soc = SimSoC(cpu_type=None, integrated_rom_size=0,
+        with_uart=False, with_timer=False, with_sdram=True, l2_bursting=enabled)
+    assert ("BURST" in soc.l2_cache.fsm.actions) == enabled
 
 
 @pytest.mark.parametrize("width", [32, 128, 256, 512])

--- a/test/tools/test_litex_sim.py
+++ b/test/tools/test_litex_sim.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: BSD-2-Clause
+import argparse
+
+import pytest
+
+pytest.importorskip("liteeth")
+pytest.importorskip("litedram")
+
+from litex.tools.litex_sim import SimSoC, sim_args
+
+
+def test_l2_refill_width_argument():
+    parser = argparse.ArgumentParser()
+    sim_args(parser)
+    assert parser.parse_args([]).min_l2_data_width == 128
+    assert parser.parse_args(["--min-l2-data-width=256"]).min_l2_data_width == 256
+
+
+@pytest.mark.parametrize("width", [32, 128, 256, 512])
+def test_l2_refill_width_reaches_cache(width):
+    soc = SimSoC(cpu_type=None, integrated_rom_size=0,
+        with_uart=False, with_timer=False, with_sdram=True, min_l2_data_width=width)
+    assert soc.l2_cache.slave.data_width == width
+
+
+@pytest.mark.parametrize("width", [0, -32, 16, 96, 128.0])
+def test_invalid_l2_refill_width(width):
+    with pytest.raises(ValueError, match="min_l2_data_width"):
+        SimSoC(min_l2_data_width=width)


### PR DESCRIPTION
## Summary

This performance series is based directly on master, independently of the BIOS and SoC review series. It keeps existing cache defaults unchanged and adds small opt-in read-path improvements.

- Add a bare-metal VexRiscv benchmark using LiteX Sim, with a latched system-cycle counter, checked results, cache-state controls, fresh build directories, failure logs and build fingerprints.
- Expose the existing SDRAM L2 refill-width setting on the simulation command line.
- Add `--l2-bursting`: consecutive read hits within a wide cache line select live lanes without the normal idle cycle; line/tag changes, writes, stalls and termination retain safe fallback paths.
- Add `--l2-refill-bypass`: return a read-miss word directly from the refill response while filling RAM. Write allocation and narrower slave interfaces retain the existing path.
- Share lane selection between normal reads, burst hits and refill responses to keep the added logic small.

No result CSV/Markdown snapshots are included in the branch history. The README documents usage and measurement assumptions; generated results stay in the requested external output directory.

## Measured cycles

VexRiscv standard, shared 32-bit Wishbone, modeled SDR SDRAM, **unchanged 8 KiB L2 and 128-bit refill width**. Medians of three checked samples for the 64 KiB working set:

| Cache options | Cold sequential read | Dependent loads |
| --- | ---: | ---: |
| Default | 138,685 | 474,559 |
| L2 bursting | 126,450 | 427,090 |
| Refill bypass | 133,984 | 457,595 |
| Both | 123,190 | 412,906 |

The low-cost burst option reduces these counts by about 9% and 10%; both options reduce them by about 11% and 13%. Compute is unchanged. Writes are effectively unchanged, apart from SDRAM refresh-phase variation.

## Resource check

An isolated cache synthesis with Yosys `synth_xilinx -family xc7 -top cache -noiopad -noclkbuf`, at the same 8 KiB/128-bit configuration with the existing `FullMemoryWE` transformation:

| Cache options | LUT cells | Flip-flops | RAMB18E1 |
| --- | ---: | ---: | ---: |
| Default | 255 | 25 | 17 |
| L2 bursting | 260 | 35 | 17 |
| Refill bypass | 321 | 25 | 17 |
| Both | 328 | 35 | 17 |

Thus the burst-only option adds **5 LUT cells and 10 flip-flops**, with no additional BRAM. Both options add **73 LUT cells and 10 flip-flops**, still with unchanged BRAM. These are tool-specific isolated synthesis counts, not whole-SoC placement/timing results.

## Validation and reproduction

Protocol tests cover cache and bus widths, lane ordering, byte writes, dirty evictions, burst boundaries, stalls, termination, refill forwarding, narrow-slave fallback and randomized traffic.

- Final software, SoC integration, simulator-backend, AXI, Wishbone, DMA and cache regression run: **480 passed, 77 subtests passed, one skipped**. The skip is the existing flashboot host test requiring a low-address mmap unavailable on this host.
- All **99 cache tests** pass, including enabled/disabled paths and 64-bit masters with narrower slave interfaces.
- Fresh final-code LiteX Sim runs reproduce all medians for burst-only and combined fast paths after the mux cleanup.
- The normal LiteX Sim BIOS boots with `--with-sdram --bus-bursting --l2-bursting --l2-refill-bypass`.

```sh
python3 -m litex.soc.software.bench.sim --output-dir=/tmp/l2-default \
    --with-sdram --bus-bursting
python3 -m litex.soc.software.bench.sim --output-dir=/tmp/l2-fast \
    --with-sdram --bus-bursting --l2-bursting --l2-refill-bypass
```

Use fresh directories. Firmware is compiled with GCC 10.2.0 at `-O2`; measurements use simulated cycles, not host simulation speed. The SDRAM model uses 100 MHz-derived timings while LiteX Sim runs its clock at 1 MHz, so these are not board-bandwidth claims. Refill bypass adds a combinational return path and needs target-specific FPGA timing validation before deployment. No universal CPU-performance or Fmax claim is made.
