### PR TITLE
cores: harden peripheral controls, handshakes and error reporting

### DIFF
--- a/litex/soc/cores/dma.py
+++ b/litex/soc/cores/dma.py
@@ -125,10 +125,17 @@ class WishboneDMAReader(LiteXModule):
             self.add_csr()
 
     def add_ctrl(self, default_base=0, default_length=0, default_enable=0, default_loop=0):
+        """Add a byte-addressed transfer controller.
+
+        Base and length must be aligned to bus words and remain stable while enabled. Empty
+        transfers complete without bus activity, including in loop mode. Misaligned transfers
+        complete with ``error`` asserted; disable the controller before starting a new transfer.
+        """
         self.base   = Signal(64, reset=default_base)
         self.length = Signal(32, reset=default_length)
         self.enable = Signal(reset=default_enable)
         self.done   = Signal()
+        self.error  = Signal()
         self.loop   = Signal(reset=default_loop)
         self.offset = Signal(32)
 
@@ -140,6 +147,7 @@ class WishboneDMAReader(LiteXModule):
         length  = Signal(self.bus.adr_width)
         self.comb += base.eq(self.base[shift:])
         self.comb += length.eq(self.length[shift:])
+        unaligned = (self.base[:shift] != 0) | (self.length[:shift] != 0) if shift else 0
 
         self.comb += self.offset.eq(offset)
 
@@ -147,7 +155,13 @@ class WishboneDMAReader(LiteXModule):
         self.comb += fsm.reset.eq(~self.enable)
         fsm.act("IDLE",
             NextValue(offset, 0),
-            NextState("RUN"),
+            If(self.length == 0,
+                NextState("DONE"),
+            ).Elif(unaligned,
+                NextState("ERROR"),
+            ).Else(
+                NextState("RUN"),
+            ),
         )
         fsm.act("RUN",
             self.sink.valid.eq(1),
@@ -165,6 +179,7 @@ class WishboneDMAReader(LiteXModule):
             )
         )
         fsm.act("DONE", self.done.eq(1))
+        fsm.act("ERROR", self.done.eq(1), self.error.eq(1))
 
     def add_csr(self, default_base=0, default_length=0, default_enable=0, default_loop=0):
         if not hasattr(self, "base"):
@@ -175,6 +190,7 @@ class WishboneDMAReader(LiteXModule):
         self._done   = CSRStatus(1,                         description="DMA Reader transfer done.")
         self._loop   = CSRStorage(reset=default_loop,       description="DMA Reader loop enable.")
         self._offset = CSRStatus(32,                        description="DMA Reader current transfer offset.")
+        self._error  = CSRStatus(1, description="DMA Reader rejected a non-word-aligned base or length. Cleared when disabled.")
 
         # # #
 
@@ -187,6 +203,7 @@ class WishboneDMAReader(LiteXModule):
             # Status.
             self._done.status.eq(self.done),
             self._offset.status.eq(self.offset),
+            self._error.status.eq(self.error),
         ]
 
 # WishboneDMAWriter --------------------------------------------------------------------------------
@@ -246,6 +263,10 @@ class WishboneDMAWriter(LiteXModule):
             self.add_csr()
 
     def add_ctrl(self, default_base=0, default_length=0, default_enable=0, default_loop=0, ready_on_idle=1):
+        """Add a controller with the same alignment/completion rules as the DMA reader.
+
+        ``ready_on_idle`` retains the optional discard behavior while the controller is idle.
+        """
         self._sink = self.sink
         self.sink  = stream.Endpoint([("data", self.bus.data_width)])
 
@@ -253,6 +274,7 @@ class WishboneDMAWriter(LiteXModule):
         self.length = Signal(32, reset=default_length)
         self.enable = Signal(reset=default_enable)
         self.done   = Signal()
+        self.error  = Signal()
         self.loop   = Signal(reset=default_loop)
         self.offset = Signal(32)
 
@@ -264,6 +286,7 @@ class WishboneDMAWriter(LiteXModule):
         length  = Signal(self.bus.adr_width)
         self.comb += base.eq(self.base[shift:])
         self.comb += length.eq(self.length[shift:])
+        unaligned = (self.base[:shift] != 0) | (self.length[:shift] != 0) if shift else 0
 
         self.comb += self.offset.eq(offset)
 
@@ -272,7 +295,13 @@ class WishboneDMAWriter(LiteXModule):
         fsm.act("IDLE",
             self.sink.ready.eq(ready_on_idle),
             NextValue(offset, 0),
-            NextState("RUN"),
+            If(self.length == 0,
+                NextState("DONE"),
+            ).Elif(unaligned,
+                NextState("ERROR"),
+            ).Else(
+                NextState("RUN"),
+            ),
         )
         fsm.act("RUN",
             self._sink.valid.eq(self.sink.valid),
@@ -292,6 +321,7 @@ class WishboneDMAWriter(LiteXModule):
             )
         )
         fsm.act("DONE", self.done.eq(1))
+        fsm.act("ERROR", self.done.eq(1), self.error.eq(1))
 
     def add_csr(self, default_base=0, default_length=0, default_enable=0, default_loop=0):
         if not hasattr(self, "base"):
@@ -302,6 +332,7 @@ class WishboneDMAWriter(LiteXModule):
         self._done   = CSRStatus(1,                         description="DMA Writer transfer done.")
         self._loop   = CSRStorage(reset=default_loop,       description="DMA Writer loop enable.")
         self._offset = CSRStatus(32,                        description="DMA Writer current transfer offset.")
+        self._error  = CSRStatus(1, description="DMA Writer rejected a non-word-aligned base or length. Cleared when disabled.")
 
         # # #
 
@@ -314,4 +345,5 @@ class WishboneDMAWriter(LiteXModule):
             # Status.
             self._done.status.eq(self.done),
             self._offset.status.eq(self.offset),
+            self._error.status.eq(self.error),
         ]

--- a/litex/soc/cores/ecc.py
+++ b/litex/soc/cores/ecc.py
@@ -277,13 +277,8 @@ class ECCDecoder(SECDED, LiteXModule):
         # Extract data / status.
         self.extract_data(codeword_c, o)
         self.comb += [
-            If(syndrome != 0,
-                # Double error detected.
-                If(~parity,
-                    ded.eq(1)
-                # Single error corrected.
-                ).Else(
-                    sec.eq(1)
-                )
-            )
+            # An overall-parity-bit error has odd parity and a zero syndrome. It still counts
+            # as a single-bit error even though no payload bit needs to be corrected.
+            sec.eq(self.enable & parity),
+            ded.eq(self.enable & (syndrome != 0) & ~parity),
         ]

--- a/litex/soc/cores/pwm.py
+++ b/litex/soc/cores/pwm.py
@@ -65,8 +65,8 @@ class PWM(LiteXModule):
 
         n = 0 if clock_domain == "sys" else 2
         self.specials += [
-            MultiReg(self._enable.storage, self.enable, n=n),
-            MultiReg(self._width.storage,  self.width,  n=n),
+            MultiReg(self._enable.storage, self.enable, odomain=clock_domain, n=n),
+            MultiReg(self._width.storage,  self.width,  odomain=clock_domain, n=n),
         ]
 
     def add_period_csr(self, clock_domain):
@@ -75,7 +75,7 @@ class PWM(LiteXModule):
             reset = self.period.reset)
 
         n = 0 if clock_domain == "sys" else 2
-        self.specials += MultiReg(self._period.storage, self.period, n=n)
+        self.specials += MultiReg(self._period.storage, self.period, odomain=clock_domain, n=n)
 
     def add_csr(self, clock_domain):
         self.add_enable_width_csr(clock_domain)

--- a/litex/soc/cores/pwm.py
+++ b/litex/soc/cores/pwm.py
@@ -13,6 +13,13 @@ from litex.soc.interconnect.csr import *
 
 # Pulse Width Modulation ---------------------------------------------------------------------------
 
+def _validate_counter_width(counter_width, default_width, default_period):
+    if not isinstance(counter_width, int) or isinstance(counter_width, bool) or not 1 <= counter_width <= 32:
+        raise ValueError("PWM counter_width must be an integer from 1 to 32.")
+    if not 0 <= default_width < 2**counter_width or not 0 <= default_period < 2**counter_width:
+        raise ValueError("PWM default width and period must fit counter_width.")
+
+
 class PWM(LiteXModule):
     """Pulse Width Modulation
 
@@ -20,18 +27,25 @@ class PWM(LiteXModule):
 
     Pulse Width Modulation can be useful for various purposes: dim leds, regulate a fan, control
     an oscillator. Software can configure the PWM width and period and enable/disable it.
+
+    ``counter_width`` optionally reduces the counter, comparators and width/period CSRs for
+    applications that do not need 32-bit resolution. The default register layout is unchanged.
+    Width/period updates are not atomic; disable the output and allow controls to settle when
+    reconfiguring a PWM in a different clock domain.
     """
     def __init__(self, pwm=None, clock_domain="sys", counter=None, with_csr=True,
         default_enable = 0,
         default_width  = 0,
         default_period = 0,
-        counter_enable = None):
+        counter_enable = None,
+        counter_width  = 32):
+        _validate_counter_width(counter_width, default_width, default_period)
         if pwm is None:
             self.pwm = pwm = Signal()
         self.reset  = Signal()
         self.enable = Signal(reset=default_enable)
-        self.width  = Signal(32, reset=default_width)
-        self.period = Signal(32, reset=default_period)
+        self.width  = Signal(counter_width, reset=default_width)
+        self.period = Signal(counter_width, reset=default_period)
 
         # # #
 
@@ -42,7 +56,7 @@ class PWM(LiteXModule):
             # A shared timebase can run while this channel's output is disabled.
             if counter_enable is None:
                 counter_enable = self.enable
-            self.counter = counter = Signal(32, reset_less=True)
+            self.counter = counter = Signal(counter_width, reset_less=True)
             sync += [
                 counter.eq(0),
                 If(counter_enable & ~self.reset,
@@ -62,7 +76,7 @@ class PWM(LiteXModule):
         self._enable = CSRStorage(description="""PWM Enable.\n
             Write ``1`` to enable PWM.""",
             reset = self.enable.reset)
-        self._width  = CSRStorage(32, reset_less=True, description="""PWM Width.\n
+        self._width  = CSRStorage(len(self.width), reset_less=True, description="""PWM Width.\n
             Defines the *Duty cycle* of the PWM. PWM is active high for *Width* ``{cd}_clk`` cycles and
             active low for *Period - Width* ``{cd}_clk`` cycles.""".format(cd=clock_domain),
             reset = self.width.reset)
@@ -74,7 +88,7 @@ class PWM(LiteXModule):
         ]
 
     def add_period_csr(self, clock_domain):
-        self._period = CSRStorage(32, reset_less=True, description="""PWM Period.\n
+        self._period = CSRStorage(len(self.period), reset_less=True, description="""PWM Period.\n
             Defines the *Period* of the PWM in ``{cd}_clk`` cycles.""".format(cd=clock_domain),
             reset = self.period.reset)
 
@@ -98,13 +112,15 @@ class MultiChannelPWM(LiteXModule):
     def __init__(self, pads, clock_domain="sys",
         default_enable = 0,
         default_width  = 0,
-        default_period = 0):
+        default_period = 0,
+        counter_width  = 32):
+        _validate_counter_width(counter_width, default_width, default_period)
 
         # # #
 
         nchannels = len(pads)
 
-        counter = Signal(32, reset_less=True)
+        counter = Signal(counter_width, reset_less=True)
         counter_enable = Signal()
         enables = []
         for n in range(nchannels):
@@ -117,6 +133,7 @@ class MultiChannelPWM(LiteXModule):
                 default_width  = default_width,
                 default_period = default_period,
                 counter_enable = counter_enable,
+                counter_width  = counter_width,
             )
 
             if n == 0:

--- a/litex/soc/cores/pwm.py
+++ b/litex/soc/cores/pwm.py
@@ -24,7 +24,8 @@ class PWM(LiteXModule):
     def __init__(self, pwm=None, clock_domain="sys", counter=None, with_csr=True,
         default_enable = 0,
         default_width  = 0,
-        default_period = 0):
+        default_period = 0,
+        counter_enable = None):
         if pwm is None:
             self.pwm = pwm = Signal()
         self.reset  = Signal()
@@ -38,10 +39,13 @@ class PWM(LiteXModule):
 
         # PWM Counter/Period logic.
         if counter is None:
+            # A shared timebase can run while this channel's output is disabled.
+            if counter_enable is None:
+                counter_enable = self.enable
             self.counter = counter = Signal(32, reset_less=True)
             sync += [
                 counter.eq(0),
-                If(self.enable & ~self.reset,
+                If(counter_enable & ~self.reset,
                     If(counter < (self.period - 1),
                         counter.eq(counter + 1)
                     )
@@ -87,6 +91,9 @@ class MultiChannelPWM(LiteXModule):
     """Multi-Channel Pulse Width Modulation
 
     PWM module with Multi-Channel support.
+
+    Channel 0 supplies the shared period. The timebase runs while any channel is enabled;
+    disabling an individual channel only disables its output.
     """
     def __init__(self, pads, clock_domain="sys",
         default_enable = 0,
@@ -98,6 +105,8 @@ class MultiChannelPWM(LiteXModule):
         nchannels = len(pads)
 
         counter = Signal(32, reset_less=True)
+        counter_enable = Signal()
+        enables = []
         for n in range(nchannels):
             pwm = PWM(
                 pwm            = pads[n],
@@ -107,6 +116,7 @@ class MultiChannelPWM(LiteXModule):
                 default_enable = default_enable,
                 default_width  = default_width,
                 default_period = default_period,
+                counter_enable = counter_enable,
             )
 
             if n == 0:
@@ -114,3 +124,5 @@ class MultiChannelPWM(LiteXModule):
                 pwm.add_period_csr(clock_domain)
             pwm.add_enable_width_csr(clock_domain)
             self.add_module(name=f"channel{n}", module=pwm)
+            enables.append(pwm.enable)
+        self.comb += counter_enable.eq(Reduce("OR", enables))

--- a/litex/soc/cores/spi/spi_master.py
+++ b/litex/soc/cores/spi/spi_master.py
@@ -7,7 +7,6 @@
 import math
 
 from migen import *
-from migen.genlib.cdc import MultiReg
 
 from litex.gen import *
 
@@ -39,9 +38,21 @@ class SPIMaster(LiteXModule):
         SPI Flash page programming or when hardware CS lines are insufficient. It allows software to keep
         CS asserted across multiple transfers. Each transfer still has to be started explicitly through the
         ``start``/``length`` control path; manual CS mode does not clock data by itself.
+
+    Transfers require 1..data_width bits and a clock divider of at least 2. Invalid starts leave
+    the core idle, set ``error`` and pulse ``irq``. The next valid start clears ``error``. Data,
+    length, divider, loopback and automatic CS selection are sampled at start; manual CS remains
+    live so software can control its lifetime independently.
     """
     pads_layout = [("clk", 1), ("cs_n", 1), ("mosi", 1), ("miso", 1)]
     def __init__(self, pads, data_width, sys_clk_freq, spi_clk_freq, with_csr=True, mode="raw"):
+        if not isinstance(data_width, int) or isinstance(data_width, bool) or not 1 <= data_width <= 255:
+            raise ValueError("SPI master data_width must be an integer from 1 to 255.")
+        if not all(math.isfinite(f) and f > 0 for f in [sys_clk_freq, spi_clk_freq]):
+            raise ValueError("SPI master clock frequencies must be finite and positive.")
+        default_divider = math.ceil(sys_clk_freq/spi_clk_freq)
+        if not 2 <= default_divider <= 65535:
+            raise ValueError("SPI master clock divider must be from 2 to 65535.")
         if mode not in ["raw", "aligned"]:
             raise ValueError("Unsupported SPI master mode: {}.".format(mode))
         self.mode = mode
@@ -57,13 +68,14 @@ class SPIMaster(LiteXModule):
         self.start       = Signal()
         self.length      = Signal(8)
         self.done        = Signal()
+        self.error       = Signal()
         self.irq         = Signal()
         self.mosi        = Signal(data_width)
         self.miso        = Signal(data_width)
         self.cs          = Signal(len(pads.cs_n), reset=1)
         self.cs_mode     = Signal()
         self.loopback    = Signal()
-        self.clk_divider = Signal(16, reset=math.ceil(sys_clk_freq/spi_clk_freq))
+        self.clk_divider = Signal(16, reset=default_divider)
 
         if with_csr:
             self.add_csr()
@@ -72,16 +84,26 @@ class SPIMaster(LiteXModule):
 
         clk_enable  = Signal()
         xfer_enable = Signal()
-        count       = Signal(max=data_width)
+        count       = Signal(max=max(data_width, 2))
         mosi_latch  = Signal()
         miso_latch  = Signal()
+        length      = Signal(8)
+        divider     = Signal(16, reset=default_divider)
+        loopback    = Signal()
+        cs_latched  = Signal.like(self.cs)
+        self.sync += If(mosi_latch,
+            length.eq(self.length),
+            divider.eq(self.clk_divider),
+            loopback.eq(self.loopback),
+            cs_latched.eq(self.cs),
+        )
 
         # Clock generation -------------------------------------------------------------------------
         clk_divider = Signal(16)
         clk_rise    = Signal()
         clk_fall    = Signal()
-        self.comb += clk_rise.eq(clk_divider == (self.clk_divider[1:] - 1))
-        self.comb += clk_fall.eq(clk_divider == (self.clk_divider     - 1))
+        self.comb += clk_rise.eq(clk_divider == (divider[1:] - 1))
+        self.comb += clk_fall.eq(clk_divider == (divider     - 1))
         self.sync += [
             clk_divider.eq(clk_divider + 1),
             If(clk_rise,
@@ -89,7 +111,12 @@ class SPIMaster(LiteXModule):
             ).Elif(clk_fall,
                 clk_divider.eq(0),
                 pads.clk.eq(0),
-            )
+            ),
+            # Start the newly sampled divider from a known phase.
+            If(mosi_latch,
+                clk_divider.eq(0),
+                pads.clk.eq(0),
+            ),
         ]
 
         # Control FSM ------------------------------------------------------------------------------
@@ -97,9 +124,15 @@ class SPIMaster(LiteXModule):
         fsm.act("IDLE",
             self.done.eq(1),
             If(self.start,
-                self.done.eq(0),
-                mosi_latch.eq(1),
-                NextState("START")
+                If((self.length == 0) | (self.length > data_width) | (self.clk_divider < 2),
+                    NextValue(self.error, 1),
+                    self.irq.eq(1),
+                ).Else(
+                    NextValue(self.error, 0),
+                    self.done.eq(0),
+                    mosi_latch.eq(1),
+                    NextState("START"),
+                ),
             )
         )
         fsm.act("START",
@@ -114,7 +147,7 @@ class SPIMaster(LiteXModule):
             xfer_enable.eq(1),
             If(clk_fall,
                 NextValue(count, count + 1),
-                If(count == (self.length - 1),
+                If(count == (length - 1),
                     NextState("STOP")
                 )
             )
@@ -132,14 +165,14 @@ class SPIMaster(LiteXModule):
         if hasattr(pads, "cs_n"):
             for i in range(len(pads.cs_n)):
                 # CS set when enabled and (Xfer enabled or Manual CS mode selected).
-                cs = (self.cs[i] & (xfer_enable | (self.cs_mode == 1)))
+                cs = Mux(self.cs_mode, self.cs[i], cs_latched[i] & xfer_enable)
                 # CS Output/Invert.
                 self.sync += pads.cs_n[i].eq(~cs)
 
         # Master Out Slave In (MOSI) generation (generated on spi_clk falling edge) ----------------
         mosi_data  = Signal(data_width)
         mosi_array = Array(mosi_data[i] for i in range(data_width))
-        mosi_sel   = Signal(max=data_width)
+        mosi_sel   = Signal(max=max(data_width, 2))
         self.sync += [
             If(mosi_latch,
                 mosi_data.eq(self.mosi),
@@ -151,11 +184,10 @@ class SPIMaster(LiteXModule):
         ]
 
         # Master In Slave Out (MISO) capture (captured on spi_clk rising edge) --------------------
-        miso      = Signal()
         miso_data = Signal(data_width)
         self.sync += [
             If(clk_rise,
-                If(self.loopback,
+                If(loopback,
                     miso_data.eq(Cat(pads.mosi, miso_data))
                 ).Else(
                     miso_data.eq(Cat(pads.miso, miso_data))
@@ -170,7 +202,7 @@ class SPIMaster(LiteXModule):
             CSRField("start",  size=1, offset=0, pulse=True,
                 description="SPI Xfer Start (Write ``1`` to start one Xfer)."),
             CSRField("length", size=8, offset=8,
-                description="SPI Xfer Length (in bits). Required for each Xfer, including in manual CS mode.")
+                description=f"SPI Xfer Length (1..{self.data_width} bits). Required for each Xfer, including in manual CS mode.")
         ])
         self._status = CSRStatus(description="SPI Status.", fields=[
             CSRField("done", size=1, offset=0, description="SPI Xfer Done (when read as ``1``)."),
@@ -178,11 +210,14 @@ class SPIMaster(LiteXModule):
                 ("``0b0``", "Raw    : MOSI transfers aligned on core's data-width."),
                 ("``0b1``", "Aligned: MOSI transfers aligned on transfers' length."),
             ]),
+            CSRField("error", size=1, offset=2,
+                description="Invalid length or divider rejected. Cleared by the next valid start."),
         ])
         self.comb += [
             self.start.eq(self._control.fields.start),
             self.length.eq(self._control.fields.length),
             self._status.fields.done.eq(self.done),
+            self._status.fields.error.eq(self.error),
             self._status.fields.mode.eq({"raw": 0b0, "aligned": 0b1}[self.mode]),
         ]
 
@@ -227,5 +262,5 @@ class SPIMaster(LiteXModule):
             self.comb += self.loopback.eq(self._loopback.fields.mode)
 
     def add_clk_divider(self):
-        self._clk_divider = CSRStorage(16, description="SPI Clk Divider.", reset=self.clk_divider.reset)
+        self._clk_divider = CSRStorage(16, description="SPI Clk Divider (2..65535), sampled at transfer start.", reset=self.clk_divider.reset)
         self.comb += self.clk_divider.eq(self._clk_divider.storage)

--- a/litex/soc/cores/uart.py
+++ b/litex/soc/cores/uart.py
@@ -136,6 +136,10 @@ class RS232PHYRX(LiteXModule):
                 NextValue(count, count + 1),
                 # Shift RX data.
                 NextValue(data, Cat(data[1:], rx)),
+                # Reject a false start at its midpoint instead of receiving a phantom byte.
+                If((count == 0) & (rx != RS232_START),
+                    NextState("IDLE"),
+                ),
                 # When 10-bit have been received...
                 If(count == (10 - 1),
                     # Produce data (but only when RX Stop bit is seen).

--- a/litex/soc/cores/uart.py
+++ b/litex/soc/cores/uart.py
@@ -11,7 +11,7 @@ from math import log2
 
 from migen import *
 from migen.genlib.record import Record
-from migen.genlib.cdc import MultiReg
+from migen.genlib.cdc import MultiReg, PulseSynchronizer
 
 from litex.gen import *
 from litex.gen.genlib.misc import WaitTimer
@@ -102,6 +102,8 @@ class RS232PHYTX(LiteXModule):
 class RS232PHYRX(LiteXModule):
     def __init__(self, pads, tuning_word):
         self.source = source = stream.Endpoint([("data", 8)])
+        self.framing_error = Signal()
+        self.overflow      = Signal()
 
         # # #
 
@@ -145,6 +147,9 @@ class RS232PHYRX(LiteXModule):
                     # Produce data (but only when RX Stop bit is seen).
                     source.valid.eq(rx == RS232_STOP),
                     source.data.eq(data),
+                    self.framing_error.eq(rx != RS232_STOP),
+                    # A serial receiver cannot backpressure the remote transmitter.
+                    self.overflow.eq((rx == RS232_STOP) & ~source.ready),
                     NextState("IDLE")
                 )
             )
@@ -165,6 +170,8 @@ class RS232PHY(LiteXModule):
         self.tx = RS232PHYTX(pads, tuning_word)
         self.rx = RS232PHYRX(pads, tuning_word)
         self.sink, self.source = self.tx.sink, self.rx.source
+        self.rx_framing_error = self.rx.framing_error
+        self.rx_overflow      = self.rx.overflow
 
 
 class RS232PHYMultiplexer(LiteXModule):
@@ -238,7 +245,8 @@ class UART(LiteXModule, UARTInterface):
             tx_fifo_depth = 16,
             rx_fifo_depth = 16,
             rx_fifo_rx_we = False,
-            phy_cd        = "sys"):
+            phy_cd        = "sys",
+            with_error_status = False):
         self._rxtx    = CSR(8, name="rxtx") # RX/TX Data.
         self._txfull  = CSRStatus(description="TX FIFO Full.", name="txfull")
         self._rxempty = CSRStatus(description="RX FIFO Empty.", name="rxempty")
@@ -299,6 +307,41 @@ class UART(LiteXModule, UARTInterface):
             # IRQ (When FIFO becomes non-empty).
             self.ev.rx.trigger.eq(rx_fifo.source.valid)
         ]
+
+        if with_error_status:
+            self.add_rx_error_status(phy_cd)
+
+    def add_rx_error_status(self, phy_cd="sys"):
+        """Add optional sticky, write-one-to-clear receive error flags.
+
+        Requires PHY error pulses: generic stream backpressure does not imply data loss. Latch
+        errors in the PHY domain so short pulses cannot disappear in the crossing to sys. Clear
+        requests cross back to the PHY; software must allow synchronization latency on readback.
+        A new error wins over a simultaneous clear in the PHY domain.
+        """
+        phy = getattr(self, "phy", None)
+        if not all(hasattr(phy, name) for name in ["rx_framing_error", "rx_overflow"]):
+            raise ValueError("UART receive error status requires a PHY with receive error signals.")
+        self._rx_errors = CSRStatus(name="rx_errors", read_only=False, fields=[
+            CSRField("framing", size=1, description="Invalid stop bit received. Write 1 to clear."),
+            CSRField("overflow", size=1, description="Received byte dropped because the RX FIFO was full. Write 1 to clear."),
+        ], description="Sticky receive errors. New errors take priority over clearing.")
+        sync = getattr(self.sync, phy_cd)
+        for n, name in enumerate(["framing", "overflow"]):
+            event = getattr(phy, {"framing": "rx_framing_error", "overflow": "rx_overflow"}[name])
+            clear = self._rx_errors.wr_stb & self._rx_errors.wr_data[n]
+            sticky = Signal()
+            status = getattr(self._rx_errors.fields, name)
+            if phy_cd != "sys":
+                clear_cdc = PulseSynchronizer("sys", phy_cd)
+                self.add_module(name=f"rx_error_clear{n}", module=clear_cdc)
+                self.comb += clear_cdc.i.eq(clear)
+                clear = clear_cdc.o
+                self.specials += MultiReg(sticky, status)
+            else:
+                self.comb += status.eq(sticky)
+            sync += If(clear, sticky.eq(0))
+            sync += If(event, sticky.eq(1))
 
     def add_auto_tx_flush(self, sys_clk_freq, timeout=1e-2, interval=2):
         # Add automatic TX flush when ready is not active for a long time (timeout), this can prevent

--- a/litex/soc/cores/video.py
+++ b/litex/soc/cores/video.py
@@ -1111,10 +1111,12 @@ class VideoFrameBuffer(LiteXModule):
             If(vtg_sink.valid & vtg_sink.de,
                 video_pipe_source.connect(source, keep={"valid", "ready"}),
                 If(first,
-                    source.valid.eq(0)
+                    # Discard the initial DMA frame independently of downstream readiness.
+                    source.valid.eq(0),
+                    video_pipe_source.ready.eq(1),
                 ),
                 vtg_sink.ready.eq(source.valid & source.ready),
-                If(video_pipe_source.valid & video_pipe_source.last,
+                If(video_pipe_source.valid & video_pipe_source.ready & video_pipe_source.last,
                     NextValue(first, 0),
                     NextState("SYNC"),
                 )
@@ -1153,8 +1155,11 @@ class VideoFrameBuffer(LiteXModule):
                source.b.eq(Cat(Signal(7, reset=0), video_pipe_source.data[0:1])),
             ]
 
-        # Underflow.
-        self.comb += self.underflow.eq(~source.valid)
+        # Underflow only when an enabled, visible pixel is requested but unavailable. Blanking,
+        # initial synchronization and downstream backpressure are not DMA starvation.
+        self.comb += self.underflow.eq(
+            fsm.ongoing("RUN") & ~fsm.reset & ~first &
+            vtg_sink.valid & vtg_sink.de & source.ready & ~video_pipe_source.valid)
 
 # Video PHYs ---------------------------------------------------------------------------------------
 

--- a/test/cores/test_ecc.py
+++ b/test/cores/test_ecc.py
@@ -6,16 +6,55 @@
 
 import unittest
 import random
+from itertools import combinations
 
 from migen import *
 
-from litedram.common import *
-from litedram.frontend.ecc import *
-
-from litex.gen.sim import *
+from litex.soc.cores.ecc import (
+    ECCEncoder, ECCDecoder, compute_m_n, compute_syndrome_positions,
+    compute_data_positions, compute_cover_positions,
+)
 
 
 class TestECC(unittest.TestCase):
+    def test_all_single_bits_and_small_double_bit_pairs(self):
+        for k in [1, 4, 8, 15, 32, 64]:
+            with self.subTest(k=k):
+                class DUT(Module):
+                    def __init__(self):
+                        self.submodules.encoder = ECCEncoder(k)
+                        self.submodules.decoder = ECCDecoder(k)
+                        self.flip = Signal(len(self.encoder.o))
+                        self.comb += self.decoder.i.eq(self.encoder.o ^ self.flip)
+                dut = DUT()
+                width = len(dut.flip)
+                flips = [(0, 0)] + [(1 << bit, 1) for bit in range(width)]
+                if k <= 8:
+                    flips += [((1 << a) | (1 << b), 2) for a, b in combinations(range(width), 2)]
+
+                def gen():
+                    for value in [0, (1 << k) - 1, ((1 << k) - 1)//3]:
+                        yield dut.encoder.i.eq(value)
+                        for flip, nerrors in flips:
+                            yield dut.decoder.enable.eq(1)
+                            yield dut.flip.eq(flip)
+                            yield
+                            if nerrors <= 1:
+                                self.assertEqual((yield dut.decoder.o), value)
+                            self.assertEqual((yield dut.decoder.sec), nerrors == 1)
+                            self.assertEqual((yield dut.decoder.ded), nerrors == 2)
+
+                            # Disabling ECC preserves the raw payload and suppresses both flags.
+                            yield dut.decoder.enable.eq(0)
+                            yield
+                            word = (yield dut.encoder.o) ^ flip
+                            raw = sum(((word >> position) & 1) << bit
+                                      for bit, position in enumerate(compute_data_positions(width - 1)))
+                            self.assertEqual((yield dut.decoder.o), raw)
+                            self.assertEqual((yield dut.decoder.sec), 0)
+                            self.assertEqual((yield dut.decoder.ded), 0)
+                run_simulation(dut, gen())
+
     def test_m_n(self):
         m, n = compute_m_n(15)
         self.assertEqual(m, 5)
@@ -61,17 +100,13 @@ class TestECC(unittest.TestCase):
             prng = random.Random(42)
             yield dut.decoder.enable.eq(1)
             for i in range(nvalues):
-                data = prng.randrange(2**k-1)
+                data = prng.randrange(2**k)
                 yield dut.encoder.i.eq(data)
-                # FIXME: error when fliping parity bit
                 if nerrors == 1:
-                    flip_bit1 = (prng.randrange(len(dut.flip)-2) + 1)
+                    flip_bit1 = prng.randrange(len(dut.flip))
                     yield dut.flip.eq(1<<flip_bit1)
                 elif nerrors == 2:
-                    flip_bit1 = (prng.randrange(len(dut.flip)-2) + 1)
-                    flip_bit2 = flip_bit1
-                    while flip_bit2 == flip_bit1:
-                        flip_bit2 = (prng.randrange(len(dut.flip)-2) + 1)
+                    flip_bit1, flip_bit2 = prng.sample(range(len(dut.flip)), 2)
                     yield dut.flip.eq((1<<flip_bit1) | (1<<flip_bit2))
                 yield
                 # if less than 2 errors, check data

--- a/test/cores/test_pwm.py
+++ b/test/cores/test_pwm.py
@@ -24,6 +24,37 @@ def sample_pwm(dut, cycles):
 
 
 class TestPWM(unittest.TestCase):
+    def test_configurable_counter_width(self):
+        for bits in [1, 8, 16, 32]:
+            with self.subTest(bits=bits):
+                period = min(2**bits - 1, 15)
+                width = max(1, period//3)
+                dut = PWM(counter_width=bits, default_enable=1,
+                          default_period=period, default_width=width)
+                self.assertEqual(len(dut.counter), bits)
+                self.assertEqual(dut._width.size, bits)
+                self.assertEqual(dut._period.size, bits)
+                def gen():
+                    for _ in range(5):
+                        yield
+                    high = 0
+                    for _ in range(4*period):
+                        high += (yield dut.pwm)
+                        yield
+                    self.assertEqual(high, 4*width)
+                run_simulation(dut, gen())
+
+    def test_counter_configuration_validation(self):
+        for bits in [0, -1, 33, 1.5, True]:
+            with self.subTest(bits=bits):
+                with self.assertRaisesRegex(ValueError, "counter_width"):
+                    PWM(counter_width=bits)
+                with self.assertRaisesRegex(ValueError, "counter_width"):
+                    MultiChannelPWM(Signal(2), counter_width=bits)
+        for defaults in [{"default_width": 256}, {"default_period": 256}, {"default_width": -1}]:
+            with self.assertRaisesRegex(ValueError, "fit"):
+                PWM(counter_width=8, **defaults)
+
     def test_csr_synchronizer_destination(self):
         for clock_domain in ["sys", "pwm"]:
             with self.subTest(clock_domain=clock_domain):
@@ -188,6 +219,14 @@ class TestPWM(unittest.TestCase):
 
 
 class TestMultiChannelPWM(unittest.TestCase):
+    def test_narrow_shared_counter(self):
+        dut = MultiChannelPWM(Signal(2), counter_width=8)
+        self.assertEqual(len(dut.channel0.counter), 8)
+        self.assertEqual(dut.channel0._period.size, 8)
+        for channel in [dut.channel0, dut.channel1]:
+            self.assertEqual(len(channel.width), 8)
+            self.assertEqual(channel._width.size, 8)
+
     def test_independent_enables(self):
         for clock_domain in ["sys", "pwm"]:
             with self.subTest(clock_domain=clock_domain):

--- a/test/cores/test_pwm.py
+++ b/test/cores/test_pwm.py
@@ -9,7 +9,7 @@ import unittest
 from migen import *
 from migen.genlib.cdc import MultiReg
 
-from litex.soc.cores.pwm import PWM
+from litex.soc.cores.pwm import PWM, MultiChannelPWM
 
 
 def sample_pwm(dut, cycles):
@@ -185,6 +185,35 @@ class TestPWM(unittest.TestCase):
                 self.assertEqual((yield dut.counter), 0)
                 self.assertEqual((yield dut.pwm), 1)  # enable & (0 < 4)
         run_simulation(dut, gen())
+
+
+class TestMultiChannelPWM(unittest.TestCase):
+    def test_independent_enables(self):
+        for clock_domain in ["sys", "pwm"]:
+            with self.subTest(clock_domain=clock_domain):
+                pads = Signal(3)
+                dut = MultiChannelPWM(pads, clock_domain=clock_domain)
+                channels = [dut.channel0, dut.channel1, dut.channel2]
+
+                def gen():
+                    yield dut.channel0._period.storage.eq(8)
+                    for channel, width in zip(channels, [1, 2, 3]):
+                        yield channel._width.storage.eq(width)
+                    # Disable channel 0 while keeping other channels active, then re-enable it.
+                    for mask in [1, 2, 4, 3, 6, 7, 0, 2, 1]:
+                        for n, channel in enumerate(channels):
+                            yield channel._enable.storage.eq((mask >> n) & 1)
+                        for _ in range(8):
+                            yield
+                        high = [0, 0, 0]
+                        for _ in range(32):
+                            for n in range(3):
+                                high[n] += (yield pads[n])
+                            yield
+                        self.assertEqual(high, [4*(n + 1) if mask & (1 << n) else 0
+                                                for n in range(3)])
+
+                run_simulation(dut, {clock_domain: gen()}, clocks={"sys": 10, "pwm": 14})
 
 
 if __name__ == "__main__":

--- a/test/cores/test_pwm.py
+++ b/test/cores/test_pwm.py
@@ -7,6 +7,7 @@
 import unittest
 
 from migen import *
+from migen.genlib.cdc import MultiReg
 
 from litex.soc.cores.pwm import PWM
 
@@ -23,6 +24,44 @@ def sample_pwm(dut, cycles):
 
 
 class TestPWM(unittest.TestCase):
+    def test_csr_synchronizer_destination(self):
+        for clock_domain in ["sys", "pwm"]:
+            with self.subTest(clock_domain=clock_domain):
+                dut = PWM(clock_domain=clock_domain)
+                regs = [s for s in dut.get_fragment().specials if isinstance(s, MultiReg)]
+                self.assertEqual(len(regs), 3)
+                self.assertTrue(all(s.odomain == clock_domain for s in regs))
+                self.assertTrue(all(s.n == (0 if clock_domain == "sys" else 2) for s in regs))
+
+    def test_csr_updates_in_pwm_domain(self):
+        dut = PWM(clock_domain="pwm")
+
+        def write_csrs():
+            # Before the first PWM edge, many sys edges must not update PWM controls.
+            yield dut._width.storage.eq(3)
+            yield dut._period.storage.eq(8)
+            yield dut._enable.storage.eq(1)
+            for _ in range(8):
+                yield
+                self.assertEqual((yield dut.enable), 0)
+                self.assertEqual((yield dut.width), 0)
+                self.assertEqual((yield dut.period), 0)
+
+        def check_pwm():
+            for _ in range(5):
+                yield
+            self.assertEqual((yield dut.enable), 1)
+            self.assertEqual((yield dut.width), 3)
+            self.assertEqual((yield dut.period), 8)
+            high = 0
+            for _ in range(32):
+                high += (yield dut.pwm)
+                yield
+            self.assertEqual(high, 12)
+
+        run_simulation(dut, {"sys": write_csrs(), "pwm": check_pwm()},
+                       clocks={"sys": 10, "pwm": (200, 100)})
+
     def test_disabled_stays_low(self):
         dut = PWM(with_csr=False)
         def gen():

--- a/test/cores/test_spi.py
+++ b/test/cores/test_spi.py
@@ -12,6 +12,124 @@ from litex.soc.cores.spi import SPIMaster, SPISlave
 
 
 class TestSPI(unittest.TestCase):
+    def test_spi_master_invalid_parameters(self):
+        for data_width in [0, -1, 256, 1.5, True]:
+            with self.subTest(data_width=data_width):
+                with self.assertRaisesRegex(ValueError, "data_width"):
+                    SPIMaster(None, data_width, 100e6, 5e6)
+        for sys_freq, spi_freq in [(0, 1), (1, 0), (-1, 1), (float("nan"), 1),
+                                   (1, float("inf")), (1, 1), (100e6, 1)]:
+            with self.subTest(sys_freq=sys_freq, spi_freq=spi_freq):
+                with self.assertRaisesRegex(ValueError, "clock"):
+                    SPIMaster(None, 32, sys_freq, spi_freq)
+
+    def test_spi_master_rejects_invalid_requests_and_recovers(self):
+        dut = SPIMaster(None, 32, 100e6, 5e6, with_csr=False, mode="aligned")
+
+        def gen():
+            yield dut.loopback.eq(1)
+            for length, divider in [(0, 2), (33, 2), (255, 2), (8, 0), (8, 1)]:
+                yield dut.length.eq(length)
+                yield dut.clk_divider.eq(divider)
+                yield dut.start.eq(1)
+                yield
+                self.assertEqual((yield dut.irq), 1)
+                yield dut.start.eq(0)
+                for _ in range(8):
+                    yield
+                    self.assertEqual((yield dut.done), 1)
+                    self.assertEqual((yield dut.error), 1)
+                    self.assertEqual((yield dut.pads.clk), 0)
+                    self.assertEqual((yield dut.pads.cs_n), 1)
+
+                yield dut.length.eq(8)
+                yield dut.clk_divider.eq(2)
+                yield dut.mosi.eq(0xa5)
+                yield dut.start.eq(1)
+                yield
+                yield dut.start.eq(0)
+                for _ in range(64):
+                    yield
+                self.assertEqual((yield dut.done), 1)
+                self.assertEqual((yield dut.error), 0)
+                self.assertEqual((yield dut.miso) & 0xff, 0xa5)
+
+        run_simulation(dut, gen())
+
+    def test_spi_master_csr_error_status(self):
+        dut = SPIMaster(None, 32, 100e6, 5e6)
+        def gen():
+            yield from dut._control.write(1)  # start, length=0
+            yield
+            self.assertEqual((yield dut._status.fields.done), 1)
+            self.assertEqual((yield dut._status.fields.error), 1)
+            yield from dut._control.write((8 << 8) | 1)
+            for _ in range(256):
+                yield
+            self.assertEqual((yield dut._status.fields.done), 1)
+            self.assertEqual((yield dut._status.fields.error), 0)
+        run_simulation(dut, gen())
+
+    def test_spi_master_lengths_and_odd_dividers(self):
+        for data_width in [1, 7, 8, 24, 32, 255]:
+            for divider in [2, 3, 5]:
+                for mode in ["raw", "aligned"]:
+                    with self.subTest(width=data_width, divider=divider, mode=mode):
+                        dut = SPIMaster(None, data_width, 100e6, 5e6, with_csr=False, mode=mode)
+                        value = ((1 << data_width) - 1) // 3 | 1
+                        def gen():
+                            yield dut.loopback.eq(1)
+                            yield dut.length.eq(data_width)
+                            yield dut.clk_divider.eq(divider)
+                            yield dut.mosi.eq(value)
+                            yield dut.start.eq(1)
+                            yield
+                            yield dut.start.eq(0)
+                            rises = 0
+                            previous = 0
+                            for _ in range((data_width + 4)*divider):
+                                yield
+                                clk = (yield dut.pads.clk)
+                                rises += clk and not previous
+                                previous = clk
+                            self.assertEqual(rises, data_width)
+                            self.assertEqual((yield dut.done), 1)
+                            self.assertEqual((yield dut.error), 0)
+                            self.assertEqual((yield dut.miso), value)
+                        run_simulation(dut, gen())
+
+    def test_spi_master_latches_transfer_settings(self):
+        pads = Record([("clk", 1), ("cs_n", 2), ("mosi", 1), ("miso", 1)])
+        dut = SPIMaster(pads, 32, 100e6, 5e6, with_csr=False, mode="aligned")
+        def gen():
+            yield dut.loopback.eq(1)
+            yield dut.length.eq(16)
+            yield dut.clk_divider.eq(4)
+            yield dut.cs.eq(1)
+            yield dut.mosi.eq(0xbeef)
+            yield dut.start.eq(1)
+            yield
+            yield dut.start.eq(0)
+            for _ in range(12):
+                yield
+            # These settings apply only to a subsequent request. Busy starts are ignored.
+            yield dut.length.eq(0)
+            yield dut.clk_divider.eq(0)
+            yield dut.loopback.eq(0)
+            yield dut.cs.eq(2)
+            yield dut.mosi.eq(0)
+            yield dut.start.eq(1)
+            yield
+            yield dut.start.eq(0)
+            for _ in range(100):
+                if (yield pads.clk):
+                    self.assertEqual((yield pads.cs_n), 0b10)
+                yield
+            self.assertEqual((yield dut.done), 1)
+            self.assertEqual((yield dut.error), 0)
+            self.assertEqual((yield dut.miso) & 0xffff, 0xbeef)
+        run_simulation(dut, gen())
+
     def test_spi_master_syntax(self):
         spi_master = SPIMaster(pads=None, data_width=32, sys_clk_freq=100e6, spi_clk_freq=5e6)
         self.assertEqual(hasattr(spi_master, "pads"), 1)

--- a/test/cores/test_uart.py
+++ b/test/cores/test_uart.py
@@ -15,6 +15,7 @@ from litex.soc.cores.uart import (
     UARTCrossover,
     UARTPads,
     RS232PHY,
+    RS232PHYRX,
     get_uart_core,
     get_uart_supported_names,
 )
@@ -29,6 +30,40 @@ class _LoopbackDUT(LiteXModule):
 
 
 class TestUART(unittest.TestCase):
+    def test_rx_rejects_short_start_glitches(self):
+        for glitch_length in [1, 2, 4]:
+            with self.subTest(glitch_length=glitch_length):
+                pads = UARTPads()
+                dut = RS232PHYRX(pads, tuning_word=2**32//16)
+                received = []
+
+                @passive
+                def monitor():
+                    while True:
+                        if (yield dut.source.valid):
+                            received.append((yield dut.source.data))
+                        yield
+
+                def drive(level, cycles):
+                    yield pads.rx.eq(level)
+                    for _ in range(cycles):
+                        yield
+
+                def gen():
+                    yield dut.source.ready.eq(1)
+                    yield from drive(1, 20)
+                    yield from drive(0, glitch_length)
+                    yield from drive(1, 24)
+                    # A real frame soon after the glitch must not be missed.
+                    value = 0xa5
+                    yield from drive(0, 16)
+                    for bit in range(8):
+                        yield from drive((value >> bit) & 1, 16)
+                    yield from drive(1, 48)
+                    self.assertEqual(received, [value])
+
+                run_simulation(dut, [gen(), monitor()])
+
     def test_supported_uart_names_include_soc_modes(self):
         self.assertIn("crossover",          get_uart_supported_names())
         self.assertIn("crossover+uartbone", get_uart_supported_names())

--- a/test/cores/test_uart.py
+++ b/test/cores/test_uart.py
@@ -9,7 +9,7 @@ import unittest
 from migen import *
 
 from litex.gen import *
-from litex.soc.interconnect import stream
+from litex.soc.interconnect import csr_bus, stream
 
 from litex.soc.cores.uart import (
     UART,
@@ -44,6 +44,48 @@ class TestUART(unittest.TestCase):
         self.assertFalse(hasattr(dut, "_rx_errors"))
         with self.assertRaisesRegex(ValueError, "PHY"):
             UART(with_error_status=True)
+
+    def test_receive_error_csr_bank_access(self):
+        baseline = UART(_ErrorPHY())
+        baseline_names = [csr.name for csr in baseline.get_csrs()]
+        for data_width in [8, 32]:
+            with self.subTest(data_width=data_width):
+                class DUT(LiteXModule):
+                    def __init__(self):
+                        self.uart = UART(_ErrorPHY(), with_error_status=True)
+                        self.bus = csr_bus.Interface(data_width=data_width)
+                        self.csrs = self.uart.get_csrs()
+                        self.bank = csr_bus.CSRBank(self.csrs, bus=self.bus)
+                dut = DUT()
+                self.assertEqual([csr.name for csr in dut.csrs], baseline_names + ["rx_errors"])
+                address = next(n for n, csr in enumerate(dut.bank.simple_csrs) if csr.name == "rx_errors")
+
+                def read():
+                    yield dut.bus.adr.eq(address)
+                    yield dut.bus.re.eq(1)
+                    yield
+                    yield
+                    result = (yield dut.bus.dat_r)
+                    yield dut.bus.re.eq(0)
+                    return result
+
+                def gen():
+                    yield dut.uart.phy.rx_framing_error.eq(1)
+                    yield dut.uart.phy.rx_overflow.eq(1)
+                    yield
+                    yield dut.uart.phy.rx_framing_error.eq(0)
+                    yield dut.uart.phy.rx_overflow.eq(0)
+                    self.assertEqual((yield from read()), 3)
+                    for mask, expected in [(1, 2), (0, 2), (2, 0)]:
+                        yield dut.bus.adr.eq(address)
+                        yield dut.bus.dat_w.eq(mask)
+                        yield dut.bus.we.eq(1)
+                        yield
+                        yield dut.bus.we.eq(0)
+                        for _ in range(4):
+                            yield
+                        self.assertEqual((yield from read()), expected)
+                run_simulation(dut, gen())
 
     def test_receive_errors_from_serial_phy(self):
         pads = UARTPads()

--- a/test/cores/test_uart.py
+++ b/test/cores/test_uart.py
@@ -9,6 +9,7 @@ import unittest
 from migen import *
 
 from litex.gen import *
+from litex.soc.interconnect import stream
 
 from litex.soc.cores.uart import (
     UART,
@@ -29,7 +30,114 @@ class _LoopbackDUT(LiteXModule):
         self.comb += self.pads.rx.eq(self.pads.tx)
 
 
+class _ErrorPHY(LiteXModule):
+    def __init__(self):
+        self.sink = stream.Endpoint([("data", 8)])
+        self.source = stream.Endpoint([("data", 8)])
+        self.rx_framing_error = Signal()
+        self.rx_overflow = Signal()
+
+
 class TestUART(unittest.TestCase):
+    def test_receive_error_status_is_optional(self):
+        dut = UART(RS232PHY(UARTPads(), 1_000_000))
+        self.assertFalse(hasattr(dut, "_rx_errors"))
+        with self.assertRaisesRegex(ValueError, "PHY"):
+            UART(with_error_status=True)
+
+    def test_receive_errors_from_serial_phy(self):
+        pads = UARTPads()
+        dut = UART(RS232PHY(pads, clk_freq=1_000_000, baudrate=62_500),
+                   rx_fifo_depth=1, with_error_status=True)
+
+        def drive(level, cycles):
+            yield pads.rx.eq(level)
+            for _ in range(cycles):
+                yield
+
+        def send(value, stop=1):
+            yield from drive(0, 16)
+            for bit in range(8):
+                yield from drive((value >> bit) & 1, 16)
+            yield from drive(stop, 16)
+            yield from drive(1, 32)
+
+        def gen():
+            yield from drive(1, 32)
+            yield from send(0x12)
+            self.assertEqual((yield dut._rx_errors.fields.overflow), 0)
+            # Do not drain the RX FIFO: subsequent valid frames must report actual loss.
+            for value in [0x34, 0x56, 0x78]:
+                yield from send(value)
+            self.assertEqual((yield dut._rx_errors.fields.overflow), 1)
+            self.assertEqual((yield dut._rx_errors.fields.framing), 0)
+            yield from send(0xa5, stop=0)
+            self.assertEqual((yield dut._rx_errors.fields.framing), 1)
+            yield dut._rx_errors.wr_data.eq(1)
+            yield dut._rx_errors.wr_stb.eq(1)
+            yield
+            yield dut._rx_errors.wr_stb.eq(0)
+            yield
+            self.assertEqual((yield dut._rx_errors.fields.framing), 0)
+            self.assertEqual((yield dut._rx_errors.fields.overflow), 1)
+
+        run_simulation(dut, gen())
+
+    def test_receive_error_latching_and_cdc(self):
+        for phy_cd, period in [("sys", 10), ("phy", 7), ("phy", 29)]:
+            with self.subTest(phy_cd=phy_cd, period=period):
+                phy = _ErrorPHY()
+                dut = UART(phy, phy_cd=phy_cd, with_error_status=True)
+                fired = Signal()
+                cleared = Signal()
+
+                def errors():
+                    yield phy.rx_framing_error.eq(1)
+                    yield
+                    yield phy.rx_framing_error.eq(0)
+                    yield phy.rx_overflow.eq(1)
+                    yield
+                    yield phy.rx_overflow.eq(0)
+                    yield fired.eq(1)
+                    while not (yield cleared):
+                        yield
+
+                def check():
+                    while not (yield fired):
+                        yield
+                    for _ in range(20):
+                        yield
+                    self.assertEqual((yield dut._rx_errors.fields.framing), 1)
+                    self.assertEqual((yield dut._rx_errors.fields.overflow), 1)
+                    for mask, expected in [(0, (1, 1)), (1, (0, 1)), (2, (0, 0))]:
+                        yield dut._rx_errors.wr_data.eq(mask)
+                        yield dut._rx_errors.wr_stb.eq(1)
+                        yield
+                        yield dut._rx_errors.wr_stb.eq(0)
+                        for _ in range(30):
+                            yield
+                        self.assertEqual(((yield dut._rx_errors.fields.framing),
+                                          (yield dut._rx_errors.fields.overflow)), expected)
+                    yield cleared.eq(1)
+
+                generators = {"sys": [check()]}
+                generators.setdefault(phy_cd, []).append(errors())
+                run_simulation(dut, generators, clocks={"sys": 10, "phy": period})
+
+    def test_new_receive_error_wins_over_clear(self):
+        dut = UART(_ErrorPHY(), with_error_status=True)
+        # Inject the event at the PHY/UART boundary to hit the exact clear cycle.
+        def gen():
+            yield dut.phy.rx_framing_error.eq(1)
+            yield dut._rx_errors.wr_data.eq(1)
+            yield dut._rx_errors.wr_stb.eq(1)
+            yield
+            yield dut._rx_errors.wr_stb.eq(0)
+            yield dut.phy.rx_framing_error.eq(0)
+            yield
+            self.assertEqual((yield dut._rx_errors.fields.framing), 1)
+        run_simulation(dut, gen())
+
     def test_rx_rejects_short_start_glitches(self):
         for glitch_length in [1, 2, 4]:
             with self.subTest(glitch_length=glitch_length):

--- a/test/cores/test_video.py
+++ b/test/cores/test_video.py
@@ -136,6 +136,90 @@ class TestVideoFrameBufferHelpers(unittest.TestCase):
 
 
 class TestVideoFrameBufferData(unittest.TestCase):
+    def test_final_pixel_is_held_under_backpressure(self):
+        for clock_domain in ["sys", "video"]:
+            with self.subTest(clock_domain=clock_domain):
+                class DUT(Module):
+                    def __init__(self):
+                        bus = wishbone.Interface(data_width=32)
+                        self.submodules.framebuffer = VideoFrameBuffer(
+                            bus, hres=1, vres=1, fifo_depth=16, clock_domain=clock_domain)
+                        self.comb += [bus.ack.eq(bus.cyc & bus.stb), bus.dat_r.eq(0x00332211)]
+                dut = DUT()
+                fb = dut.framebuffer
+
+                def gen():
+                    yield fb.dma._enable.storage.eq(1)
+                    yield fb.vtg_sink.valid.eq(1)
+                    yield fb.vtg_sink.de.eq(1)
+                    yield fb.vtg_sink.last.eq(1)
+                    yield fb.source.ready.eq(0)
+                    # Startup discard must not depend on downstream ready, either.
+                    for frame in range(3):
+                        for _ in range(100):
+                            yield
+                            if (yield fb.source.valid):
+                                break
+                        else:
+                            self.fail("Framebuffer did not produce a pixel.")
+                        for _ in range(8):
+                            self.assertEqual((yield fb.source.valid), 1)
+                            self.assertEqual((yield fb.source.de), 1)
+                            self.assertEqual(((yield fb.source.r), (yield fb.source.g),
+                                              (yield fb.source.b)), (0x11, 0x22, 0x33))
+                            self.assertEqual((yield fb.underflow), 0)
+                            yield
+                        yield fb.source.ready.eq(1)
+                        yield
+                        yield fb.source.ready.eq(0)
+                        yield
+
+                run_simulation(dut, {clock_domain: gen()}, clocks={"sys": 10, "video": 14})
+
+    def test_underflow_only_reports_requested_visible_pixels(self):
+        class DUT(Module):
+            def __init__(self):
+                bus = wishbone.Interface(data_width=32)
+                self.memory_enable = Signal(reset=1)
+                self.submodules.framebuffer = VideoFrameBuffer(bus, hres=1, vres=1, fifo_depth=4)
+                self.comb += bus.ack.eq(bus.cyc & bus.stb & self.memory_enable)
+        dut = DUT()
+        fb = dut.framebuffer
+
+        def gen():
+            yield fb.vtg_sink.valid.eq(1)
+            yield fb.vtg_sink.de.eq(1)
+            yield fb.vtg_sink.last.eq(1)
+            yield fb.source.ready.eq(1)
+            for _ in range(8):
+                yield
+                self.assertEqual((yield fb.underflow), 0)  # Disabled.
+            yield fb.dma._enable.storage.eq(1)
+            for _ in range(40):
+                yield
+            yield dut.memory_enable.eq(0)
+            for _ in range(40):
+                yield
+            self.assertEqual((yield fb.underflow), 1)
+            for control in [fb.vtg_sink.de, fb.vtg_sink.valid, fb.source.ready]:
+                yield control.eq(0)
+                yield
+                self.assertEqual((yield fb.underflow), 0)
+                yield control.eq(1)
+                yield
+                self.assertEqual((yield fb.underflow), 1)
+            yield dut.memory_enable.eq(1)
+            for _ in range(40):
+                yield
+            self.assertEqual((yield fb.underflow), 0)
+            yield dut.memory_enable.eq(0)
+            yield fb.dma._enable.storage.eq(0)
+            for _ in range(10):
+                yield
+            self.assertEqual((yield fb.underflow), 0)
+
+        run_simulation(dut, gen())
+
     @staticmethod
     def _timings(hres):
         return {

--- a/test/interconnect/test_dma.py
+++ b/test/interconnect/test_dma.py
@@ -437,5 +437,62 @@ class TestDMAWriter(unittest.TestCase):
         self.assertEqual([v for _, v in captures], payload)
 
 
+class TestDMAControl(unittest.TestCase):
+    def test_empty_and_misaligned_transfers(self):
+        for kind in [WishboneDMAReader, WishboneDMAWriter]:
+            for data_width in [8, 16, 32, 64]:
+                word_bytes = data_width//8
+                cases = [(0, 0, False), (word_bytes, 0, False)]
+                for offset in range(1, word_bytes):
+                    cases += [(offset, word_bytes, True), (0, offset, True),
+                              (0, word_bytes + offset, True)]
+                for base, length, error in cases:
+                    for loop in [0, 1]:
+                        with self.subTest(kind=kind.__name__, width=data_width,
+                                          base=base, length=length, loop=loop):
+                            bus = wishbone.Interface(data_width=data_width)
+                            dut = kind(bus, with_csr=True)
+
+                            def gen():
+                                yield dut._base.storage.eq(base)
+                                yield dut._length.storage.eq(length)
+                                yield dut._loop.storage.eq(loop)
+                                yield dut._enable.storage.eq(1)
+                                yield bus.ack.eq(1)
+                                if kind is WishboneDMAReader:
+                                    yield dut.source.ready.eq(1)
+                                else:
+                                    yield dut.sink.valid.eq(1)
+                                for cycle in range(16):
+                                    yield
+                                    self.assertEqual((yield bus.cyc), 0)
+                                    self.assertEqual((yield bus.stb), 0)
+                                    if cycle >= 3:
+                                        self.assertEqual((yield dut._done.status), 1)
+                                        self.assertEqual((yield dut._error.status), error)
+                                yield dut._enable.storage.eq(0)
+                                for _ in range(3):
+                                    yield
+                                self.assertEqual((yield dut.done), 0)
+                                self.assertEqual((yield dut.error), 0)
+
+                                # Re-arm with a valid, one-word transfer after completion/error.
+                                yield dut._base.storage.eq(word_bytes)
+                                yield dut._length.storage.eq(word_bytes)
+                                yield dut._loop.storage.eq(0)
+                                yield dut._enable.storage.eq(1)
+                                beats = 0
+                                for _ in range(16):
+                                    yield
+                                    if (yield bus.cyc) and (yield bus.stb):
+                                        self.assertEqual((yield bus.adr), 1)
+                                        beats += 1
+                                self.assertEqual(beats, 1)
+                                self.assertEqual((yield dut.done), 1)
+                                self.assertEqual((yield dut.error), 0)
+
+                            run_simulation(dut, gen())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Ten focused commits addressing the in-tree peripheral review, independently based on `master`:

- **DMA:** finish zero-byte requests without bus traffic, including loop mode; reject non-word-aligned bases/lengths instead of truncating or running indefinitely. Append a completion-error CSR without moving existing registers.
- **PWM:** synchronize controls into the selected PWM domain; run the shared counter while any channel is enabled so disabling channel 0 does not freeze other outputs.
- **SPI master:** validate width/frequency parameters and reject invalid runtime lengths/dividers without getting stuck busy. Sample data, length, divider, loopback and automatic CS at start. Keep manual CS control live and report rejection in the existing status register.
- **UART:** reject false starts at the start-bit midpoint. Optionally expose sticky, write-one-to-clear framing/overflow flags, with errors latched in the PHY domain before synchronization to software.
- **Video framebuffer:** hold the final pixel until accepted, discard the initial frame independently of downstream readiness, and distinguish actual visible-pixel starvation from blanking/startup/backpressure.
- **ECC:** report a single-bit error in the overall parity bit even with a zero Hamming syndrome; suppress flags when ECC is disabled. Test the LiteX implementation directly and include every error-bit position.
- **Optional PWM resource reduction:** allow 1–32-bit counter/control resolution, retaining the existing 32-bit default.

## Compatibility and scope

- Existing DMA register offsets are preserved; the new error register is appended. Transfer parameters must be word-aligned and stable while enabled. Empty requests complete even in loop mode; disable before re-arming.
- SPI `error` occupies bit 2 of the existing status register; invalid starts pulse `irq` and remain idle. The next valid start clears the error. Widths are restricted to the 1–255 bits representable by the transfer-length field, and dividers to 2–65535.
- UART error status is opt-in (`UART(..., with_error_status=True)` or `add_rx_error_status(...)`) and requires a PHY exposing receive error events; RS232 provides these. Clear flags by writing the desired bit mask to the register. Cross-domain clears have synchronization latency; a simultaneous new event wins in the PHY domain.
- PWM keeps its default CSR layout. Selecting a smaller `counter_width` also narrows width/period CSRs. Period/width updates remain non-atomic; asynchronous reconfiguration precautions are documented. No new shadow-register/update protocol is introduced here.
- ECC correction logic is unchanged. Exploratory datapath rewrites were not retained because their isolated 64-bit resource results were worse.
- No benchmark/result CSV or Markdown snapshots are added to the repository or commit history. Measurement artifacts remain outside the checkout.

## Validation

Broad regression suite:

```text
python3 -m pytest -q -p no:cacheprovider \
  test/cores \
  test/interconnect/test_dma.py \
  test/interconnect/test_csr.py \
  test/interconnect/test_csr_bus.py \
  test/interconnect/test_csr_eventmanager.py \
  test/soc/test_soc.py test/soc/test_builder.py test/soc/test_export.py

591 passed, 405 subtests passed
```

After adding the final CSR-bank regression:

```text
python3 -m pytest -q -p no:cacheprovider test/cores/test_uart.py
15 passed, 8 subtests passed
```

Fresh normal VexRiscv LiteX Sim BIOS build/boot:

```text
python3 -m pytest -q -p no:cacheprovider 'test/soc/test_integration.py::test_cpu[vexriscv]'
1 passed
```

Tests cover DMA 8/16/32/64-bit widths and recovery; independent PWM clocks and channel masks; SPI invalid starts, busy-setting changes, 1–255-bit widths and odd dividers; UART glitches, serial faults, cross-domain error latching, clear priority and real 8/32-bit CSR banks; framebuffer backpressure/starvation; and every single-bit ECC position through 64-bit payloads plus all double-bit pairs at small widths.

## Isolated PWM resource probe

Yosys `synth_xilinx -family xc7`, PWM datapath with `with_csr=False`, no I/O or clock buffers:

| Counter width | LUT cells | Flip-flops | CARRY4 |
| --- | ---: | ---: | ---: |
| 32 (default) | 77 | 33 | 22 |
| 16 | 41 | 17 | 12 |
| 8 | 21 | 9 | 6 |

No BRAM in these configurations. These are isolated, tool-specific cell counts, excluding CSR storage—not placed whole-SoC results or an Fmax claim.
