### PR TITLE
liblitedram: calibrate physical Gowin5 delays and bootstrap write training

### DIFF
--- a/litex/soc/software/liblitedram/accessors.c
+++ b/litex/soc/software/liblitedram/accessors.c
@@ -51,6 +51,10 @@ void sdram_rst_clock_delay(void) {
 	cdelay(100);
 }
 
+#endif // defined(SDRAM_PHY_WRITE_LEVELING_CAPABLE)
+
+#if defined(SDRAM_PHY_WRITE_LEVELING_CAPABLE) || defined(SDRAM_PHY_WRITE_DQ_DQS_TRAINING_CAPABLE)
+
 int write_dq_delay[SDRAM_PHY_MODULES];
 void write_inc_dq_delay(int module) {
 	/* Increment DQ delay */
@@ -71,10 +75,20 @@ void write_rst_dq_delay(int module) {
 #else
 	/* Reset DQ delay */
 	ddrphy_wdly_dq_rst_write(1);
+#ifdef CSR_DDRPHY_WDLY_DQ_DIR_ADDR
+	ddrphy_wdly_dq_dir_write(1);
+	for (int i = 0; i < SDRAM_PHY_DELAYS - 1; i++)
+		ddrphy_wdly_dq_inc_write(1);
+	ddrphy_wdly_dq_dir_write(0);
+#endif
 	cdelay(100);
 #endif //defined(SDRAM_PHY_USDDRPHY) || defined(SDRAM_PHY_USPDDRPHY)
 	write_dq_delay[module] = 0;
 }
+
+#endif // defined(SDRAM_PHY_WRITE_LEVELING_CAPABLE) || defined(SDRAM_PHY_WRITE_DQ_DQS_TRAINING_CAPABLE)
+
+#if defined(SDRAM_PHY_WRITE_LEVELING_CAPABLE)
 
 void write_inc_dqs_delay(int module) {
 	/* Increment DQS delay */

--- a/litex/soc/software/liblitedram/accessors.c
+++ b/litex/soc/software/liblitedram/accessors.c
@@ -21,6 +21,13 @@ void read_rst_dq_delay(int module) {
 	/* Reset delay */
 	read_dq_delay[module] = 0;
 	ddrphy_rdly_dq_rst_write(1);
+#ifdef CSR_DDRPHY_RDLY_DQ_DIR_ADDR
+	/* GW5 resets to the DLL value. Move to zero before scanning all taps. */
+	ddrphy_rdly_dq_dir_write(1);
+	for (int i = 0; i < SDRAM_PHY_DELAYS - 1; i++)
+		ddrphy_rdly_dq_inc_write(1);
+	ddrphy_rdly_dq_dir_write(0);
+#endif
 }
 
 #endif // defined(SDRAM_PHY_READ_LEVELING_CAPABLE)

--- a/litex/soc/software/liblitedram/accessors.h
+++ b/litex/soc/software/liblitedram/accessors.h
@@ -34,9 +34,17 @@ extern int sdram_clock_delay;
 void sdram_inc_clock_delay(void);
 void sdram_rst_clock_delay(void);
 
+#endif // defined(SDRAM_PHY_WRITE_LEVELING_CAPABLE)
+
+#if defined(SDRAM_PHY_WRITE_LEVELING_CAPABLE) || defined(SDRAM_PHY_WRITE_DQ_DQS_TRAINING_CAPABLE)
+
 extern int write_dq_delay[SDRAM_PHY_MODULES];
 void write_inc_dq_delay(int module);
 void write_rst_dq_delay(int module);
+
+#endif // defined(SDRAM_PHY_WRITE_LEVELING_CAPABLE) || defined(SDRAM_PHY_WRITE_DQ_DQS_TRAINING_CAPABLE)
+
+#if defined(SDRAM_PHY_WRITE_LEVELING_CAPABLE)
 
 void write_inc_dqs_delay(int module);
 void write_rst_dqs_delay(int module);

--- a/litex/soc/software/liblitedram/sdram.c
+++ b/litex/soc/software/liblitedram/sdram.c
@@ -579,7 +579,7 @@ static int run_test_pattern(int module, int dq_line) {
 /* Locate the largest passing delay window for the current bitslip and program
  * the delay to its center. Two consecutive passing taps are required before a
  * window is trusted, since single-edge taps can be unstable. */
-static void sdram_leveling_center_module(
+static int sdram_leveling_center_module(
 	int module, int show_short, int show_long, action_callback rst_delay,
 	action_callback inc_delay, int dq_line) {
 
@@ -681,6 +681,7 @@ static void sdram_leveling_center_module(
 			retries--;
 		}
 	}
+	return delay_min >= 0 && errors == 0;
 }
 
 /*-----------------------------------------------------------------------*/
@@ -1561,7 +1562,7 @@ static void sdram_write_latency_calibration(void) {
 
 /* Write DQ-DQS training needs reads to be usable while it moves write delays, so
  * first choose and center the best read bitslip for the current lane. */
-static void sdram_read_leveling_best_bitslip(int module, int dq_line) {
+static int sdram_read_leveling_best_bitslip(int module, int dq_line) {
 	unsigned int score;
 	int bitslip;
 	int best_bitslip = 0;
@@ -1587,7 +1588,7 @@ static void sdram_read_leveling_best_bitslip(int module, int dq_line) {
 	sdram_leveling_action(module, dq_line, read_rst_dq_bitslip);
 	for (bitslip=0; bitslip<best_bitslip; bitslip++)
 		sdram_leveling_action(module, dq_line, read_inc_dq_bitslip);
-	sdram_leveling_center_module(module, 0, 0,
+	return sdram_leveling_center_module(module, 0, 0,
 		read_rst_dq_delay, read_inc_dq_delay, dq_line);
 }
 
@@ -1597,8 +1598,19 @@ static void sdram_write_dq_dqs_training(void) {
 
 	for(module=0; module<SDRAM_PHY_MODULES; module++) {
 		for (dq_line = 0; dq_line < DQ_COUNT; dq_line++) {
-			/* Find best bitslip */
-			sdram_read_leveling_best_bitslip(module, dq_line);
+			/* Find usable reads. If writes are initially outside their valid
+			 * window, move write data before trying read leveling again. */
+			if (!sdram_read_leveling_best_bitslip(module, dq_line)) {
+				int write_step = SDRAM_PHY_DELAYS >= 32 ? SDRAM_PHY_DELAYS/32 : 1;
+				sdram_leveling_action(module, dq_line, write_rst_dq_delay);
+				for (int delay = 0; delay < SDRAM_PHY_DELAYS; delay++) {
+					if ((delay % write_step) == 0 &&
+						sdram_read_leveling_best_bitslip(module, dq_line))
+						break;
+					if (delay < SDRAM_PHY_DELAYS - 1)
+						sdram_leveling_action(module, dq_line, write_inc_dq_delay);
+				}
+			}
 			/* Center DQ-DQS window */
 			sdram_leveling_center_module(module, 1, 1,
 				write_rst_dq_delay, write_inc_dq_delay, dq_line);

--- a/test/software/test_litedram_accessors.py
+++ b/test/software/test_litedram_accessors.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: BSD-2-Clause
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("with_direction", [False, True])
+def test_read_delay_reset_and_scan(tmp_path, with_direction):
+    repo = Path(__file__).resolve().parents[2]
+    generated = tmp_path / "generated"
+    generated.mkdir()
+    (generated / "csr.h").write_text("""
+#define CSR_SDRAM_BASE 1
+#define CSR_DDRPHY_BASE 1
+void ddrphy_dly_sel_write(unsigned int value);
+void ddrphy_rdly_dq_rst_write(unsigned int value);
+void ddrphy_rdly_dq_inc_write(unsigned int value);
+void ddrphy_rdly_dq_dir_write(unsigned int value);
+void cdelay(int cycles);
+""")
+    (generated / "sdram_phy.h").write_text("""
+#define SDRAM_PHY_READ_LEVELING_CAPABLE
+#define SDRAM_PHY_GW5DDRPHY
+#define SDRAM_PHY_MODULES 2
+#define SDRAM_PHY_DELAYS 256
+""")
+    source = tmp_path / "delay.c"
+    source.write_text(r'''
+#include <assert.h>
+#include <liblitedram/accessors.h>
+
+static unsigned int selected, direction, dll_value;
+static int delay[2];
+
+void ddrphy_dly_sel_write(unsigned int value) { selected = value; }
+void cdelay(int cycles) { }
+void ddrphy_rdly_dq_dir_write(unsigned int value) { direction = value; }
+void ddrphy_rdly_dq_rst_write(unsigned int value) {
+    for (int lane = 0; lane < 2; lane++) {
+        if (selected & (1 << lane)) {
+#ifdef MODEL_HAS_DIRECTION
+            delay[lane] = dll_value;
+#else
+            delay[lane] = 0;
+#endif
+        }
+    }
+}
+void ddrphy_rdly_dq_inc_write(unsigned int value) {
+    for (int lane = 0; lane < 2; lane++) {
+        if (selected & (1 << lane)) {
+            if (direction && delay[lane] > 0)
+                delay[lane]--;
+            if (!direction && delay[lane] < 255)
+                delay[lane]++;
+        }
+    }
+}
+
+int main(void) {
+    for (dll_value = 0; dll_value < 256; dll_value++) {
+        for (int lane = 0; lane < 2; lane++) {
+            delay[1 - lane] = 123;
+            sdram_leveling_action(lane, 0, read_rst_dq_delay);
+            assert(direction == 0);
+            for (int tap = 0; tap < 256; tap++) {
+                assert(read_dq_delay[lane] == tap);
+                assert(delay[lane] == tap);
+                assert(delay[1 - lane] == 123);
+                if (tap < 255)
+                    sdram_leveling_action(lane, 0, read_inc_dq_delay);
+            }
+        }
+    }
+    return 0;
+}
+''')
+    binary = tmp_path / "delay"
+    flags = ["-DCSR_DDRPHY_RDLY_DQ_DIR_ADDR=1", "-DMODEL_HAS_DIRECTION=1"] if with_direction else []
+    subprocess.check_call([
+        "gcc", "-std=gnu99", "-Wall", "-Werror", *flags,
+        f"-I{tmp_path}", f"-I{repo}/litex/soc/software", str(source),
+        str(repo / "litex/soc/software/liblitedram/accessors.c"), "-o", str(binary),
+    ])
+    subprocess.check_call([str(binary)])

--- a/test/software/test_litedram_accessors.py
+++ b/test/software/test_litedram_accessors.py
@@ -7,27 +7,39 @@ import pytest
 
 
 @pytest.mark.parametrize("with_direction", [False, True])
-def test_read_delay_reset_and_scan(tmp_path, with_direction):
+@pytest.mark.parametrize("write", [False, True])
+def test_delay_reset_and_scan(tmp_path, with_direction, write):
     repo = Path(__file__).resolve().parents[2]
+    prefix = "write" if write else "read"
+    csr = "wdly" if write else "rdly"
+    capability = "WRITE_DQ_DQS_TRAINING" if write else "READ_LEVELING"
+    direction_macro = f"CSR_DDRPHY_{csr.upper()}_DQ_DIR_ADDR"
     generated = tmp_path / "generated"
     generated.mkdir()
-    (generated / "csr.h").write_text("""
+    (generated / "csr.h").write_text(f"""
 #define CSR_SDRAM_BASE 1
 #define CSR_DDRPHY_BASE 1
 void ddrphy_dly_sel_write(unsigned int value);
-void ddrphy_rdly_dq_rst_write(unsigned int value);
-void ddrphy_rdly_dq_inc_write(unsigned int value);
-void ddrphy_rdly_dq_dir_write(unsigned int value);
+void ddrphy_{csr}_dq_rst_write(unsigned int value);
+void ddrphy_{csr}_dq_inc_write(unsigned int value);
+void ddrphy_{csr}_dq_dir_write(unsigned int value);
 void cdelay(int cycles);
 """)
-    (generated / "sdram_phy.h").write_text("""
-#define SDRAM_PHY_READ_LEVELING_CAPABLE
+    (generated / "sdram_phy.h").write_text(f"""
+#define SDRAM_PHY_{capability}_CAPABLE
 #define SDRAM_PHY_GW5DDRPHY
 #define SDRAM_PHY_MODULES 2
 #define SDRAM_PHY_DELAYS 256
 """)
     source = tmp_path / "delay.c"
-    source.write_text(r'''
+    source.write_text(f"""
+#define phy_set_direction ddrphy_{csr}_dq_dir_write
+#define phy_reset_delay ddrphy_{csr}_dq_rst_write
+#define phy_inc_delay ddrphy_{csr}_dq_inc_write
+#define reset_delay {prefix}_rst_dq_delay
+#define inc_delay {prefix}_inc_dq_delay
+#define software_delay {prefix}_dq_delay
+""" + r'''
 #include <assert.h>
 #include <liblitedram/accessors.h>
 
@@ -36,8 +48,8 @@ static int delay[2];
 
 void ddrphy_dly_sel_write(unsigned int value) { selected = value; }
 void cdelay(int cycles) { }
-void ddrphy_rdly_dq_dir_write(unsigned int value) { direction = value; }
-void ddrphy_rdly_dq_rst_write(unsigned int value) {
+void phy_set_direction(unsigned int value) { direction = value; }
+void phy_reset_delay(unsigned int value) {
     for (int lane = 0; lane < 2; lane++) {
         if (selected & (1 << lane)) {
 #ifdef MODEL_HAS_DIRECTION
@@ -48,7 +60,7 @@ void ddrphy_rdly_dq_rst_write(unsigned int value) {
         }
     }
 }
-void ddrphy_rdly_dq_inc_write(unsigned int value) {
+void phy_inc_delay(unsigned int value) {
     for (int lane = 0; lane < 2; lane++) {
         if (selected & (1 << lane)) {
             if (direction && delay[lane] > 0)
@@ -63,14 +75,14 @@ int main(void) {
     for (dll_value = 0; dll_value < 256; dll_value++) {
         for (int lane = 0; lane < 2; lane++) {
             delay[1 - lane] = 123;
-            sdram_leveling_action(lane, 0, read_rst_dq_delay);
+            sdram_leveling_action(lane, 0, reset_delay);
             assert(direction == 0);
             for (int tap = 0; tap < 256; tap++) {
-                assert(read_dq_delay[lane] == tap);
+                assert(software_delay[lane] == tap);
                 assert(delay[lane] == tap);
                 assert(delay[1 - lane] == 123);
                 if (tap < 255)
-                    sdram_leveling_action(lane, 0, read_inc_dq_delay);
+                    sdram_leveling_action(lane, 0, inc_delay);
             }
         }
     }
@@ -78,7 +90,7 @@ int main(void) {
 }
 ''')
     binary = tmp_path / "delay"
-    flags = ["-DCSR_DDRPHY_RDLY_DQ_DIR_ADDR=1", "-DMODEL_HAS_DIRECTION=1"] if with_direction else []
+    flags = [f"-D{direction_macro}=1", "-DMODEL_HAS_DIRECTION=1"] if with_direction else []
     subprocess.check_call([
         "gcc", "-std=gnu99", "-Wall", "-Werror", *flags,
         f"-I{tmp_path}", f"-I{repo}/litex/soc/software", str(source),


### PR DESCRIPTION
Gowin5 delay reset loads the DLL-derived tap count, and the delay counters saturate rather than wrap. The previous read-leveling loop could reach an endpoint and repeatedly test the same physical delay, making results such as `63+-63` misleading.

Home the read delay to physical zero before scanning when the PHY exposes its direction CSR. Do the same for the new write-delay control. Keep the legacy reset path for PHYs without these CSRs.

DLL-on quarter-rate operation also needs write DQ training. Make its DQ accessors available independently of write leveling, and let training search for a usable initial write delay when read calibration fails. Once reads work, retain the existing full write-window centering and final read leveling. The centering helper now returns whether its selected center actually passes.

Companion PHY: https://github.com/enjoy-digital/litedram/pull/403. Merge this PR before enabling the new PHY controls. Generated-clock support is separate: https://github.com/enjoy-digital/litex/pull/2577.

Validation: compiled C accessor tests cover all 256 DLL starting values, both byte lanes and every physical tap, for read/write controls and the legacy interface (4 tests). On the connected Console 60K, the integrated changes pass repeated BIOS/controller checks at 83⅓ MHz system clock, 1:4, DLL enabled. A full `mem_test 0x40000000 0x20000000` writes and verifies all 512 MiB with zero errors and no read retries. 100 MHz remains intermittent and is not qualified. A full-range pass at low frequency still means the available delay range lies inside the passing window; it does not establish margins beyond that range.
