### PR TITLE
build/gowin: support generated clock constraints

### DIFF
--- a/litex/build/gowin/gowin.py
+++ b/litex/build/gowin/gowin.py
@@ -144,6 +144,7 @@ class GowinToolchain(GenericToolchain):
         self.options = {}
         self.additional_cst_commands = []
         self.additional_tcl_commands = []
+        self.generated_clocks = []
 
     def finalize(self):
         if self.platform.verilog_include_paths:
@@ -204,21 +205,29 @@ class GowinToolchain(GenericToolchain):
 
     def build_timing_constraints(self, vns):
         sdc = []
+        def clock_object(clk):
+            name = vns.get_name(clk)
+            kind = "ports" if any(sig == name for sig, _, _, _ in self.named_sc) else "nets"
+            return f"[get_{kind} {{{name}}}]"
+
         for clk, [period, name] in sorted(self.clocks.items(), key=lambda x: x[0].duid):
-            clk_sig = self._vns.get_name(clk)
             if name is None:
-                name = clk_sig
-            # Constrain IO clocks with get_ports and internal clocks (ex: PLL outputs) with get_nets.
-            is_port = False
-            for sig, pins, others, resname in self.named_sc:
-                if sig == clk_sig:
-                    is_port = True
-            if is_port:
-                sdc.append(f"create_clock -name {name} -period {str(period)} [get_ports {{{clk_sig}}}]")
-            else:
-                sdc.append(f"create_clock -name {name} -period {str(period)} [get_nets {{{clk_sig}}}]")
+                name = vns.get_name(clk)
+            sdc.append(f"create_clock -name {name} -period {period} {clock_object(clk)}")
+        for clk, source, divide_by, multiply_by, name in self.generated_clocks:
+            name = vns.get_name(clk) if name is None else name
+            sdc.append(f"create_generated_clock -name {name} -source {clock_object(source)} "
+                f"-divide_by {divide_by} -multiply_by {multiply_by} {clock_object(clk)}")
         tools.write_to_file(f"{self._build_name}.sdc", "\n".join(sdc))
         return (f"{self._build_name}.sdc", "SDC")
+
+    def add_generated_clock_constraint(self, clk, source, divide_by=1, multiply_by=1, name=None):
+        # Add parent clocks before their derived clocks.
+        if any(not isinstance(factor, int) or factor < 1 for factor in (divide_by, multiply_by)):
+            raise ValueError("Generated clock factors must be positive integers.")
+        clk.attr.add("keep")
+        source.attr.add("keep")
+        self.generated_clocks.append((clk, source, divide_by, multiply_by, name))
 
     # Project (tcl) --------------------------------------------------------------------------------
 

--- a/litex/build/gowin/platform.py
+++ b/litex/build/gowin/platform.py
@@ -49,3 +49,7 @@ class GowinPlatform(GenericPlatform):
 
     def add_false_path_constraint(self, from_, to):
         pass
+
+    def add_generated_clock_constraint(self, clk, source, divide_by=1, multiply_by=1, name=None):
+        self.toolchain.add_generated_clock_constraint(clk, source,
+            divide_by=divide_by, multiply_by=multiply_by, name=name)

--- a/test/build/test_gowin_toolchain.py
+++ b/test/build/test_gowin_toolchain.py
@@ -9,7 +9,7 @@ import tempfile
 import unittest
 from unittest import mock
 
-from migen import ClockDomain
+from migen import ClockDomain, Instance
 
 from litex.gen import LiteXModule
 from litex.build.generic_platform import IOStandard, Pins
@@ -61,6 +61,34 @@ class TestGowinToolchain(unittest.TestCase):
                     self.assertIn('IO_LOC "dqs_p[0]" Y3,AA3;', cst)
                     self.assertIn('IO_LOC "dqs_p[1]" V9,V8;', cst)
                     self.assertNotIn('IO_LOC "dqs_n', cst)
+
+    def test_generated_clock_chain(self):
+        platform = GowinPlatform("GW5AT-LV60PG484AC1/I0",
+            io=[("clk50", 0, Pins("A1"))], devicename="GW5AT-60B")
+        dut = LiteXModule()
+        dut.cd_sys = ClockDomain("sys")
+        dut.cd_fast = ClockDomain("fast")
+        clk50 = platform.request("clk50")
+        dut.specials += Instance("PLLA", i_CLKIN=clk50, o_CLKOUT0=dut.cd_fast.clk)
+        dut.specials += Instance("CLKDIV", p_DIV_MODE="4",
+            i_HCLKIN=dut.cd_fast.clk, i_RESETN=1, i_CALIB=0, o_CLKOUT=dut.cd_sys.clk)
+        platform.add_period_constraint(clk50, 20)
+        platform.add_generated_clock_constraint(dut.cd_fast.clk, clk50,
+            multiply_by=20, divide_by=3, name="ddr_clk")
+        platform.add_generated_clock_constraint(dut.cd_sys.clk, dut.cd_fast.clk, divide_by=4)
+
+        with tempfile.TemporaryDirectory() as build_dir:
+            platform.build(dut, build_dir=build_dir, build_name="top", run=False)
+            with open(os.path.join(build_dir, "top.sdc")) as f:
+                sdc = f.read().splitlines()
+
+        self.assertEqual(sdc, [
+            "create_clock -name clk50 -period 20.0 [get_ports {clk50}]",
+            "create_generated_clock -name ddr_clk -source [get_ports {clk50}] "
+            "-divide_by 3 -multiply_by 20 [get_nets {fast_clk}]",
+            "create_generated_clock -name sys_clk -source [get_nets {fast_clk}] "
+            "-divide_by 4 -multiply_by 1 [get_nets {sys_clk}]",
+        ])
 
     def test_apicula_uses_generated_system_clock_target(self):
         platform = _ApiculaPlatform()


### PR DESCRIPTION
Gowin5 DDR3 targets derive `sys` from a PLL output through a gated `CLKDIV`. Explicit generated clocks preserve that relationship during placement and timing analysis; treating `sys` as an independent clock loses the relationship to the memory clock.

Add `GowinPlatform.add_generated_clock_constraint(clk, source, divide_by=1, multiply_by=1, name=None)`. Emit the constraints after base clocks, in registration order, resolving signal names through the Verilog namespace. This supports the input → PLL → CLKDIV chain without hardcoding primitive instance names. Source and target should be the driven clock nets, since synthesis can remove aliases.

Validation: 8 Gowin toolchain tests and 4 subtests pass, including an elaborated two-stage generated-clock chain. Full Gowin 1.9.12 builds pass for the Tang Console 60K/138K, Mega 138K and Mega 138K Pro with the companion target changes in https://github.com/litex-hub/litex-boards/pull/791. The Console 60K at 83⅓ MHz reports no setup/hold violations within the system and memory clock domains; startup/delay-control crossings remain visible, so this is not a claim of complete timing closure.
