### PR TITLE
build/gowin: recognize class-suffixed differential SSTL standards

### DIFF
--- a/litex/build/gowin/gowin.py
+++ b/litex/build/gowin/gowin.py
@@ -72,7 +72,7 @@ def _gowin_tcl_path(path, use_windows_paths=False):
 
 def _is_differential_iostandard(iostandard):
     name = iostandard.name.upper()
-    return name.endswith("D") or "LVDS" in name
+    return name.endswith(("D", "D_I", "D_II")) or "LVDS" in name
 
 def _use_differential_constraint(other):
     iostandards = [c for c in other if isinstance(c, IOStandard)]

--- a/test/build/test_gowin_toolchain.py
+++ b/test/build/test_gowin_toolchain.py
@@ -12,7 +12,7 @@ from unittest import mock
 from migen import ClockDomain
 
 from litex.gen import LiteXModule
-from litex.build.generic_platform import Pins
+from litex.build.generic_platform import IOStandard, Pins
 from litex.build.gowin import gowin
 from litex.build.gowin.platform import GowinPlatform
 from litex.soc.cores.clock.gowin_gw1n import GW1NPLL
@@ -43,6 +43,25 @@ class _ApiculaSoC(LiteXModule):
 
 
 class TestGowinToolchain(unittest.TestCase):
+    def test_cst_pairs_sstl_differential_pins_with_class_suffix(self):
+        for standard in ("SSTL15D", "SSTL15D_I", "SSTL18D_II", "LVCMOS15"):
+            with self.subTest(standard=standard), tempfile.TemporaryDirectory() as build_dir:
+                constraints = [
+                    ("dqs_p", ["Y3", "V9"], [IOStandard(standard)], ("ddram", 0, "dqs_p")),
+                    ("dqs_n", ["AA3", "V8"], [IOStandard(standard)], ("ddram", 0, "dqs_n")),
+                ]
+                name = os.path.join(build_dir, "top")
+                gowin._build_cst(constraints, [], [], name)
+                with open(name + ".cst") as f:
+                    cst = f.read()
+                if standard == "LVCMOS15":
+                    self.assertIn('IO_LOC "dqs_p[0]" Y3;', cst)
+                    self.assertIn('IO_LOC "dqs_n[0]" AA3;', cst)
+                else:
+                    self.assertIn('IO_LOC "dqs_p[0]" Y3,AA3;', cst)
+                    self.assertIn('IO_LOC "dqs_p[1]" V9,V8;', cst)
+                    self.assertNotIn('IO_LOC "dqs_n', cst)
+
     def test_apicula_uses_generated_system_clock_target(self):
         platform = _ApiculaPlatform()
         soc      = _ApiculaSoC(platform, sys_clk_freq=48e6)


### PR DESCRIPTION
Gowin DDR3 designs using class-suffixed differential standards such as `SSTL15D_I` currently get separate positive/negative `IO_LOC` constraints. Gowin requires a paired constraint, e.g. `IO_LOC "dqs_p[0]" Y3,AA3;`. The existing detector recognizes names ending in `D`, but misses the `_I` and `_II` forms.

Recognize those two suffixes as differential. Preserve separate constraints for single-ended ports even when their names end in `_p`/`_n`.

This is needed by the Tang Console GW5AT-60B DDR3 update in https://github.com/litex-hub/litex-boards/pull/780. The original Console DDR3 reference uses [`SSTL15D_I` and paired DQS/clock constraints](https://github.com/nand2mario/ddr3_framebuffer_gowin/blob/master/src/console60k/console60k.cst).

Validation:

- `pytest -q test/build/test_gowin_toolchain.py`: 7 passed, 4 subtests passed. The new regression covers emitted vector pin constraints for unsuffixed, class-I, class-II, and single-ended standards.
- Full Gowin 1.9.12 synthesis, placement, routing and bitstream generation for Tang Console GW5AT-60B with the companion board and LiteDRAM changes. Generated DQS and CK constraints contain the expected positive/negative pin pairs.
- The same toolchain also builds the companion Mega 138K and Console 138K DDR3 configurations using unsuffixed standards.

These additional boards are not connected, so these are build checks only. Their remaining timing violations are recorded in the board PR; this change does not claim hardware validation or timing closure.
