### PR TITLE
cores/video: Reuse GTP HDMI encoding for UltraScale+ GTH transmitters

### DIFF
--- a/litex/soc/cores/video.py
+++ b/litex/soc/cores/video.py
@@ -1445,8 +1445,47 @@ class VideoS7HDMIPHY(LiteXModule):
             self.specials += Instance("OBUFDS", i_I=pad_o, o_O=pad_p, o_OB=pad_n)
 
 
+class VideoGTHDMILane(LiteXModule):
+    """TMDS encoder and 20-bit gearbox for a transceiver HDMI data lane.
+
+    The TX clock must run at half the pixel clock frequency, from the same reference.
+    The source is consumed continuously; video cannot be backpressured.
+    """
+    def __init__(self, clock_domain, tx_clock_domain):
+        self.d      = Signal(8)
+        self.c      = Signal(2)
+        self.de     = Signal()
+        self.source = source = stream.Endpoint([("data", 20)])
+
+        # # #
+
+        # TMDS Encoding.
+        self.encoder = encoder = ClockDomainsRenamer(clock_domain)(TMDSEncoder())
+        self.comb += [
+            encoder.d.eq(self.d),
+            encoder.c.eq(self.c),
+            encoder.de.eq(self.de),
+        ]
+
+        # 10:20 (transceivers have a minimum 20-bit datapath).
+        self.converter = converter = ClockDomainsRenamer(clock_domain)(stream.Converter(10, 20))
+        self.comb += [
+            converter.sink.valid.eq(1),
+            converter.sink.data.eq(encoder.out),
+        ]
+
+        # Clock Domain Crossing (pixel clock --> TX word clock).
+        self.cdc = cdc = stream.ClockDomainCrossing(
+            [("data", 20)], cd_from=clock_domain, cd_to=tx_clock_domain)
+        self.comb += [
+            converter.source.connect(cdc.sink),
+            cdc.source.connect(source),
+        ]
+
+
 class VideoS7GTPHDMIPHY(LiteXModule):
-    def __init__(self, pads, sys_clk_freq, clock_domain="sys", clk_freq=148.5e6, refclk=None):
+    def __init__(self, pads, sys_clk_freq, clock_domain="sys", clk_freq=148.5e6, refclk=None,
+        refclk_freq=None, tx_polarity=1):
         assert sys_clk_freq >= clk_freq
         self.sink = sink = stream.Endpoint(video_data_layout)
 
@@ -1476,28 +1515,19 @@ class VideoS7GTPHDMIPHY(LiteXModule):
                 o_O   = refclk_se
             )
             refclk = refclk_se
-        self.pll = pll = GTPQuadPLL(refclk, clk_freq, 1.485e9)
+        self.pll = pll = GTPQuadPLL(refclk, refclk_freq or clk_freq, 10*clk_freq)
 
         # Encode/Serialize Datas.
         for color, channel in _dvi_c2d.items():
-            # TMDS Encoding.
-            encoder = ClockDomainsRenamer(clock_domain)(TMDSEncoder())
-            self.submodules += encoder
-            self.comb += encoder.d.eq(getattr(sink, color))
-            self.comb += encoder.c.eq(Cat(sink.hsync, sink.vsync) if channel == 0 else 0)
-            self.comb += encoder.de.eq(sink.de)
-
-            # 10:20 (SerDes has a minimal 20:1 Serialization ratio).
-            converter = ClockDomainsRenamer(clock_domain)(stream.Converter(10, 20))
-            self.submodules += converter
-            self.comb += converter.sink.valid.eq(1)
-            self.comb += converter.sink.data.eq(encoder.out)
-
-            # Clock Domain Crossing (video_clk --> gtp_tx)
-            cdc = stream.ClockDomainCrossing([("data", 20)], cd_from=clock_domain, cd_to=f"gtp{color}_tx")
-            self.submodules += cdc
-            self.comb += converter.source.connect(cdc.sink)
-            self.comb += cdc.source.ready.eq(1) # No backpressure.
+            # TMDS Encoding / Gearbox / Clock Domain Crossing.
+            lane = VideoGTHDMILane(clock_domain, f"gtp{color}_tx")
+            self.submodules += lane
+            self.comb += [
+                lane.d.eq(getattr(sink, color)),
+                lane.c.eq(Cat(sink.hsync, sink.vsync) if channel == 0 else 0),
+                lane.de.eq(sink.de),
+                lane.source.ready.eq(1),
+            ]
 
             # 20:1 Serialization + Differential Signaling.
             class GTPPads:
@@ -1508,11 +1538,86 @@ class VideoS7GTPHDMIPHY(LiteXModule):
             # FIXME: Find a way to avoid RX pads.
             rx_pads = GTPPads(p=getattr(pads, f"rx{channel}_p"),    n=getattr(pads, f"rx{channel}_n"))
             gtp = GTP(pll, tx_pads, rx_pads=rx_pads, sys_clk_freq=sys_clk_freq,
-                tx_polarity      = 1, # FIXME: Specific to Decklink Mini 4K, make it configurable.
+                qpll_reset       = (channel == 0),
+                tx_polarity      = tx_polarity,
                 tx_buffer_enable = True,
                 rx_buffer_enable = True,
                 clock_aligner    = False
             )
             setattr(self.submodules, f"gtp{color}", gtp)
             self.comb += gtp.tx_produce_pattern.eq(1)
-            self.comb += gtp.tx_pattern.eq(cdc.source.data)
+            self.comb += gtp.tx_pattern.eq(lane.source.data)
+
+
+class VideoUSPGTHHDMIPHY(LiteXModule):
+    """DVI-compatible video over four UltraScale+ GTH transmitters.
+
+    The three data lanes and the clock lane must occupy one GTH quad. A dedicated
+    GTH reference clock is required: refclk is the O output of an IBUFDS_GTE4.
+    The pixel clock must derive from the same reference. The board supplies the
+    external AC-coupled TMDS to HDMI level shifter.
+    """
+    def __init__(self, pads, sys_clk_freq, refclk, refclk_freq,
+        clock_domain="sys", clk_freq=74.25e6, tx_polarity=0):
+        self.sink  = sink = stream.Endpoint(video_data_layout)
+        self.ready = Signal()
+
+        # # #
+
+        from liteiclink.serdes.gth4_ultrascale import GTH4QuadPLL, GTH4
+
+        # Always ack Sink, no backpressure.
+        self.comb += sink.ready.eq(1)
+
+        # GTH Quad PLL.
+        self.pll = pll = GTH4QuadPLL(refclk, refclk_freq, 10*clk_freq)
+
+        # Four serializers, with one PLL reset owner and a shared TX word clock.
+        gths = []
+        for name, channel in [("clk", None), *list(_dvi_c2d.items())]:
+            tx_pads = Record([("p", 1), ("n", 1)])
+            tx_pads.p = getattr(pads, "clk_p" if channel is None else f"data{channel}_p")
+            tx_pads.n = getattr(pads, "clk_n" if channel is None else f"data{channel}_n")
+            rx_pads = Record([("p", 1), ("n", 1)])
+            rx_pads.p = Constant(0)
+            rx_pads.n = Constant(0)
+            gth = GTH4(pll, tx_pads, rx_pads, sys_clk_freq,
+                tx_clk           = gths[0].cd_tx.clk if gths else None,
+                rx_clk           = ClockSignal("sys"),
+                tx_buffer_enable = True,
+                rx_buffer_enable = True,
+                clock_aligner    = False,
+                tx_polarity      = tx_polarity,
+                pll_master       = (channel is None),
+            )
+            setattr(self, f"gth{name}", gth)
+            gths.append(gth)
+            self.comb += gth.rx_enable.eq(0)
+
+            # Feed the TX datapath directly: tx_pattern is a control-domain signal in LiteICLink.
+            # These words already cross into the shared TX clock domain through the lane FIFOs.
+            data = Signal(20)
+            gth.gth_params.update(
+                i_RXPD    = 0b11,
+                i_TXDATA  = Cat(data[0:8], data[10:18]),
+                i_TXCTRL0 = Cat(data[8], data[18]),
+                i_TXCTRL1 = Cat(data[9], data[19]),
+            )
+
+            # Clock: two periods per 20-bit word, five high and five low bits per pixel.
+            if channel is None:
+                self.comb += data.eq(0b00000111110000011111)
+
+            # Data: use the same gearbox and CDC as the 7-Series GTP PHY.
+            else:
+                lane = VideoGTHDMILane(clock_domain, "gthclk_tx")
+                self.submodules += lane
+                self.comb += [
+                    lane.d.eq(getattr(sink, name)),
+                    lane.c.eq(Cat(sink.hsync, sink.vsync) if channel == 0 else 0),
+                    lane.de.eq(sink.de),
+                    lane.source.ready.eq(1),
+                    data.eq(lane.source.data),
+                ]
+
+        self.comb += self.ready.eq(Cat(*[gth.tx_ready for gth in gths]) == 0b1111)

--- a/test/cores/test_video_gt_hdmi.py
+++ b/test/cores/test_video_gt_hdmi.py
@@ -1,0 +1,128 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import random
+import unittest
+import importlib.util
+
+from migen import Instance, Module, Record, Signal, passive, run_simulation
+from migen.fhdl.structure import _Assign
+
+from litex.soc.cores.video import VideoGTHDMILane, VideoS7GTPHDMIPHY, VideoUSPGTHHDMIPHY
+
+from test.cores.test_code_tmds import tmds_encode
+
+# Tests --------------------------------------------------------------------------------------------
+
+class TestVideoGTHDMI(unittest.TestCase):
+    def test_lane(self):
+        # Exercise changing data/control symbols across several TX clock phases. Check every
+        # symbol, including its order within a 20-bit word, against the independent TMDS model.
+        prng = random.Random(42)
+        items = [(0, 0, 0)]*20
+        items += [(prng.randrange(256), n % 4, int(n % 29 >= 4)) for n in range(1024)]
+        expected = []
+        disparity = 0
+        for data, ctrl, de in items:
+            encoded, disparity = tmds_encode(data, ctrl, de, disparity)
+            expected.append(encoded)
+
+        for phase in [1, 7, 13, 19]:
+            with self.subTest(phase=phase):
+                dut = VideoGTHDMILane("video", "tx")
+                received = []
+
+                def send():
+                    yield dut.source.ready.eq(1)
+                    for data, ctrl, de in items:
+                        yield dut.d.eq(data)
+                        yield dut.c.eq(ctrl)
+                        yield dut.de.eq(de)
+                        yield
+                    for _ in range(40):
+                        yield
+
+                @passive
+                def receive():
+                    while True:
+                        if (yield dut.source.valid):
+                            word = yield dut.source.data
+                            received.extend([word & 0x3ff, word >> 10])
+                        yield
+
+                run_simulation(dut, {"video": send(), "tx": receive()},
+                    clocks={"video": 10, "tx": (20, phase)})
+                # Ignore startup latency, then require the complete sequence without drops/repeats.
+                start = next(n for n in range(40) if received[n:n+8] == expected[20:28])
+                self.assertEqual(received[start:start+len(items)-20], expected[20:])
+
+    @unittest.skipUnless(importlib.util.find_spec("liteiclink"), "LiteICLink is required")
+    def test_gtp_clocking(self):
+        layout = [(f"{name}_{polarity}", 1)
+            for name in ["clk", "data0", "data1", "data2", "rx0", "rx1", "rx2"]
+            for polarity in ["p", "n"]]
+        for pixel_clk_freq, refclk_freq, polarity in [(148.5e6, 148.5e6, 1), (74.25e6, 148.5e6, 0)]:
+            with self.subTest(pixel_clk_freq=pixel_clk_freq, polarity=polarity):
+                dut = VideoS7GTPHDMIPHY(Record(layout), 148.5e6,
+                    clk_freq    = pixel_clk_freq,
+                    refclk      = Signal(),
+                    refclk_freq = refclk_freq,
+                    tx_polarity = polarity,
+                )
+                self.assertEqual(dut.pll.config["linerate"], 10*pixel_clk_freq)
+                for color in ["r", "g", "b"]:
+                    self.assertEqual(getattr(dut, f"gtp{color}").gtp_params["i_TXPOLARITY"], polarity)
+                fragment = dut.get_fragment()
+                drivers = [stmt for stmt in fragment.comb
+                    if isinstance(stmt, _Assign) and stmt.l is dut.pll.reset]
+                self.assertEqual(len(drivers), 1)
+
+    @unittest.skipUnless(importlib.util.find_spec("liteiclink"), "LiteICLink is required")
+    def test_gth_clock_lane(self):
+        layout = [(f"{name}_{polarity}", 1)
+            for name in ["clk", "data0", "data1", "data2"] for polarity in ["p", "n"]]
+        for pixel_clk_freq in [74.25e6, 148.5e6]:
+            with self.subTest(pixel_clk_freq=pixel_clk_freq):
+                dut = VideoUSPGTHHDMIPHY(Record(layout), 100e6, Signal(), 148.5e6,
+                    clock_domain = "video",
+                    clk_freq     = pixel_clk_freq,
+                )
+                self.assertEqual(dut.pll.config["linerate"], 10*pixel_clk_freq)
+                for color in ["r", "g", "b"]:
+                    gth = getattr(dut, f"gth{color}")
+                    self.assertIs(gth.cd_tx.clk, dut.gthclk.cd_tx.clk)
+                    self.assertEqual(gth.gth_params["i_RXPD"], 0b11)
+
+                # Reconstruct the serial clock from the primitive's raw TX data/control inputs.
+                # There must be two complete 50% duty-cycle pixel clocks in each TX word.
+                probe = Module()
+                probe.comb += dut._fragment.comb
+                params = dut.gthclk.gth_params
+
+                def check_clock():
+                    yield
+                    data  = yield params["i_TXDATA"]
+                    ctrl0 = yield params["i_TXCTRL0"]
+                    ctrl1 = yield params["i_TXCTRL1"]
+                    bits = []
+                    for n in range(2):
+                        symbol = ((data >> (8*n)) & 0xff)
+                        symbol |= ((ctrl0 >> n) & 1) << 8
+                        symbol |= ((ctrl1 >> n) & 1) << 9
+                        bits.extend((symbol >> bit) & 1 for bit in range(10))
+                    self.assertEqual(bits, ([1]*5 + [0]*5)*2)
+
+                run_simulation(probe, check_clock())
+                fragment = dut.get_fragment()
+                self.assertEqual(sum(isinstance(s, Instance) and s.of == "GTHE4_CHANNEL"
+                    for s in fragment.specials), 4)
+                drivers = [stmt for stmt in fragment.comb
+                    if isinstance(stmt, _Assign) and stmt.l is dut.pll.reset]
+                self.assertEqual(len(drivers), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add a four-lane UltraScale+ GTH PHY for DVI-compatible video through an external TMDS level shifter, used by the ModRetro M64 in https://github.com/litex-hub/litex-boards/pull/790.

Extract the existing DeckLink GTP PHY's TMDS encoder, 10-to-20-bit gearbox and clock-domain crossing into `VideoGTHDMILane`, shared by both PHYs. The GTP PHY now derives its line rate from the pixel clock, accepts a separate reference frequency and configurable polarity, and gives one channel ownership of the shared PLL reset. Existing defaults retain DeckLink's 1080p60 configuration and inverted data polarity.

`VideoUSPGTHHDMIPHY` uses LiteICLink's GTH4/QPLL support. Three transmitters carry RGB and the fourth sends two pixel-clock periods per 20-bit word. All four share the TX word clock and one PLL reset owner; unused receivers are powered down. TMDS words feed the raw TX inputs after their FIFO crossing, avoiding the control-domain synchronizers on LiteICLink's `tx_pattern` input. The caller supplies a dedicated, buffered GTH reference and a pixel clock derived from the same source.

Validation:

- Eight tests pass for the shared gearbox, TMDS encoder and colorbars. The new tests check symbol order against the independent TMDS model across four clock phases, GTP line rate/polarity/reset ownership, and the GTH clock pattern, shared clock and reset ownership.
- DeckLink Mini 4K 1080p60 terminal gateware generation passes.
- M64 720p60 colorbars with all four PSRAMs completes BIOS compilation and Vivado 2024.1 synthesis, placement, routing and bitstream generation. Setup slack is +0.933ns; hold slack is +0.012ns. No unclocked registers or unconstrained internal endpoints. All 60 RGB transmitter input bits have timed, passing paths in the routed checkpoint.
- The routed M64 build uses four GTHE4_CHANNELs, one GTHE4_COMMON and the dedicated reference-clock input, without relaxing transceiver placement/clocking DRCs. DRC warnings concern VexRiscv DSP pipelining and unused LiteICLink monitoring/control nets.

No M64 hardware testing has been performed. The build assumes a 148.5MHz reference; the target requires its actual frequency explicitly because the M64 clock-generator configuration is not documented. Clock-generator and retimer controls stay in the board target.
