### PR TITLE
cores/icap: allow a synchronous externally generated clock

### DIFF
--- a/litex/soc/cores/icap.py
+++ b/litex/soc/cores/icap.py
@@ -80,7 +80,8 @@ class ICAP(LiteXModule):
 
     A warm boot can for example be triggered by writing IPROG CMD (0xf) to CMD register (0b100).
     """
-    def __init__(self, with_csr=True, clk_divider=16, primitive="ICAPE2", simulation=False):
+    def __init__(self, with_csr=True, clk_divider=16, primitive="ICAPE2", simulation=False,
+                 external_clock=None):
         self.write      = Signal()
         self.read       = Signal()
         self.done       = Signal()
@@ -98,9 +99,14 @@ class ICAP(LiteXModule):
 
         # Create slow ICAP Clk.
         self.cd_icap = ClockDomain()
-        icap_clk_counter = Signal(int(math.log2(clk_divider)))
-        self.sync += icap_clk_counter.eq(icap_clk_counter + 1)
-        self.sync += self.cd_icap.clk.eq(icap_clk_counter[-1])
+        if external_clock is None:
+            icap_clk_counter = Signal(int(math.log2(clk_divider)))
+            self.sync += icap_clk_counter.eq(icap_clk_counter + 1)
+            self.sync += self.cd_icap.clk.eq(icap_clk_counter[-1])
+        else:
+            # The caller supplies a slow clock synchronous to sys (for example
+            # another MMCM output) and retains timing checks on CSR crossings.
+            self.comb += self.cd_icap.clk.eq(external_clock)
 
         # Generate ICAP bitstream sequence.
         self._csib  = _csib  = Signal(reset=1)

--- a/test/cores/test_icap_clock.py
+++ b/test/cores/test_icap_clock.py
@@ -1,0 +1,55 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import ClockDomain, ClockSignal, Module, Signal, run_simulation
+from litex.soc.cores.icap import ICAP, ICAPCMDs, ICAPRegisters, ICAP_SYNC
+
+
+class TestICAPClock(unittest.TestCase):
+    def test_external_clock_removes_fabric_divider(self):
+        external = Signal()
+        dut = ICAP(with_csr=False, simulation=True, external_clock=external)
+        fragment = dut.get_fragment()
+        self.assertFalse(fragment.sync.get("sys", []))
+        self.assertTrue(any(getattr(statement, "l", None) is dut.cd_icap.clk and
+                            getattr(statement, "r", None) is external
+                            for statement in fragment.comb))
+        default = ICAP(with_csr=False, simulation=True).get_fragment()
+        self.assertEqual(len(default.sync["sys"]), 2)
+
+    def test_command_sequence_with_both_clock_sources(self):
+        captures = []
+        for external in (False, True):
+            class DUT(Module):
+                def __init__(self):
+                    self.clock_domains.cd_input = ClockDomain("input")
+                    self.submodules.icap = ICAP(with_csr=False, simulation=True,
+                        external_clock=ClockSignal("input") if external else None)
+            dut = DUT()
+            words = []
+
+            def stimulus():
+                yield dut.icap.addr.eq(ICAPRegisters.CMD)
+                yield dut.icap.write_data.eq(ICAPCMDs.IPROG)
+                yield dut.icap.write.eq(1)
+                for _ in range(400):
+                    yield
+                self.assertEqual((yield dut.icap.done), 1)
+
+            def monitor():
+                for _ in range(24):
+                    if not (yield dut.icap._csib):
+                        words.append((yield dut.icap._i))
+                    yield
+
+            run_simulation(dut, {"sys": stimulus(), "icap": monitor()},
+                           clocks={"sys": 10, "icap": 160, "input": 160})
+            self.assertIn(ICAP_SYNC, words)
+            self.assertIn(ICAPCMDs.IPROG, words)
+            captures.append(words)
+        self.assertEqual(captures[0], captures[1])


### PR DESCRIPTION
## Summary

Allow `ICAP` to use a caller-provided slow clock through an optional
`external_clock` constructor argument. This lets a design use another output of
the system MMCM/PLL instead of a fabric-divided clock for the ICAP primitive and
command state machine.

The existing divider remains the default. The CSR interface, command sequence,
and supported primitives are unchanged.

## Clock contract

The supplied clock must be slow enough for the selected ICAP primitive and
synchronous to `sys`. The caller must retain timing analysis of the existing
control/data crossings. This is not support for an unrelated asynchronous clock
and does not add a CDC handshake. A clock generated by the same MMCM as `sys`
allows these paths to be timed without declaring the domains asynchronous.

## Validation

- Structural regression checks cover the default divider and externally driven
  clock, including absence of the fabric divider in the latter case.
- Simulation compares the IPROG command sequence for both configurations.
- `PYTHONPATH=. pytest -q test/cores/test_icap_clock.py test/cores/test_icap.py test/cores/test_clock.py test/interconnect/test_csr.py --tb=short`
  passes: **80 tests and 87 subtests**.
