### PR TITLE
soc: connect CPU debug to Xilinx JTAG USER chains

### DIFF
--- a/doc/cpu_jtag_debug.md
+++ b/doc/cpu_jtag_debug.md
@@ -1,0 +1,81 @@
+# CPU debugging through the FPGA JTAG port
+
+`--with-cpu-jtag-debug` connects an enabled CPU JTAG instruction interface to
+a Xilinx USER chain. It allows OpenOCD/GDB to use the FPGA's existing JTAG cable
+without routing a separate CPU TAP to external pins.
+
+This option connects the transport; the CPU's own options select its debug
+implementation. For VexRiscv-SMP's official RISC-V debug module on Arty:
+
+```sh
+python3 -m litex_boards.targets.digilent_arty \
+    --cpu-type=vexriscv_smp --cpu-count=1 \
+    --with-privileged-debug --hardware-breakpoints=2 \
+    --with-cpu-jtag-debug --build --load
+```
+
+Without `--with-cpu-jtag-debug`, no CPU USER-chain connection is added, even
+when the CPU's debug module is enabled. Do not combine it with an external
+CPU TAP (`--jtag-tap` on VexRiscv-SMP). Custom targets can instead call
+`soc.add_cpu_jtag_debug(chain=4, clk_freq=10e6, clock_domain="sys")` after adding
+the CPU. The CPU must expose the `jtag_clk`, `jtag_tdi`, `jtag_tdo`,
+`jtag_enable`, `jtag_capture`, `jtag_shift`, `jtag_update` and `jtag_reset`
+instruction signals, with clock-domain crossing implemented in its debug
+transport. This interface is also used by NaxRiscv and VexiiRiscv when their
+JTAG instruction option is enabled.
+
+## Chain allocation and timing
+
+- `--cpu-jtag-debug-chain=N` selects USER1 through USER4; the default is USER4.
+- `--cpu-jtag-debug-clk-freq=10e6` specifies the maximum TCK frequency for
+  timing analysis. It does not program the cable speed. Configure OpenOCD
+  at or below this frequency and rebuild if increasing the limit.
+- JTAGBone and JTAG UART normally use USER1, so they can coexist with CPU
+  debug on USER4. The same chain cannot be assigned to two users. Pass the
+  platform to any custom `XilinxJTAG` instance so it participates in the
+  allocation checks; raw vendor `Instance` objects are not tracked.
+
+The JTAG stream PHY qualifies shared BSCAN capture/shift signals with the
+USER-chain select signal, so CPU-debug scans do not enter JTAGBone or JTAG UART.
+
+The helper constrains TCK and declares it asynchronous to the CPU's system
+clock. It uses a kept alias of `ClockSignal(clock_domain)` and does not require
+a particular target CRG hierarchy. It adds no synchronizers: these must
+already be part of the CPU debug transport.
+
+## Supported hardware
+
+The helper uses `BSCANE2` or `BSCAN_SPARTAN6` according to the device. The
+original [hardware validation](https://github.com/litex-hub/linux-on-litex-vexriscv/pull/458)
+was on an Arty A7-35T using VexRiscv-SMP.
+Other supported Xilinx device families still need their board-specific
+OpenOCD TAP configuration and hardware qualification.
+
+Zynq and Zynq UltraScale+ devices are currently rejected because their BSCAN
+TDI has a one-cycle delay which this CPU transport connection does not
+compensate for. Other FPGA vendors are not yet supported by this helper.
+
+## OpenOCD and GDB on Arty
+
+Use a RISC-V capable OpenOCD with `riscv use_bscan_tunnel` support and the
+`riscv_jtag_tunneled.tcl` configuration from the
+[LiteX JTAG debugging guide](https://github.com/enjoy-digital/litex/wiki/JTAG-GDB-Debugging-with-VexRiscv-SMP-NaxRiscv-VexiiRiscv-CPUs).
+With that guide's `digilent_arty.cfg` and a one-hart CPU:
+
+```sh
+openocd -f digilent_arty.cfg -c 'set TAP_NAME xc7.tap' \
+    -f riscv_jtag_tunneled.tcl
+riscv64-unknown-elf-gdb build/digilent_arty/software/bios/bios.elf \
+    -ex 'target extended-remote localhost:3333'
+```
+
+The tunnel configuration must select the FPGA TAP, enable
+`riscv use_bscan_tunnel 6 1`, and match the built hart count (`RISCV_COUNT` in
+the guide's script). USER4 is IR `0x23` on Arty's six-bit TAP. Other devices
+can have different IR widths/encodings, and changing the USER chain requires
+changing the OpenOCD tunnel IR as well (`riscv set_bscan_tunnel_ir` on versions
+that provide it).
+
+JTAGBone and OpenOCD can use the same cable in turn. Chain separation does
+not make simultaneous access by two independent cable drivers safe; release
+the cable before switching clients.

--- a/litex/soc/cores/jtag.py
+++ b/litex/soc/cores/jtag.py
@@ -291,7 +291,19 @@ class AlteraJTAG(LiteXModule):
 # Xilinx JTAG --------------------------------------------------------------------------------------
 
 class XilinxJTAG(LiteXModule):
-    def __init__(self, primitive, chain=1):
+    def __init__(self, primitive, chain=1, platform=None):
+        if not isinstance(chain, int) or not 1 <= chain <= 4:
+            raise ValueError("Xilinx JTAG chain must be an integer from 1 to 4.")
+        # Share chain allocation with other users of this platform (CPU debug, JTAGBone, UART).
+        if platform is not None:
+            if not hasattr(platform, "_xilinx_jtag_chains"):
+                platform._xilinx_jtag_chains = set()
+            if chain in platform._xilinx_jtag_chains:
+                raise ValueError(f"Xilinx JTAG chain {chain} is already in use.")
+            platform._xilinx_jtag_chains.add(chain)
+
+        self.chain   = chain
+        self.sel     = Signal()
         self.reset   = Signal()
         self.capture = Signal()
         self.shift   = Signal()
@@ -307,6 +319,7 @@ class XilinxJTAG(LiteXModule):
         self.specials += Instance(primitive,
             p_JTAG_CHAIN = chain,
 
+            o_SEL     = self.sel,
             o_RESET   = self.reset,
             o_CAPTURE = self.capture,
             o_SHIFT   = self.shift,
@@ -528,7 +541,7 @@ class JTAGPHY(LiteXModule):
         if jtag is None:
             # Xilinx.
             if XilinxJTAG.get_primitive(device) is not None:
-                jtag = XilinxJTAG(primitive=XilinxJTAG.get_primitive(device), chain=chain)
+                jtag = XilinxJTAG(primitive=XilinxJTAG.get_primitive(device), chain=chain, platform=platform)
                 jtag_tdi_delay = XilinxJTAG.get_tdi_delay(device)
             # Lattice.
             elif device[:5] == "LFE5U":
@@ -550,6 +563,14 @@ class JTAGPHY(LiteXModule):
                 print(device)
                 raise NotImplementedError
             self.jtag = jtag
+
+        # BSCAN state signals are shared across USER chains. Ignore scans of other users,
+        # such as a CPU debug transport, while this stream's chain is not selected.
+        jtag_capture = jtag.capture
+        jtag_shift   = jtag.shift
+        if hasattr(jtag, "sel"):
+            jtag_capture = jtag_capture & jtag.sel
+            jtag_shift   = jtag_shift   & jtag.sel
 
         # JTAG clock domain ------------------------------------------------------------------------
         self.cd_jtag = ClockDomain()
@@ -579,7 +600,7 @@ class JTAGPHY(LiteXModule):
         jtag_tdo = jtag.tdo
         if jtag_tdi_delay:
             jtag_tdi_sr = Signal(data_width + 2 - jtag_tdi_delay)
-            self.sync.jtag += If(jtag.shift, jtag_tdi_sr.eq(Cat(jtag.tdi, jtag_tdi_sr)))
+            self.sync.jtag += If(jtag_shift, jtag_tdi_sr.eq(Cat(jtag.tdi, jtag_tdi_sr)))
             jtag_tdi = jtag_tdi_sr[-1]
 
         # JTAG Xfer FSM ----------------------------------------------------------------------------
@@ -604,11 +625,11 @@ class JTAGPHY(LiteXModule):
         update_ready = Signal()
 
         # Detect shift falling edge (transition from Shift-DR to Exit1-DR)
-        # This is when the valid bit (bit9) is available but jtag.shift is already 0
+        # This is when the valid bit (bit9) is available but jtag_shift is already 0
         shift_d = Signal()
-        self.sync.jtag += shift_d.eq(jtag.shift)
+        self.sync.jtag += shift_d.eq(jtag_shift)
         shift_falling = Signal()
-        self.comb += shift_falling.eq(shift_d & ~jtag.shift)
+        self.comb += shift_falling.eq(shift_d & ~jtag_shift)
 
         fsm = FSM(reset_state="XFER-READY")
         fsm = ClockDomainsRenamer("jtag")(fsm)
@@ -619,11 +640,11 @@ class JTAGPHY(LiteXModule):
         # starts in XFER-READY at the beginning of each DR scan. The 'ready'
         # signal is updated outside the FSM (via sync.jtag), so it survives
         # FSM resets and is correctly output via combinational TDO.
-        self.comb += fsm.reset.eq(jtag.reset | jtag.capture)
+        self.comb += fsm.reset.eq(jtag.reset | jtag_capture)
 
         fsm.act("XFER-READY",
             jtag_tdo.eq(ready),
-            If(jtag.shift,
+            If(jtag_shift,
                 sink.ready.eq(jtag_tdi),
                 NextValue(valid, sink.valid),
                 NextValue(data,  sink.data),
@@ -633,7 +654,7 @@ class JTAGPHY(LiteXModule):
         )
         fsm.act("XFER-DATA",
             jtag_tdo.eq(data[0]),
-            If(jtag.shift,
+            If(jtag_shift,
                 NextValue(count, count + 1),
                 NextValue(data, Cat(data[1:], jtag_tdi)),
                 If(count == (data_width - 1),
@@ -643,7 +664,7 @@ class JTAGPHY(LiteXModule):
         )
         fsm.act("XFER-VALID",
             jtag_tdo.eq(valid),
-            If(jtag.shift,
+            If(jtag_shift,
                 NextValue(rx_valid_in, jtag_tdi),
                 NextState("XFER-PADDING")
             )
@@ -651,9 +672,9 @@ class JTAGPHY(LiteXModule):
         fsm.act("XFER-PADDING",
             # Padding cycle: finalize the current word and return to XFER-READY.
             # rx_valid_in was registered in XFER-VALID; data holds the 8 RX bits.
-            # Handle both concatenated scans (jtag.shift stays high) and individual
+            # Handle both concatenated scans (jtag_shift stays high) and individual
             # scans (shift_falling fires when TAP exits Shift-DR).
-            If(jtag.shift,
+            If(jtag_shift,
                 update_rx.eq(1),
                 update_ready.eq(1),
                 NextState("XFER-READY")

--- a/litex/soc/integration/soc.py
+++ b/litex/soc/integration/soc.py
@@ -2310,6 +2310,55 @@ class LiteXSoC(SoC):
         self.add_module(name=name,          module=uartbone)
         self.bus.add_master(name=name, master=uartbone.wishbone)
 
+    # Add CPU JTAG Debug ---------------------------------------------------------------------------
+    def add_cpu_jtag_debug(self, chain=4, clk_freq=10e6, clock_domain="sys"):
+        """Connect the CPU's JTAG instruction port to a Xilinx USER chain.
+
+        The CPU must already expose its instruction interface. This connects the transport;
+        it does not enable a CPU debug module or create an external JTAG TAP. ``clk_freq`` is
+        the maximum TCK frequency used for timing analysis, not a generated clock.
+        """
+        from litex.soc.cores.jtag import XilinxJTAG
+
+        self.check_if_exists("cpu_jtag_debug")
+        ports = ("clk", "tdi", "tdo", "enable", "capture", "shift", "update", "reset")
+        cpu = getattr(self, "cpu", None)
+        if not all(hasattr(cpu, f"jtag_{port}") for port in ports):
+            self.logger.error("CPU JTAG debug requires a CPU with a JTAG instruction interface; "
+                              "an external JTAG TAP cannot be connected to a USER chain.")
+            raise SoCError()
+        primitive = XilinxJTAG.get_primitive(self.platform.device)
+        if not self.platform.jtag_support or primitive is None:
+            self.logger.error(f"CPU JTAG debug is not supported on {self.platform.device}.")
+            raise SoCError()
+        if XilinxJTAG.get_tdi_delay(self.platform.device):
+            self.logger.error("CPU JTAG debug does not yet support the delayed BSCAN TDI "
+                              f"on {self.platform.device}.")
+            raise SoCError()
+        if not math.isfinite(clk_freq) or clk_freq <= 0:
+            raise ValueError("CPU JTAG debug clock frequency must be finite and positive.")
+
+        self.cpu_jtag_debug = jtag = XilinxJTAG(primitive, chain=chain, platform=self.platform)
+        self.comb += [
+            cpu.jtag_clk.eq(jtag.tck),
+            cpu.jtag_tdi.eq(jtag.tdi),
+            cpu.jtag_enable.eq(jtag.sel),
+            cpu.jtag_capture.eq(jtag.capture),
+            cpu.jtag_shift.eq(jtag.shift),
+            cpu.jtag_update.eq(jtag.update),
+            cpu.jtag_reset.eq(jtag.reset),
+            jtag.tdo.eq(cpu.jtag_tdo),
+        ]
+
+        # The CPU's debug transport implements the crossing between TCK and its system clock.
+        # Keep an alias for timing constraints without depending on a target's CRG layout.
+        debug_sys_clk = Signal()
+        self.comb += debug_sys_clk.eq(ClockSignal(clock_domain))
+        self.platform.add_period_constraint(jtag.tck, 1e9/clk_freq)
+        self.platform.add_false_path_constraints(debug_sys_clk, jtag.tck)
+        self.add_config("CPU_JTAG_DEBUG_CHAIN", chain)
+        self.add_config("CPU_JTAG_DEBUG_CLK_FREQ", int(clk_freq))
+
     # Add JTAGBone ---------------------------------------------------------------------------------
     def add_jtagbone(self, name="jtagbone", chain=1):
         # Imports.
@@ -3749,6 +3798,11 @@ class SoCCore(LiteXSoC):
         with_jtagbone              = False,
         jtagbone_chain             = 1,
 
+        # CPU JTAG Debug.
+        with_cpu_jtag_debug        = False,
+        cpu_jtag_debug_chain       = 4,
+        cpu_jtag_debug_clk_freq    = 10e6,
+
         # UARTBone.
         with_uartbone              = False,
 
@@ -3917,6 +3971,13 @@ class SoCCore(LiteXSoC):
                 raise SoCError()
             self.add_jtagbone(name="jtagbone", chain=jtagbone_chain)
 
+        # Add CPU JTAG Debug.
+        if with_cpu_jtag_debug:
+            self.add_cpu_jtag_debug(
+                chain    = cpu_jtag_debug_chain,
+                clk_freq = cpu_jtag_debug_clk_freq,
+            )
+
         # Add Timer.
         if with_timer:
             self.add_timer(name="timer0")
@@ -4018,6 +4079,11 @@ def soc_core_args(parser, cpu_type="vexriscv", cpu_variant=None):
     # JTAGBone parameters.
     soc_group.add_argument("--with-jtagbone",            action="store_true",                help="Enable JTAGBone support.")
     soc_group.add_argument("--jtagbone-chain",           default=1,          type=auto_int,  help="JTAGBone chain index.")
+
+    # CPU JTAG Debug parameters.
+    soc_group.add_argument("--with-cpu-jtag-debug",     action="store_true",                help="Connect the CPU JTAG instruction interface to a Xilinx USER chain.")
+    soc_group.add_argument("--cpu-jtag-debug-chain",    default=4,           type=auto_int, help="CPU debug USER chain index (1-4).")
+    soc_group.add_argument("--cpu-jtag-debug-clk-freq", default=10e6,        type=float,    help="Maximum CPU debug TCK frequency for timing analysis (Hz).")
 
     # Timer parameters.
     soc_group.add_argument("--no-timer",                 action="store_true",                help="Disable timer.")

--- a/test/cores/test_jtag.py
+++ b/test/cores/test_jtag.py
@@ -40,10 +40,12 @@ class MockJTAG(Module):
     vendor-specific hardware.  Pass an instance to JTAGPHY(jtag=...) to
     bypass device detection.
     """
-    def __init__(self):
+    def __init__(self, with_sel=False):
         self.tck     = Signal()
         self.tdi     = Signal()
         self.tdo     = Signal()
+        if with_sel:
+            self.sel = Signal(reset=1)
         self.shift   = Signal()
         self.capture = Signal()
         self.reset   = Signal()
@@ -65,11 +67,11 @@ class JTAGPHYTestDUT(Module):
     ClockSignal, so get_fragment() filters them out (the simulator drives
     clock domains directly via its TimeManager).
     """
-    def __init__(self, data_width=8):
+    def __init__(self, data_width=8, with_sel=False):
         # Provide jtag clock domain with reset (for AsyncResetSynchronizer).
         self.clock_domains.cd_jtag = ClockDomain("jtag")
 
-        self.submodules.jtag_tap = jtag_tap = MockJTAG()
+        self.submodules.jtag_tap = jtag_tap = MockJTAG(with_sel=with_sel)
         self.submodules.phy = phy = JTAGPHY(
             jtag         = jtag_tap,
             data_width   = data_width,
@@ -229,6 +231,33 @@ class TestJTAGPHY(unittest.TestCase):
         self._run(dut, gen)
         self.assertEqual(result["valid"], 1)
         self.assertEqual(result["data"],  0x42)
+
+    def test_scans_of_another_user_chain_do_not_reach_the_stream(self):
+        dut = JTAGPHYTestDUT(data_width=self.DATA_WIDTH, with_sel=True)
+        result = {}
+
+        def gen():
+            # BSCAN CAPTURE/SHIFT/TDI are shared by all USER chains. CPU debug on another
+            # chain must not inject data into JTAGBone/JTAG UART while this PHY is deselected.
+            yield dut.jtag_tap.sel.eq(0)
+            for _ in range(5):
+                yield
+            yield from self._scan(dut, host_data=0xAA, host_valid=1)
+            for _ in range(5):
+                yield
+            result["unselected_valid"] = (yield dut.source.valid)
+
+            yield dut.jtag_tap.sel.eq(1)
+            yield from self._scan(dut, host_data=0x42, host_valid=1)
+            for _ in range(5):
+                yield
+            result["selected_valid"] = (yield dut.source.valid)
+            result["selected_data"] = (yield dut.source.data)
+
+        self._run(dut, gen)
+        self.assertEqual(result["unselected_valid"], 0)
+        self.assertEqual(result["selected_valid"], 1)
+        self.assertEqual(result["selected_data"], 0x42)
 
     def test_rx_high_byte(self):
         """Host->Target: 0xDE has bit 7 set, verifies full byte width."""

--- a/test/soc/test_cpu_jtag.py
+++ b/test/soc/test_cpu_jtag.py
@@ -1,0 +1,168 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import argparse
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from migen import ClockDomain, Instance, Module
+
+from litex.build.xilinx import XilinxPlatform
+from litex.soc.cores.cpu.vexriscv_smp import VexRiscvSMP
+from litex.soc.integration.soc import SoCCore, SoCError, soc_core_args, soc_core_argdict
+
+
+class TestCPUJTAGDebug(unittest.TestCase):
+    def setUp(self):
+        for name, value in [("privileged_debug", True), ("jtag_tap", False), ("reset_vector", 0)]:
+            context = patch.object(VexRiscvSMP, name, value)
+            context.start()
+            self.addCleanup(context.stop)
+
+    def make_soc(self, device="xc7a35ticsg324-1L", **kwargs):
+        platform = XilinxPlatform(device, [], toolchain="vivado")
+        options = dict(
+            cpu_type            = "vexriscv_smp",
+            integrated_rom_size = 0x8000,
+            with_uart           = False,
+            with_timer          = False,
+            with_ctrl           = False,
+        )
+        options.update(kwargs)
+        return SoCCore(platform, clk_freq=100e6, **options)
+
+    def test_cpu_debug_mode_does_not_implicitly_connect_jtag(self):
+        for privileged_debug in [False, True]:
+            with self.subTest(privileged_debug=privileged_debug):
+                VexRiscvSMP.privileged_debug = privileged_debug
+                soc = self.make_soc()
+                self.assertFalse(hasattr(soc, "cpu_jtag_debug"))
+                self.assertFalse(hasattr(soc.platform, "_xilinx_jtag_chains"))
+
+    def test_user_chain_and_clock_options(self):
+        soc = self.make_soc(
+            with_cpu_jtag_debug     = True,
+            cpu_jtag_debug_chain    = 2,
+            cpu_jtag_debug_clk_freq = 5e6,
+        )
+        self.assertEqual(soc.cpu_jtag_debug.chain, 2)
+        self.assertEqual(soc.platform.toolchain.clocks[soc.cpu_jtag_debug.tck][0], 200)
+        self.assertEqual(soc.constants["CONFIG_CPU_JTAG_DEBUG_CHAIN"], 2)
+        self.assertEqual(soc.constants["CONFIG_CPU_JTAG_DEBUG_CLK_FREQ"], 5000000)
+
+    def test_external_tap_is_rejected_before_allocating_a_chain(self):
+        VexRiscvSMP.jtag_tap = True
+        soc = self.make_soc()
+        with self.assertLogs("SoC", level="ERROR") as logs, self.assertRaises(SoCError):
+            soc.add_cpu_jtag_debug()
+        self.assertIn("JTAG instruction interface", " ".join(logs.output))
+        self.assertFalse(hasattr(soc.platform, "_xilinx_jtag_chains"))
+
+    def test_cpu_without_debug_port_is_rejected(self):
+        soc = self.make_soc(cpu_type=None)
+        with self.assertLogs("SoC", level="ERROR"), self.assertRaises(SoCError):
+            soc.add_cpu_jtag_debug()
+
+    def test_unsupported_device_is_rejected(self):
+        for device in ["LFE5U-85F-6BG381C", "xc7z020clg400-1", "xczu7ev-ffvc1156-2-e"]:
+            with self.subTest(device=device):
+                soc = self.make_soc(device=device)
+                with self.assertLogs("SoC", level="ERROR"), self.assertRaises(SoCError):
+                    soc.add_cpu_jtag_debug()
+                self.assertFalse(hasattr(soc.platform, "_xilinx_jtag_chains"))
+
+    def test_invalid_chain_is_rejected(self):
+        for chain in [0, 5, -1, 1.5, "4"]:
+            with self.subTest(chain=chain), self.assertRaisesRegex(ValueError, "integer from 1 to 4"):
+                self.make_soc(with_cpu_jtag_debug=True, cpu_jtag_debug_chain=chain)
+
+    def test_invalid_clock_is_rejected_before_allocating_a_chain(self):
+        for clk_freq in [0, -1, float("inf"), float("nan")]:
+            with self.subTest(clk_freq=clk_freq):
+                soc = self.make_soc()
+                with self.assertRaisesRegex(ValueError, "finite and positive"):
+                    soc.add_cpu_jtag_debug(clk_freq=clk_freq)
+                soc.add_cpu_jtag_debug()
+
+    def test_duplicate_attachment_is_rejected_even_on_another_chain(self):
+        soc = self.make_soc(with_cpu_jtag_debug=True)
+        with self.assertLogs("SoC", level="ERROR"), self.assertRaises(SoCError):
+            soc.add_cpu_jtag_debug(chain=2)
+
+    def test_jtagbone_and_debug_can_use_different_chains(self):
+        soc = self.make_soc(with_jtagbone=True, with_cpu_jtag_debug=True)
+        self.assertEqual(soc.jtagbone.phy.jtag.chain, 1)
+        self.assertEqual(soc.cpu_jtag_debug.chain, 4)
+
+    def test_chain_collision_is_rejected_in_both_addition_orders(self):
+        for debug_first in [False, True]:
+            with self.subTest(debug_first=debug_first):
+                soc = self.make_soc()
+                if debug_first:
+                    soc.add_cpu_jtag_debug()
+                    with self.assertRaisesRegex(ValueError, "chain 4 is already in use"):
+                        soc.add_jtagbone(chain=4)
+                else:
+                    soc.add_jtagbone(chain=4)
+                    with self.assertRaisesRegex(ValueError, "chain 4 is already in use"):
+                        soc.add_cpu_jtag_debug()
+
+    def test_jtag_uart_reserves_its_chain(self):
+        soc = self.make_soc(with_uart=True, uart_name="jtag_uart")
+        with self.assertRaisesRegex(ValueError, "chain 1 is already in use"):
+            soc.add_cpu_jtag_debug(chain=1)
+        soc.add_cpu_jtag_debug(chain=4)
+
+    def test_chain_allocation_is_local_to_each_platform(self):
+        first = self.make_soc(with_cpu_jtag_debug=True)
+        second = self.make_soc(with_cpu_jtag_debug=True)
+        self.assertEqual(first.cpu_jtag_debug.chain, second.cpu_jtag_debug.chain)
+
+    def test_bscan_ports_and_constraints_without_a_crg_attribute(self):
+        # Exercise actual Verilog/XDC generation, while keeping CPU netlist generation out of
+        # this transport test. The instruction signals stand in for the CPU instance's ports.
+        soc = self.make_soc(with_cpu_jtag_debug=True, cpu_jtag_debug_clk_freq=5e6)
+        dut = Module()
+        dut.clock_domains.cd_sys = ClockDomain("sys")
+        dut.submodules.jtag = soc.cpu_jtag_debug
+        dut.comb += soc._fragment.comb
+        ports = [getattr(soc.cpu, "jtag_" + name) for name in
+                 ["clk", "tdi", "tdo", "enable", "capture", "shift", "update", "reset"]]
+        # Preserve the CPU-facing signals as top-level ports for inspection.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            soc.platform.build(dut, build_dir=tmpdir, build_name="cpu_jtag", run=False,
+                               ios=set(ports + [dut.cd_sys.clk]))
+            with open(os.path.join(tmpdir, "cpu_jtag.v")) as f:
+                verilog = f.read()
+            with open(os.path.join(tmpdir, "cpu_jtag.xdc")) as f:
+                xdc = f.read()
+        for port in ["TCK", "TDI", "TDO", "SEL", "CAPTURE", "SHIFT", "UPDATE", "RESET"]:
+            self.assertIn("." + port, verilog)
+        self.assertIn("BSCANE2", verilog)
+        self.assertRegex(verilog, r"\.JTAG_CHAIN\s*\(3'd4\)")
+        self.assertIn("-period 200.0", xdc)
+        self.assertIn("get_nets debug_sys_clk", xdc)
+        self.assertRegex(xdc, r"set_clock_groups .* -asynchronous")
+
+    def test_spartan6_uses_its_own_primitive(self):
+        soc = self.make_soc(device="xc6slx45-csg324-3", with_cpu_jtag_debug=True)
+        primitives = [s.of for s in soc.cpu_jtag_debug._fragment.specials if isinstance(s, Instance)]
+        self.assertEqual(primitives, ["BSCAN_SPARTAN6"])
+
+    def test_cli_options_reach_soc_constructor(self):
+        parser = argparse.ArgumentParser()
+        soc_core_args(parser)
+        args = parser.parse_args([
+            "--with-cpu-jtag-debug",
+            "--cpu-jtag-debug-chain=2",
+            "--cpu-jtag-debug-clk-freq=5e6",
+        ])
+        options = soc_core_argdict(args)
+        self.assertTrue(options["with_cpu_jtag_debug"])
+        self.assertEqual(options["cpu_jtag_debug_chain"], 2)
+        self.assertEqual(options["cpu_jtag_debug_clk_freq"], 5e6)


### PR DESCRIPTION
CPU debug instruction ports currently need target-specific wiring to reach the FPGA's JTAG cable. Add an explicit `--with-cpu-jtag-debug` option and `LiteXSoC.add_cpu_jtag_debug()` helper that connect the existing CPU instruction interface through `XilinxJTAG`.

For example, an Arty VexRiscv-SMP build can use `--with-privileged-debug --with-cpu-jtag-debug`: the first enables the official RISC-V debug module, while the second connects its transport to USER4. Default builds and externally wired TAPs retain their existing behavior.

- Expose BSCAN `SEL`, configure the USER chain and maximum TCK frequency, and constrain the system/TCK crossing without relying on a target's CRG hierarchy.
- Track Xilinx USER-chain allocation per platform, detecting collisions between CPU debug, JTAGBone and JTAG UART in either addition order.
- Qualify JTAGPHY capture/shift with `SEL`. BSCAN state signals are shared, so without this, scans of the CPU-debug chain can be decoded as JTAGBone/JTAG UART traffic. The new simulation test fails before this fix and passes afterward.
- Reject missing instruction interfaces, external TAPs, invalid parameters, unsupported vendors and Zynq/ZynqMP's uncompensated delayed TDI.
- Document Arty/OpenOCD usage, chain selection and device limitations.

Based on Saket Sinha's initial BSCAN implementation and Arty hardware report in https://github.com/litex-hub/linux-on-litex-vexriscv/pull/458. His contribution is credited in the commit.

Companion integration: https://github.com/litex-hub/linux-on-litex-vexriscv/pull/459. Merge this LiteX PR first, then rerun the companion PR's CI against the updated LiteX master.

Validation:

- `python3 -m pytest -q test/soc/test_cpu_jtag.py test/soc/test_soc.py test/cores/test_jtag.py`: 184 passed, plus 100 subtests.
- Combined with the Linux-on-LiteX integration: Arty builds for one hart and two harts with JTAGBone on USER1 passed CPU/gateware/DTS generation and BIOS compilation. CPU debug uses USER4.
- Verilog/XDC generation, chain conflicts, disabled transport, TAP rejection and scan isolation have automated coverage.
- The revised implementation has not been synthesized, programmed onto an FPGA or revalidated with OpenOCD/GDB on hardware. The original PR's hardware results belong to its original implementation.
