### PR TITLE
bios: harden boot loading, command parsing and bounded I/O

### DIFF
--- a/doc/bios_config.md
+++ b/doc/bios_config.md
@@ -96,6 +96,28 @@ Custom linker scripts can reserve a buffer and export
 must not overlap BIOS code, data or stack. Zynq linker scripts do not currently
 provide this optional buffer.
 
+## Boot Manifests
+
+Network, SD and SATA boot share the same manifest validation. Image entries
+map filenames to load addresses; optional `bootargs` metadata sets the entry
+point and registers:
+
+```json
+{
+    "image.bin": "0x40000000",
+    "bootargs": {
+        "addr": "0x40000000",
+        "r1": "0x12345678"
+    }
+}
+```
+
+Without `addr`, the BIOS jumps to the last image's load address. Registers
+default to zero. Top-level `addr`, `r1`, `r2` and `r3` remain supported.
+Duplicate keys, invalid addresses and unsupported nesting are rejected
+before loading. Each image is bounded by available RAM and the next image's
+destination, including aliases of the same physical memory.
+
 ## Flash Boot Bounds
 
 `FLASH_BOOT_MAX_SIZE` limits the accepted image payload length (by default,

--- a/doc/bios_config.md
+++ b/doc/bios_config.md
@@ -45,6 +45,15 @@ Some BIOS options are build flags rather than generated SoC constants:
 
 When using `Builder`, this can be selected with `bios_console_no_ansi=True`.
 
+## Flash Boot Bounds
+
+`FLASH_BOOT_MAX_SIZE` limits the accepted image payload length (by default,
+`MAIN_RAM_SIZE`, or 16 MiB without main RAM). When `SPIFLASH_BASE` and
+`SPIFLASH_SIZE` are present, the BIOS also checks that the eight-byte header
+and payload fit in that flash mapping before reading the payload for CRC.
+Targets using a different mapping can set `FLASH_BOOT_REGION_BASE` and
+`FLASH_BOOT_REGION_SIZE` to describe it. Both values must be supplied together.
+
 ## Generated SoC Metadata
 
 LiteX generates several `CONFIG_` values from the SoC, CPU, bus and CSR

--- a/doc/bios_config.md
+++ b/doc/bios_config.md
@@ -45,6 +45,42 @@ Some BIOS options are build flags rather than generated SoC constants:
 
 When using `Builder`, this can be selected with `bios_console_no_ansi=True`.
 
+The make/environment variables `BIOS_ROM_BUDGET` and `BIOS_SRAM_BUDGET` set
+optional byte limits checked after linking. For example,
+`BIOS_ROM_BUDGET=0x10000 BIOS_SRAM_BUDGET=0x1800 litex_sim ...` fails if
+the selected configuration exceeds 64 KiB of ROM or 6 KiB of allocated SRAM.
+SRAM usage includes an explicit boot buffer or stack section, but not an
+implicit stack. Use `--bios-stack-margin` as well to protect stack headroom.
+Choose limits per CPU/feature configuration; no budgets are enabled by default.
+
+## Command Usage
+
+`help <command>` shows a command's description and registered usage.
+Core memory, flash and boot commands reject missing or excess arguments
+before invoking a handler. Lines exceeding `MAX_PARAM` are rejected entirely.
+
+Target commands can opt into the same checks with:
+
+```c
+define_command_args(example, example_handler, "Example command",
+    "example <value> [count]", 1, 2, SYSTEM_CMDS);
+```
+
+Existing `define_command()` registrations remain supported. Checked unsigned
+parsers in `<libbase/parse.h>` accept decimal, `0`-prefixed octal and
+`0x`-prefixed hexadecimal numbers, rejecting signs, whitespace and overflow.
+
+## Transfer Timeouts
+
+TFTP uses a five-second request/inactivity deadline by default, configurable
+with `TFTP_TIMEOUT_US`. SPI SD byte transfers use `SPISDCARD_XFER_TIMEOUT_US`
+(10 ms by default). These are system-clock deadlines rather than polling
+iteration counts.
+
+The shared timeout helper uses uptime when available. Otherwise, it puts
+timer0 in free-running mode; callers must not reprogram timer0 (including via
+`busy_wait`) while a deadline is active. Nested deadlines are supported.
+
 ## SRAM Boot Images
 
 The BIOS reserves its SRAM for runtime data and stack. Serial and manifest

--- a/doc/bios_config.md
+++ b/doc/bios_config.md
@@ -45,6 +45,21 @@ Some BIOS options are build flags rather than generated SoC constants:
 
 When using `Builder`, this can be selected with `bios_console_no_ansi=True`.
 
+## SRAM Boot Images
+
+The BIOS reserves its SRAM for runtime data and stack. Serial and manifest
+loads into that region are rejected by default, including through aliases.
+With the standard BIOS linker script, a fresh build with the make/environment
+variable `BIOS_BOOT_SRAM_SIZE` reserves an image buffer at the beginning of
+SRAM and moves BIOS data after it. For example, `BIOS_BOOT_SRAM_SIZE=0x1000`
+reserves 4 KiB. Leave enough SRAM for BIOS data and stack, and use
+`--bios-stack-margin` to enforce the required remaining stack space.
+
+Custom linker scripts can reserve a buffer and export
+`__bios_boot_sram_start` / `__bios_boot_sram_end` (exclusive end). The buffer
+must not overlap BIOS code, data or stack. Zynq linker scripts do not currently
+provide this optional buffer.
+
 ## Flash Boot Bounds
 
 `FLASH_BOOT_MAX_SIZE` limits the accepted image payload length (by default,

--- a/litex/soc/software/bios/Makefile
+++ b/litex/soc/software/bios/Makefile
@@ -63,6 +63,10 @@ ifneq ($(BIOS_STACK_MARGIN),)
 MEMUSAGE_ARGS += --fail-stack-margin $(BIOS_STACK_MARGIN)
 endif
 
+ifneq ($(BIOS_BOOT_SRAM_SIZE),)
+LDFLAGS += -Wl,--defsym=__bios_boot_sram_size=$(BIOS_BOOT_SRAM_SIZE)
+endif
+
 all: bios.bin
 	$(PYTHON) -m litex.soc.software.memusage $(MEMUSAGE_ARGS) bios.elf $(CURDIR)/../include/generated/regions.ld $(TRIPLE)
 

--- a/litex/soc/software/bios/Makefile
+++ b/litex/soc/software/bios/Makefile
@@ -63,6 +63,13 @@ ifneq ($(BIOS_STACK_MARGIN),)
 MEMUSAGE_ARGS += --fail-stack-margin $(BIOS_STACK_MARGIN)
 endif
 
+ifneq ($(BIOS_ROM_BUDGET),)
+MEMUSAGE_ARGS += --max-rom $(BIOS_ROM_BUDGET)
+endif
+ifneq ($(BIOS_SRAM_BUDGET),)
+MEMUSAGE_ARGS += --max-sram $(BIOS_SRAM_BUDGET)
+endif
+
 ifneq ($(BIOS_BOOT_SRAM_SIZE),)
 LDFLAGS += -Wl,--defsym=__bios_boot_sram_size=$(BIOS_BOOT_SRAM_SIZE)
 endif

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -447,100 +447,124 @@ static char boot_json_buffer[BOOT_JSON_BUFFER_SIZE];
 typedef int (*boot_json_load_cb)(void *opaque, const char *filename,
 	unsigned long load_addr, size_t max_size);
 
+static int boot_json_key_is(const char *json, const jsmntok_t *key, const char *name)
+{
+	return key->end - key->start == (int)strlen(name) &&
+		!strncmp(json + key->start, name, key->end - key->start);
+}
+
+static int boot_json_is_image(const char *json, const jsmntok_t *key)
+{
+	return !boot_json_key_is(json, key, "bootargs") &&
+		!boot_json_key_is(json, key, "addr") &&
+		!boot_json_key_is(json, key, "r1") &&
+		!boot_json_key_is(json, key, "r2") &&
+		!boot_json_key_is(json, key, "r3");
+}
+
 static void boot_from_json_buffer(const char *json_buffer, int size,
 	boot_json_load_cb load_cb, void *opaque)
 {
-	int i;
-	int count;
-
-	/* json_name must accommodate long filenames (FatFs is built with LFN
-	   support), but keep these scratch buffers off .bss. */
 	char json_name[256];
 	char json_value[64];
-
-	unsigned long boot_r1 = 0;
-	unsigned long boot_r2 = 0;
-	unsigned long boot_r3 = 0;
-	unsigned long boot_addr = 0;
-
-	uint8_t image_found = 0;
-	uint8_t boot_addr_found = 0;
-
-	/* Parse JSON file */
+	unsigned long boot_r1 = 0, boot_r2 = 0, boot_r3 = 0, boot_addr = 0;
+	int image_found = 0, boot_addr_found = 0;
 	static jsmntok_t t[64];
 	jsmn_parser p;
+	int count;
+
 	jsmn_init(&p);
 	count = jsmn_parse(&p, json_buffer, size, t, sizeof(t)/sizeof(*t));
 	if (count < 0) {
-		if (count == JSMN_ERROR_NOMEM)
-			printf("Error: too many entries in boot JSON (max %d tokens)\n",
-				(int)(sizeof(t)/sizeof(*t)));
-		else
-			printf("Error: failed to parse boot JSON (%d)\n", count);
+		printf("Error: failed to parse boot JSON (%d; max %d tokens)\n",
+			count, (int)(sizeof(t)/sizeof(*t)));
 		return;
 	}
-	for (i=0; i<count-1; i++) {
-		/* Elements are JSON strings with 1 children */
-		if ((t[i].type == JSMN_STRING) && (t[i].size == 1)) {
-			/* Get Element's filename. Abort instead of skipping the entry:
-			   booting with one of the listed images missing (e.g. a kernel
-			   without its device tree) would fail in harder-to-debug ways. */
-			if (!json_token_to_string(json_name, sizeof(json_name), json_buffer, &t[i])) {
-				printf("Error: boot JSON filename is too long\n");
-				return;
-			}
-			/* bootargs is consumed by other tools, not by the BIOS. Do not
-			   constrain it to the address scratch buffer's size. */
-			if (strcmp(json_name, "bootargs") == 0)
-				continue;
-			/* Get Element's address */
-			if (!json_token_to_string(json_value, sizeof(json_value), json_buffer, &t[i+1])) {
-				printf("Error: boot JSON value for \"%s\" is too long\n", json_name);
-				return;
-			}
-			/* Get boot addr (optional) */
-			if (strcmp(json_name, "addr") == 0) {
-				if (!boot_parse_address(json_value, &boot_addr))
-					return;
-				boot_addr_found = 1;
-			}
-			/* Get boot r1 (optional) */
-			else if (strcmp(json_name, "r1") == 0) {
-				if (!boot_parse_address(json_value, &boot_r1))
-					return;
-			}
-			/* Get boot r2 (optional) */
-			else if (strcmp(json_name, "r2") == 0) {
-				if (!boot_parse_address(json_value, &boot_r2))
-					return;
-			}
-			/* Get boot r3 (optional) */
-			else if (strcmp(json_name, "r3") == 0) {
-				if (!boot_parse_address(json_value, &boot_r3))
-					return;
-			/* Copy Image to address */
-			} else {
-				unsigned long load_addr;
-				size_t max_size;
-
-				if (!boot_parse_address(json_value, &load_addr))
-					return;
-				if (!boot_load_max_size(load_addr, &max_size))
-					return;
-				if (!load_cb(opaque, json_name, load_addr, max_size))
-					return;
-				image_found = 1;
-				if (boot_addr_found == 0) /* Boot to last Image address if no bootargs.addr specified */
-					boot_addr = load_addr;
-			}
-		}
+	if (count < 1 || t[0].type != JSMN_OBJECT || count != 1 + 2*t[0].size) {
+		printf("Error: boot JSON must be a flat object\n");
+		return;
 	}
 
-	/* Boot */
-	if (image_found)
-		boot(boot_r1, boot_r2, boot_r3, boot_addr);
-	else
+	/* Validate the complete manifest before writing any image. */
+	for (int i = 1; i < count; i += 2) {
+		unsigned long value;
+		size_t max_size;
+
+		if (t[i].type != JSMN_STRING || t[i].size != 1 ||
+		    (t[i+1].type != JSMN_STRING && t[i+1].type != JSMN_PRIMITIVE) ||
+		    !json_token_to_string(json_name, sizeof(json_name), json_buffer, &t[i])) {
+			printf("Error: invalid boot JSON entry\n");
+			return;
+		}
+		for (int j = 1; j < i; j += 2) {
+			if (boot_json_key_is(json_buffer, &t[j], json_name)) {
+				printf("Error: duplicate boot JSON key \"%s\"\n", json_name);
+				return;
+			}
+		}
+		/* bootargs is consumed by other tools and can exceed json_value. */
+		if (boot_json_key_is(json_buffer, &t[i], "bootargs"))
+			continue;
+		if (!json_token_to_string(json_value, sizeof(json_value), json_buffer, &t[i+1]) ||
+		    !boot_parse_address(json_value, &value))
+			return;
+		if (!strcmp(json_name, "addr")) {
+			boot_addr = value;
+			boot_addr_found = 1;
+		} else if (!strcmp(json_name, "r1")) {
+			boot_r1 = value;
+		} else if (!strcmp(json_name, "r2")) {
+			boot_r2 = value;
+		} else if (!strcmp(json_name, "r3")) {
+			boot_r3 = value;
+		} else {
+			if (!boot_load_max_size(value, &max_size))
+				return;
+			image_found = 1;
+			if (!boot_addr_found)
+				boot_addr = value;
+		}
+	}
+	if (!image_found) {
 		printf("Error: no boot image found in boot JSON\n");
+		return;
+	}
+
+	/* Bound every image by the next destination, regardless of file order.
+	   Reusing the parsed tokens avoids an additional SRAM image table. */
+	for (int i = 1; i < count; i += 2) {
+		unsigned long load_addr, physical;
+		size_t max_size;
+
+		if (!boot_json_is_image(json_buffer, &t[i]))
+			continue;
+		json_token_to_string(json_name, sizeof(json_name), json_buffer, &t[i]);
+		json_token_to_string(json_value, sizeof(json_value), json_buffer, &t[i+1]);
+		if (!boot_parse_address(json_value, &load_addr))
+			return;
+		physical = boot_physical_address(load_addr);
+		if (!boot_load_max_size(load_addr, &max_size))
+			return;
+		for (int j = 1; j < count; j += 2) {
+			unsigned long other;
+
+			if (j == i || !boot_json_is_image(json_buffer, &t[j]))
+				continue;
+			json_token_to_string(json_value, sizeof(json_value), json_buffer, &t[j+1]);
+			if (!boot_parse_address(json_value, &other))
+				return;
+			other = boot_physical_address(other);
+			if (other == physical) {
+				printf("Error: boot images share load address 0x%08lx\n", load_addr);
+				return;
+			}
+			if (other > physical && max_size > other - physical)
+				max_size = other - physical;
+		}
+		if (!load_cb(opaque, json_name, load_addr, max_size))
+			return;
+	}
+	boot(boot_r1, boot_r2, boot_r3, boot_addr);
 }
 #endif
 

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <system.h>
 #include <string.h>
@@ -80,7 +81,7 @@ enum {
 	ACK_OK
 };
 
-#if defined(MAIN_RAM_BASE) || defined(MAIN_RAM_BASE_VA) || defined(SRAM_BASE) || defined(SRAM_BASE_VA)
+#if defined(MAIN_RAM_BASE) || defined(MAIN_RAM_BASE_VA) || defined(SRAM_BASE) || defined(SRAM_BASE_VA) || defined(SPIFLASH_BASE) || defined(FLASH_BOOT_REGION_BASE)
 static int boot_region_max_size(unsigned long addr, unsigned long base, unsigned long size, size_t *max_size)
 {
 	/* Compare offsets instead of region end so that regions ending exactly at
@@ -785,15 +786,43 @@ void netboot(int nb_params, char **params)
 #endif
 #endif
 
-static unsigned int check_image_in_flash(unsigned int base_address)
+/* Targets with another flash mapping can describe its bounds explicitly. */
+#if defined(FLASH_BOOT_REGION_BASE) != defined(FLASH_BOOT_REGION_SIZE)
+#error "FLASH_BOOT_REGION_BASE and FLASH_BOOT_REGION_SIZE must be specified together"
+#endif
+#if !defined(FLASH_BOOT_REGION_BASE) && defined(SPIFLASH_BASE)
+#define FLASH_BOOT_REGION_BASE SPIFLASH_BASE
+#define FLASH_BOOT_REGION_SIZE SPIFLASH_SIZE
+#endif
+
+static unsigned int check_image_in_flash(unsigned long base_address)
 {
 	uint32_t length;
 	uint32_t crc;
 	uint32_t got_crc;
+#ifdef FLASH_BOOT_REGION_BASE
+	size_t available;
+
+	if (!boot_region_max_size(base_address, FLASH_BOOT_REGION_BASE,
+		FLASH_BOOT_REGION_SIZE, &available) || available < 8) {
+		printf("Error: flash image header is outside flash\n");
+		return 0;
+	}
+#endif
 
 	length = MMPTR(base_address);
 	if((length < 32) || (length > FLASH_BOOT_MAX_SIZE)) {
 		printf("Error: invalid image length 0x%08lx\n", (unsigned long)length);
+		return 0;
+	}
+	/* Validate the source before CRC reads any payload bytes. The image
+	   policy limit alone need not fit the remaining flash mapping. */
+	if (base_address > ULONG_MAX - 8 || length - 1 > ULONG_MAX - base_address - 8
+#ifdef FLASH_BOOT_REGION_BASE
+		|| length > available - 8
+#endif
+	) {
+		printf("Error: flash image extends beyond flash or the address space\n");
 		return 0;
 	}
 
@@ -808,7 +837,7 @@ static unsigned int check_image_in_flash(unsigned int base_address)
 }
 
 #if defined(MAIN_RAM_BASE_VA) && defined(FLASH_BOOT_ADDRESS)
-static int copy_image_from_flash_to_ram(unsigned int flash_address, unsigned long ram_address)
+static int copy_image_from_flash_to_ram(unsigned long flash_address, unsigned long ram_address)
 {
 	uint32_t length;
 	uint32_t offset;
@@ -824,7 +853,7 @@ static int copy_image_from_flash_to_ram(unsigned int flash_address, unsigned lon
 				(unsigned long)length, (unsigned long)max_size);
 			return 0;
 		}
-		printf("Copying 0x%08x to 0x%08lx (%lu bytes)...\n", flash_address, ram_address, (unsigned long)length);
+		printf("Copying 0x%08lx to 0x%08lx (%lu bytes)...\n", flash_address, ram_address, (unsigned long)length);
 		offset = 0;
 		init_progression_bar(length);
 		while (length > 0) {

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -313,9 +313,6 @@ int serialboot(void)
 					break;
 				}
 
-				/* Reset failures */
-				failures = 0;
-
 				/* Copy payload when it fits in writable memory */
 				load_addr = (char *)(uintptr_t) get_uint32(&frame.payload[0]);
 				load_size = frame.payload_length - 4;
@@ -333,6 +330,8 @@ int serialboot(void)
 					clean_cpu_dcache_range(load_addr, load_size);
 #endif
 
+				/* Only a successful load ends a run of consecutive errors. */
+				failures = 0;
 				/* Acknowledge and continue */
 				uart_write(SFL_ACK_SUCCESS);
 				break;

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -29,6 +29,7 @@
 #include <libbase/crc.h>
 #include <libbase/jsmn.h>
 #include <libbase/progress.h>
+#include <libbase/parse.h>
 
 #include <libliteeth/udp.h>
 #include <libliteeth/tftp.h>
@@ -390,10 +391,7 @@ static int json_token_to_string(char *dst, size_t dst_size, const char *json, js
 
 static int boot_parse_address(const char *value, unsigned long *address)
 {
-	char *end;
-
-	*address = strtoul(value, &end, 0);
-	if ((end == value) || (*end != 0)) {
+	if (!parse_ulong(value, address)) {
 		printf("Error: invalid boot address \"%s\"\n", value);
 		return 0;
 	}

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -870,320 +870,140 @@ void flashboot(void)
 /* SDCard Boot                                                           */
 /*-----------------------------------------------------------------------*/
 
-#if defined(CSR_SPISDCARD_BASE) || defined(CSR_SDCARD_BASE)
+#if defined(CSR_SPISDCARD_BASE) || defined(CSR_SDCARD_BASE) || defined(CSR_SATA_SECTOR2MEM_BASE)
 
-static int copy_file_from_sdcard_to_ram(const char * filename, unsigned long ram_address, size_t max_size)
+/* The selected FatFs disk operations determine the boot medium. Keep file
+ * validation and cleanup common to SDCard and SATA, including boot.json. */
+static enum boot_load_result fatfs_load_file(const char *filename, void *buffer,
+	size_t max_size, size_t *loaded_size, int progress)
 {
-	FRESULT fr;
 	FATFS fs;
 	FIL file;
-	uint32_t br;
-	uint32_t offset;
-	unsigned long length;
+	FRESULT fr;
+	enum boot_load_result result = BOOT_LOAD_IO_ERROR;
+	size_t length;
+	size_t offset = 0;
 
+	*loaded_size = 0;
 	fr = f_mount(&fs, "", 1);
 	if (fr != FR_OK) {
 		printf("Error: filesystem mount failed (FatFs error %d)\n", fr);
-		return 0;
+		/* FatFs registers the object even when the immediate mount fails. */
+		f_mount(0, "", 0);
+		return result;
 	}
 	fr = f_open(&file, filename, FA_READ);
 	if (fr != FR_OK) {
-		printf("%s file not found.\n", filename);
+		printf("Error: cannot open %s (FatFs error %d)\n", filename, fr);
 		f_mount(0, "", 0);
-		return 0;
+		return (fr == FR_NO_FILE || fr == FR_NO_PATH) ? BOOT_LOAD_NOT_FOUND : result;
 	}
 
+	if (f_size(&file) == 0 || f_size(&file) > max_size) {
+		printf("Error: %s is empty or too large for destination (max 0x%lx bytes)\n",
+			filename, (unsigned long)max_size);
+		result = BOOT_LOAD_INVALID;
+		goto close;
+	}
 	length = f_size(&file);
-	if (length == 0) {
-		printf("Error: %s is empty\n", filename);
-		f_close(&file);
-		f_mount(0, "", 0);
-		return 0;
+	if (progress) {
+		printf("Copying %s to %p (%lu bytes)...\n", filename, buffer, (unsigned long)length);
+		init_progression_bar(length);
 	}
-	if (length > max_size) {
-		printf("Error: %s is too large for destination (0x%08lx > 0x%08lx bytes)\n",
-			filename, length, (unsigned long)max_size);
-		f_close(&file);
-		f_mount(0, "", 0);
-		return 0;
-	}
-	printf("Copying %s to 0x%08lx (%ld bytes)...\n", filename, ram_address, length);
-	init_progression_bar(length);
-	offset = 0;
-	for (;;) {
-		fr = f_read(&file, (void*) ram_address + offset,  0x8000, (UINT *)&br);
-		if (fr != FR_OK) {
-			printf("Error: file read failed\n");
-			f_close(&file);
-			f_mount(0, "", 0);
-			return 0;
-		}
-		if (br == 0)
-			break;
-		offset += br;
-		show_progress(offset);
-	}
-	show_progress(offset);
-	printf("\n");
+	while (offset < length) {
+		UINT br;
+		UINT chunk = length - offset > 0x8000 ? 0x8000 : length - offset;
 
+		fr = f_read(&file, (char *)buffer + offset, chunk, &br);
+		if (fr != FR_OK || br != chunk) {
+			printf("Error: incomplete read of %s at 0x%lx (FatFs error %d)\n",
+				filename, (unsigned long)offset, fr);
+			goto close;
+		}
+		offset += br;
+		if (progress)
+			show_progress(offset);
+	}
+	if (progress)
+		printf("\n");
+	*loaded_size = length;
+	result = BOOT_LOAD_OK;
+close:
 	f_close(&file);
 	f_mount(0, "", 0);
-
-	return 1;
+	return result;
 }
 
-static int sdcardboot_json_load(void *opaque, const char *filename,
+static int fatfsboot_json_load(void *opaque, const char *filename,
 	unsigned long load_addr, size_t max_size)
 {
-	(void)opaque;
+	size_t size;
 
-	/* Copy Image from SDCard to address */
-	return copy_file_from_sdcard_to_ram(filename, load_addr, max_size) != 0;
+	(void)opaque;
+	return fatfs_load_file(filename, (void *)load_addr, max_size, &size, 1) == BOOT_LOAD_OK;
 }
 
-static void sdcardboot_from_json(const char * filename)
+static void fatfsboot_from_json(const char *filename)
 {
-	FRESULT fr;
-	FATFS fs;
-	FIL file;
+	size_t size;
 
-	uint32_t length;
-
-	/* Read JSON file */
-	fr = f_mount(&fs, "", 1);
-	if (fr != FR_OK) {
-		printf("Error: filesystem mount failed (FatFs error %d)\n", fr);
+	if (fatfs_load_file(filename, boot_json_buffer, sizeof(boot_json_buffer) - 1,
+		&size, 0) != BOOT_LOAD_OK)
 		return;
-	}
-	fr = f_open(&file, filename, FA_READ);
-	if (fr != FR_OK) {
-		printf("%s file not found.\n", filename);
-		f_mount(0, "", 0);
-		return;
-	}
-
-	length = f_size(&file);
-	if (length >= sizeof(boot_json_buffer)) {
-		printf("Error: %s is too large for boot JSON buffer\n", filename);
-		f_close(&file);
-		f_mount(0, "", 0);
-		return;
-	}
-	fr = f_read(&file, boot_json_buffer,
-		sizeof(boot_json_buffer) - 1, (UINT *) &length);
-
-	/* Close JSON file */
-	f_close(&file);
-	f_mount(0, "", 0);
-	if (fr != FR_OK)
-		return;
-	boot_json_buffer[length] = 0;
-
-	/* Parse JSON file */
-	boot_from_json_buffer(boot_json_buffer, length, sdcardboot_json_load, NULL);
+	boot_json_buffer[size] = 0;
+	boot_from_json_buffer(boot_json_buffer, size, fatfsboot_json_load, NULL);
 }
 
 #ifdef MAIN_RAM_BASE_VA
-static void sdcardboot_from_bin(const char * filename)
+static void fatfsboot_from_bin(const char *filename)
 {
-	uint32_t result;
-	result = copy_file_from_sdcard_to_ram(filename, MAIN_RAM_BASE_VA, MAIN_RAM_SIZE);
-	if (result == 0)
+	size_t size;
+
+	if (fatfs_load_file(filename, (void *)MAIN_RAM_BASE_VA, MAIN_RAM_SIZE,
+		&size, 1) != BOOT_LOAD_OK)
 		return;
 	boot(0, 0, 0, MAIN_RAM_BASE_VA);
 }
 #endif
 
+static void fatfsboot(int nb_params, char **params)
+{
+	if (nb_params > 0) {
+		printf("Booting from %s (JSON)...\n", params[0]);
+		fatfsboot_from_json(params[0]);
+	} else {
+		printf("Booting from boot.json...\n");
+		fatfsboot_from_json("boot.json");
+#ifdef MAIN_RAM_BASE_VA
+		printf("Booting from boot.bin...\n");
+		fatfsboot_from_bin("boot.bin");
+#endif
+	}
+}
+#endif
+
+#if defined(CSR_SPISDCARD_BASE) || defined(CSR_SDCARD_BASE)
 void sdcardboot(int nb_params, char **params)
 {
-	char * filename = NULL;
-
-	if (nb_params > 0)
-		filename = params[0];
-
 #ifdef CSR_SPISDCARD_BASE
 	printf("Booting from SDCard in SPI-Mode...\n");
-	fatfs_set_ops_spisdcard();	/* use spisdcard disk access ops */
+	fatfs_set_ops_spisdcard();
 #endif
 #ifdef CSR_SDCARD_BASE
 	printf("Booting from SDCard in SD-Mode...\n");
-	fatfs_set_ops_sdcard();		/* use sdcard disk access ops */
+	fatfs_set_ops_sdcard();
 #endif
-
-	if (filename) {
-		printf("Booting from %s (JSON)...\n", filename);
-		sdcardboot_from_json(filename);
-	} else {
-		/* Boot from boot.json */
-		printf("Booting from boot.json...\n");
-		sdcardboot_from_json("boot.json");
-
-#ifdef MAIN_RAM_BASE_VA
-		/* Boot from boot.bin */
-		printf("Booting from boot.bin...\n");
-		sdcardboot_from_bin("boot.bin");
-#endif
-	}
-
-	/* Boot failed if we are here... */
+	fatfsboot(nb_params, params);
 	printf("SDCard boot failed.\n");
 }
 #endif
 
-/*-----------------------------------------------------------------------*/
-/* SATA Boot                                                             */
-/*-----------------------------------------------------------------------*/
-
-#if defined(CSR_SATA_SECTOR2MEM_BASE)
-
-static int copy_file_from_sata_to_ram(const char * filename, unsigned long ram_address, size_t max_size)
-{
-	FRESULT fr;
-	FATFS fs;
-	FIL file;
-	uint32_t br;
-	uint32_t offset;
-	unsigned long length;
-
-	fr = f_mount(&fs, "", 1);
-	if (fr != FR_OK) {
-		printf("Error: filesystem mount failed (FatFs error %d)\n", fr);
-		return 0;
-	}
-	fr = f_open(&file, filename, FA_READ);
-	if (fr != FR_OK) {
-		printf("%s file not found.\n", filename);
-		f_mount(0, "", 0);
-		return 0;
-	}
-
-	length = f_size(&file);
-	if (length == 0) {
-		printf("Error: %s is empty\n", filename);
-		f_close(&file);
-		f_mount(0, "", 0);
-		return 0;
-	}
-	if (length > max_size) {
-		printf("Error: %s is too large for destination (0x%08lx > 0x%08lx bytes)\n",
-			filename, length, (unsigned long)max_size);
-		f_close(&file);
-		f_mount(0, "", 0);
-		return 0;
-	}
-	printf("Copying %s to 0x%08lx (%ld bytes)...\n", filename, ram_address, length);
-	init_progression_bar(length);
-	offset = 0;
-	for (;;) {
-		fr = f_read(&file, (void*) ram_address + offset,  0x8000, (UINT *) &br);
-		if (fr != FR_OK) {
-			printf("Error: file read failed\n");
-			f_close(&file);
-			f_mount(0, "", 0);
-			return 0;
-		}
-		if (br == 0)
-			break;
-		offset += br;
-		show_progress(offset);
-	}
-	show_progress(offset);
-	printf("\n");
-
-	f_close(&file);
-	f_mount(0, "", 0);
-
-	return 1;
-}
-
-static int sataboot_json_load(void *opaque, const char *filename,
-	unsigned long load_addr, size_t max_size)
-{
-	(void)opaque;
-
-	/* Copy Image from SATA to address */
-	return copy_file_from_sata_to_ram(filename, load_addr, max_size) != 0;
-}
-
-static void sataboot_from_json(const char * filename)
-{
-	FRESULT fr;
-	FATFS fs;
-	FIL file;
-
-	uint32_t length;
-
-	/* Read JSON file */
-	fr = f_mount(&fs, "", 1);
-	if (fr != FR_OK) {
-		printf("Error: filesystem mount failed (FatFs error %d)\n", fr);
-		return;
-	}
-	fr = f_open(&file, filename, FA_READ);
-	if (fr != FR_OK) {
-		printf("%s file not found.\n", filename);
-		f_mount(0, "", 0);
-		return;
-	}
-
-	length = f_size(&file);
-	if (length >= sizeof(boot_json_buffer)) {
-		printf("Error: %s is too large for boot JSON buffer\n", filename);
-		f_close(&file);
-		f_mount(0, "", 0);
-		return;
-	}
-	fr = f_read(&file, boot_json_buffer,
-		sizeof(boot_json_buffer) - 1, (UINT *) &length);
-
-	/* Close JSON file */
-	f_close(&file);
-	f_mount(0, "", 0);
-	if (fr != FR_OK)
-		return;
-	boot_json_buffer[length] = 0;
-
-	/* Parse JSON file */
-	boot_from_json_buffer(boot_json_buffer, length, sataboot_json_load, NULL);
-}
-
-#ifdef MAIN_RAM_BASE_VA
-static void sataboot_from_bin(const char * filename)
-{
-	uint32_t result;
-	result = copy_file_from_sata_to_ram(filename, MAIN_RAM_BASE_VA, MAIN_RAM_SIZE);
-	if (result == 0)
-		return;
-	boot(0, 0, 0, MAIN_RAM_BASE_VA);
-}
-#endif
-
+#ifdef CSR_SATA_SECTOR2MEM_BASE
 void sataboot(int nb_params, char **params)
 {
-	char * filename = NULL;
-
-	if (nb_params > 0)
-		filename = params[0];
-
 	printf("Booting from SATA...\n");
-	fatfs_set_ops_sata();		/* use sata disk access ops */
-
-	if (filename) {
-		printf("Booting from %s (JSON)...\n", filename);
-		sataboot_from_json(filename);
-	} else {
-		/* Boot from boot.json */
-		printf("Booting from boot.json...\n");
-		sataboot_from_json("boot.json");
-
-#ifdef MAIN_RAM_BASE_VA
-		/* Boot from boot.bin */
-		printf("Booting from boot.bin...\n");
-		sataboot_from_bin("boot.bin");
-#endif
-	}
-
-	/* Boot failed if we are here... */
+	fatfs_set_ops_sata();
+	fatfsboot(nb_params, params);
 	printf("SATA boot failed.\n");
 }
 #endif

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -566,6 +566,19 @@ static void boot_from_json_buffer(const char *json_buffer, int size,
 		} else {
 			if (!boot_load_max_size(value, &max_size))
 				return;
+			for (int j = 1; j < i; j += 2) {
+				unsigned long other;
+
+				if (!boot_json_is_image(json_buffer, &t[j]))
+					continue;
+				json_token_to_string(json_value, sizeof(json_value), json_buffer, &t[j+1]);
+				if (!boot_parse_address(json_value, &other))
+					return;
+				if (boot_physical_address(other) == boot_physical_address(value)) {
+					printf("Error: boot images share load address 0x%08lx\n", value);
+					return;
+				}
+			}
 			image_found = 1;
 			if (!boot_addr_found)
 				boot_addr = value;
@@ -600,10 +613,6 @@ static void boot_from_json_buffer(const char *json_buffer, int size,
 			if (!boot_parse_address(json_value, &other))
 				return;
 			other = boot_physical_address(other);
-			if (other == physical) {
-				printf("Error: boot images share load address 0x%08lx\n", load_addr);
-				return;
-			}
 			if (other > physical && max_size > other - physical)
 				max_size = other - physical;
 		}

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -95,26 +95,64 @@ static int boot_region_max_size(unsigned long addr, unsigned long base, unsigned
 }
 #endif
 
+/* Compare physical addresses so aliases cannot bypass load reservations. */
+static unsigned long boot_physical_address(unsigned long addr)
+{
+#if defined(MAIN_RAM_BASE) && defined(MAIN_RAM_BASE_VA)
+	if (addr >= MAIN_RAM_BASE_VA && addr - MAIN_RAM_BASE_VA < MAIN_RAM_SIZE)
+		return MAIN_RAM_BASE + (addr - MAIN_RAM_BASE_VA);
+#endif
+#if defined(SRAM_BASE) && defined(SRAM_BASE_VA)
+	if (addr >= SRAM_BASE_VA && addr - SRAM_BASE_VA < SRAM_SIZE)
+		return SRAM_BASE + (addr - SRAM_BASE_VA);
+#endif
+	return addr;
+}
+
+#ifdef SRAM_BASE
+#define BIOS_SRAM_BASE SRAM_BASE
+#elif defined(SRAM_BASE_VA)
+#define BIOS_SRAM_BASE SRAM_BASE_VA
+#endif
+
 static int boot_load_max_size(unsigned long addr, size_t *max_size)
 {
-	(void)max_size;
-	/* Limit boot image loads to known writable memory regions. */
+	unsigned long physical = boot_physical_address(addr);
+	int found = 0;
+
+#ifdef BIOS_SRAM_BASE
+	/* SRAM holds the BIOS runtime and its growing stack. Only a buffer
+	   explicitly reserved by the linker is available for image loading.
+	   Custom linker scripts without these symbols reserve all SRAM. */
+	extern char __bios_boot_sram_start[] __attribute__((weak));
+	extern char __bios_boot_sram_end[] __attribute__((weak));
+	unsigned long start = boot_physical_address((unsigned long)__bios_boot_sram_start);
+	unsigned long end = boot_physical_address((unsigned long)__bios_boot_sram_end);
+	size_t available;
+
+	if (boot_region_max_size(physical, BIOS_SRAM_BASE, SRAM_SIZE, &available)) {
+		if (end > start && start >= BIOS_SRAM_BASE &&
+		    start - BIOS_SRAM_BASE < SRAM_SIZE &&
+		    end - start <= SRAM_SIZE - (start - BIOS_SRAM_BASE) &&
+		    boot_region_max_size(physical, start, end - start, max_size))
+			return 1;
+		printf("Error: boot load address 0x%08lx overlaps BIOS SRAM\n", addr);
+		return 0;
+	}
+#endif
 #ifdef MAIN_RAM_BASE
-	if (boot_region_max_size(addr, MAIN_RAM_BASE, MAIN_RAM_SIZE, max_size))
-		return 1;
+	found = boot_region_max_size(physical, MAIN_RAM_BASE, MAIN_RAM_SIZE, max_size);
+#elif defined(MAIN_RAM_BASE_VA)
+	found = boot_region_max_size(physical, MAIN_RAM_BASE_VA, MAIN_RAM_SIZE, max_size);
 #endif
-#ifdef MAIN_RAM_BASE_VA
-	if (boot_region_max_size(addr, MAIN_RAM_BASE_VA, MAIN_RAM_SIZE, max_size))
-		return 1;
+	if (found) {
+#ifdef BIOS_SRAM_BASE
+		/* A target may carve its SRAM reservation out of main RAM. */
+		if (physical < BIOS_SRAM_BASE && *max_size > BIOS_SRAM_BASE - physical)
+			*max_size = BIOS_SRAM_BASE - physical;
 #endif
-#ifdef SRAM_BASE
-	if (boot_region_max_size(addr, SRAM_BASE, SRAM_SIZE, max_size))
 		return 1;
-#endif
-#ifdef SRAM_BASE_VA
-	if (boot_region_max_size(addr, SRAM_BASE_VA, SRAM_SIZE, max_size))
-		return 1;
-#endif
+	}
 
 	printf("Error: boot load address 0x%08lx is outside writable memory\n", addr);
 	return 0;
@@ -717,7 +755,10 @@ static void netboot_from_json(const char * filename, unsigned int ip, unsigned s
 static void netboot_from_bin(const char * filename, unsigned int ip, unsigned short tftp_port)
 {
 	int size;
-	size = copy_file_from_tftp_to_ram(ip, tftp_port, filename, (void *)MAIN_RAM_BASE_VA, MAIN_RAM_SIZE);
+	size_t max_size;
+	if (!boot_load_max_size(MAIN_RAM_BASE_VA, &max_size))
+		return;
+	size = copy_file_from_tftp_to_ram(ip, tftp_port, filename, (void *)MAIN_RAM_BASE_VA, max_size);
 	if (size <= 0)
 		return;
 	boot(0, 0, 0, MAIN_RAM_BASE_VA);
@@ -985,8 +1026,11 @@ static void fatfsboot_from_json(const char *filename)
 static void fatfsboot_from_bin(const char *filename)
 {
 	size_t size;
+	size_t max_size;
 
-	if (fatfs_load_file(filename, (void *)MAIN_RAM_BASE_VA, MAIN_RAM_SIZE,
+	if (!boot_load_max_size(MAIN_RAM_BASE_VA, &max_size))
+		return;
+	if (fatfs_load_file(filename, (void *)MAIN_RAM_BASE_VA, max_size,
 		&size, 1) != BOOT_LOAD_OK)
 		return;
 	boot(0, 0, 0, MAIN_RAM_BASE_VA);

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -894,6 +894,12 @@ static int copy_file_from_sdcard_to_ram(const char * filename, unsigned long ram
 	}
 
 	length = f_size(&file);
+	if (length == 0) {
+		printf("Error: %s is empty\n", filename);
+		f_close(&file);
+		f_mount(0, "", 0);
+		return 0;
+	}
 	if (length > max_size) {
 		printf("Error: %s is too large for destination (0x%08lx > 0x%08lx bytes)\n",
 			filename, length, (unsigned long)max_size);
@@ -1052,6 +1058,12 @@ static int copy_file_from_sata_to_ram(const char * filename, unsigned long ram_a
 	}
 
 	length = f_size(&file);
+	if (length == 0) {
+		printf("Error: %s is empty\n", filename);
+		f_close(&file);
+		f_mount(0, "", 0);
+		return 0;
+	}
 	if (length > max_size) {
 		printf("Error: %s is too large for destination (0x%08lx > 0x%08lx bytes)\n",
 			filename, length, (unsigned long)max_size);

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -462,6 +462,50 @@ static int boot_json_is_image(const char *json, const jsmntok_t *key)
 		!boot_json_key_is(json, key, "r3");
 }
 
+/* Flatten the optional bootargs object in place, preserving the image order.
+   The remaining passes can then validate both nested and top-level metadata
+   without another token array or special cases in the image loader. */
+static int boot_json_flatten(const char *json, jsmntok_t *t, int count)
+{
+	int bootargs_found = 0;
+
+	if (count < 1 || t[0].type != JSMN_OBJECT)
+		return 0;
+	for (int i = 1; i + 1 < count; i += 2) {
+		if (t[i+1].end >= t[0].end)
+			return 0;
+		if (boot_json_key_is(json, &t[i], "bootargs")) {
+			if (bootargs_found++)
+				return 0;
+			if (t[i].type != JSMN_STRING || t[i].size != 1)
+				return 0;
+			if (t[i+1].type == JSMN_OBJECT) {
+				int next = i + 2 + 2*t[i+1].size;
+
+				if (next > count)
+					return 0;
+				for (int j = i + 2; j < next; j += 2) {
+					if (boot_json_is_image(json, &t[j]) ||
+					    boot_json_key_is(json, &t[j], "bootargs") ||
+					    (t[j+1].type != JSMN_STRING && t[j+1].type != JSMN_PRIMITIVE) ||
+					    t[j+1].end >= t[i+1].end)
+						return 0;
+				}
+				if (next < count && t[next].start < t[i+1].end)
+					return 0;
+				t[0].size += t[i+1].size - 1;
+				memmove(&t[i], &t[i+2], (count - i - 2)*sizeof(*t));
+				count -= 2;
+				i -= 2;
+				continue;
+			}
+		}
+		if (t[i+1].type != JSMN_STRING && t[i+1].type != JSMN_PRIMITIVE)
+			return 0;
+	}
+	return count == 1 + 2*t[0].size ? count : 0;
+}
+
 static void boot_from_json_buffer(const char *json_buffer, int size,
 	boot_json_load_cb load_cb, void *opaque)
 {
@@ -480,8 +524,9 @@ static void boot_from_json_buffer(const char *json_buffer, int size,
 			count, (int)(sizeof(t)/sizeof(*t)));
 		return;
 	}
-	if (count < 1 || t[0].type != JSMN_OBJECT || count != 1 + 2*t[0].size) {
-		printf("Error: boot JSON must be a flat object\n");
+	count = boot_json_flatten(json_buffer, t, count);
+	if (!count) {
+		printf("Error: invalid boot JSON structure\n");
 		return;
 	}
 
@@ -502,7 +547,8 @@ static void boot_from_json_buffer(const char *json_buffer, int size,
 				return;
 			}
 		}
-		/* bootargs is consumed by other tools and can exceed json_value. */
+		/* Preserve legacy ignored scalar bootargs without copying its value.
+		   Object bootargs have already been flattened into metadata entries. */
 		if (boot_json_key_is(json_buffer, &t[i], "bootargs"))
 			continue;
 		if (!json_token_to_string(json_value, sizeof(json_value), json_buffer, &t[i+1]) ||

--- a/litex/soc/software/bios/boot.c
+++ b/litex/soc/software/bios/boot.c
@@ -452,17 +452,17 @@ static void boot_from_json_buffer(const char *json_buffer, int size,
 				printf("Error: boot JSON filename is too long\n");
 				return;
 			}
+			/* bootargs is consumed by other tools, not by the BIOS. Do not
+			   constrain it to the address scratch buffer's size. */
+			if (strcmp(json_name, "bootargs") == 0)
+				continue;
 			/* Get Element's address */
 			if (!json_token_to_string(json_value, sizeof(json_value), json_buffer, &t[i+1])) {
 				printf("Error: boot JSON value for \"%s\" is too long\n", json_name);
 				return;
 			}
-			/* Skip bootargs (optional) */
-			if (strcmp(json_name, "bootargs") == 0) {
-				continue;
-			}
 			/* Get boot addr (optional) */
-			else if (strcmp(json_name, "addr") == 0) {
+			if (strcmp(json_name, "addr") == 0) {
 				if (!boot_parse_address(json_value, &boot_addr))
 					return;
 				boot_addr_found = 1;

--- a/litex/soc/software/bios/boot.h
+++ b/litex/soc/software/bios/boot.h
@@ -1,6 +1,13 @@
 #ifndef __BOOT_H
 #define __BOOT_H
 
+enum boot_load_result {
+	BOOT_LOAD_OK,
+	BOOT_LOAD_NOT_FOUND,
+	BOOT_LOAD_INVALID,
+	BOOT_LOAD_IO_ERROR,
+};
+
 typedef int (*boot_method_handler)(void);
 
 struct boot_method {

--- a/litex/soc/software/bios/cmds/cmd_bios.c
+++ b/litex/soc/software/bios/cmds/cmd_bios.c
@@ -20,7 +20,7 @@
  */
 static void help_handler(int nb_params, char **params)
 {
-	struct command_struct * const *cmd;
+	const struct command_struct * const *cmd;
 	int i, not_empty;
 
 	puts("\nLiteX BIOS, available commands:\n");

--- a/litex/soc/software/bios/cmds/cmd_bios.c
+++ b/litex/soc/software/bios/cmds/cmd_bios.c
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <system.h>
 
 #include <libbase/crc.h>
@@ -23,6 +24,19 @@ static void help_handler(int nb_params, char **params)
 	const struct command_struct * const *cmd;
 	int i, not_empty;
 
+	if (nb_params == 1) {
+		for (cmd = __bios_cmd_start; cmd != __bios_cmd_end; cmd++) {
+			if (strcmp(params[0], (*cmd)->name))
+				continue;
+			printf("%s - %s\n", (*cmd)->name, (*cmd)->help ? (*cmd)->help : "-");
+			if ((*cmd)->usage)
+				printf("Usage: %s\n", (*cmd)->usage);
+			return;
+		}
+		printf("Command not found: %s\n", params[0]);
+		return;
+	}
+
 	puts("\nLiteX BIOS, available commands:\n");
 
 	for (i = 0; i < NB_OF_GROUPS; i++) {
@@ -38,7 +52,7 @@ static void help_handler(int nb_params, char **params)
 	}
 }
 
-define_command(help, help_handler, "Print this help", SYSTEM_CMDS);
+define_command_args(help, help_handler, "Print this help", "help [command]", 0, 1, SYSTEM_CMDS);
 
 /**
  * Command "ident"

--- a/litex/soc/software/bios/cmds/cmd_boot.c
+++ b/litex/soc/software/bios/cmds/cmd_boot.c
@@ -24,10 +24,6 @@ static void boot_handler(int nb_params, char **params)
 	unsigned long r2;
 	unsigned long r3;
 
-	if (nb_params < 1) {
-		printf("boot <address> [r1] [r2] [r3]\n");
-		return;
-	}
 	addr = strtoul(params[0], &c, 0);
 	if (*c != 0) {
 		printf("Error: invalid address\n");
@@ -59,7 +55,8 @@ static void boot_handler(int nb_params, char **params)
 	}
 	boot(r1, r2, r3, addr);
 }
-define_command(boot, boot_handler, "Boot from Memory",  BOOT_CMDS);
+define_command_args(boot, boot_handler, "Boot from Memory",
+	"boot <address> [r1] [r2] [r3]", 1, 4, BOOT_CMDS);
 
 /**
  * Command "reboot"
@@ -73,7 +70,8 @@ static void reboot_handler(int nb_params, char **params)
 	ctrl_reset_write(1);
 }
 
-define_command(reboot, reboot_handler, "Reboot",  BOOT_CMDS);
+define_command_args(reboot, reboot_handler, "Reboot",
+	"reboot", 0, 0, BOOT_CMDS);
 #endif
 
 /**
@@ -83,7 +81,8 @@ define_command(reboot, reboot_handler, "Reboot",  BOOT_CMDS);
  *
  */
 #ifdef FLASH_BOOT_ADDRESS
-define_command(flashboot, flashboot, "Boot from Flash", BOOT_CMDS);
+define_command_args(flashboot, flashboot, "Boot from Flash",
+	"flashboot", 0, 0, BOOT_CMDS);
 #endif
 
 /**
@@ -93,7 +92,8 @@ define_command(flashboot, flashboot, "Boot from Flash", BOOT_CMDS);
  *
  */
 #ifdef ROM_BOOT_ADDRESS
-define_command(romboot, romboot, "Boot from ROM", BOOT_CMDS);
+define_command_args(romboot, romboot, "Boot from ROM",
+	"romboot", 0, 0, BOOT_CMDS);
 #endif
 
 /**
@@ -103,7 +103,8 @@ define_command(romboot, romboot, "Boot from ROM", BOOT_CMDS);
  *
  */
 #ifdef CSR_UART_BASE
-define_command(serialboot, serialboot, "Boot from Serial (SFL)", BOOT_CMDS);
+define_command_args(serialboot, serialboot, "Boot from Serial (SFL)",
+	"serialboot", 0, 0, BOOT_CMDS);
 #endif
 
 /**
@@ -113,7 +114,8 @@ define_command(serialboot, serialboot, "Boot from Serial (SFL)", BOOT_CMDS);
  *
  */
 #ifdef CSR_ETHMAC_BASE
-define_command(netboot, netboot, "Boot via Ethernet (TFTP)", BOOT_CMDS);
+define_command_args(netboot, netboot, "Boot via Ethernet (TFTP)",
+	"netboot [manifest]", 0, 1, BOOT_CMDS);
 #endif
 
 /**
@@ -123,7 +125,8 @@ define_command(netboot, netboot, "Boot via Ethernet (TFTP)", BOOT_CMDS);
  *
  */
 #if defined(CSR_SPISDCARD_BASE) || defined(CSR_SDCARD_BASE)
-define_command(sdcardboot, sdcardboot, "Boot from SDCard", BOOT_CMDS);
+define_command_args(sdcardboot, sdcardboot, "Boot from SDCard",
+	"sdcardboot [manifest]", 0, 1, BOOT_CMDS);
 #endif
 
 /**
@@ -133,5 +136,6 @@ define_command(sdcardboot, sdcardboot, "Boot from SDCard", BOOT_CMDS);
  *
  */
 #if defined(CSR_SATA_SECTOR2MEM_BASE)
-define_command(sataboot, sataboot, "Boot from SATA", BOOT_CMDS);
+define_command_args(sataboot, sataboot, "Boot from SATA",
+	"sataboot [manifest]", 0, 1, BOOT_CMDS);
 #endif

--- a/litex/soc/software/bios/cmds/cmd_mem.c
+++ b/litex/soc/software/bios/cmds/cmd_mem.c
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <libbase/parse.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <libbase/memtest.h>
@@ -38,7 +39,7 @@ define_command(mem_list, mem_list_handler, "List available memory regions", MEM_
  */
 static void mem_read_handler(int nb_params, char **params)
 {
-	char *c;
+	unsigned long address;
 	unsigned int *addr;
 	unsigned int length;
 
@@ -46,16 +47,15 @@ static void mem_read_handler(int nb_params, char **params)
 		printf("mem_read <address> [length]\n");
 		return;
 	}
-	addr = (unsigned int *)strtoul(params[0], &c, 0);
-	if (*c != 0) {
+	if (!parse_ulong(params[0], &address)) {
 		printf("Error: invalid address\n");
 		return;
 	}
+	addr = (unsigned int *)address;
 	if (nb_params == 1) {
 		length = 4;
 	} else {
-		length = strtoul(params[1], &c, 0);
-		if(*c != 0) {
+		if (!parse_uint(params[1], &length)) {
 			printf("Error: invalid length\n");
 			return;
 		}
@@ -74,7 +74,7 @@ define_command(mem_read, mem_read_handler, "Read address space", MEM_CMDS);
  */
 static void mem_write_handler(int nb_params, char **params)
 {
-	char *c;
+	unsigned long address;
 	void *addr;
 	unsigned int value;
 	unsigned int count;
@@ -87,15 +87,13 @@ static void mem_write_handler(int nb_params, char **params)
 	}
 
 	size = 4;
-	addr = (void *)strtoul(params[0], &c, 0);
-
-	if (*c != 0) {
+	if (!parse_ulong(params[0], &address)) {
 		printf("Error: invalid address\n");
 		return;
 	}
+	addr = (void *)address;
 
-	value = strtoul(params[1], &c, 0);
-	if(*c != 0) {
+	if (!parse_uint(params[1], &value)) {
 		printf("Error: invalid value\n");
 		return;
 	}
@@ -103,16 +101,14 @@ static void mem_write_handler(int nb_params, char **params)
 	if (nb_params == 2) {
 		count = 1;
 	} else {
-		count = strtoul(params[2], &c, 0);
-		if(*c != 0) {
+		if (!parse_uint(params[2], &count)) {
 			printf("Error: invalid count\n");
 			return;
 		}
 	}
 
 	if (nb_params == 4) {
-		size = strtoul(params[3], &c, 0);
-		if (*c != 0) {
+		if (!parse_uint(params[3], &size)) {
 			printf("Error: invalid size\n");
 			return;
 		}
@@ -151,7 +147,7 @@ define_command(mem_write, mem_write_handler, "Write address space", MEM_CMDS);
  */
 static void mem_copy_handler(int nb_params, char **params)
 {
-	char *c;
+	unsigned long address;
 	unsigned int *dstaddr;
 	unsigned int *srcaddr;
 	unsigned int count;
@@ -162,23 +158,22 @@ static void mem_copy_handler(int nb_params, char **params)
 		return;
 	}
 
-	dstaddr = (unsigned int *)strtoul(params[0], &c, 0);
-	if (*c != 0) {
+	if (!parse_ulong(params[0], &address)) {
 		printf("Error: invalid destination address\n");
 		return;
 	}
+	dstaddr = (unsigned int *)address;
 
-	srcaddr = (unsigned int *)strtoul(params[1], &c, 0);
-	if (*c != 0) {
+	if (!parse_ulong(params[1], &address)) {
 		printf("Error: invalid source address\n");
 		return;
 	}
+	srcaddr = (unsigned int *)address;
 
 	if (nb_params == 2) {
 		count = 1;
 	} else {
-		count = strtoul(params[2], &c, 0);
-		if (*c != 0) {
+		if (!parse_uint(params[2], &count)) {
 			printf("Error: invalid count\n");
 			return;
 		}
@@ -198,7 +193,7 @@ define_command(mem_copy, mem_copy_handler, "Copy address space", MEM_CMDS);
  */
 static void mem_test_handler(int nb_params, char **params)
 {
-	char *c;
+	unsigned long address;
 	unsigned int *addr;
 	/* Default to the same bounded size as the boot-time memtest: testing
 	   "everything" from addr would write over the BIOS data/stack. */
@@ -209,15 +204,14 @@ static void mem_test_handler(int nb_params, char **params)
 		return;
 	}
 
-	addr = (unsigned int *)strtoul(params[0], &c, 0);
-	if (*c != 0) {
+	if (!parse_ulong(params[0], &address)) {
 		printf("Error: invalid address\n");
 		return;
 	}
+	addr = (unsigned int *)address;
 
 	if (nb_params >= 2) {
-		maxsize = strtoul(params[1], &c, 0);
-		if (*c != 0) {
+		if (!parse_ulong(params[1], &maxsize)) {
 			printf("Error: invalid size\n");
 			return;
 		}
@@ -236,7 +230,7 @@ define_command(mem_test, mem_test_handler, "Test memory access", MEM_CMDS);
  */
 static void mem_speed_handler(int nb_params, char **params)
 {
-	char *c;
+	unsigned long address;
 	unsigned int *addr;
 	unsigned long size;
 	bool read_only = false;
@@ -247,32 +241,31 @@ static void mem_speed_handler(int nb_params, char **params)
 		return;
 	}
 
-	addr = (unsigned int *)strtoul(params[0], &c, 0);
-	if (*c != 0) {
+	if (!parse_ulong(params[0], &address)) {
 		printf("Error: invalid address\n");
 		return;
 	}
+	addr = (unsigned int *)address;
 
-	size = strtoul(params[1], &c, 0);
-	if (*c != 0) {
+	if (!parse_ulong(params[1], &size)) {
 		printf("Error: invalid size\n");
 		return;
 	}
 
 	if (nb_params >= 3) {
-		read_only = (bool) strtoul(params[2], &c, 0);
-		if (*c != 0) {
+		if (!parse_ulong(params[2], &address)) {
 			printf("Error: invalid readonly value\n");
 			return;
 		}
+		read_only = (bool)address;
 	}
 
 	if (nb_params >= 4) {
-		random = (bool) strtoul(params[3], &c, 0);
-		if (*c != 0) {
+		if (!parse_ulong(params[3], &address)) {
 			printf("Error: invalid random value\n");
 			return;
 		}
+		random = (bool)address;
 	}
 
 	memspeed(addr, size, read_only, random);
@@ -287,7 +280,7 @@ define_command(mem_speed, mem_speed_handler, "Test memory speed", MEM_CMDS);
  */
 static void mem_cmp_handler(int nb_params, char **params)
 {
-	char *c;
+	unsigned long address;
 	unsigned int *addr1;
 	unsigned int *addr2;
 	unsigned int count;
@@ -298,20 +291,19 @@ static void mem_cmp_handler(int nb_params, char **params)
 		return;
 	}
 
-	addr1 = (unsigned int *)strtoul(params[0], &c, 0);
-	if (*c != 0) {
+	if (!parse_ulong(params[0], &address)) {
 		printf("Error: invalid addr1\n");
 		return;
 	}
+	addr1 = (unsigned int *)address;
 
-	addr2 = (unsigned int *)strtoul(params[1], &c, 0);
-	if (*c != 0) {
+	if (!parse_ulong(params[1], &address)) {
 		printf("Error: invalid addr2\n");
 		return;
 	}
+	addr2 = (unsigned int *)address;
 
-	count = strtoul(params[2], &c, 0);
-	if (*c != 0) {
+	if (!parse_uint(params[2], &count)) {
 		printf("Error: invalid count\n");
 		return;
 	}

--- a/litex/soc/software/bios/cmds/cmd_mem.c
+++ b/litex/soc/software/bios/cmds/cmd_mem.c
@@ -29,7 +29,8 @@ static void mem_list_handler(int nb_params, char **params)
 #endif
 }
 
-define_command(mem_list, mem_list_handler, "List available memory regions", MEM_CMDS);
+define_command_args(mem_list, mem_list_handler, "List available memory regions",
+	"mem_list", 0, 0, MEM_CMDS);
 
 /**
  * Command "mem_read"
@@ -43,10 +44,6 @@ static void mem_read_handler(int nb_params, char **params)
 	unsigned int *addr;
 	unsigned int length;
 
-	if (nb_params < 1) {
-		printf("mem_read <address> [length]\n");
-		return;
-	}
 	if (!parse_ulong(params[0], &address)) {
 		printf("Error: invalid address\n");
 		return;
@@ -64,7 +61,8 @@ static void mem_read_handler(int nb_params, char **params)
 	dump_bytes(addr, length, (unsigned long)addr);
 }
 
-define_command(mem_read, mem_read_handler, "Read address space", MEM_CMDS);
+define_command_args(mem_read, mem_read_handler, "Read address space",
+	"mem_read <address> [length]", 1, 2, MEM_CMDS);
 
 /**
  * Command "mem_write"
@@ -81,10 +79,6 @@ static void mem_write_handler(int nb_params, char **params)
 	unsigned int size;
 	unsigned int i;
 
-	if (nb_params < 2) {
-		printf("mem_write <address> <value> [count] [size]\n");
-		return;
-	}
 
 	size = 4;
 	if (!parse_ulong(params[0], &address)) {
@@ -137,7 +131,8 @@ static void mem_write_handler(int nb_params, char **params)
 	}
 }
 
-define_command(mem_write, mem_write_handler, "Write address space", MEM_CMDS);
+define_command_args(mem_write, mem_write_handler, "Write address space",
+	"mem_write <address> <value> [count] [size]", 2, 4, MEM_CMDS);
 
 /**
  * Command "mem_copy"
@@ -153,10 +148,6 @@ static void mem_copy_handler(int nb_params, char **params)
 	unsigned int count;
 	unsigned int i;
 
-	if (nb_params < 2) {
-		printf("mem_copy <dst> <src> [count (32-bit words)]\n");
-		return;
-	}
 
 	if (!parse_ulong(params[0], &address)) {
 		printf("Error: invalid destination address\n");
@@ -183,7 +174,8 @@ static void mem_copy_handler(int nb_params, char **params)
 		*dstaddr++ = *srcaddr++;
 }
 
-define_command(mem_copy, mem_copy_handler, "Copy address space", MEM_CMDS);
+define_command_args(mem_copy, mem_copy_handler, "Copy address space",
+	"mem_copy <dst> <src> [count (32-bit words)]", 2, 3, MEM_CMDS);
 
 /**
  * Command "mem_test"
@@ -199,10 +191,6 @@ static void mem_test_handler(int nb_params, char **params)
 	   "everything" from addr would write over the BIOS data/stack. */
 	unsigned long maxsize = MEMTEST_DATA_SIZE;
 
-	if (nb_params < 1) {
-		printf("mem_test <addr> [maxsize]\n");
-		return;
-	}
 
 	if (!parse_ulong(params[0], &address)) {
 		printf("Error: invalid address\n");
@@ -220,7 +208,8 @@ static void mem_test_handler(int nb_params, char **params)
 
 	memtest(addr, maxsize);
 }
-define_command(mem_test, mem_test_handler, "Test memory access", MEM_CMDS);
+define_command_args(mem_test, mem_test_handler, "Test memory access",
+	"mem_test <addr> [maxsize]", 1, 2, MEM_CMDS);
 
 /**
  * Command "mem_speed"
@@ -236,10 +225,6 @@ static void mem_speed_handler(int nb_params, char **params)
 	bool read_only = false;
 	bool random = false;
 
-	if (nb_params < 2) {
-		printf("mem_speed <addr> <size> [readonly] [random]\n");
-		return;
-	}
 
 	if (!parse_ulong(params[0], &address)) {
 		printf("Error: invalid address\n");
@@ -270,7 +255,8 @@ static void mem_speed_handler(int nb_params, char **params)
 
 	memspeed(addr, size, read_only, random);
 }
-define_command(mem_speed, mem_speed_handler, "Test memory speed", MEM_CMDS);
+define_command_args(mem_speed, mem_speed_handler, "Test memory speed",
+	"mem_speed <addr> <size> [readonly] [random]", 2, 4, MEM_CMDS);
 
 /**
  * Command "mem_cmp"
@@ -286,10 +272,6 @@ static void mem_cmp_handler(int nb_params, char **params)
 	unsigned int count;
 	unsigned int i;
 	bool same = true;
-	if (nb_params < 3) {
-		printf("mem_cmp <addr1> <addr2> <count (32-bit words)>\n");
-		return;
-	}
 
 	if (!parse_ulong(params[0], &address)) {
 		printf("Error: invalid addr1\n");
@@ -322,4 +304,5 @@ static void mem_cmp_handler(int nb_params, char **params)
 	else
 		printf("mem_cmp finished, different content.\n");
 }
-define_command(mem_cmp, mem_cmp_handler, "Compare memory content", MEM_CMDS);
+define_command_args(mem_cmp, mem_cmp_handler, "Compare memory content",
+	"mem_cmp <addr1> <addr2> <count (32-bit words)>", 3, 3, MEM_CMDS);

--- a/litex/soc/software/bios/cmds/cmd_spiflash.c
+++ b/litex/soc/software/bios/cmds/cmd_spiflash.c
@@ -27,10 +27,6 @@ static void flash_write_handler(int nb_params, char **params)
 	unsigned long mem_addr;
 	unsigned int count;
 
-	if (nb_params < 2) {
-		printf("flash_write <offset> <mem_addr> [count]\n");
-		return;
-	}
 
 	if (!parse_uint(params[0], &addr)) {
 		printf("Error: invalid offset\n");
@@ -55,7 +51,8 @@ static void flash_write_handler(int nb_params, char **params)
 		printf("Error: flash write failed (is the region erased? see flash_erase_range)\n");
 }
 
-define_command(flash_write, flash_write_handler, "Write to flash", SPIFLASH_CMDS);
+define_command_args(flash_write, flash_write_handler, "Write to flash",
+	"flash_write <offset> <mem_addr> [count]", 2, 3, SPIFLASH_CMDS);
 
 static void flash_from_sdcard_handler(int nb_params, char **params)
 {
@@ -67,10 +64,6 @@ static void flash_from_sdcard_handler(int nb_params, char **params)
 	unsigned long length;
 	uint8_t buf[512];
 
-	if (nb_params < 1) {
-		printf("flash_from_sdcard <filename>\n");
-		return;
-	}
 
 	char* filename = params[0];
 
@@ -118,17 +111,14 @@ static void flash_from_sdcard_handler(int nb_params, char **params)
 	f_close(&file);
 	f_mount(0, "", 0);
 }
-define_command(flash_from_sdcard, flash_from_sdcard_handler, "Write file from SD card to flash", SPIFLASH_CMDS);
+define_command_args(flash_from_sdcard, flash_from_sdcard_handler, "Write file from SD card to flash",
+	"flash_from_sdcard <filename>", 1, 1, SPIFLASH_CMDS);
 
 static void flash_erase_range_handler(int nb_params, char **params)
 {
 	unsigned int addr;
 	unsigned int count;
 
-	if (nb_params < 2) {
-		printf("flash_erase_range <offset> <count>\n");
-		return;
-	}
 
 	if (!parse_uint(params[0], &addr)) {
 		printf("Error: invalid offset\n");
@@ -143,5 +133,6 @@ static void flash_erase_range_handler(int nb_params, char **params)
 	spiflash_erase_range(addr, count);
 }
 
-define_command(flash_erase_range, flash_erase_range_handler, "Erase flash range", SPIFLASH_CMDS);
+define_command_args(flash_erase_range, flash_erase_range_handler, "Erase flash range",
+	"flash_erase_range <offset> <count>", 2, 2, SPIFLASH_CMDS);
 #endif

--- a/litex/soc/software/bios/cmds/cmd_spiflash.c
+++ b/litex/soc/software/bios/cmds/cmd_spiflash.c
@@ -2,6 +2,8 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
+#include <libbase/parse.h>
 
 #include <generated/csr.h>
 
@@ -21,9 +23,8 @@
 #if (defined CSR_SPIFLASH_MASTER_CS_ADDR)
 static void flash_write_handler(int nb_params, char **params)
 {
-	char *c;
 	unsigned int addr;
-	unsigned int mem_addr;
+	unsigned long mem_addr;
 	unsigned int count;
 
 	if (nb_params < 2) {
@@ -31,14 +32,12 @@ static void flash_write_handler(int nb_params, char **params)
 		return;
 	}
 
-	addr = strtoul(params[0], &c, 0);
-	if (*c != 0) {
+	if (!parse_uint(params[0], &addr)) {
 		printf("Error: invalid offset\n");
 		return;
 	}
 
-	mem_addr = strtoul(params[1], &c, 0);
-	if (*c != 0) {
+	if (!parse_ulong(params[1], &mem_addr)) {
 		printf("Error: invalid mem_addr\n");
 		return;
 	}
@@ -46,8 +45,7 @@ static void flash_write_handler(int nb_params, char **params)
 	if (nb_params == 2) {
 		count = 1;
 	} else {
-		count = strtoul(params[2], &c, 0);
-		if (*c != 0) {
+		if (!parse_uint(params[2], &count)) {
 			printf("Error: invalid count\n");
 			return;
 		}
@@ -124,23 +122,20 @@ define_command(flash_from_sdcard, flash_from_sdcard_handler, "Write file from SD
 
 static void flash_erase_range_handler(int nb_params, char **params)
 {
-	char *c;
-	uint32_t addr;
-	uint32_t count;
+	unsigned int addr;
+	unsigned int count;
 
 	if (nb_params < 2) {
 		printf("flash_erase_range <offset> <count>\n");
 		return;
 	}
 
-	addr = strtoul(params[0], &c, 0);
-	if (*c != 0) {
+	if (!parse_uint(params[0], &addr)) {
 		printf("Error: invalid offset\n");
 		return;
 	}
 
-	count = strtoul(params[1], &c, 0);
-	if (*c != 0) {
+	if (!parse_uint(params[1], &count)) {
 		printf("Error: invalid count\n");
 		return;
 	}

--- a/litex/soc/software/bios/command.h
+++ b/litex/soc/software/bios/command.h
@@ -25,20 +25,26 @@ struct command_struct {
 	const char *name;
 	const char *help;
 	int group;
+	const char *usage;
+	unsigned char min_args;
+	unsigned char max_args;
 };
 
 extern const struct command_struct *const __bios_cmd_start[];
 extern const struct command_struct *const __bios_cmd_end[];
 
 #ifdef BIOS_CONSOLE_DISABLE
-	#define define_command(cmd_name, handler, help_txt, group_id)
+	#define define_command_args(cmd_name, handler, help_txt, usage_txt, min_count, max_count, group_id)
 #else
-	#define define_command(cmd_name, handler, help_txt, group_id) \
+	#define define_command_args(cmd_name, handler, help_txt, usage_txt, min_count, max_count, group_id) \
 		const struct command_struct s_##cmd_name = {					     \
 			.func = (cmd_handler)handler,					     \
 			.name = #cmd_name,						     \
 			.help = help_txt,						     \
 			.group = group_id,						     \
+			.usage = usage_txt, \
+			.min_args = min_count, \
+			.max_args = max_count, \
 		};									     \
 		const struct command_struct *const __bios_cmd_##cmd_name __attribute__((__used__)) \
 		__attribute__((__section__(".bios_cmd"))) = &s_##cmd_name
@@ -46,4 +52,8 @@ extern const struct command_struct *const __bios_cmd_end[];
 	const struct command_struct *command_dispatcher(char *command, int nb_params, char **params);
 
 	#endif
+
+/* Preserve source compatibility for target-specific command registrations. */
+#define define_command(cmd_name, handler, help_txt, group_id) \
+	define_command_args(cmd_name, handler, help_txt, 0, 0, MAX_PARAM, group_id)
 #endif

--- a/litex/soc/software/bios/command.h
+++ b/litex/soc/software/bios/command.h
@@ -27,23 +27,23 @@ struct command_struct {
 	int group;
 };
 
-extern struct command_struct *const __bios_cmd_start[];
-extern struct command_struct *const __bios_cmd_end[];
+extern const struct command_struct *const __bios_cmd_start[];
+extern const struct command_struct *const __bios_cmd_end[];
 
 #ifdef BIOS_CONSOLE_DISABLE
 	#define define_command(cmd_name, handler, help_txt, group_id)
 #else
 	#define define_command(cmd_name, handler, help_txt, group_id) \
-		struct command_struct s_##cmd_name = {					     \
+		const struct command_struct s_##cmd_name = {					     \
 			.func = (cmd_handler)handler,					     \
 			.name = #cmd_name,						     \
 			.help = help_txt,						     \
 			.group = group_id,						     \
 		};									     \
-		const struct command_struct *__bios_cmd_##cmd_name __attribute__((__used__)) \
+		const struct command_struct *const __bios_cmd_##cmd_name __attribute__((__used__)) \
 		__attribute__((__section__(".bios_cmd"))) = &s_##cmd_name
 
-	struct command_struct *command_dispatcher(char *command, int nb_params, char **params);
+	const struct command_struct *command_dispatcher(char *command, int nb_params, char **params);
 
 	#endif
 #endif

--- a/litex/soc/software/bios/complete.c
+++ b/litex/soc/software/bios/complete.c
@@ -23,7 +23,7 @@ static int command_match(const char *instr, const char *name)
 
 static int command_complete_suffix(char *instr, char *outstr, int outlen)
 {
-	struct command_struct * const *cmd;
+	const struct command_struct * const *cmd;
 	const char *name;
 	int pos = strlen(instr);
 	int outpos = 0;
@@ -56,7 +56,7 @@ static int command_complete_suffix(char *instr, char *outstr, int outlen)
 
 static void command_matches_print_by_column(char *instr)
 {
-	struct command_struct * const *cmd;
+	const struct command_struct * const *cmd;
 	int len = 0, num, i = 0;
 
 	for (cmd = __bios_cmd_start; cmd != __bios_cmd_end; cmd++) {

--- a/litex/soc/software/bios/helpers.c
+++ b/litex/soc/software/bios/helpers.c
@@ -139,8 +139,8 @@ int get_param(char *buf, char **cmd, char **params)
 			return nb_param;
 
 		if (nb_param >= MAX_PARAM) {
-			printf("Warning: too many parameters (max %d), excess ignored\n", MAX_PARAM);
-			return nb_param;
+			printf("Error: too many parameters (max %d)\n", MAX_PARAM);
+			return -1;
 		}
 
 		params[nb_param++] = buf;
@@ -160,6 +160,10 @@ const struct command_struct *command_dispatcher(char *command, int nb_params, ch
 
 	for (cmd = __bios_cmd_start; cmd != __bios_cmd_end; cmd++) {
 		if (!strcmp(command, (*cmd)->name)) {
+			if (nb_params < (*cmd)->min_args || nb_params > (*cmd)->max_args) {
+				printf("Usage: %s\n", (*cmd)->usage ? (*cmd)->usage : (*cmd)->name);
+				return *cmd;
+			}
 			(*cmd)->func(nb_params, params);
 			return (*cmd);
 		}

--- a/litex/soc/software/bios/helpers.c
+++ b/litex/soc/software/bios/helpers.c
@@ -154,9 +154,9 @@ int get_param(char *buf, char **cmd, char **params)
 	}
 }
 
-struct command_struct *command_dispatcher(char *command, int nb_params, char **params)
+const struct command_struct *command_dispatcher(char *command, int nb_params, char **params)
 {
-	struct command_struct * const *cmd;
+	const struct command_struct * const *cmd;
 
 	for (cmd = __bios_cmd_start; cmd != __bios_cmd_end; cmd++) {
 		if (!strcmp(command, (*cmd)->name)) {

--- a/litex/soc/software/bios/helpers.h
+++ b/litex/soc/software/bios/helpers.h
@@ -8,7 +8,7 @@ void crcbios(void);
 void bios_print_section(const char *name);
 void bios_print_status(const char *label, int success);
 int get_param(char *buf, char **cmd, char **params);
-struct command_struct *command_dispatcher(char *command, int nb_params, char **params);
+const struct command_struct *command_dispatcher(char *command, int nb_params, char **params);
 void init_dispatcher(void);
 
 #endif

--- a/litex/soc/software/bios/linker.ld
+++ b/litex/soc/software/bios/linker.ld
@@ -90,6 +90,15 @@ SECTIONS
 		PROVIDE_HIDDEN (__fini_array_end = .);
 	} > rom
 
+	/* Optional image buffer: never include it in data initialization or BSS. */
+	.boot_sram (NOLOAD) :
+	{
+		__bios_boot_sram_start = .;
+		. += DEFINED(__bios_boot_sram_size) ? __bios_boot_sram_size : 0;
+		. = ALIGN(8);
+		__bios_boot_sram_end = .;
+	} > sram
+
 	.data :
 	{
 		. = ALIGN(8);

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -178,7 +178,7 @@ __attribute__((__used__)) int main(int i, char **c)
 	char buffer[CMD_LINE_BUFFER_SIZE];
 	char *params[MAX_PARAM];
 	char *command;
-	struct command_struct *cmd;
+	const struct command_struct *cmd;
 	int nb_params;
 #endif
 	int sdr_ok;

--- a/litex/soc/software/bios/main.c
+++ b/litex/soc/software/bios/main.c
@@ -348,7 +348,7 @@ __attribute__((__used__)) int main(int i, char **c)
 		if (buffer[0] != 0) {
 			nb_params = get_param(buffer, &command, params);
 			/* Ignore whitespace-only lines */
-			if (*command != 0) {
+			if (nb_params >= 0 && *command != 0) {
 				cmd = command_dispatcher(command, nb_params, params);
 				if (!cmd)
 					printf("Command not found\n");

--- a/litex/soc/software/bios/readline_simple.c
+++ b/litex/soc/software/bios/readline_simple.c
@@ -24,6 +24,7 @@ int readline(char *s, int size)
 	static char skip = 0;
 	char c[2];
 	int ptr;
+	int escape = 0;
 
 	if (size <= 0)
 		return -1;
@@ -38,9 +39,27 @@ int readline(char *s, int size)
 		}
 
 		c[0] = getchar();
+		if (c[0] == 0x03) {
+			s[0] = 0;
+			skip = 0;
+			return -1;
+		}
 		if (c[0] == skip)
 			continue;
 		skip = 0;
+		/* Ignore complete CSI/SS3 key sequences, including their printable
+		   suffixes. Consume incrementally so a lone ESC cannot block input. */
+		if (c[0] == 0x1b) {
+			escape = 1;
+			continue;
+		}
+		if (escape && c[0] != '\r' && c[0] != '\n') {
+			if (escape == 1)
+				escape = (c[0] == '[' || c[0] == 'O') ? 2 : 0;
+			else if (c[0] >= 0x40 && c[0] <= 0x7e)
+				escape = 0;
+			continue;
+		}
 		switch(c[0]) {
 		case 0x7f:
 		case 0x08:

--- a/litex/soc/software/libbase/Makefile
+++ b/litex/soc/software/libbase/Makefile
@@ -7,6 +7,7 @@ OBJECTS =  \
 	console.o  \
 	format.o   \
 	parse.o    \
+	timeout.o  \
 	system.o   \
 	progress.o \
 	memtest.o  \

--- a/litex/soc/software/libbase/Makefile
+++ b/litex/soc/software/libbase/Makefile
@@ -6,6 +6,7 @@ OBJECTS =  \
 	crc32.o    \
 	console.o  \
 	format.o   \
+	parse.o    \
 	system.o   \
 	progress.o \
 	memtest.o  \

--- a/litex/soc/software/libbase/parse.c
+++ b/litex/soc/software/libbase/parse.c
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <limits.h>
+#include "parse.h"
+
+int parse_ulong(const char *text, unsigned long *value)
+{
+	unsigned long result = 0;
+	unsigned int base = 10;
+	unsigned int digits = 0;
+
+	if (text[0] == '0') {
+		base = 8;
+		if (text[1] == 'x' || text[1] == 'X') {
+			base = 16;
+			text += 2;
+		}
+	}
+	while (*text) {
+		unsigned int digit;
+		char c = *text++;
+
+		if (c >= '0' && c <= '9')
+			digit = c - '0';
+		else if (c >= 'a' && c <= 'f')
+			digit = c - 'a' + 10;
+		else if (c >= 'A' && c <= 'F')
+			digit = c - 'A' + 10;
+		else
+			return 0;
+		if (digit >= base || result > (ULONG_MAX - digit) / base)
+			return 0;
+		result = result * base + digit;
+		digits++;
+	}
+	if (!digits)
+		return 0;
+	*value = result;
+	return 1;
+}
+
+int parse_uint(const char *text, unsigned int *value)
+{
+	unsigned long result;
+
+	if (!parse_ulong(text, &result) || result > UINT_MAX)
+		return 0;
+	*value = result;
+	return 1;
+}

--- a/litex/soc/software/libbase/parse.h
+++ b/litex/soc/software/libbase/parse.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef __LIBBASE_PARSE_H
+#define __LIBBASE_PARSE_H
+
+/* Parse a complete unsigned integer, using the same decimal/octal/hexadecimal
+ * prefixes as strtoul(..., 0). Reject signs, whitespace and overflow; leave the
+ * destination unchanged on failure. */
+int parse_ulong(const char *text, unsigned long *value);
+int parse_uint(const char *text, unsigned int *value);
+
+#endif

--- a/litex/soc/software/libbase/timeout.c
+++ b/litex/soc/software/libbase/timeout.c
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <generated/csr.h>
+#include <generated/soc.h>
+#include "timeout.h"
+
+static uint64_t timeout_cycles(void)
+{
+#ifdef CSR_TIMER0_UPTIME_CYCLES_ADDR
+	timer0_uptime_latch_write(1);
+	return timer0_uptime_cycles_read();
+#else
+	timer0_update_value_write(1);
+	return timer0_value_read();
+#endif
+}
+
+void timeout_start(struct timeout *timeout, unsigned int us)
+{
+#ifndef CSR_TIMER0_UPTIME_CYCLES_ADDR
+	/* Keep the same time base for nested deadlines. busy_wait/serialboot may
+	   have used timer0 since the previous operation, so check its mode. */
+	if (!timer0_en_read() || timer0_reload_read() != UINT32_MAX) {
+		timer0_en_write(0);
+		timer0_reload_write(UINT32_MAX);
+		timer0_load_write(UINT32_MAX);
+		timer0_en_write(1);
+	}
+#endif
+	timeout->remaining = ((uint64_t)CONFIG_CLOCK_FREQUENCY * us + 999999) / 1000000;
+	timeout->last = timeout_cycles();
+}
+
+int timeout_expired(struct timeout *timeout)
+{
+	uint64_t now = timeout_cycles();
+#ifdef CSR_TIMER0_UPTIME_CYCLES_ADDR
+	uint64_t elapsed = now - timeout->last;
+#else
+	uint32_t elapsed = (uint32_t)timeout->last - (uint32_t)now;
+#endif
+	timeout->last = now;
+	if (elapsed >= timeout->remaining) {
+		timeout->remaining = 0;
+		return 1;
+	}
+	timeout->remaining -= elapsed;
+	return 0;
+}

--- a/litex/soc/software/libbase/timeout.h
+++ b/litex/soc/software/libbase/timeout.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+#ifndef __LIBBASE_TIMEOUT_H
+#define __LIBBASE_TIMEOUT_H
+
+#include <stdint.h>
+
+struct timeout {
+	uint64_t remaining;
+	uint64_t last;
+};
+
+/* Nested deadlines share the uptime counter, or timer0 in free-running mode.
+ * Without uptime, do not reprogram timer0 (e.g. busy_wait) while a deadline is
+ * active, and poll at least once per 2^32 system-clock cycles. */
+void timeout_start(struct timeout *timeout, unsigned int us);
+int timeout_expired(struct timeout *timeout);
+
+#endif

--- a/litex/soc/software/libliteeth/tftp.c
+++ b/litex/soc/software/libliteeth/tftp.c
@@ -14,12 +14,17 @@
 #include <string.h>
 
 #include <libbase/progress.h>
+#include <libbase/timeout.h>
 
 #include <libliteeth/udp.h>
 #include <libliteeth/tftp.h>
 
 /* Local TFTP client port (arbitrary) */
 #define PORT_IN		7642
+
+#ifndef TFTP_TIMEOUT_US
+#define TFTP_TIMEOUT_US 5000000
+#endif
 
 enum {
 	TFTP_RRQ	= 1,	/* Read request */
@@ -223,7 +228,7 @@ int tftp_get(uint32_t ip, uint16_t server_port, const char *filename,
 {
 	int len;
 	int tries;
-	int i;
+	struct timeout timeout;
 	int length_before;
 
 	if(!udp_arp_resolve(ip)) {
@@ -251,10 +256,11 @@ int tftp_get(uint32_t ip, uint16_t server_port, const char *filename,
 		packet_data = udp_get_tx_buffer();
 		len = format_request(packet_data, TFTP_RRQ, filename);
 		udp_send(PORT_IN, server_port, len);
-		for(i=0;i<2000000;i++) {
+		timeout_start(&timeout, TFTP_TIMEOUT_US);
+		do {
 			udp_service();
 			if((total_length > 0) || transfer_finished) break;
-		}
+		} while (!timeout_expired(&timeout));
 		if((total_length > 0) || transfer_finished) break;
 		tries--;
 		if(tries == 0) {
@@ -263,12 +269,12 @@ int tftp_get(uint32_t ip, uint16_t server_port, const char *filename,
 		}
 	}
 
-	i = 12000000;
+	timeout_start(&timeout, TFTP_TIMEOUT_US);
 	length_before = total_length;
 	init_progression_bar(0);
 	while(!transfer_finished) {
 		if(length_before != total_length) {
-			i = 12000000;
+			timeout_start(&timeout, TFTP_TIMEOUT_US);
 			length_before = total_length;
 			/* TFTP does not know the file size up front: print one '#' per
 			   downloaded MB, plus a spinner for intra-MB activity. */
@@ -276,7 +282,7 @@ int tftp_get(uint32_t ip, uint16_t server_port, const char *filename,
 			if ((total_length & (0x8000 - 1)) == 0)
 				show_progress(-1);
 		}
-		if(i-- == 0) {
+		if(timeout_expired(&timeout)) {
 			udp_set_callback(NULL);
 			return -1;
 		}
@@ -293,7 +299,7 @@ int tftp_put(uint32_t ip, uint16_t server_port, const char *filename,
 {
 	int len, send;
 	int tries;
-	int i;
+	struct timeout timeout;
 	int block = 0, sent = 0;
 
 	if(!udp_arp_resolve(ip))
@@ -318,14 +324,15 @@ int tftp_put(uint32_t ip, uint16_t server_port, const char *filename,
 		packet_data = udp_get_tx_buffer();
 		len = format_request(packet_data, TFTP_WRQ, filename);
 		udp_send(PORT_IN, server_port, len);
-		for(i=0;i<2000000;i++) {
-			last_ack = -1;
+		last_ack = -1;
+		timeout_start(&timeout, TFTP_TIMEOUT_US);
+		do {
 			udp_service();
 			if(last_ack == block)
 				goto send_data;
 			if(transfer_finished)
 				goto fail;
-		}
+		} while (!timeout_expired(&timeout));
 		tries--;
 		if(tries == 0)
 			goto fail;
@@ -344,14 +351,15 @@ send_data:
 			packet_data = udp_get_tx_buffer();
 			len = format_data(packet_data, block, buffer, send);
 			udp_send(PORT_IN, data_port, len);
-			for(i=0;i<12000000;i++) {
+			timeout_start(&timeout, TFTP_TIMEOUT_US);
+			do {
 				udp_service();
 				if(transfer_finished)
 					goto fail;
 				/* Block numbers wrap modulo 2^16 on transfers > 64MB. */
 				if(last_ack == (uint16_t)block)
 					goto next;
-			}
+			} while (!timeout_expired(&timeout));
 			if (!--tries)
 				goto fail;
 		}

--- a/litex/soc/software/libliteeth/udp.c
+++ b/litex/soc/software/libliteeth/udp.c
@@ -16,6 +16,7 @@
 #include <system.h>
 
 #include <libbase/crc.h>
+#include <libbase/timeout.h>
 
 #include <libliteeth/inet.h>
 #include <libliteeth/udp.h>
@@ -156,10 +157,15 @@ static uint32_t txslot;
 static uint32_t txlen;
 static ethernet_buffer *txbuffer;
 
-static void send_packet(void)
+static int send_packet(void)
 {
+	struct timeout timeout;
 	/* wait buffer to be available */
-	while(!(ethmac_sram_reader_ready_read()));
+	timeout_start(&timeout, 100000);
+	while (!ethmac_sram_reader_ready_read()) {
+		if (timeout_expired(&timeout))
+			return 0;
+	}
 
 	/* fill txbuffer */
 #ifndef HW_PREAMBLE_CRC
@@ -188,6 +194,7 @@ static void send_packet(void)
 	/* update txslot / txbuffer */
 	txslot = (txslot+1)%ETHMAC_TX_SLOTS;
 	txbuffer = (ethernet_buffer *)(ETHMAC_BASE + ETHMAC_SLOT_SIZE * (ETHMAC_RX_SLOTS + txslot));
+	return 1;
 }
 
 static uint8_t my_mac[6];
@@ -281,7 +288,7 @@ int udp_arp_resolve(uint32_t ip)
 	struct arp_frame *arp;
 	int i;
 	int tries;
-	int timeout;
+	struct timeout timeout;
 
 	if(cached_ip == ip) {
 		for(i=0;i<6;i++)
@@ -317,17 +324,21 @@ int udp_arp_resolve(uint32_t ip)
 		for(i=0;i<6;i++)
 			arp->target_mac[i] = 0;
 
-		send_packet();
+		if (!send_packet()) {
+			arp_pending = 0;
+			return 0;
+		}
 
 		/* Do we get a reply ? */
-		for(timeout=0;timeout<100000;timeout++) {
+		timeout_start(&timeout, 1000000);
+		do {
 			udp_service();
 			for(i=0;i<6;i++)
 				if(cached_mac[i]) {
 					arp_pending = 0;
 					return 1;
 				}
-		}
+		} while (!timeout_expired(&timeout));
 	}
 
 	arp_pending = 0;
@@ -421,9 +432,7 @@ int udp_send(uint16_t src_port, uint16_t dst_port, uint32_t length)
 		sizeof(struct udp_header)+length, 1);
 	txbuffer->frame.contents.udp.udp.checksum = htons(r);
 
-	send_packet();
-
-	return 1;
+	return send_packet();
 }
 
 static unsigned ping_seq_number = 0;
@@ -481,7 +490,8 @@ int send_ping(uint32_t ip, unsigned short payload_length)
 	tx_icmp->icmp.checksum = htons(r);
 
 	txlen = payload_length + sizeof(struct ethernet_header) + sizeof(struct icmp_frame);
-	send_packet();
+	if (!send_packet())
+		return -1;
 
 	ping_ts_send = 1;
 #ifdef CSR_TIMER0_UPTIME_CYCLES_ADDR

--- a/litex/soc/software/liblitesdcard/spisdcard.c
+++ b/litex/soc/software/liblitesdcard/spisdcard.c
@@ -12,6 +12,7 @@
 #include <generated/mem.h>
 #include <generated/soc.h>
 #include <system.h>
+#include <libbase/timeout.h>
 
 #include <libfatfs/ff.h>
 #include <libfatfs/diskio.h>
@@ -26,6 +27,10 @@
 #endif
 #ifndef SPISDCARD_CLK_FREQ
 #define SPISDCARD_CLK_FREQ 20000000
+#endif
+
+#ifndef SPISDCARD_XFER_TIMEOUT_US
+#define SPISDCARD_XFER_TIMEOUT_US 10000
 #endif
 
 /* OCR CCS bit: 1 on high/extended capacity cards (block addressing), 0 on
@@ -55,13 +60,29 @@ static void spi_set_clk_freq(uint32_t clk_freq) {
 /* SPI SDCard low-level functions                                        */
 /*----------------------------------------------------------------------*/
 
-static uint8_t spi_xfer(uint8_t byte) {
+static int spi_wait_done(void) {
+    struct timeout timeout;
+
+    if (spisdcard_status_read() & SPI_DONE)
+        return 1;
+    timeout_start(&timeout, SPISDCARD_XFER_TIMEOUT_US);
+    while (!(spisdcard_status_read() & SPI_DONE)) {
+        if (timeout_expired(&timeout)) {
+            printf("SPI SDCard transfer timeout\n");
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int spi_xfer(uint8_t byte) {
     /* Write byte on MOSI */
     spisdcard_mosi_write(byte);
     /* Initiate SPI Xfer */
     spisdcard_control_write(8*SPI_LENGTH | SPI_START);
     /* Wait SPI Xfer to be done */
-    while((spisdcard_status_read() & SPI_DONE) != SPI_DONE);
+    if (!spi_wait_done())
+        return -1;
     /* Read MISO and return it */
     return spisdcard_miso_read();
 }
@@ -84,12 +105,16 @@ static int spisdcard_select(void) {
     spisdcard_cs_write(SPI_CS_LOW);
 
     /* Generate 8 dummy clocks */
-    spi_xfer(0xff);
+    if (spi_xfer(0xff) < 0)
+        return 0;
 
     /* Wait 500ms for the card to be ready */
     timeout = 500;
     while(timeout > 0) {
-        if (spi_xfer(0xff) == 0xff)
+        int byte = spi_xfer(0xff);
+        if (byte < 0)
+            return 0;
+        if (byte == 0xff)
             return 1;
         busy_wait(1);
         timeout--;
@@ -105,16 +130,23 @@ static int spisdcard_select(void) {
 /* SPI SDCard bytes Xfer functions                                       */
 /*-----------------------------------------------------------------------*/
 
-static void spisdcardwrite_bytes(uint8_t* buf, uint16_t n) {
+static int spisdcardwrite_bytes(uint8_t* buf, uint16_t n) {
     uint16_t i;
     for (i=0; i<n; i++)
-        spi_xfer(buf[i]);
+        if (spi_xfer(buf[i]) < 0)
+            return 0;
+    return 1;
 }
 
-static void spisdcardread_bytes(uint8_t* buf, uint16_t n) {
+static int spisdcardread_bytes(uint8_t* buf, uint16_t n) {
     uint16_t i;
-    for (i=0; i<n; i++)
-        buf[i] = spi_xfer(0xff);
+    for (i=0; i<n; i++) {
+        int byte = spi_xfer(0xff);
+        if (byte < 0)
+            return 0;
+        buf[i] = byte;
+    }
+    return 1;
 }
 
 /*-----------------------------------------------------------------------*/
@@ -128,7 +160,10 @@ static uint8_t spisdcardreceive_block(uint8_t *buf) {
     /* Wait 100ms for a start of block */
     timeout = 100000;
     while(timeout > 0) {
-        if (spi_xfer(0xff) == 0xfe)
+        int byte = spi_xfer(0xff);
+        if (byte < 0)
+            return 0;
+        if (byte == 0xfe)
             break;
         busy_wait_us(1);
         timeout--;
@@ -140,13 +175,14 @@ static uint8_t spisdcardreceive_block(uint8_t *buf) {
     spisdcard_mosi_write(0xff);
     for (i=0; i<512; i++) {
         spisdcard_control_write(8*SPI_LENGTH | SPI_START);
-        while ((spisdcard_status_read() & SPI_DONE) != SPI_DONE);
+        if (!spi_wait_done())
+            return 0;
         *buf++ = spisdcard_miso_read();
     }
 
     /* Discard CRC */
-    spi_xfer(0xff);
-    spi_xfer(0xff);
+    if (spi_xfer(0xff) < 0 || spi_xfer(0xff) < 0)
+        return 0;
 
     return 1;
 }
@@ -155,7 +191,7 @@ static uint8_t spisdcardreceive_block(uint8_t *buf) {
 /* SPI SDCard Command functions                                          */
 /*-----------------------------------------------------------------------*/
 
-static uint8_t spisdcardsend_cmd(uint8_t cmd, uint32_t arg)
+static int spisdcardsend_cmd(uint8_t cmd, uint32_t arg)
 {
     uint8_t byte;
     uint8_t buf[6];
@@ -164,9 +200,9 @@ static uint8_t spisdcardsend_cmd(uint8_t cmd, uint32_t arg)
     /* Send CMD55 for ACMD */
     if (cmd & 0x80) {
         cmd &= 0x7f;
-        byte = spisdcardsend_cmd(CMD55, 0);
-        if (byte > 1)
-            return byte;
+        int response = spisdcardsend_cmd(CMD55, 0);
+        if (response < 0 || response > 1)
+            return response;
     }
 
     /* Select the card and wait for it, except for:
@@ -176,7 +212,7 @@ static uint8_t spisdcardsend_cmd(uint8_t cmd, uint32_t arg)
     if (cmd != CMD12 && cmd != CMD0) {
         spisdcard_deselect();
         if (spisdcard_select() == 0)
-            return 0xff;
+            return -1;
     }
 
     /* Send Command */
@@ -191,14 +227,16 @@ static uint8_t spisdcardsend_cmd(uint8_t cmd, uint32_t arg)
         buf[5] = 0x87;      /* Valid CRC for CMD8 (0x1AA) */
     else
         buf[5] = 0x01;      /* Dummy CRC + Stop */
-    spisdcardwrite_bytes(buf, 6);
+    if (!spisdcardwrite_bytes(buf, 6))
+        return -1;
 
     /* Receive Command response */
-    if (cmd == CMD12)
-        spisdcardread_bytes(&byte, 1);  /* Read stuff byte */
+    if (cmd == CMD12 && !spisdcardread_bytes(&byte, 1)) /* Read stuff byte */
+        return -1;
     timeout = 10; /* Wait for a valid response (up to 10 attempts) */
     while (timeout > 0) {
-        spisdcardread_bytes(&byte, 1);
+        if (!spisdcardread_bytes(&byte, 1))
+            return -1;
         if ((byte & 0x80) == 0)
             break;
 
@@ -215,6 +253,7 @@ uint8_t spisdcard_init(void) {
     uint8_t  i;
     uint8_t  buf[4];
     uint16_t timeout;
+    int response;
 
     /* Set SPI clk freq to initialization frequency */
     spi_set_clk_freq(SPISDCARD_CLK_FREQ_INIT);
@@ -224,11 +263,15 @@ uint8_t spisdcard_init(void) {
         /* Set SDCard in SPI Mode (generate 80 dummy clocks) */
         spisdcard_cs_write(SPI_CS_HIGH);
         for (i=0; i<10; i++)
-            spi_xfer(0xff);
+            if (spi_xfer(0xff) < 0)
+                return 0;
         spisdcard_cs_write(SPI_CS_LOW);
 
         /* Set SDCard in Idle state */
-        if (spisdcardsend_cmd(CMD0, 0) == 0x1)
+        response = spisdcardsend_cmd(CMD0, 0);
+        if (response < 0)
+            return 0;
+        if (response == 0x1)
             break;
 
         timeout--;
@@ -239,12 +282,16 @@ uint8_t spisdcard_init(void) {
     /* Set SDCard voltages, only supported by ver2.00+ SDCards */
     if (spisdcardsend_cmd(CMD8, 0x1AA) != 0x1)
         return 0;
-    spisdcardread_bytes(buf, 4); /* Get additional bytes of R7 response */
+    if (!spisdcardread_bytes(buf, 4)) /* Get additional bytes of R7 response */
+        return 0;
 
     /* Set SDCard in Operational state (1s timeout) */
     timeout = 1000;
     while (timeout > 0) {
-        if (spisdcardsend_cmd(ACMD41, 1 << 30) == 0)
+        response = spisdcardsend_cmd(ACMD41, 1 << 30);
+        if (response < 0)
+            return 0;
+        if (response == 0)
             break;
         busy_wait(1);
         timeout--;
@@ -256,7 +303,8 @@ uint8_t spisdcard_init(void) {
        take byte addresses in block commands instead of block addresses. */
     if (spisdcardsend_cmd(CMD58, 0) != 0)
         return 0;
-    spisdcardread_bytes(buf, 4); /* Get trailing bytes of R3 response (OCR) */
+    if (!spisdcardread_bytes(buf, 4)) /* Get trailing bytes of R3 response (OCR) */
+        return 0;
     spisdcard_ccs = (buf[0] >> 6) & 0x1;
 
     /* Set SPI clk freq to operational frequency */

--- a/litex/soc/software/memusage.py
+++ b/litex/soc/software/memusage.py
@@ -87,7 +87,7 @@ def print_size(name, size, total=None):
         print("{}: {} \t({:.2f}%)".format(name, format_size(size), size/total*100.0))
 
 
-def print_usage(bios, regions, triple, fail_stack_margin=None):
+def print_usage(bios, regions, triple, fail_stack_margin=None, max_rom=None, max_sram=None):
     linker_regions = parse_regions(regions)
     sections       = parse_sections(bios, triple)
     failed         = False
@@ -158,6 +158,11 @@ def print_usage(bios, regions, triple, fail_stack_margin=None):
                 format_size(stack_available),
                 format_size(fail_stack_margin)))
             failed = True
+    for name, used, limit in [("ROM", rom_usage, max_rom), ("SRAM", sram_usage, max_sram)]:
+        if limit is not None and used > limit:
+            print("ERROR: {} usage exceeds budget ({} > {}).".format(
+                name, format_size(used), format_size(limit)))
+            failed = True
     print("")
     return 1 if failed else 0
 
@@ -165,11 +170,16 @@ def main():
     parser = argparse.ArgumentParser(description="Print bios memory usage")
     parser.add_argument("--fail-stack-margin", type=lambda x: int(x, 0), default=None,
         help="Fail when available BIOS stack space is below this byte count.")
+    parser.add_argument("--max-rom", type=lambda x: int(x, 0), default=None,
+        help="Fail when ROM usage exceeds this byte count.")
+    parser.add_argument("--max-sram", type=lambda x: int(x, 0), default=None,
+        help="Fail when allocated SRAM usage exceeds this byte count (excludes implicit stack).")
     parser.add_argument("input", help="input file")
     parser.add_argument("regions", help="regions definitions")
     parser.add_argument("triple", help="toolchain triple")
     args = parser.parse_args()
-    sys.exit(print_usage(args.input, args.regions, args.triple, args.fail_stack_margin))
+    sys.exit(print_usage(args.input, args.regions, args.triple,
+        args.fail_stack_margin, args.max_rom, args.max_sram))
 
 
 if __name__ == "__main__":

--- a/test/software/test_bios_boot.py
+++ b/test/software/test_bios_boot.py
@@ -833,3 +833,117 @@ def test_bios_flashboot_host_coverage(tmp_path):
     if result.returncode == 77:
         pytest.skip("host cannot provide low-address mmap for BIOS flashboot test")
     assert result.returncode == 0
+
+
+@pytest.mark.parametrize("medium,csr", [
+    ("sdcard", "CSR_SDCARD_BASE"),
+    ("sata", "CSR_SATA_SECTOR2MEM_BASE"),
+])
+def test_bios_storage_loads(tmp_path, medium, csr):
+    repo = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    include_dir = tmp_path / "include"
+    source = tmp_path / "storage.c"
+    binary = tmp_path / "storage"
+    _write_bios_stubs(include_dir)
+    _write(source, f"""
+        #include <assert.h>
+        #include <setjmp.h>
+        #include <stdint.h>
+        #include <stdio.h>
+        #include <string.h>
+
+        static unsigned char ram[0x10010];
+        #define {csr} 1
+        #define MAIN_RAM_BASE_VA ((unsigned long)ram)
+        #define MAIN_RAM_SIZE (sizeof(ram) - 16)
+        static jmp_buf jump;
+        static unsigned int file_size, file_offset;
+        static int mount_error, open_error, read_error;
+        static int closes, unmounts, reads, boots;
+
+        #include "{repo}/litex/soc/software/bios/boot.c"
+
+        void boot_helper(unsigned long r1, unsigned long r2, unsigned long r3, unsigned long addr)
+        {{
+            (void)r1; (void)r2; (void)r3;
+            assert(addr == MAIN_RAM_BASE_VA);
+            boots++;
+            longjmp(jump, 1);
+        }}
+        void bios_print_section(const char *name) {{ (void)name; }}
+        FRESULT f_mount(FATFS *fs, const char *path, int opt)
+        {{
+            (void)path; (void)opt;
+            if (!fs) {{ unmounts++; return FR_OK; }}
+            return mount_error;
+        }}
+        FRESULT f_open(FIL *file, const char *path, int mode)
+        {{
+            (void)path; (void)mode;
+            file->size = file_size;
+            file_offset = 0;
+            return open_error;
+        }}
+        unsigned int f_size(FIL *file) {{ return file->size; }}
+        FRESULT f_read(FIL *file, void *buffer, unsigned int btr, UINT *br)
+        {{
+            (void)file;
+            reads++;
+            if (read_error) return read_error;
+            *br = file_size - file_offset;
+            if (*br > btr) *br = btr;
+            memset(buffer, 0x5a, *br);
+            file_offset += *br;
+            return FR_OK;
+        }}
+        FRESULT f_close(FIL *file) {{ (void)file; closes++; return FR_OK; }}
+
+        static void reset(unsigned int size)
+        {{
+            file_size = size;
+            mount_error = open_error = read_error = 0;
+            closes = unmounts = reads = boots = 0;
+            memset(ram, 0xa5, sizeof(ram));
+        }}
+
+        int main(void)
+        {{
+            reset(0);
+            if (!setjmp(jump)) {medium}boot_from_bin("empty.bin");
+            assert(boots == 0 && reads == 0 && closes == 1 && unmounts == 1);
+            assert(ram[0] == 0xa5);
+
+            reset(MAIN_RAM_SIZE + 1);
+            if (!setjmp(jump)) {medium}boot_from_bin("oversized.bin");
+            assert(boots == 0 && reads == 0 && closes == 1 && unmounts == 1);
+
+            reset(MAIN_RAM_SIZE);
+            if (!setjmp(jump)) {medium}boot_from_bin("valid.bin");
+            assert(boots == 1 && closes == 1 && unmounts == 1);
+            for (unsigned int i = 0; i < MAIN_RAM_SIZE; i++) assert(ram[i] == 0x5a);
+            for (unsigned int i = MAIN_RAM_SIZE; i < sizeof(ram); i++) assert(ram[i] == 0xa5);
+
+            reset(32);
+            mount_error = 1;
+            if (!setjmp(jump)) {medium}boot_from_bin("mount-error.bin");
+            assert(boots == 0 && reads == 0 && closes == 0);
+
+            reset(32);
+            open_error = 1;
+            if (!setjmp(jump)) {medium}boot_from_bin("open-error.bin");
+            assert(boots == 0 && reads == 0 && closes == 0 && unmounts == 1);
+
+            reset(32);
+            read_error = 1;
+            if (!setjmp(jump)) {medium}boot_from_bin("read-error.bin");
+            assert(boots == 0 && closes == 1 && unmounts == 1);
+            return 0;
+        }}
+    """)
+    subprocess.check_call([
+        "gcc", "-std=gnu99", "-Wall", "-Wextra",
+        "-ffunction-sections", "-fdata-sections",
+        f"-I{include_dir}", f"-I{repo}/litex/soc/software",
+        str(source), "-Wl,--gc-sections", "-o", str(binary),
+    ])
+    subprocess.check_call([str(binary)])

--- a/test/software/test_bios_boot.py
+++ b/test/software/test_bios_boot.py
@@ -400,6 +400,7 @@ def test_bios_boot_helpers_host_coverage(tmp_path):
                 "[{{\\"first.bin\\":\\"0x1000\\"}}]",
                 "{{\\"first.bin\\":{{\\"addr\\":\\"0x1000\\"}}}}",
                 "{{\\"first.bin\\":\\"0x1000\\",\\"alias.bin\\":\\"0x11000\\"}}",
+                "{{\\"first.bin\\":\\"0x1000\\",\\"second.bin\\":\\"0x1800\\",\\"alias.bin\\":\\"0x11800\\"}}",
                 "{{\\"first.bin\\":\\"0x1000\\",\\"bootargs\\":{{\\"r1\\":\\"-1\\"}}}}",
                 "{{\\"first.bin\\":\\"0x1000\\",\\"bootargs\\":{{\\"r1\\":[]}}}}",
                 "{{\\"first.bin\\":\\"0x1000\\",\\"bootargs\\":{{\\"r1\\":{{\\"r2\\":\\"0\\"}}}}}}",

--- a/test/software/test_bios_boot.py
+++ b/test/software/test_bios_boot.py
@@ -94,6 +94,8 @@ def _write_bios_stubs(include_dir):
         typedef struct { int dummy; } FATFS;
         typedef struct { unsigned int size; } FIL;
         #define FR_OK 0
+        #define FR_NO_FILE 4
+        #define FR_NO_PATH 5
         #define FA_READ 1
         FRESULT f_mount(FATFS *fs, const char *path, int opt);
         FRESULT f_open(FIL *file, const char *path, int mode);
@@ -858,7 +860,7 @@ def test_bios_storage_loads(tmp_path, medium, csr):
         #define MAIN_RAM_SIZE (sizeof(ram) - 16)
         static jmp_buf jump;
         static unsigned int file_size, file_offset;
-        static int mount_error, open_error, read_error;
+        static int mount_error, open_error, read_error, short_read;
         static int closes, unmounts, reads, boots;
 
         #include "{repo}/litex/soc/software/bios/boot.c"
@@ -890,7 +892,7 @@ def test_bios_storage_loads(tmp_path, medium, csr):
             (void)file;
             reads++;
             if (read_error) return read_error;
-            *br = file_size - file_offset;
+            *br = short_read ? 0 : file_size - file_offset;
             if (*br > btr) *br = btr;
             memset(buffer, 0x5a, *br);
             file_offset += *br;
@@ -901,7 +903,7 @@ def test_bios_storage_loads(tmp_path, medium, csr):
         static void reset(unsigned int size)
         {{
             file_size = size;
-            mount_error = open_error = read_error = 0;
+            mount_error = open_error = read_error = short_read = 0;
             closes = unmounts = reads = boots = 0;
             memset(ram, 0xa5, sizeof(ram));
         }}
@@ -909,34 +911,44 @@ def test_bios_storage_loads(tmp_path, medium, csr):
         int main(void)
         {{
             reset(0);
-            if (!setjmp(jump)) {medium}boot_from_bin("empty.bin");
+            if (!setjmp(jump)) fatfsboot_from_bin("empty.bin");
             assert(boots == 0 && reads == 0 && closes == 1 && unmounts == 1);
             assert(ram[0] == 0xa5);
 
             reset(MAIN_RAM_SIZE + 1);
-            if (!setjmp(jump)) {medium}boot_from_bin("oversized.bin");
+            if (!setjmp(jump)) fatfsboot_from_bin("oversized.bin");
             assert(boots == 0 && reads == 0 && closes == 1 && unmounts == 1);
 
             reset(MAIN_RAM_SIZE);
-            if (!setjmp(jump)) {medium}boot_from_bin("valid.bin");
+            if (!setjmp(jump)) fatfsboot_from_bin("valid.bin");
             assert(boots == 1 && closes == 1 && unmounts == 1);
             for (unsigned int i = 0; i < MAIN_RAM_SIZE; i++) assert(ram[i] == 0x5a);
             for (unsigned int i = MAIN_RAM_SIZE; i < sizeof(ram); i++) assert(ram[i] == 0xa5);
 
             reset(32);
             mount_error = 1;
-            if (!setjmp(jump)) {medium}boot_from_bin("mount-error.bin");
-            assert(boots == 0 && reads == 0 && closes == 0);
+            if (!setjmp(jump)) fatfsboot_from_bin("mount-error.bin");
+            assert(boots == 0 && reads == 0 && closes == 0 && unmounts == 1);
 
             reset(32);
             open_error = 1;
-            if (!setjmp(jump)) {medium}boot_from_bin("open-error.bin");
+            if (!setjmp(jump)) fatfsboot_from_bin("open-error.bin");
             assert(boots == 0 && reads == 0 && closes == 0 && unmounts == 1);
 
             reset(32);
             read_error = 1;
-            if (!setjmp(jump)) {medium}boot_from_bin("read-error.bin");
+            if (!setjmp(jump)) fatfsboot_from_bin("read-error.bin");
             assert(boots == 0 && closes == 1 && unmounts == 1);
+            reset(32);
+            short_read = 1;
+            if (!setjmp(jump)) fatfsboot_from_bin("short.bin");
+            assert(boots == 0 && closes == 1 && unmounts == 1);
+
+            size_t loaded;
+            reset(32);
+            open_error = FR_NO_FILE;
+            assert(fatfs_load_file("missing.bin", ram, sizeof(ram), &loaded, 0) == BOOT_LOAD_NOT_FOUND);
+            assert(loaded == 0);
             return 0;
         }}
     """)

--- a/test/software/test_bios_boot.py
+++ b/test/software/test_bios_boot.py
@@ -337,6 +337,20 @@ def test_bios_boot_helpers_host_coverage(tmp_path):
             return 0;
         }}
 
+        static int test_manifest_ignores_long_bootargs(void)
+        {{
+            char json[512];
+            struct load_ctx ctx = {{.count = 0, .fail_after = -1}};
+
+            snprintf(json, sizeof(json),
+                "{{\\"bootargs\\":\\"%0256d\\",\\"image.bin\\":\\"0x1000\\"}}", 0);
+            if (setjmp(boot_jmp) == 0)
+                boot_from_json_buffer(json, strlen(json), record_load, &ctx);
+            REQUIRE(ctx.count == 1);
+            REQUIRE(boot_addr == 0x1000);
+            return 0;
+        }}
+
         static int test_manifest_defaults_to_last_image(void)
         {{
             const char *json =
@@ -588,6 +602,8 @@ def test_bios_boot_helpers_host_coverage(tmp_path):
             if (test_boot_load_max_size())
                 return 1;
             if (test_manifest_explicit_boot_address())
+                return 1;
+            if (test_manifest_ignores_long_bootargs())
                 return 1;
             if (test_manifest_defaults_to_last_image())
                 return 1;

--- a/test/software/test_bios_boot.py
+++ b/test/software/test_bios_boot.py
@@ -646,6 +646,7 @@ def test_bios_boot_helpers_host_coverage(tmp_path):
         f"-I{repo}/litex/soc/software/bios",
         str(source),
         f"{repo}/litex/soc/software/libbase/crc16.c",
+        f"{repo}/litex/soc/software/libbase/parse.c",
         "-Wl,--gc-sections",
         "-o",
         str(binary),
@@ -807,6 +808,7 @@ def test_bios_flashboot_host_coverage(tmp_path):
         str(source),
         f"{repo}/litex/soc/software/libbase/crc16.c",
         f"{repo}/litex/soc/software/libbase/crc32.c",
+        f"{repo}/litex/soc/software/libbase/parse.c",
         "-Wl,--gc-sections",
         "-o",
         str(binary),
@@ -934,6 +936,7 @@ def test_bios_storage_loads(tmp_path, medium, csr):
         "gcc", "-std=gnu99", "-Wall", "-Wextra",
         "-ffunction-sections", "-fdata-sections",
         f"-I{include_dir}", f"-I{repo}/litex/soc/software",
-        str(source), "-Wl,--gc-sections", "-o", str(binary),
+        str(source), f"{repo}/litex/soc/software/libbase/parse.c",
+        "-Wl,--gc-sections", "-o", str(binary),
     ])
     subprocess.check_call([str(binary)])

--- a/test/software/test_bios_boot.py
+++ b/test/software/test_bios_boot.py
@@ -125,8 +125,10 @@ def test_bios_boot_helpers_host_coverage(tmp_path):
         #define CONFIG_CLOCK_FREQUENCY 1000000
         #define CONFIG_BIOS_NO_DELAYS 1
         #define MAIN_RAM_BASE 0x1000
+        #define MAIN_RAM_BASE_VA 0x11000
         #define MAIN_RAM_SIZE 0x1000
         #define SRAM_BASE 0x3000
+        #define SRAM_BASE_VA 0x13000
         #define SRAM_SIZE 0x100
 
         static jmp_buf boot_jmp;
@@ -310,8 +312,19 @@ def test_bios_boot_helpers_host_coverage(tmp_path):
             REQUIRE(max_size == 1);
             REQUIRE(boot_load_max_size(MAIN_RAM_BASE + MAIN_RAM_SIZE - 16, &max_size) == 1);
             REQUIRE(max_size == 16);
+#ifdef BIOS_TEST_SRAM_BUFFER
             REQUIRE(boot_load_max_size(SRAM_BASE + 0x20, &max_size) == 1);
-            REQUIRE(max_size == SRAM_SIZE - 0x20);
+            REQUIRE(max_size == 0x60);
+            REQUIRE(boot_load_max_size(SRAM_BASE_VA + 0x20, &max_size) == 1);
+            REQUIRE(max_size == 0x60);
+            REQUIRE(boot_load_max_size(SRAM_BASE + 0x80, &max_size) == 0);
+            REQUIRE(boot_load_max_size(SRAM_BASE_VA + 0x80, &max_size) == 0);
+#else
+            REQUIRE(boot_load_max_size(SRAM_BASE + 0x20, &max_size) == 0);
+            REQUIRE(boot_load_max_size(SRAM_BASE_VA + 0x20, &max_size) == 0);
+#endif
+            REQUIRE(boot_load_max_size(MAIN_RAM_BASE_VA + 0x20, &max_size) == 1);
+            REQUIRE(max_size == MAIN_RAM_SIZE - 0x20);
             REQUIRE(boot_load_max_size(MAIN_RAM_BASE - 1, &max_size) == 0);
             REQUIRE(boot_load_max_size(MAIN_RAM_BASE + MAIN_RAM_SIZE, &max_size) == 0);
             return 0;
@@ -652,6 +665,14 @@ def test_bios_boot_helpers_host_coverage(tmp_path):
         str(binary),
     ]
     subprocess.check_call(cmd)
+    subprocess.check_call([str(binary)])
+
+    # Reserve an explicit SRAM buffer through linker symbols, using its alias.
+    subprocess.check_call(cmd + [
+        "-no-pie", "-DBIOS_TEST_SRAM_BUFFER",
+        "-Wl,--defsym=__bios_boot_sram_start=0x13000",
+        "-Wl,--defsym=__bios_boot_sram_end=0x13080",
+    ])
     subprocess.check_call([str(binary)])
 
 

--- a/test/software/test_bios_boot.py
+++ b/test/software/test_bios_boot.py
@@ -238,6 +238,7 @@ def test_bios_boot_helpers_host_coverage(tmp_path):
         struct load_ctx {{
             int count;
             int fail_after;
+            size_t image_size;
             struct load_event events[8];
         }};
 
@@ -255,6 +256,8 @@ def test_bios_boot_helpers_host_coverage(tmp_path):
             }}
 
             if ((ctx->fail_after >= 0) && (index >= ctx->fail_after))
+                return 0;
+            if (ctx->image_size > max_size)
                 return 0;
             return 1;
         }}
@@ -349,6 +352,50 @@ def test_bios_boot_helpers_host_coverage(tmp_path):
             REQUIRE(boot_r2 == 0x22);
             REQUIRE(boot_r3 == 0x33);
             REQUIRE(boot_addr == 0x1800);
+            return 0;
+        }}
+
+        static int test_manifest_preflight_and_image_bounds(void)
+        {{
+            const char *invalid[] = {{
+                "{{\\"first.bin\\":\\"0x1000\\",\\"bad.bin\\":\\"-1\\"}}",
+                "{{\\"first.bin\\":\\"0x1000\\",\\"addr\\":\\"0x10000000000000000\\"}}",
+                "{{\\"first.bin\\":\\"0x1000\\",\\"first.bin\\":\\"0x1100\\"}}",
+                "[{{\\"first.bin\\":\\"0x1000\\"}}]",
+                "{{\\"first.bin\\":{{\\"addr\\":\\"0x1000\\"}}}}",
+                "{{\\"first.bin\\":\\"0x1000\\",\\"alias.bin\\":\\"0x11000\\"}}",
+            }};
+            struct load_ctx ctx;
+            const char *reverse = "{{\\"second.bin\\":\\"0x11100\\",\\"first.bin\\":\\"0x1000\\"}}";
+            const char *forward = "{{\\"first.bin\\":\\"0x1000\\",\\"second.bin\\":\\"0x11100\\"}}";
+
+            for (unsigned int i = 0; i < sizeof(invalid)/sizeof(*invalid); i++) {{
+                memset(&ctx, 0, sizeof(ctx));
+                ctx.fail_after = -1;
+                boot_addr = 0;
+                if (!setjmp(boot_jmp))
+                    boot_from_json_buffer(invalid[i], strlen(invalid[i]), record_load, &ctx);
+                REQUIRE(ctx.count == 0);
+                REQUIRE(boot_addr == 0);
+            }}
+            memset(&ctx, 0, sizeof(ctx));
+            ctx.fail_after = -1;
+            ctx.image_size = 0x100;
+            if (!setjmp(boot_jmp))
+                boot_from_json_buffer(reverse, strlen(reverse), record_load, &ctx);
+            REQUIRE(ctx.count == 2);
+            REQUIRE(ctx.events[1].max_size == 0x100);
+            REQUIRE(boot_addr == 0x1000);
+
+            memset(&ctx, 0, sizeof(ctx));
+            ctx.fail_after = -1;
+            ctx.image_size = 0x101;
+            boot_addr = 0;
+            if (!setjmp(boot_jmp))
+                boot_from_json_buffer(forward, strlen(forward), record_load, &ctx);
+            REQUIRE(ctx.count == 1);
+            REQUIRE(ctx.events[0].max_size == 0x100);
+            REQUIRE(boot_addr == 0);
             return 0;
         }}
 
@@ -617,6 +664,8 @@ def test_bios_boot_helpers_host_coverage(tmp_path):
             if (test_boot_load_max_size())
                 return 1;
             if (test_manifest_explicit_boot_address())
+                return 1;
+            if (test_manifest_preflight_and_image_bounds())
                 return 1;
             if (test_manifest_ignores_long_bootargs())
                 return 1;

--- a/test/software/test_bios_boot.py
+++ b/test/software/test_bios_boot.py
@@ -355,6 +355,42 @@ def test_bios_boot_helpers_host_coverage(tmp_path):
             return 0;
         }}
 
+        static int test_manifest_nested_bootargs(void)
+        {{
+            const char *json[] = {{
+                "{{\\"bootargs\\":{{\\"addr\\":\\"0x1800\\",\\"r1\\":\\"0x11\\","
+                "\\"r2\\":\\"0x22\\",\\"r3\\":\\"0x33\\"}},\\"image.bin\\":\\"0x1000\\"}}",
+                "{{\\"image.bin\\":\\"0x1000\\",\\"bootargs\\":{{\\"addr\\":\\"0x1800\\","
+                "\\"r1\\":\\"0x11\\",\\"r2\\":\\"0x22\\",\\"r3\\":\\"0x33\\"}}}}",
+                "{{\\"first.bin\\":\\"0x1000\\",\\"bootargs\\":{{\\"r1\\":\\"0x11\\","
+                "\\"r2\\":\\"0x22\\",\\"r3\\":\\"0x33\\"}},\\"last.bin\\":\\"0x1800\\"}}",
+            }};
+            struct load_ctx ctx;
+            const char *empty = "{{\\"bootargs\\":{{}},\\"image.bin\\":\\"0x1000\\"}}";
+
+            for (unsigned int i = 0; i < sizeof(json)/sizeof(*json); i++) {{
+                memset(&ctx, 0, sizeof(ctx));
+                ctx.fail_after = -1;
+                boot_addr = 0;
+                if (!setjmp(boot_jmp))
+                    boot_from_json_buffer(json[i], strlen(json[i]), record_load, &ctx);
+                REQUIRE(ctx.count == (i == 2 ? 2 : 1));
+                REQUIRE(boot_addr == 0x1800);
+                REQUIRE(boot_r1 == 0x11);
+                REQUIRE(boot_r2 == 0x22);
+                REQUIRE(boot_r3 == 0x33);
+            }}
+            memset(&ctx, 0, sizeof(ctx));
+            ctx.fail_after = -1;
+            boot_addr = 0;
+            if (!setjmp(boot_jmp))
+                boot_from_json_buffer(empty, strlen(empty), record_load, &ctx);
+            REQUIRE(ctx.count == 1);
+            REQUIRE(boot_addr == 0x1000);
+            REQUIRE(boot_r1 == 0 && boot_r2 == 0 && boot_r3 == 0);
+            return 0;
+        }}
+
         static int test_manifest_preflight_and_image_bounds(void)
         {{
             const char *invalid[] = {{
@@ -364,6 +400,16 @@ def test_bios_boot_helpers_host_coverage(tmp_path):
                 "[{{\\"first.bin\\":\\"0x1000\\"}}]",
                 "{{\\"first.bin\\":{{\\"addr\\":\\"0x1000\\"}}}}",
                 "{{\\"first.bin\\":\\"0x1000\\",\\"alias.bin\\":\\"0x11000\\"}}",
+                "{{\\"first.bin\\":\\"0x1000\\",\\"bootargs\\":{{\\"r1\\":\\"-1\\"}}}}",
+                "{{\\"first.bin\\":\\"0x1000\\",\\"bootargs\\":{{\\"r1\\":[]}}}}",
+                "{{\\"first.bin\\":\\"0x1000\\",\\"bootargs\\":{{\\"r1\\":{{\\"r2\\":\\"0\\"}}}}}}",
+                "{{\\"first.bin\\":\\"0x1000\\",\\"bootargs\\":{{\\"extra.bin\\":\\"0x1800\\"}}}}",
+                "{{\\"first.bin\\":\\"0x1000\\",\\"bootargs\\":{{\\"r1\\":\\"1\\",\\"r1\\":\\"2\\"}}}}",
+                "{{\\"first.bin\\":\\"0x1000\\",\\"r1\\":\\"1\\",\\"bootargs\\":{{\\"r1\\":\\"2\\"}}}}",
+                "{{\\"first.bin\\":\\"0x1000\\",\\"bootargs\\":{{}},\\"bootargs\\":{{}}}}",
+                "{{\\"first.bin\\":\\"0x1000\\",\\"bootargs\\":\\"ignored\\",\\"bootargs\\":{{}}}}",
+                "{{\\"first.bin\\":\\"0x1000\\",\\"bootargs\\":{{\\"bootargs\\":{{}}}}}}",
+                "{{\\"first.bin\\":\\"0x1000\\",\\"bootargs\\":{{}}}} {{}}",
             }};
             struct load_ctx ctx;
             const char *reverse = "{{\\"second.bin\\":\\"0x11100\\",\\"first.bin\\":\\"0x1000\\"}}";
@@ -664,6 +710,8 @@ def test_bios_boot_helpers_host_coverage(tmp_path):
             if (test_boot_load_max_size())
                 return 1;
             if (test_manifest_explicit_boot_address())
+                return 1;
+            if (test_manifest_nested_bootargs())
                 return 1;
             if (test_manifest_preflight_and_image_bounds())
                 return 1;

--- a/test/software/test_bios_boot.py
+++ b/test/software/test_bios_boot.py
@@ -677,20 +677,19 @@ def test_bios_flashboot_host_coverage(tmp_path):
         #include <stdint.h>
         #include <stdio.h>
         #include <string.h>
-        #include <sys/mman.h>
-        #include <unistd.h>
 
-        #ifndef MAP_32BIT
-        #define MAP_32BIT 0
-        #endif
-
+        static uint32_t flash_words[0x2000 / 4];
+        static unsigned char ram_bytes[0x1000];
         static unsigned long flash_base;
+        static unsigned long flash_mapped_size = sizeof(flash_words);
         static unsigned long ram_base;
         static const unsigned long ram_size = 0x1000;
         static jmp_buf boot_jmp;
         static unsigned long boot_addr;
 
-        #define FLASH_BOOT_ADDRESS ((unsigned int)flash_base)
+        #define FLASH_BOOT_ADDRESS flash_base
+        #define SPIFLASH_BASE flash_base
+        #define SPIFLASH_SIZE flash_mapped_size
         #define MAIN_RAM_BASE ram_base
         #define MAIN_RAM_BASE_VA ram_base
         #define MAIN_RAM_SIZE ram_size
@@ -721,27 +720,6 @@ def test_bios_flashboot_host_coverage(tmp_path):
             }} \\
         }} while (0)
 
-        static int map_low_memory(void)
-        {{
-            void *flash;
-            void *ram;
-
-            flash = mmap(NULL, 0x02000000, PROT_READ | PROT_WRITE,
-                MAP_PRIVATE | MAP_ANONYMOUS | MAP_32BIT, -1, 0);
-            if (flash == MAP_FAILED)
-                return 77;
-            ram = mmap(NULL, ram_size, PROT_READ | PROT_WRITE,
-                MAP_PRIVATE | MAP_ANONYMOUS | MAP_32BIT, -1, 0);
-            if (ram == MAP_FAILED)
-                return 77;
-
-            flash_base = (unsigned long)flash;
-            ram_base = (unsigned long)ram;
-            if ((flash_base > 0xffffffffUL) || (ram_base > 0xffffffffUL))
-                return 77;
-            return 0;
-        }}
-
         static void write_image(uint32_t length, int valid_crc)
         {{
             uint32_t crc;
@@ -762,7 +740,7 @@ def test_bios_flashboot_host_coverage(tmp_path):
             write_image(31, 1);
             REQUIRE(check_image_in_flash(FLASH_BOOT_ADDRESS) == 0);
 
-            write_image(16 * 1024 * 1024 + 1, 1);
+            write_image(ram_size + 1, 1);
             REQUIRE(check_image_in_flash(FLASH_BOOT_ADDRESS) == 0);
 
             write_image(64, 0);
@@ -770,6 +748,14 @@ def test_bios_flashboot_host_coverage(tmp_path):
 
             write_image(64, 1);
             REQUIRE(check_image_in_flash(FLASH_BOOT_ADDRESS) == 64);
+
+            flash_mapped_size = 64;
+            REQUIRE(check_image_in_flash(FLASH_BOOT_ADDRESS) == 0);
+            flash_mapped_size = 72;
+            REQUIRE(check_image_in_flash(FLASH_BOOT_ADDRESS) == 64);
+            REQUIRE(check_image_in_flash(flash_base + flash_mapped_size - 4) == 0);
+            REQUIRE(check_image_in_flash(flash_base - 4) == 0);
+            flash_mapped_size = sizeof(flash_words);
             return 0;
         }}
 
@@ -795,11 +781,8 @@ def test_bios_flashboot_host_coverage(tmp_path):
 
         int main(void)
         {{
-            int r;
-
-            r = map_low_memory();
-            if (r != 0)
-                return r;
+            flash_base = (unsigned long)flash_words;
+            ram_base = (unsigned long)ram_bytes;
             if (test_flash_image_validation())
                 return 1;
             if (test_flash_copy_and_boot())
@@ -816,8 +799,6 @@ def test_bios_flashboot_host_coverage(tmp_path):
         "-Wstrict-prototypes",
         "-Wold-style-definition",
         "-Wmissing-prototypes",
-        "-Wno-format",
-        "-Wno-int-to-pointer-cast",
         "-ffunction-sections",
         "-fdata-sections",
         f"-I{include_dir}",
@@ -831,10 +812,7 @@ def test_bios_flashboot_host_coverage(tmp_path):
         str(binary),
     ]
     subprocess.check_call(cmd)
-    result = subprocess.run([str(binary)], check=False)
-    if result.returncode == 77:
-        pytest.skip("host cannot provide low-address mmap for BIOS flashboot test")
-    assert result.returncode == 0
+    subprocess.check_call([str(binary)])
 
 
 @pytest.mark.parametrize("medium,csr", [

--- a/test/software/test_bios_boot.py
+++ b/test/software/test_bios_boot.py
@@ -179,7 +179,7 @@ def test_bios_boot_helpers_host_coverage(tmp_path):
             return 0;
         }}
 
-        static unsigned char uart_in[512];
+        static unsigned char uart_in[4096];
         static int uart_in_len;
         static int uart_in_pos;
         static unsigned char uart_out[512];
@@ -538,6 +538,24 @@ def test_bios_boot_helpers_host_coverage(tmp_path):
             return 0;
         }}
 
+        static int test_serialboot_stops_after_consecutive_invalid_loads(void)
+        {{
+            static const unsigned char ack[] = SFL_MAGIC_ACK;
+            unsigned char bad_load[4] = {{0x00, 0x00, 0x50, 0x00}};
+
+            reset_serial(ack, SFL_MAGIC_LEN);
+            for (int i = 0; i < MAX_FAILURES + 1; i++)
+                append_frame(SFL_CMD_LOAD, bad_load, sizeof(bad_load));
+            append_frame(SFL_CMD_ABORT, NULL, 0);
+
+            REQUIRE(serialboot() == 1);
+            REQUIRE(uart_in_pos == SFL_MAGIC_LEN + MAX_FAILURES * 8);
+            REQUIRE(uart_out_len == SFL_MAGIC_LEN + MAX_FAILURES);
+            for (int i = SFL_MAGIC_LEN; i < uart_out_len; i++)
+                REQUIRE(uart_out[i] == SFL_ACK_ERROR);
+            return 0;
+        }}
+
         static int test_serialboot_jump_boots_requested_address(void)
         {{
             static const unsigned char ack[] = SFL_MAGIC_ACK;
@@ -586,6 +604,8 @@ def test_bios_boot_helpers_host_coverage(tmp_path):
             if (test_serialboot_rejects_out_of_range_load_and_recovers())
                 return 1;
             if (test_serialboot_protocol_errors_recover_with_abort())
+                return 1;
+            if (test_serialboot_stops_after_consecutive_invalid_loads())
                 return 1;
             if (test_serialboot_jump_boots_requested_address())
                 return 1;

--- a/test/software/test_bios_commands.py
+++ b/test/software/test_bios_commands.py
@@ -107,3 +107,93 @@ int main(void)
         "-Wl,--gc-sections", "-o", str(binary),
     ])
     subprocess.check_call([str(binary)])
+
+
+def test_dispatch_help_and_completion(tmp_path):
+    repo = Path(__file__).resolve().parents[2]
+    generated = tmp_path / "generated"
+    generated.mkdir()
+    for name in ["csr", "soc", "mem"]:
+        (generated / f"{name}.h").write_text("")
+    (tmp_path / "system.h").write_text(r'''
+#pragma once
+#include <stddef.h>
+static inline void flush_cpu_dcache(void) {}
+static inline void flush_l2_cache(void) {}
+static inline void flush_cpu_dcache_range(void *p, size_t n) { (void)p; (void)n; }
+''')
+    linker = tmp_path / "commands.ld"
+    linker.write_text('''
+SECTIONS {
+    .bios_cmd : {
+        __bios_cmd_start = .;
+        KEEP(*(.bios_cmd))
+        __bios_cmd_end = .;
+    }
+} INSERT AFTER .rodata;
+''')
+    source = tmp_path / "dispatch.c"
+    source.write_text(r'''
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#define MEM_REGIONS ""
+#include <bios/helpers.c>
+#include <bios/complete.c>
+#include <bios/readline.c>
+#include <bios/cmds/cmd_mem.c>
+#include <bios/cmds/cmd_bios.c>
+
+int memtest(unsigned int *addr, unsigned long size) { (void)addr; (void)size; return 1; }
+void memspeed(unsigned int *addr, unsigned long size, bool ro, bool random)
+{ (void)addr; (void)size; (void)ro; (void)random; }
+unsigned int crc32(const unsigned char *buffer, unsigned int len)
+{ (void)buffer; (void)len; return 0; }
+int uart_read_nonblock(void) { return 1; }
+
+int main(void)
+{
+    uint32_t memory = 0;
+    char address[32], suffix[32];
+    char *args[] = {address, "0x12345678", "1", "4", "extra"};
+    char *help_args[] = {"mem_write"};
+    char line[] = "cmd 1 2 3 4 5 6 7 8 9";
+    char *command, *params[MAX_PARAM];
+    snprintf(address, sizeof(address), "0x%lx", (unsigned long)&memory);
+    assert(command_dispatcher("mem_write", 5, args));
+    assert(memory == 0);
+    assert(command_dispatcher("mem_write", 1, args));
+    assert(memory == 0);
+    assert(command_dispatcher("mem_write", 4, args));
+    assert(memory == 0x12345678);
+    assert(command_dispatcher("help", 1, help_args));
+    assert(memory == 0x12345678);
+    assert(!command_dispatcher("nonexistent", 0, NULL));
+    assert(get_param(line, &command, params) == -1);
+    complete("mem_wr", suffix, sizeof(suffix));
+    assert(!strcmp(suffix, "ite"));
+    complete("mem_wr", suffix, 2);
+    assert(!strcmp(suffix, "i"));
+    complete("mem_c", suffix, sizeof(suffix));
+    assert(!strcmp(suffix, ""));
+    assert(complete("mem_c", suffix, sizeof(suffix)) == 1);
+    const char *input = "mem_wr\t\n";
+    char line_buffer[CMD_LINE_BUFFER_SIZE];
+    for (int i = strlen(input) - 1; i >= 0; i--) ungetc(input[i], stdin);
+    hist_init();
+    assert(readline(line_buffer, sizeof(line_buffer)) == 9);
+    assert(!strcmp(line_buffer, "mem_write"));
+    return 0;
+}
+''')
+    binary = tmp_path / "dispatch"
+    subprocess.check_call([
+        "gcc", "-std=gnu99", "-Wall", "-Werror", "-ffunction-sections", "-fdata-sections",
+        f"-I{tmp_path}", f"-I{repo}/litex/soc/software", str(source),
+        str(repo / "litex/soc/software/libbase/parse.c"),
+        f"-Wl,-T,{linker}", "-Wl,--gc-sections", "-o", str(binary),
+    ])
+    output = subprocess.check_output([str(binary)], text=True)
+    assert "Usage: mem_write <address> <value> [count] [size]" in output
+    assert "mem_write - Write address space" in output
+    assert "Error: too many parameters" in output

--- a/test/software/test_bios_commands.py
+++ b/test/software/test_bios_commands.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: BSD-2-Clause
+
+import subprocess
+from pathlib import Path
+
+
+def test_checked_unsigned_arguments(tmp_path):
+    repo = Path(__file__).resolve().parents[2]
+    source = tmp_path / "parse.c"
+    source.write_text(r'''
+#include <assert.h>
+#include <limits.h>
+#include <stdio.h>
+#include <libbase/parse.h>
+
+int main(void)
+{
+    unsigned long value = 123;
+    unsigned int small = 42;
+    char boundary[64];
+    const char *invalid[] = {"", "-1", "+1", " 1", "1 ", "0x", "08", "0xg", "1x"};
+
+    for (unsigned int i = 0; i < sizeof(invalid) / sizeof(*invalid); i++) {
+        assert(!parse_ulong(invalid[i], &value));
+        assert(value == 123);
+    }
+    assert(parse_ulong("0", &value) && value == 0);
+    assert(parse_ulong("077", &value) && value == 63);
+    assert(parse_ulong("0xAbCd", &value) && value == 0xabcd);
+    assert(parse_ulong("1234", &value) && value == 1234);
+    snprintf(boundary, sizeof(boundary), "%lu", ULONG_MAX);
+    assert(parse_ulong(boundary, &value) && value == ULONG_MAX);
+    snprintf(boundary, sizeof(boundary), "0x%lx0", ULONG_MAX);
+    assert(!parse_ulong(boundary, &value) && value == ULONG_MAX);
+    snprintf(boundary, sizeof(boundary), "%u", UINT_MAX);
+    assert(parse_uint(boundary, &small) && small == UINT_MAX);
+    snprintf(boundary, sizeof(boundary), "0x%x0", UINT_MAX);
+    assert(!parse_uint(boundary, &small) && small == UINT_MAX);
+    return 0;
+}
+''')
+    binary = tmp_path / "parse"
+    subprocess.check_call([
+        "gcc", "-std=gnu99", "-Wall", "-Wextra", "-Werror",
+        f"-I{repo}/litex/soc/software", str(source),
+        str(repo / "litex/soc/software/libbase/parse.c"), "-o", str(binary),
+    ])
+    subprocess.check_call([str(binary)])
+
+
+def test_memory_and_flash_arguments(tmp_path):
+    repo = Path(__file__).resolve().parents[2]
+    generated = tmp_path / "generated"
+    generated.mkdir()
+    for name in ["csr", "soc", "mem"]:
+        (generated / f"{name}.h").write_text("")
+    source = tmp_path / "commands.c"
+    source.write_text(r'''
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#define BIOS_CONSOLE_DISABLE
+#define CSR_SPIFLASH_MASTER_CS_ADDR 1
+#define MEM_REGIONS ""
+#include <bios/cmds/cmd_mem.c>
+#include <bios/cmds/cmd_spiflash.c>
+
+static uint8_t *flash_source;
+static unsigned int flash_count;
+int spiflash_write_stream(uint32_t offset, uint8_t *source, uint32_t count)
+{
+    assert(offset == 0);
+    flash_source = source;
+    flash_count++;
+    return count;
+}
+int main(void)
+{
+    uint32_t memory[4] = {0};
+    char address[32];
+    char *write_args[] = {address, "0x12345678", "1", "4"};
+    char *flash_args[] = {"0", address, "4"};
+    snprintf(address, sizeof(address), "0x%lx", (unsigned long)memory);
+    mem_write_handler(4, write_args);
+    assert(memory[0] == 0x12345678 && memory[1] == 0);
+    write_args[1] = "0x100000000";
+    mem_write_handler(4, write_args);
+    assert(memory[0] == 0x12345678);
+    write_args[1] = "-1";
+    mem_write_handler(4, write_args);
+    assert(memory[0] == 0x12345678);
+    flash_write_handler(3, flash_args);
+    assert(flash_count == 1 && flash_source == (uint8_t *)memory);
+    flash_args[2] = "0x100000000";
+    flash_write_handler(3, flash_args);
+    assert(flash_count == 1);
+    return 0;
+}
+''')
+    binary = tmp_path / "commands"
+    subprocess.check_call([
+        "gcc", "-std=gnu99", "-Wall", "-Werror", "-Wno-unused-function",
+        "-ffunction-sections", "-fdata-sections", f"-I{tmp_path}",
+        f"-I{repo}/litex/soc/software", str(source),
+        str(repo / "litex/soc/software/libbase/parse.c"),
+        "-Wl,--gc-sections", "-o", str(binary),
+    ])
+    subprocess.check_call([str(binary)])

--- a/test/software/test_bios_console.py
+++ b/test/software/test_bios_console.py
@@ -212,3 +212,49 @@ def test_bios_readline_host_coverage(tmp_path):
     no_ansi_binary = tmp_path / "bios_readline_harness_no_ansi"
     subprocess.check_call(cmd + ["-DBIOS_CONSOLE_NO_ANSI", str(source), "-o", str(no_ansi_binary)])
     subprocess.check_call([str(no_ansi_binary)])
+
+
+def test_lite_console_controls_and_bounds(tmp_path):
+    repo = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    include_dir = tmp_path / "include"
+    _write(include_dir / "generated" / "csr.h")
+    source = tmp_path / "lite.c"
+    _write(source, f"""
+        #include <assert.h>
+        #include <stdio.h>
+        #include <string.h>
+        #include "{repo}/litex/soc/software/bios/readline_simple.c"
+        int uart_read_nonblock(void) {{ return 1; }}
+
+        static int read_input(const char *input, char *buffer, int size)
+        {{
+            for (int i = strlen(input) - 1; i >= 0; i--) ungetc(input[i], stdin);
+            return readline(buffer, size);
+        }}
+        int main(void)
+        {{
+            char buffer[8];
+            assert(read_input("danger\\003", buffer, sizeof(buffer)) == -1);
+            assert(buffer[0] == 0);
+            read_input("abc\\bD\\n", buffer, sizeof(buffer));
+            assert(!strcmp(buffer, "abD"));
+            read_input("ab\\033[Dc\\033[3~d\\033OA\\n", buffer, sizeof(buffer));
+            assert(!strcmp(buffer, "abcd"));
+            read_input("abc\\033\\n", buffer, sizeof(buffer));
+            assert(!strcmp(buffer, "abc"));
+            read_input("1234567890\\n", buffer, sizeof(buffer));
+            assert(!strcmp(buffer, "1234567"));
+            read_input("one\\r\\ntwo\\n", buffer, sizeof(buffer));
+            assert(!strcmp(buffer, "one"));
+            readline(buffer, sizeof(buffer));
+            assert(!strcmp(buffer, "two"));
+            return 0;
+        }}
+    """)
+    binary = tmp_path / "lite"
+    subprocess.check_call([
+        "gcc", "-std=gnu99", "-Wall", "-Wextra", "-Werror",
+        f"-I{include_dir}", f"-I{repo}/litex/soc/software",
+        str(source), "-o", str(binary),
+    ])
+    subprocess.check_call([str(binary)], timeout=10)

--- a/test/software/test_bios_network.py
+++ b/test/software/test_bios_network.py
@@ -14,11 +14,25 @@ def _write(path, contents=""):
     path.write_text(textwrap.dedent(contents))
 
 
+def _write_timeout_stub(include_dir):
+    _write(include_dir / "libbase" / "timeout.h", """
+        #ifndef __TIMEOUT_H
+        #define __TIMEOUT_H
+        struct timeout { unsigned int left; };
+        static inline void timeout_start(struct timeout *t, unsigned int us)
+        { (void)us; t->left = 4; }
+        static inline int timeout_expired(struct timeout *t)
+        { if (t->left) t->left--; return !t->left; }
+        #endif
+    """)
+
+
 def test_liteeth_tftp_receive_bounds_host_coverage(tmp_path):
     repo = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
     include_dir = tmp_path / "include"
     source = tmp_path / "tftp_harness.c"
     binary = tmp_path / "tftp_harness"
+    _write_timeout_stub(include_dir)
 
     _write(include_dir / "generated" / "soc.h")
     _write(include_dir / "libbase" / "progress.h", """
@@ -308,6 +322,15 @@ def test_liteeth_tftp_receive_bounds_host_coverage(tmp_path):
                 return 1;
             if (test_error_packet_finishes_with_failure())
                 return 1;
+            uint8_t dst[8];
+            reset_rx(dst, sizeof(dst));
+            REQUIRE(tftp_get(0, 69, "missing.bin", dst, sizeof(dst)) == -1);
+            REQUIRE(current_callback == NULL);
+            REQUIRE(send_count == 5);
+            reset_rx(dst, sizeof(dst));
+            REQUIRE(tftp_put(0, 69, "missing.bin", dst, sizeof(dst)) == -1);
+            REQUIRE(current_callback == NULL);
+            REQUIRE(send_count == 5);
             return 0;
         }}
     """)
@@ -335,6 +358,7 @@ def test_liteeth_arp_cache_update_host_coverage(tmp_path):
     include_dir = tmp_path / "include"
     source = tmp_path / "arp_harness.c"
     binary = tmp_path / "arp_harness"
+    _write_timeout_stub(include_dir)
 
     _write(include_dir / "generated" / "csr.h", """
         #define CSR_ETHMAC_BASE 1
@@ -365,6 +389,8 @@ def test_liteeth_arp_cache_update_host_coverage(tmp_path):
         #include <string.h>
 
         static uint8_t ethmac_memory[2048*4];
+        static int tx_ready = 1;
+        static int tx_starts;
 
         void flush_cpu_dcache(void) {{}}
         uint32_t crc32(const unsigned char *buffer, unsigned int len)
@@ -373,10 +399,10 @@ def test_liteeth_arp_cache_update_host_coverage(tmp_path):
             (void)len;
             return 0;
         }}
-        uint32_t ethmac_sram_reader_ready_read(void) {{ return 1; }}
+        uint32_t ethmac_sram_reader_ready_read(void) {{ return tx_ready; }}
         void ethmac_sram_reader_slot_write(uint32_t value) {{ (void)value; }}
         void ethmac_sram_reader_length_write(uint32_t value) {{ (void)value; }}
-        void ethmac_sram_reader_start_write(uint32_t value) {{ (void)value; }}
+        void ethmac_sram_reader_start_write(uint32_t value) {{ (void)value; tx_starts++; }}
         void ethmac_sram_reader_ev_pending_write(uint32_t value) {{ (void)value; }}
         uint32_t ethmac_sram_writer_ev_pending_read(void) {{ return 0; }}
         void ethmac_sram_writer_ev_pending_write(uint32_t value) {{ (void)value; }}
@@ -442,6 +468,14 @@ def test_liteeth_arp_cache_update_host_coverage(tmp_path):
             make_arp_reply(server_ip, mac_b);
             process_arp();
             REQUIRE(memcmp(cached_mac, mac_a, sizeof(mac_a)) == 0);
+            tx_ready = 0;
+            REQUIRE(udp_send(1000, 2000, 0) == 0);
+            REQUIRE(tx_starts == 0);
+            REQUIRE(udp_arp_resolve(server_ip + 1) == 0);
+            REQUIRE(tx_starts == 0 && arp_pending == 0);
+            tx_ready = 1;
+            REQUIRE(udp_arp_resolve(server_ip + 2) == 0);
+            REQUIRE(tx_starts == 8 && arp_pending == 0);
             return 0;
         }}
     """)

--- a/test/software/test_memusage.py
+++ b/test/software/test_memusage.py
@@ -6,6 +6,8 @@
 
 import textwrap
 
+import pytest
+
 from litex.soc.software import memusage
 
 
@@ -148,3 +150,24 @@ def test_memusage_fails_on_requested_explicit_stack_size(tmp_path, capsys, monke
     assert result == 1
     assert "  .stack: 1.00KiB" in output
     assert "ERROR: SRAM .stack is below required minimum (1.00KiB < 2.00KiB)." in output
+
+
+@pytest.mark.parametrize("max_rom,max_sram,failed", [
+    (0x1100, 0x400, False),
+    (0x10ff, 0x400, True),
+    (0x1100, 0x3ff, True),
+    (None, None, False),
+])
+def test_memory_budgets_include_reserved_boot_buffer(tmp_path, monkeypatch, max_rom, max_sram, failed):
+    regions = tmp_path / "regions.ld"
+    write_regions(regions)
+    sections = [
+        section(".text",      0x00000000, 0x1000, "AX"),
+        section(".boot_sram", 0x10000000, 0x0200, "WA", "NOBITS"),
+        section(".data",      0x10000200, 0x0100, "WA"),
+        section(".bss",       0x10000300, 0x0100, "WA", "NOBITS"),
+    ]
+    monkeypatch.setattr(memusage, "parse_sections", lambda bios, triple: sections)
+    result = memusage.print_usage("bios.elf", str(regions), "riscv64-unknown-elf",
+        max_rom=max_rom, max_sram=max_sram)
+    assert result == int(failed)

--- a/test/software/test_spisdcard.py
+++ b/test/software/test_spisdcard.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: BSD-2-Clause
+
+import subprocess
+from pathlib import Path
+
+
+def test_spi_transfer_failures_reach_storage_callers(tmp_path):
+    repo = Path(__file__).resolve().parents[2]
+    generated = tmp_path / "generated"
+    generated.mkdir()
+    for name in ["csr", "mem", "soc"]:
+        (generated / f"{name}.h").write_text("")
+    (tmp_path / "system.h").write_text("")
+    source = tmp_path / "spisd.c"
+    source.write_text(r'''
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+#include <libbase/timeout.h>
+#define CSR_SPISDCARD_BASE 1
+#define CONFIG_CLOCK_FREQUENCY 100000000
+#define min(a, b) ((a) < (b) ? (a) : (b))
+#define max(a, b) ((a) > (b) ? (a) : (b))
+static int transfers, status_reads, stuck, block_mode, fail_transfer;
+void timeout_start(struct timeout *t, unsigned int us) { (void)us; t->remaining = 4; }
+int timeout_expired(struct timeout *t) { return !--t->remaining; }
+void busy_wait(unsigned int ms) { (void)ms; }
+void busy_wait_us(unsigned int us) { (void)us; }
+static void spisdcard_clk_divider_write(uint32_t v) { (void)v; }
+static void spisdcard_mosi_write(uint32_t v) { (void)v; }
+static void spisdcard_cs_write(uint32_t v) { (void)v; }
+static void spisdcard_control_write(uint32_t v) { (void)v; transfers++; }
+static uint32_t spisdcard_status_read(void)
+{
+    status_reads++;
+    return stuck || transfers == fail_transfer ? 0 : 1;
+}
+static uint32_t spisdcard_miso_read(void)
+{
+    return block_mode && transfers == 1 ? 0xfe : 0x5a;
+}
+#include <liblitesdcard/spisdcard.c>
+DISKOPS *FfDiskOps;
+
+int main(void)
+{
+    uint8_t buffer[512];
+    assert(spi_xfer(0xff) == 0x5a);
+    transfers = status_reads = 0;
+    stuck = 1;
+    assert(spi_xfer(0xff) == -1);
+    assert(status_reads <= 6);
+    transfers = 0;
+    assert(!spisdcard_init());
+    assert(transfers == 1);
+    transfers = 0;
+    assert(spisd_disk_read(0, buffer, 0, 1) == RES_ERROR);
+    assert(transfers <= 3);
+    transfers = 0;
+    stuck = 0;
+    block_mode = 1;
+    fail_transfer = 4;
+    memset(buffer, 0xa5, sizeof(buffer));
+    assert(!spisdcardreceive_block(buffer));
+    assert(buffer[0] == 0x5a && buffer[1] == 0x5a && buffer[2] == 0xa5);
+    transfers = 0;
+    fail_transfer = 0;
+    assert(spisdcardreceive_block(buffer));
+    for (unsigned int i = 0; i < sizeof(buffer); i++) assert(buffer[i] == 0x5a);
+    return 0;
+}
+''')
+    binary = tmp_path / "spisd"
+    subprocess.check_call([
+        "gcc", "-std=gnu99", "-Wall", "-Werror", f"-I{tmp_path}",
+        f"-I{repo}/litex/soc/software", str(source), "-o", str(binary),
+    ])
+    subprocess.check_call([str(binary)], timeout=10)

--- a/test/software/test_timeout.py
+++ b/test/software/test_timeout.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: BSD-2-Clause
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("uptime", [False, True])
+def test_nested_deadlines_and_counter_wrap(tmp_path, uptime):
+    repo = Path(__file__).resolve().parents[2]
+    generated = tmp_path / "generated"
+    generated.mkdir()
+    (generated / "csr.h").write_text("")
+    (generated / "soc.h").write_text("#define CONFIG_CLOCK_FREQUENCY 1000000\n")
+    source = tmp_path / "timeout.c"
+    source.write_text(r'''
+#include <assert.h>
+#include <stdint.h>
+static uint64_t cycles;
+static uint32_t enabled, reload;
+static unsigned int loads;
+static uint32_t timer0_en_read(void) { return enabled; }
+static uint32_t timer0_reload_read(void) { return reload; }
+static void timer0_en_write(uint32_t v) { enabled = v; }
+static void timer0_reload_write(uint32_t v) { reload = v; }
+static void timer0_load_write(uint32_t v) { (void)v; loads++; }
+static void timer0_update_value_write(uint32_t v) { (void)v; }
+static uint32_t timer0_value_read(void) { return UINT32_MAX - (uint32_t)cycles; }
+static void timer0_uptime_latch_write(uint32_t v) { (void)v; }
+static uint64_t timer0_uptime_cycles_read(void) { return cycles; }
+#include <libbase/timeout.c>
+
+int main(void)
+{
+    struct timeout outer, inner;
+    cycles = UINT64_MAX - 5;
+    timeout_start(&outer, 10);
+    assert(!timeout_expired(&outer));
+    cycles += 4;
+    timeout_start(&inner, 3);
+    assert(!timeout_expired(&outer));
+    cycles += 2;
+    assert(!timeout_expired(&inner));
+    assert(!timeout_expired(&outer));
+    cycles++;
+    assert(timeout_expired(&inner));
+    assert(!timeout_expired(&outer));
+    cycles += 3;
+    assert(timeout_expired(&outer));
+    assert(timeout_expired(&outer));
+#ifndef CSR_TIMER0_UPTIME_CYCLES_ADDR
+    assert(loads == 1);
+#endif
+    timeout_start(&inner, 0);
+    assert(timeout_expired(&inner));
+    return 0;
+}
+''')
+    binary = tmp_path / "timeout"
+    subprocess.check_call([
+        "gcc", "-std=gnu99", "-Wall", "-Wextra", "-Werror", "-Wno-unused-function",
+        f"-I{tmp_path}", f"-I{repo}/litex/soc/software",
+        *(["-DCSR_TIMER0_UPTIME_CYCLES_ADDR=1"] if uptime else []),
+        str(source), "-o", str(binary),
+    ])
+    subprocess.check_call([str(binary)])


### PR DESCRIPTION
## Summary

This is a 16-commit BIOS review series, based directly on master and independent of the SoC integration and CPU-performance series.

- Validate boot destinations and lengths before writing memory, preserve the BIOS runtime SRAM, and reject malformed or overlapping boot manifests before loading images.
- Share bounded FatFs loading between SD and SATA; handle empty images, flash limits and failed serial loads consistently.
- Add shared unsigned-argument parsing, command arity/usage checks, and cancellation/escape handling for the lite console.
- Bound network and SPI-SD waits so missing or stalled hardware cannot hang boot indefinitely.
- Keep immutable command descriptors in ROM and add optional ROM/SRAM footprint budgets, with documentation and host regression tests.

Each commit contains its motivation and focused validation notes.

## Validation

- `python3 -m pytest -q test/software test/soc/test_builder.py`: **74 passed**, on this branch in an independent worktree.
- A freshly built VexRiscv LiteX Sim BIOS reaches the interactive prompt.

No generated benchmark results are included.
