### PR TITLE
cores/ram: Add AP Memory x16 PSRAM controller

### DIFF
--- a/litex/soc/cores/ram/apmemory.py
+++ b/litex/soc/cores/ram/apmemory.py
@@ -15,10 +15,10 @@ from litex.gen.genlib.misc import WaitTimer
 from litex.soc.interconnect import wishbone
 from litex.soc.interconnect.csr import CSRField, CSRStatus
 
-# AP Memory OPI/HPI PSRAM ---------------------------------------------------------------------------
-
 # APS256XXN-OBx9, Rev. 1.2: https://www.apmemory.com/tw/downloadFiles/0325021716tb786912
 # APS512XXN-OBx9, Rev. 1.0: https://www.apmemory.com/en/downloadFiles/1025112710dj710649
+
+# AP Memory PHY ------------------------------------------------------------------------------------
 
 class APMemoryPHY(LiteXModule):
     """Low-speed x16 OPI/HPI PHY for AP Memory's standard-temperature OB9 devices.
@@ -44,6 +44,9 @@ class APMemoryPHY(LiteXModule):
         self.error   = Signal()
         self.dat_r   = Signal(32)
 
+        # # #
+
+        # Pads -------------------------------------------------------------------------------------
         # Pads can also be simulation records with o/oe/i fields.
         dq_o   = Signal(16)
         dq_oe  = Signal(2)
@@ -52,19 +55,35 @@ class APMemoryPHY(LiteXModule):
         dqs_oe = Signal()
         dqs_i  = Signal(2)
         if hasattr(pads.dq, "o"):
-            self.comb += [pads.dq.o.eq(dq_o), pads.dq.oe.eq(dq_oe), dq_i.eq(pads.dq.i)]
-            self.comb += [pads.dqs.o.eq(dqs_o), pads.dqs.oe.eq(dqs_oe), dqs_i.eq(pads.dqs.i)]
+            self.comb += [
+                pads.dq.o.eq(dq_o),
+                pads.dq.oe.eq(dq_oe),
+                dq_i.eq(pads.dq.i),
+            ]
+            self.comb += [
+                pads.dqs.o.eq(dqs_o),
+                pads.dqs.oe.eq(dqs_oe),
+                dqs_i.eq(pads.dqs.i),
+            ]
         else:
             for lane in range(2):
                 self.specials += Tristate(pads.dq[8*lane:8*(lane + 1)],
-                    o=dq_o[8*lane:8*(lane + 1)], oe=dq_oe[lane], i=dq_i[8*lane:8*(lane + 1)])
-            self.specials += Tristate(pads.dqs, o=dqs_o, oe=dqs_oe, i=dqs_i)
+                    o  = dq_o[8*lane:8*(lane + 1)],
+                    oe = dq_oe[lane],
+                    i  = dq_i[8*lane:8*(lane + 1)],
+                )
+            self.specials += Tristate(pads.dqs,
+                o  = dqs_o,
+                oe = dqs_oe,
+                i  = dqs_i,
+            )
 
+        # Read Sampling ----------------------------------------------------------------------------
         # DQ is stable when a synchronized DQS transition qualifies its later sample.
-        dq_sample   = Signal(16)
-        dqs_meta    = Signal(2)
-        dqs_sample  = Signal(2)
-        dqs_last    = Signal(2)
+        dq_sample  = Signal(16)
+        dqs_meta   = Signal(2)
+        dqs_sample = Signal(2)
+        dqs_last   = Signal(2)
         # Keep the sampling stages explicit: their input paths need a maximum delay constraint,
         # whereas MultiReg would mark them as false paths in the platform toolchain.
         for signal in [dq_sample, dqs_meta, dqs_sample]:
@@ -76,16 +95,16 @@ class APMemoryPHY(LiteXModule):
             dqs_last.eq(dqs_sample),
         ]
 
-        cmd     = Signal(8)
-        address = Signal(32)
-        dat_w   = Signal(32)
-        sel     = Signal(4)
-        phase   = Signal(2)
-        edge    = Signal(7)
-        active  = Signal()
-        timeout = Signal(max=math.ceil(3e-6*sys_clk_freq) + 1)
-        armed   = Signal(2)
-        counts  = [Signal(2) for _ in range(2)]
+        cmd      = Signal(8)
+        address  = Signal(32)
+        dat_w    = Signal(32)
+        sel      = Signal(4)
+        phase    = Signal(2)
+        edge     = Signal(7)
+        active   = Signal()
+        timeout  = Signal(max=math.ceil(3e-6*sys_clk_freq) + 1)
+        armed    = Signal(2)
+        counts   = [Signal(2) for _ in range(2)]
         received = Signal()
         self.comb += received.eq((counts[0] == 2) & ((cmd == 0x40) | (counts[1] == 2)))
 
@@ -94,19 +113,23 @@ class APMemoryPHY(LiteXModule):
                 armed[lane].eq(0),
                 count.eq(0),
             ).Elif(~cmd[7] & (edge >= 6),
-                If(~dqs_sample[lane], armed[lane].eq(1)),
+                If(~dqs_sample[lane],
+                    armed[lane].eq(1),
+                ),
                 If(armed[lane] & (count < 2) & (dqs_sample[lane] != dqs_last[lane]),
                     # The first beat is a rising edge, the second a falling edge.
                     If(dqs_sample[lane] == (count == 0),
                         Case(count, {
                             n: self.dat_r[16*n + 8*lane:16*n + 8*(lane + 1)].eq(
-                                dq_sample[8*lane:8*(lane + 1)]) for n in range(2)
+                                dq_sample[8*lane:8*(lane + 1)])
+                            for n in range(2)
                         }),
                         count.eq(count + 1),
                     )
                 )
             )
 
+        # Write Data -------------------------------------------------------------------------------
         # Command and address always use DQ[7:0], including after enabling x16 mode.
         tx_data = Signal(16)
         tx_oe   = Signal(2)
@@ -142,32 +165,37 @@ class APMemoryPHY(LiteXModule):
             )
         ]
 
+        # Transfer FSM -----------------------------------------------------------------------------
         self.fsm = fsm = FSM(reset_state="IDLE")
         fsm.act("IDLE",
             If(self.start,
-                NextValue(cmd,     self.cmd),
-                NextValue(address, self.address),
-                NextValue(dat_w,   self.dat_w),
-                NextValue(sel,     self.sel),
+                NextValue(cmd,        self.cmd),
+                NextValue(address,    self.address),
+                NextValue(dat_w,      self.dat_w),
+                NextValue(sel,        self.sel),
                 NextValue(self.error, 0),
-                NextValue(pads.cs_n, 0),
-                NextValue(phase, 0),
-                NextValue(edge, 0),
-                NextValue(timeout, 0),
+                NextValue(pads.cs_n,  0),
+                NextValue(phase,      0),
+                NextValue(edge,       0),
+                NextValue(timeout,    0),
                 NextState("TRANSFER"),
             )
         )
         fsm.act("TRANSFER",
             active.eq(1),
             NextValue(phase, phase + 1),
-            If(timeout != math.ceil(3e-6*sys_clk_freq), NextValue(timeout, timeout + 1)),
+            If(timeout != math.ceil(3e-6*sys_clk_freq),
+                NextValue(timeout, timeout + 1),
+            ),
             If(phase == 0,
                 NextValue(dq_o,   tx_data),
                 NextValue(dq_oe,  tx_oe),
                 NextValue(dqs_o,  tx_mask),
                 NextValue(dqs_oe, tx_dm),
             ),
-            If(phase == 2, NextValue(pads.clk, ~pads.clk)),
+            If(phase == 2,
+                NextValue(pads.clk, ~pads.clk),
+            ),
             If(phase == 3,
                 NextValue(edge, edge + 1),
                 # Finish on a falling edge and leave CLK low between transactions.
@@ -179,9 +207,9 @@ class APMemoryPHY(LiteXModule):
                     (timeout == math.ceil(3e-6*sys_clk_freq))),
                     NextValue(self.error, ~cmd[7] & ~received),
                     NextValue(pads.cs_n, 1),
-                    NextValue(dq_oe, 0),
+                    NextValue(dq_oe,  0),
                     NextValue(dqs_oe, 0),
-                    NextValue(phase, 0),
+                    NextValue(phase,  0),
                     NextState("RECOVER"),
                 )
             )
@@ -194,7 +222,7 @@ class APMemoryPHY(LiteXModule):
             )
         )
         pads.cs_n.reset = 1
-
+# AP Memory Controller -----------------------------------------------------------------------------
 
 class APMemory(LiteXModule):
     """32-bit Wishbone controller for APS256XXN/APS512XXN-OB9 PSRAM in x16 mode.
@@ -206,19 +234,26 @@ class APMemory(LiteXModule):
     def __init__(self, pads, sys_clk_freq, size=32*1024*1024, with_csr=True):
         if size not in [32*1024*1024, 64*1024*1024]:
             raise ValueError("APMemory supports 32MiB APS256XXN and 64MiB APS512XXN devices.")
-        self.bus        = bus = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+        self.bus = bus = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+
         self.ready      = Signal()
         self.init_error = Signal()
         self.timeout    = Signal()
         self.id         = Signal(16)
 
-        self.phy = phy = APMemoryPHY(pads, sys_clk_freq)
+        # # #
+
+        # PHY / Timers -----------------------------------------------------------------------------
+        self.phy     = phy     = APMemoryPHY(pads, sys_clk_freq)
         self.powerup = powerup = WaitTimer(math.ceil(150e-6*sys_clk_freq))
         self.reset   = reset   = WaitTimer(math.ceil(2e-6*sys_clk_freq))
 
-        self.sync += If(phy.done & phy.error, self.timeout.eq(1))
+        self.sync += If(phy.done & phy.error,
+            self.timeout.eq(1),
+        )
         self.comb += bus.dat_r.eq(phy.dat_r)
 
+        # Bus Access -------------------------------------------------------------------------------
         # x16 addresses have a ten-bit word column. Wire CA10 is unused, not a row bit.
         # APS512 needs 15 row bits per its geometry/PASR tables; Rev. 1.0's CA table omits RA14.
         word_address = bus.adr[:log2_int(size//4)]
@@ -229,34 +264,62 @@ class APMemory(LiteXModule):
         aborted      = Signal()
         failed       = Signal()
 
+        # Initialization / Access FSM ---------------------------------------------------------------
         self.fsm = fsm = FSM(reset_state="POWERUP")
         fsm.act("POWERUP",
             powerup.wait.eq(1),
-            If(powerup.done, NextState("RESET")),
+            If(powerup.done,
+                NextState("RESET"),
+            ),
         )
-        fsm.act("RESET", phy.start.eq(1), phy.cmd.eq(0xff), NextState("RESET-WAIT"))
-        fsm.act("RESET-WAIT", If(phy.done, NextState("RESET-RECOVER")))
+        fsm.act("RESET",
+            phy.start.eq(1),
+            phy.cmd.eq(0xff),
+            NextState("RESET-WAIT"),
+        )
+        fsm.act("RESET-WAIT",
+            If(phy.done,
+                NextState("RESET-RECOVER"),
+            ),
+        )
         fsm.act("RESET-RECOVER",
             reset.wait.eq(1),
-            If(reset.done, NextState("X16")),
+            If(reset.done,
+                NextState("X16"),
+            ),
         )
         fsm.act("X16",
-            phy.start.eq(1), phy.cmd.eq(0xc0), phy.address.eq(8), phy.dat_w.eq(0x40),
+            phy.start.eq(1),
+            phy.cmd.eq(0xc0),
+            phy.address.eq(8),
+            phy.dat_w.eq(0x40),
             NextState("X16-WAIT"),
         )
-        fsm.act("X16-WAIT", If(phy.done, NextState("VERIFY")))
+        fsm.act("X16-WAIT",
+            If(phy.done,
+                NextState("VERIFY"),
+            ),
+        )
         fsm.act("VERIFY",
-            phy.start.eq(1), phy.cmd.eq(0x40), phy.address.eq(8), NextState("VERIFY-WAIT"),
+            phy.start.eq(1),
+            phy.cmd.eq(0x40),
+            phy.address.eq(8),
+            NextState("VERIFY-WAIT"),
         )
         fsm.act("VERIFY-WAIT",
             If(phy.done,
                 If(phy.error | (phy.dat_r[:8] != 0x40),
                     NextState("FAILED"),
-                ).Else(NextState("IDENTIFY"))
+                ).Else(
+                    NextState("IDENTIFY"),
+                )
             )
         )
         fsm.act("IDENTIFY",
-            phy.start.eq(1), phy.cmd.eq(0x40), phy.address.eq(1), NextState("IDENTIFY-WAIT"),
+            phy.start.eq(1),
+            phy.cmd.eq(0x40),
+            phy.address.eq(1),
+            NextState("IDENTIFY-WAIT"),
         )
         fsm.act("IDENTIFY-WAIT",
             If(phy.done,
@@ -270,25 +333,35 @@ class APMemory(LiteXModule):
                 )
             )
         )
-        fsm.act("FAILED", self.init_error.eq(1), bus.err.eq(bus.cyc & bus.stb))
+        fsm.act("FAILED",
+            self.init_error.eq(1),
+            bus.err.eq(bus.cyc & bus.stb),
+        )
         fsm.act("IDLE",
             If(bus.cyc & bus.stb,
                 NextValue(address, Cat(C(0, 1), word_address[:9], C(0, 1), word_address[9:])),
-                NextValue(dat_w, bus.dat_w),
-                NextValue(sel,   bus.sel),
-                NextValue(write, bus.we),
+                NextValue(dat_w,   bus.dat_w),
+                NextValue(sel,     bus.sel),
+                NextValue(write,   bus.we),
                 NextValue(aborted, 0),
                 NextState("ACCESS"),
             )
         )
         fsm.act("ACCESS",
-            phy.start.eq(1), phy.cmd.eq(Mux(write, 0xa0, 0x20)),
-            phy.address.eq(address), phy.dat_w.eq(dat_w), phy.sel.eq(sel),
-            If(~bus.cyc, NextValue(aborted, 1)),
+            phy.start.eq(1),
+            phy.cmd.eq(Mux(write, 0xa0, 0x20)),
+            phy.address.eq(address),
+            phy.dat_w.eq(dat_w),
+            phy.sel.eq(sel),
+            If(~bus.cyc,
+                NextValue(aborted, 1),
+            ),
             NextState("ACCESS-WAIT"),
         )
         fsm.act("ACCESS-WAIT",
-            If(~bus.cyc, NextValue(aborted, 1)),
+            If(~bus.cyc,
+                NextValue(aborted, 1),
+            ),
             If(phy.done,
                 NextValue(failed, phy.error),
                 NextState("RESPONSE"),
@@ -300,6 +373,7 @@ class APMemory(LiteXModule):
             NextState("IDLE"),
         )
 
+        # CSRs -------------------------------------------------------------------------------------
         if with_csr:
             self.status = CSRStatus(fields=[
                 CSRField("ready",      description="Initialization completed and device ID matched."),

--- a/litex/soc/cores/ram/apmemory.py
+++ b/litex/soc/cores/ram/apmemory.py
@@ -1,0 +1,315 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import math
+
+from migen import *
+from migen.fhdl.specials import Tristate
+
+from litex.gen import *
+from litex.gen.genlib.misc import WaitTimer
+
+from litex.soc.interconnect import wishbone
+from litex.soc.interconnect.csr import CSRField, CSRStatus
+
+# AP Memory OPI/HPI PSRAM ---------------------------------------------------------------------------
+
+# APS256XXN-OBx9, Rev. 1.2: https://www.apmemory.com/tw/downloadFiles/0325021716tb786912
+# APS512XXN-OBx9, Rev. 1.0: https://www.apmemory.com/en/downloadFiles/1025112710dj710649
+
+class APMemoryPHY(LiteXModule):
+    """Low-speed x16 OPI/HPI PHY for AP Memory's standard-temperature OB9 devices.
+
+    CLK runs at sys/8. Data changes two sys cycles before/after each CLK edge. Read data is
+    sampled one sys cycle after the first DQS synchronizer stage; each byte lane follows its own
+    DQS. This requires a 50..100MHz system clock and bounded FPGA I/O delays: 5ns for inputs,
+    CLK and CE#, and 8ns for DQ/DM outputs (including tristate enables). Board signal skew must
+    stay below 1ns. The platform must constrain these paths. At the end of a transaction, CE#
+    and the output enables are released one sys cycle after the final falling CLK edge.
+    It does not use the devices' maximum clock rate or support the 1us extended-temperature tCEM.
+    """
+    def __init__(self, pads, sys_clk_freq):
+        if not 50e6 <= sys_clk_freq <= 100e6:
+            raise ValueError("APMemoryPHY requires a 50..100MHz system clock.")
+
+        self.start   = Signal()
+        self.cmd     = Signal(8)
+        self.address = Signal(32)
+        self.dat_w   = Signal(32)
+        self.sel     = Signal(4)
+        self.done    = Signal()
+        self.error   = Signal()
+        self.dat_r   = Signal(32)
+
+        # Pads can also be simulation records with o/oe/i fields.
+        dq_o   = Signal(16)
+        dq_oe  = Signal(2)
+        dq_i   = Signal(16)
+        dqs_o  = Signal(2)
+        dqs_oe = Signal()
+        dqs_i  = Signal(2)
+        if hasattr(pads.dq, "o"):
+            self.comb += [pads.dq.o.eq(dq_o), pads.dq.oe.eq(dq_oe), dq_i.eq(pads.dq.i)]
+            self.comb += [pads.dqs.o.eq(dqs_o), pads.dqs.oe.eq(dqs_oe), dqs_i.eq(pads.dqs.i)]
+        else:
+            for lane in range(2):
+                self.specials += Tristate(pads.dq[8*lane:8*(lane + 1)],
+                    o=dq_o[8*lane:8*(lane + 1)], oe=dq_oe[lane], i=dq_i[8*lane:8*(lane + 1)])
+            self.specials += Tristate(pads.dqs, o=dqs_o, oe=dqs_oe, i=dqs_i)
+
+        # DQ is stable when a synchronized DQS transition qualifies its later sample.
+        dq_sample   = Signal(16)
+        dqs_meta    = Signal(2)
+        dqs_sample  = Signal(2)
+        dqs_last    = Signal(2)
+        # Keep the sampling stages explicit: their input paths need a maximum delay constraint,
+        # whereas MultiReg would mark them as false paths in the platform toolchain.
+        for signal in [dq_sample, dqs_meta, dqs_sample]:
+            signal.attr.update({"async_reg", "no_shreg_extract", "no_retiming"})
+        self.sync += [
+            dq_sample.eq(dq_i),
+            dqs_meta.eq(dqs_i),
+            dqs_sample.eq(dqs_meta),
+            dqs_last.eq(dqs_sample),
+        ]
+
+        cmd     = Signal(8)
+        address = Signal(32)
+        dat_w   = Signal(32)
+        sel     = Signal(4)
+        phase   = Signal(2)
+        edge    = Signal(7)
+        active  = Signal()
+        timeout = Signal(max=math.ceil(3e-6*sys_clk_freq) + 1)
+        armed   = Signal(2)
+        counts  = [Signal(2) for _ in range(2)]
+        received = Signal()
+        self.comb += received.eq((counts[0] == 2) & ((cmd == 0x40) | (counts[1] == 2)))
+
+        for lane, count in enumerate(counts):
+            self.sync += If(~active,
+                armed[lane].eq(0),
+                count.eq(0),
+            ).Elif(~cmd[7] & (edge >= 6),
+                If(~dqs_sample[lane], armed[lane].eq(1)),
+                If(armed[lane] & (count < 2) & (dqs_sample[lane] != dqs_last[lane]),
+                    # The first beat is a rising edge, the second a falling edge.
+                    If(dqs_sample[lane] == (count == 0),
+                        Case(count, {
+                            n: self.dat_r[16*n + 8*lane:16*n + 8*(lane + 1)].eq(
+                                dq_sample[8*lane:8*(lane + 1)]) for n in range(2)
+                        }),
+                        count.eq(count + 1),
+                    )
+                )
+            )
+
+        # Command and address always use DQ[7:0], including after enabling x16 mode.
+        tx_data = Signal(16)
+        tx_oe   = Signal(2)
+        tx_mask = Signal(2)
+        tx_dm   = Signal()
+        self.comb += [
+            If(edge < 6,
+                tx_oe.eq(1),
+                Case(edge, {
+                    0: tx_data.eq(cmd),
+                    1: tx_data.eq(cmd),
+                    2: tx_data.eq(address[24:32]),
+                    3: tx_data.eq(address[16:24]),
+                    4: tx_data.eq(address[8:16]),
+                    5: tx_data.eq(address[0:8]),
+                }),
+            ).Elif(cmd == 0xc0,
+                # Register writes have one cycle of latency (counting from A1).
+                tx_oe.eq(1),
+                tx_data.eq(dat_w[:8]),
+                tx_dm.eq(1),
+            ).Elif((cmd == 0xa0) & (edge >= 14),
+                # Reset MR4 selects write latency 5. Each bus word is two x16 beats.
+                tx_oe.eq(3),
+                tx_dm.eq(1),
+                If(edge[0],
+                    tx_data.eq(dat_w[16:32]),
+                    tx_mask.eq(~sel[2:4]),
+                ).Else(
+                    tx_data.eq(dat_w[0:16]),
+                    tx_mask.eq(~sel[0:2]),
+                )
+            )
+        ]
+
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            If(self.start,
+                NextValue(cmd,     self.cmd),
+                NextValue(address, self.address),
+                NextValue(dat_w,   self.dat_w),
+                NextValue(sel,     self.sel),
+                NextValue(self.error, 0),
+                NextValue(pads.cs_n, 0),
+                NextValue(phase, 0),
+                NextValue(edge, 0),
+                NextValue(timeout, 0),
+                NextState("TRANSFER"),
+            )
+        )
+        fsm.act("TRANSFER",
+            active.eq(1),
+            NextValue(phase, phase + 1),
+            If(timeout != math.ceil(3e-6*sys_clk_freq), NextValue(timeout, timeout + 1)),
+            If(phase == 0,
+                NextValue(dq_o,   tx_data),
+                NextValue(dq_oe,  tx_oe),
+                NextValue(dqs_o,  tx_mask),
+                NextValue(dqs_oe, tx_dm),
+            ),
+            If(phase == 2, NextValue(pads.clk, ~pads.clk)),
+            If(phase == 3,
+                NextValue(edge, edge + 1),
+                # Finish on a falling edge and leave CLK low between transactions.
+                If(edge[0] & (
+                    ((cmd == 0xff) & (edge == 7)) |
+                    ((cmd == 0xc0) & (edge == 7)) |
+                    ((cmd == 0xa0) & (edge == 15)) |
+                    (~cmd[7] & received) |
+                    (timeout == math.ceil(3e-6*sys_clk_freq))),
+                    NextValue(self.error, ~cmd[7] & ~received),
+                    NextValue(pads.cs_n, 1),
+                    NextValue(dq_oe, 0),
+                    NextValue(dqs_oe, 0),
+                    NextValue(phase, 0),
+                    NextState("RECOVER"),
+                )
+            )
+        )
+        fsm.act("RECOVER",
+            NextValue(phase, phase + 1),
+            If(phase == 3,
+                self.done.eq(1),
+                NextState("IDLE"),
+            )
+        )
+        pads.cs_n.reset = 1
+
+
+class APMemory(LiteXModule):
+    """32-bit Wishbone controller for APS256XXN/APS512XXN-OB9 PSRAM in x16 mode.
+
+    Initialization uses Global Reset, enables x16 through MR8, and checks MR8/vendor/density.
+    The default read/write latency codes are retained. Reads follow DQS (variable latency).
+    Each access transfers one 32-bit word, with per-byte write masks and a bounded CE# low time.
+    """
+    def __init__(self, pads, sys_clk_freq, size=32*1024*1024, with_csr=True):
+        if size not in [32*1024*1024, 64*1024*1024]:
+            raise ValueError("APMemory supports 32MiB APS256XXN and 64MiB APS512XXN devices.")
+        self.bus        = bus = wishbone.Interface(data_width=32, address_width=32, addressing="word")
+        self.ready      = Signal()
+        self.init_error = Signal()
+        self.timeout    = Signal()
+        self.id         = Signal(16)
+
+        self.phy = phy = APMemoryPHY(pads, sys_clk_freq)
+        self.powerup = powerup = WaitTimer(math.ceil(150e-6*sys_clk_freq))
+        self.reset   = reset   = WaitTimer(math.ceil(2e-6*sys_clk_freq))
+
+        self.sync += If(phy.done & phy.error, self.timeout.eq(1))
+        self.comb += bus.dat_r.eq(phy.dat_r)
+
+        # x16 addresses have a ten-bit word column. Wire CA10 is unused, not a row bit.
+        # APS512 needs 15 row bits per its geometry/PASR tables; Rev. 1.0's CA table omits RA14.
+        word_address = bus.adr[:log2_int(size//4)]
+        address      = Signal(32)
+        dat_w        = Signal(32)
+        sel          = Signal(4)
+        write        = Signal()
+        aborted      = Signal()
+        failed       = Signal()
+
+        self.fsm = fsm = FSM(reset_state="POWERUP")
+        fsm.act("POWERUP",
+            powerup.wait.eq(1),
+            If(powerup.done, NextState("RESET")),
+        )
+        fsm.act("RESET", phy.start.eq(1), phy.cmd.eq(0xff), NextState("RESET-WAIT"))
+        fsm.act("RESET-WAIT", If(phy.done, NextState("RESET-RECOVER")))
+        fsm.act("RESET-RECOVER",
+            reset.wait.eq(1),
+            If(reset.done, NextState("X16")),
+        )
+        fsm.act("X16",
+            phy.start.eq(1), phy.cmd.eq(0xc0), phy.address.eq(8), phy.dat_w.eq(0x40),
+            NextState("X16-WAIT"),
+        )
+        fsm.act("X16-WAIT", If(phy.done, NextState("VERIFY")))
+        fsm.act("VERIFY",
+            phy.start.eq(1), phy.cmd.eq(0x40), phy.address.eq(8), NextState("VERIFY-WAIT"),
+        )
+        fsm.act("VERIFY-WAIT",
+            If(phy.done,
+                If(phy.error | (phy.dat_r[:8] != 0x40),
+                    NextState("FAILED"),
+                ).Else(NextState("IDENTIFY"))
+            )
+        )
+        fsm.act("IDENTIFY",
+            phy.start.eq(1), phy.cmd.eq(0x40), phy.address.eq(1), NextState("IDENTIFY-WAIT"),
+        )
+        fsm.act("IDENTIFY-WAIT",
+            If(phy.done,
+                NextValue(self.id, Cat(phy.dat_r[:8], phy.dat_r[16:24])),
+                If(phy.error | (phy.dat_r[:5] != 0x0d) |
+                    (phy.dat_r[16:19] != (7 if size == 32*1024*1024 else 6)),
+                    NextState("FAILED"),
+                ).Else(
+                    NextValue(self.ready, 1),
+                    NextState("IDLE"),
+                )
+            )
+        )
+        fsm.act("FAILED", self.init_error.eq(1), bus.err.eq(bus.cyc & bus.stb))
+        fsm.act("IDLE",
+            If(bus.cyc & bus.stb,
+                NextValue(address, Cat(C(0, 1), word_address[:9], C(0, 1), word_address[9:])),
+                NextValue(dat_w, bus.dat_w),
+                NextValue(sel,   bus.sel),
+                NextValue(write, bus.we),
+                NextValue(aborted, 0),
+                NextState("ACCESS"),
+            )
+        )
+        fsm.act("ACCESS",
+            phy.start.eq(1), phy.cmd.eq(Mux(write, 0xa0, 0x20)),
+            phy.address.eq(address), phy.dat_w.eq(dat_w), phy.sel.eq(sel),
+            If(~bus.cyc, NextValue(aborted, 1)),
+            NextState("ACCESS-WAIT"),
+        )
+        fsm.act("ACCESS-WAIT",
+            If(~bus.cyc, NextValue(aborted, 1)),
+            If(phy.done,
+                NextValue(failed, phy.error),
+                NextState("RESPONSE"),
+            )
+        )
+        fsm.act("RESPONSE",
+            bus.ack.eq(bus.cyc & bus.stb & ~aborted & ~failed),
+            bus.err.eq(bus.cyc & bus.stb & ~aborted &  failed),
+            NextState("IDLE"),
+        )
+
+        if with_csr:
+            self.status = CSRStatus(fields=[
+                CSRField("ready",      description="Initialization completed and device ID matched."),
+                CSRField("init_error", description="Initialization failed; reset the core to retry."),
+                CSRField("timeout",    description="A read timed out. Cleared by core reset."),
+            ])
+            self.identification = CSRStatus(16, description="MR1 in bits 7:0, MR2 in bits 15:8.")
+            self.comb += [
+                self.status.fields.ready.eq(self.ready),
+                self.status.fields.init_error.eq(self.init_error),
+                self.status.fields.timeout.eq(self.timeout),
+                self.identification.status.eq(self.id),
+            ]

--- a/test/cores/test_apmemory.py
+++ b/test/cores/test_apmemory.py
@@ -1,0 +1,296 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import *
+
+from litex.soc.cores.ram.apmemory import APMemory, APMemoryPHY
+
+
+def make_pads():
+    return Record([
+        ("clk", 1), ("cs_n", 1),
+        ("dq",  [("o", 16), ("oe", 2), ("i", 16)]),
+        ("dqs", [("o", 2),  ("oe", 1), ("i", 2)]),
+    ])
+
+
+class APMemoryModel:
+    """Pin-level OB9 model: CA decoding, mode registers, DDR data, DQS and byte masks.
+
+    All times are in ns. Read responses are scheduled from external CLK edges; the model has
+    no access to controller state. A sparse byte-addressed array covers both device densities.
+    """
+    def __init__(self, pads, size, tick=10, latency=5, delays=(10, 20), dq_skew=0):
+        self.pads       = pads
+        self.size       = size
+        self.tick       = tick
+        self.latency    = latency
+        self.delays     = delays
+        self.dq_skew    = dq_skew
+        self.respond    = True
+        self.accept_x16 = True
+        self.memory     = {}
+        self.commands   = []
+        self.mr         = {0: 0x08, 1: 0x0d, 2: 0x1f if size == 32*1024*1024 else 0x1e,
+                           3: 0, 4: 0x40, 8: 0x05}
+
+    @passive
+    def run(self):
+        p = self.pads
+        now = 0
+        last_cs, last_clk = 1, 0
+        start, end, last_edge = 0, -1000, -1000
+        reset_end = None
+        edges, address, cmd = 0, 0, None
+        events = []
+        dq, dqs = 0xffff, 3
+        while True:
+            cs, clk = (yield p.cs_n), (yield p.clk)
+            if not cs and last_cs:
+                assert now - end >= 15, "CE# recovery time"
+                if reset_end is not None:
+                    assert now - reset_end >= 2000, "Global Reset recovery time"
+                start, edges, address, cmd = now, 0, 0, None
+            if cs and not last_cs:
+                assert not clk, "CLK must finish low"
+                assert now - start <= 4000, "Maximum CE# low time"
+                assert now - last_edge >= 2, "CE# hold time"
+                assert edges >= 6, "Minimum CE# low clocks"
+                if cmd == 0xff:
+                    assert start >= 150000, "Power-up delay"
+                    assert edges == 8, "Global Reset requires four clocks"
+                    reset_end = now
+                self.commands.append((cmd, address, edges))
+                end, events, dq, dqs = now, [], 0xffff, 3
+            if not cs and clk != last_clk:
+                assert now - start >= 2, "CE# setup time"
+                last_edge = now
+                host_data = (yield p.dq.o)
+                if edges < 6:
+                    assert (yield p.dq.oe) == 1, "CA uses only the lower byte lane"
+                    if edges == 0:
+                        assert clk
+                        cmd = host_data & 0xff
+                        assert cmd in [0xff, 0xc0, 0x40, 0x20, 0xa0]
+                    elif edges >= 2:
+                        address = (address << 8) | (host_data & 0xff)
+                if cmd in [0x20, 0xa0] and edges == 6:
+                    assert self.mr[8] & 0x40, "Memory access before x16 enable"
+                    assert address & 0x401 == 0, "Even x16 column; CA10 is unused"
+                if cmd == 0xc0 and edges == 6:
+                    assert (yield p.dq.oe) == 1
+                    assert (yield p.dqs.oe) and (yield p.dqs.o) == 0
+                    if self.accept_x16:
+                        self.mr[address] = host_data & 0xff
+                if cmd == 0xa0 and edges >= 14:
+                    assert (yield p.dq.oe) == 3
+                    assert (yield p.dqs.oe)
+                    offset = (address >> 11)*2048 + (address & 0x3ff)*2 + (edges - 14)*2
+                    assert offset + 1 < self.size
+                    for lane in range(2):
+                        if not ((yield p.dqs.o) >> lane) & 1:
+                            self.memory[offset + lane] = (host_data >> (8*lane)) & 0xff
+                if cmd in [0x20, 0x40] and self.respond:
+                    if edges >= 6:
+                        assert (yield p.dq.oe) == 0 and (yield p.dqs.oe) == 0
+                    for lane in range(2 if cmd == 0x20 else 1):
+                        if edges == 4:
+                            events.append((now + self.delays[lane], "dqs", lane, 0))
+                        beat = edges - (4 + 2*self.latency)
+                        if beat >= 0:
+                            if cmd == 0x40:
+                                pair = {0: 1, 1: 2, 2: 3, 3: 4, 4: 8, 8: 0}
+                                value = self.mr[address if beat % 2 == 0 else pair[address]]
+                            else:
+                                offset = (address >> 11)*2048 + (address & 0x3ff)*2 + beat*2
+                                value = self.memory.get(offset + lane, 0)
+                            events.append((now + self.delays[lane], "dqs", lane, 1 - beat % 2))
+                            events.append((now + self.delays[lane] + self.dq_skew, "dq", lane, value))
+                edges += 1
+            for event in sorted(events):
+                when, kind, lane, value = event
+                if when <= now:
+                    if kind == "dqs":
+                        dqs = (dqs & ~(1 << lane)) | (value << lane)
+                    else:
+                        dq = (dq & ~(0xff << (8*lane))) | (value << (8*lane))
+            events = [event for event in events if event[0] > now]
+            yield p.dq.i.eq(dq)
+            yield p.dqs.i.eq(dqs)
+            last_cs, last_clk = cs, clk
+            now += self.tick
+            yield
+
+
+def access(bus, address, value=None, sel=0xf, error=False, hold_cyc=False):
+    yield bus.adr.eq(address//4)
+    yield bus.dat_w.eq(value or 0)
+    yield bus.sel.eq(sel)
+    yield bus.we.eq(value is not None)
+    yield bus.cyc.eq(1)
+    yield bus.stb.eq(1)
+    yield
+    for _ in range(1000):
+        if (yield bus.ack) or (yield bus.err):
+            assert bool((yield bus.err)) == error
+            result = (yield bus.dat_r)
+            break
+        yield
+    else:
+        raise AssertionError("Wishbone access did not complete")
+    yield bus.stb.eq(0)
+    yield bus.cyc.eq(hold_cyc)
+    yield
+    return result
+
+
+class TestAPMemory(unittest.TestCase):
+    def wait_ready(self, cores):
+        for _ in range(20000):
+            states = []
+            for core in cores:
+                states.append((yield core.ready) or (yield core.init_error))
+            if all(states):
+                return
+            yield
+        self.fail("PSRAM initialization did not complete")
+
+    def test_four_devices(self):
+        dut = Module()
+        sizes = [32*1024*1024]*3 + [64*1024*1024]
+        pads = [make_pads() for _ in sizes]
+        cores = [APMemory(p, 100e6, size=s) for p, s in zip(pads, sizes)]
+        models = [APMemoryModel(p, s, latency=5 + i) for i, (p, s) in enumerate(zip(pads, sizes))]
+        dut.submodules += cores
+
+        def bench():
+            yield from self.wait_ready(cores)
+            for i, (core, model, size) in enumerate(zip(cores, models, sizes)):
+                self.assertEqual((yield core.ready), 1)
+                self.assertEqual((yield core.id) & 0x7ff, (7 if i < 3 else 6)*256 + 0x0d)
+                self.assertEqual([cmd for cmd, _, _ in model.commands[:4]], [0xff, 0xc0, 0x40, 0x40])
+                # Distinguish all lanes, both sides of a row, the high address bit and the last word.
+                offsets = [0, 4, 0x7fc, 0x800, size//2, size - 4]
+                for n, offset in enumerate(offsets):
+                    yield from access(core.bus, offset, 0x12345678 ^ (i << 24) ^ n, hold_cyc=True)
+                for n, offset in enumerate(offsets):
+                    self.assertEqual((yield from access(core.bus, offset, hold_cyc=True)),
+                        0x12345678 ^ (i << 24) ^ n)
+                # CA10 must not alias columns or steal the highest row address bit.
+                self.assertIn((0xa0, ((size//2)//2048) << 11, 16), model.commands)
+                for mask in range(16):
+                    old = yield from access(core.bus, 0)
+                    new = 0xfedcba98 ^ mask
+                    yield from access(core.bus, 0, new, sel=mask)
+                    expected = sum(((new if mask & (1 << b) else old) & (0xff << (8*b))) for b in range(4))
+                    self.assertEqual((yield from access(core.bus, 0)), expected)
+
+            # Four requests in flight at once, with different data at the same local address.
+            for i, core in enumerate(cores):
+                yield core.bus.adr.eq(16)
+                yield core.bus.dat_w.eq(0xaabbcc00 + i)
+                yield core.bus.we.eq(1)
+                yield core.bus.sel.eq(15)
+                yield core.bus.cyc.eq(1)
+                yield core.bus.stb.eq(1)
+            yield
+            pending = set(range(4))
+            for _ in range(1000):
+                for i in list(pending):
+                    if (yield cores[i].bus.ack):
+                        yield cores[i].bus.cyc.eq(0)
+                        yield cores[i].bus.stb.eq(0)
+                        pending.remove(i)
+                if not pending:
+                    break
+                yield
+            self.assertFalse(pending)
+            yield
+            for i, core in enumerate(cores):
+                self.assertEqual((yield from access(core.bus, 64)), 0xaabbcc00 + i)
+
+            # A missing response terminates with ERR and CE# high, then a later access can succeed.
+            models[0].respond = False
+            yield from access(cores[0].bus, 0, error=True)
+            self.assertEqual((yield cores[0].timeout), 1)
+            self.assertEqual((yield pads[0].cs_n), 1)
+            models[0].respond = True
+            self.assertEqual((yield from access(cores[0].bus, 64)), 0xaabbcc00)
+
+            # Abandon a request, then present another before the old transaction finishes.
+            bus = cores[0].bus
+            yield bus.adr.eq(0)
+            yield bus.cyc.eq(1)
+            yield bus.stb.eq(1)
+            for _ in range(20):
+                yield
+            yield bus.cyc.eq(0)
+            yield
+            self.assertEqual((yield from access(bus, 64)), 0xaabbcc00)
+
+        run_simulation(dut, [bench()] + [m.run() for m in models])
+
+    def test_initialization_errors(self):
+        dut = Module()
+        pads = [make_pads() for _ in range(3)]
+        cores = [APMemory(p, 100e6) for p in pads]
+        models = [APMemoryModel(p, 32*1024*1024) for p in pads]
+        models[0].respond = False
+        models[1].accept_x16 = False
+        models[2].mr[2] = 0x1e # Wrong density.
+        dut.submodules += cores
+
+        def bench():
+            yield from self.wait_ready(cores)
+            for core in cores:
+                self.assertEqual((yield core.ready), 0)
+                self.assertEqual((yield core.init_error), 1)
+                yield from access(core.bus, 0, error=True)
+            self.assertEqual((yield cores[0].timeout), 1)
+
+        run_simulation(dut, [bench()] + [m.run() for m in models])
+
+    def test_read_timing(self):
+        # Test the PHY separately with 2ns resolution, response delays crossing sys edges,
+        # lane skew, and late DQ. Both clock limits must support the full variable-latency range.
+        for sys_freq in [50e6, 100e6]:
+            for skew, delay in [(s, d) for s in [-8, 8] for d in [2, 6, 10, 14, 18]]:
+                with self.subTest(sys_freq=sys_freq, dq_skew=skew, delay=delay):
+                    pads = make_pads()
+                    phy = APMemoryPHY(pads, sys_freq)
+                    model = APMemoryModel(pads, 32*1024*1024, tick=2,
+                        delays=(delay + 8, delay + 18), dq_skew=skew)
+                    model.mr[8] = 0x40
+                    model.memory = {0: 0x12, 1: 0x34, 2: 0x56, 3: 0x78}
+
+                    def bench():
+                        for latency in range(5, 11):
+                            model.latency = latency
+                            yield phy.cmd.eq(0x20)
+                            yield phy.start.eq(1)
+                            yield
+                            yield phy.start.eq(0)
+                            for _ in range(500):
+                                if (yield phy.done):
+                                    break
+                                yield
+                            else:
+                                self.fail("Read did not finish")
+                            self.assertEqual((yield phy.error), 0)
+                            self.assertEqual((yield phy.dat_r), 0x78563412)
+                            yield
+
+                    run_simulation(phy, {"sys": bench(), "model": model.run()},
+                        clocks={"sys": int(1e9/sys_freq), "model": 2})
+
+    def test_parameters(self):
+        for freq in [0, 49e6, 101e6]:
+            with self.assertRaises(ValueError):
+                APMemory(make_pads(), freq)
+        with self.assertRaises(ValueError):
+            APMemory(make_pads(), 100e6, size=16*1024*1024)

--- a/test/cores/test_apmemory.py
+++ b/test/cores/test_apmemory.py
@@ -5,19 +5,25 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import unittest
+import itertools
 
-from migen import *
+from migen import Module, Record, passive, run_simulation
 
 from litex.soc.cores.ram.apmemory import APMemory, APMemoryPHY
 
 
+# Pads ---------------------------------------------------------------------------------------------
+
 def make_pads():
     return Record([
-        ("clk", 1), ("cs_n", 1),
+        ("clk",  1),
+        ("cs_n", 1),
         ("dq",  [("o", 16), ("oe", 2), ("i", 16)]),
         ("dqs", [("o", 2),  ("oe", 1), ("i", 2)]),
     ])
 
+
+# Model --------------------------------------------------------------------------------------------
 
 class APMemoryModel:
     """Pin-level OB9 model: CA decoding, mode registers, DDR data, DQS and byte masks.
@@ -36,8 +42,14 @@ class APMemoryModel:
         self.accept_x16 = True
         self.memory     = {}
         self.commands   = []
-        self.mr         = {0: 0x08, 1: 0x0d, 2: 0x1f if size == 32*1024*1024 else 0x1e,
-                           3: 0, 4: 0x40, 8: 0x05}
+        self.mr         = {
+            0: 0x08,
+            1: 0x0d,
+            2: 0x1f if size == 32*1024*1024 else 0x1e,
+            3: 0,
+            4: 0x40,
+            8: 0x05,
+        }
 
     @passive
     def run(self):
@@ -127,6 +139,8 @@ class APMemoryModel:
             yield
 
 
+# Wishbone Helpers ---------------------------------------------------------------------------------
+
 def access(bus, address, value=None, sel=0xf, error=False, hold_cyc=False):
     yield bus.adr.eq(address//4)
     yield bus.dat_w.eq(value or 0)
@@ -149,6 +163,8 @@ def access(bus, address, value=None, sel=0xf, error=False, hold_cyc=False):
     return result
 
 
+# Tests --------------------------------------------------------------------------------------------
+
 class TestAPMemory(unittest.TestCase):
     def wait_ready(self, cores):
         for _ in range(20000):
@@ -161,10 +177,10 @@ class TestAPMemory(unittest.TestCase):
         self.fail("PSRAM initialization did not complete")
 
     def test_four_devices(self):
-        dut = Module()
-        sizes = [32*1024*1024]*3 + [64*1024*1024]
-        pads = [make_pads() for _ in sizes]
-        cores = [APMemory(p, 100e6, size=s) for p, s in zip(pads, sizes)]
+        dut    = Module()
+        sizes  = [32*1024*1024]*3 + [64*1024*1024]
+        pads   = [make_pads() for _ in sizes]
+        cores  = [APMemory(p, 100e6, size=s) for p, s in zip(pads, sizes)]
         models = [APMemoryModel(p, s, latency=5 + i) for i, (p, s) in enumerate(zip(pads, sizes))]
         dut.submodules += cores
 
@@ -179,15 +195,20 @@ class TestAPMemory(unittest.TestCase):
                 for n, offset in enumerate(offsets):
                     yield from access(core.bus, offset, 0x12345678 ^ (i << 24) ^ n, hold_cyc=True)
                 for n, offset in enumerate(offsets):
-                    self.assertEqual((yield from access(core.bus, offset, hold_cyc=True)),
-                        0x12345678 ^ (i << 24) ^ n)
+                    self.assertEqual(
+                        (yield from access(core.bus, offset, hold_cyc=True)),
+                        0x12345678 ^ (i << 24) ^ n,
+                    )
                 # CA10 must not alias columns or steal the highest row address bit.
                 self.assertIn((0xa0, ((size//2)//2048) << 11, 16), model.commands)
                 for mask in range(16):
                     old = yield from access(core.bus, 0)
                     new = 0xfedcba98 ^ mask
                     yield from access(core.bus, 0, new, sel=mask)
-                    expected = sum(((new if mask & (1 << b) else old) & (0xff << (8*b))) for b in range(4))
+                    expected = sum(
+                        ((new if mask & (1 << b) else old) & (0xff << (8*b)))
+                        for b in range(4)
+                    )
                     self.assertEqual((yield from access(core.bus, 0)), expected)
 
             # Four requests in flight at once, with different data at the same local address.
@@ -236,9 +257,9 @@ class TestAPMemory(unittest.TestCase):
         run_simulation(dut, [bench()] + [m.run() for m in models])
 
     def test_initialization_errors(self):
-        dut = Module()
-        pads = [make_pads() for _ in range(3)]
-        cores = [APMemory(p, 100e6) for p in pads]
+        dut    = Module()
+        pads   = [make_pads() for _ in range(3)]
+        cores  = [APMemory(p, 100e6) for p in pads]
         models = [APMemoryModel(p, 32*1024*1024) for p in pads]
         models[0].respond = False
         models[1].accept_x16 = False
@@ -259,13 +280,16 @@ class TestAPMemory(unittest.TestCase):
         # Test the PHY separately with 2ns resolution, response delays crossing sys edges,
         # lane skew, and late DQ. Both clock limits must support the full variable-latency range.
         for sys_freq in [50e6, 100e6]:
-            for skew, delay in [(s, d) for s in [-8, 8] for d in [2, 6, 10, 14, 18]]:
+            for skew, delay in itertools.product([-8, 8], [2, 6, 10, 14, 18]):
                 with self.subTest(sys_freq=sys_freq, dq_skew=skew, delay=delay):
-                    pads = make_pads()
-                    phy = APMemoryPHY(pads, sys_freq)
-                    model = APMemoryModel(pads, 32*1024*1024, tick=2,
-                        delays=(delay + 8, delay + 18), dq_skew=skew)
-                    model.mr[8] = 0x40
+                    pads  = make_pads()
+                    phy   = APMemoryPHY(pads, sys_freq)
+                    model = APMemoryModel(pads, 32*1024*1024,
+                        tick    = 2,
+                        delays  = (delay + 8, delay + 18),
+                        dq_skew = skew,
+                    )
+                    model.mr[8]  = 0x40
                     model.memory = {0: 0x12, 1: 0x34, 2: 0x56, 3: 0x78}
 
                     def bench():
@@ -286,7 +310,8 @@ class TestAPMemory(unittest.TestCase):
                             yield
 
                     run_simulation(phy, {"sys": bench(), "model": model.run()},
-                        clocks={"sys": int(1e9/sys_freq), "model": 2})
+                        clocks={"sys": int(1e9/sys_freq), "model": 2},
+                    )
 
     def test_parameters(self):
         for freq in [0, 49e6, 101e6]:


### PR DESCRIPTION
AP Memory's APS256XXN/APS512XXN-OB9 parts use an OPI/HPI command format that the existing HyperRAM controller does not implement. Add a reusable x16 controller and PHY for these devices, used by the ModRetro M64's four PSRAM buses.

The core provides a 32-bit Wishbone interface, powers up through Global Reset, enables x16 mode through MR8, and verifies the mode/vendor/density registers. Reads follow each byte lane's DQS at variable latency; writes use the two DM signals for byte enables. Each access transfers one word, with a timeout that bounds CE# low time. Initialization status, device ID and read timeouts are exposed through CSRs.

This is a conservative implementation: the PSRAM clock is sys/8 with a 50–100MHz system clock. Platforms must constrain input/CLK/CE# paths to 5ns and DQ/DM output paths to 8ns (including tristate enables), with board signal skew below 1ns. It supports standard-temperature OB9 parts with 4µs tCEM; it does not support the extended-temperature 1µs limit.

Sources are linked in the core. APS512 Rev. 1.0 has an inconsistent command table that omits RA14; the implementation retains 15 row bits as required by the device geometry and PASR tables. The upper address range needs confirmation on hardware.

Validation:

- Pin-level simulations cover initialization and failure reporting, four concurrent devices, byte masks, row/high-address boundaries, aborts, timeout/recovery, and read latency 5–10 across both clock limits and multiple DQS phases/lane skews.
- All four controller tests pass, including 20 read-timing combinations.
- The M64 target passes five generation configurations and builds its BIOS with all four devices enabled.
- Vivado 2024.1 synthesis, placement, routing and bitstream generation passed for the M64 at 100MHz system / 12.5MHz PSRAM: setup slack +0.885ns, hold slack +0.014ns. All 80 PSRAM pins are present. The 72 receive paths intentionally have maximum-delay-only constraints into the DQ/DQS samplers; Vivado reports these as partial input delays.

No physical PSRAM testing has been performed. The M64 target integration is in https://github.com/litex-hub/litex-boards/pull/790.
