### PR TITLE
soc/cores/clock/gowin_gw5a: select PLL limits and primitive by density.

### DIFF
--- a/litex/soc/cores/clock/gowin_gw5a.py
+++ b/litex/soc/cores/clock/gowin_gw5a.py
@@ -5,6 +5,8 @@
 # Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
+import re
+
 from migen import *
 
 from litex.gen import *
@@ -32,24 +34,36 @@ class GW5APLL(LiteXModule):
         self.clkouts    = {}
         self.config     = {}
         self.params     = {}
-        self.vco_freq_range = self.get_vco_freq_range(device)
-        self.pfd_freq_range = self.get_pfd_freq_range(device)
+        self.primitive      = self.get_primitive(devicename)
+        self.vco_freq_range = self.get_vco_freq_range(devicename)
+        self.pfd_freq_range = self.get_pfd_freq_range(devicename)
 
     @staticmethod
-    def get_vco_freq_range(device):
-        if device.startswith("GW5A-"):
-            return (800e6, 1600e6) # As restricted by Gowin toolchain 1.9.9b3.
-        elif device.startswith(("GW5AT-", "GW5AST-")):
-            return (800e6, 2000e6) # Datasheet values.
-        raise ValueError(f"Unsupported device {device}.")
+    def get_primitive(devicename):
+        # Ignore the die revision suffix (A, B, C, ES, ...).
+        device = re.sub(r"[A-Z]+$", "", devicename)
+        # Gowin UG306, Tables 5-1 and 5-11.
+        if device in ("GW5A-25", "GW5A-60", "GW5AT-15", "GW5AT-60"):
+            return "PLLA"
+        elif device in ("GW5A-138", "GW5AT-75", "GW5AT-138", "GW5AST-138"):
+            return "PLL"
+        raise ValueError(f"Unsupported device {devicename}.")
 
-    @staticmethod
-    def get_pfd_freq_range(device):
-        if device.startswith("GW5A-"):
-            return (19e6, 400e6) # As restricted by Gowin toolchain 1.9.9b3.
-        elif device.startswith(("GW5AT-", "GW5AST-")):
-            return (10e6, 400e6) # Datasheet values.
-        raise ValueError(f"Unsupported device {device}.")
+    @classmethod
+    def get_vco_freq_range(cls, devicename):
+        # Gowin UG306, section 2.3: 15K/25K/60K use PLLA, 75K/138K use PLL.
+        return {
+            "PLLA": (700e6, 1400e6),
+            "PLL":  (650e6, 1300e6),
+        }[cls.get_primitive(devicename)]
+
+    @classmethod
+    def get_pfd_freq_range(cls, devicename):
+        # PLL Switching Characteristics in Gowin DS1103, DS981 and DS1239.
+        return {
+            "PLLA": (19e6, 87.5e6),
+            "PLL":  (19e6, 81.25e6),
+        }[cls.get_primitive(devicename)]
 
     def register_clkin(self, clkin, freq):
         check_freq_positive(freq, "Input clock frequency")
@@ -228,16 +242,14 @@ class GW5APLL(LiteXModule):
             o_CLKFBOUT = Open()
         )
 
-        if self.device.startswith(("GW5A-", "GW5AT-")): # GW5A/GW5AT use PLLA.
-            primitive_name = "PLLA"
+        if self.primitive == "PLLA":
             self.params.update(
                 i_MDCLK  = 0,
                 i_MDOPC  = Constant(0, 2),
                 i_MDAINC = 0,
                 i_MDWDI  = Constant(0, 8),
             )
-        else: # GW5AST uses PLL.
-            primitive_name = "PLL"
+        else:
             self.params.update(
                 p_DYN_IDIV_SEL     = "FALSE", # Disable dynamic IDIV.
                 p_DYN_FBDIV_SEL    = "FALSE", # Disable dynamic FBDIV.
@@ -293,4 +305,4 @@ class GW5APLL(LiteXModule):
             self.params["p_CLKOUT%d_PE_COARSE" % i] = config["pe%d" % i]
             self.params["p_CLKOUT%d_PE_FINE" % i] = config["pe%d_fine" % i]
 
-        self.specials += Instance(primitive_name, name=self.name or "", **self.params)
+        self.specials += Instance(self.primitive, name=self.name or "", **self.params)

--- a/litex/soc/cores/clock/gowin_gw5a.py
+++ b/litex/soc/cores/clock/gowin_gw5a.py
@@ -37,25 +37,19 @@ class GW5APLL(LiteXModule):
 
     @staticmethod
     def get_vco_freq_range(device):
-        vco_freq_range = None
-        if device.startswith('GW5A-'):
-            vco_freq_range = (800e6, 1600e6) # As restricted by Gowin toolchain 1.9.9b3
-        elif device.startswith('GW5A-') or device.startswith('GW5AT-') or device.startswith('GW5AST-'):
-            vco_freq_range = (800e6, 2000e6) # datasheet values
-        if vco_freq_range is None:
-            raise ValueError(f"Unsupported device {device}.")
-        return vco_freq_range
+        if device.startswith("GW5A-"):
+            return (800e6, 1600e6) # As restricted by Gowin toolchain 1.9.9b3.
+        elif device.startswith(("GW5AT-", "GW5AST-")):
+            return (800e6, 2000e6) # Datasheet values.
+        raise ValueError(f"Unsupported device {device}.")
 
     @staticmethod
     def get_pfd_freq_range(device):
-        pfd_freq_range = None
-        if device.startswith('GW5A-'):
-            pfd_freq_range = (19e6, 400e6) # As restricted by Gowin toolchain 1.9.9b3
-        elif device.startswith('GW5AT-') or device.startswith('GW5AST-'):
-            pfd_freq_range = (10e6, 400e6) # datasheet values
-        if pfd_freq_range is None:
-            raise ValueError(f"Unsupported device {device}.")
-        return pfd_freq_range
+        if device.startswith("GW5A-"):
+            return (19e6, 400e6) # As restricted by Gowin toolchain 1.9.9b3.
+        elif device.startswith(("GW5AT-", "GW5AST-")):
+            return (10e6, 400e6) # Datasheet values.
+        raise ValueError(f"Unsupported device {device}.")
 
     def register_clkin(self, clkin, freq):
         check_freq_positive(freq, "Input clock frequency")
@@ -234,16 +228,16 @@ class GW5APLL(LiteXModule):
             o_CLKFBOUT = Open()
         )
 
-        if self.device.startswith('GW5A-') or self.device.startswith("GW5AT-"): # GW5A(T), uses PLLA
-            primitive_name = 'PLLA'
+        if self.device.startswith(("GW5A-", "GW5AT-")): # GW5A/GW5AT use PLLA.
+            primitive_name = "PLLA"
             self.params.update(
                 i_MDCLK  = 0,
                 i_MDOPC  = Constant(0, 2),
                 i_MDAINC = 0,
                 i_MDWDI  = Constant(0, 8),
             )
-        else: # GW5A{,S}T, uses PLL
-            primitive_name = 'PLL'
+        else: # GW5AST uses PLL.
+            primitive_name = "PLL"
             self.params.update(
                 p_DYN_IDIV_SEL     = "FALSE", # Disable dynamic IDIV.
                 p_DYN_FBDIV_SEL    = "FALSE", # Disable dynamic FBDIV.

--- a/litex/soc/cores/clock/gowin_gw5a.py
+++ b/litex/soc/cores/clock/gowin_gw5a.py
@@ -40,21 +40,15 @@ class GW5APLL(LiteXModule):
 
     @staticmethod
     def get_primitive(devicename):
-        # Ignore the die revision suffix (A, B, C, ES, ...).
-        device = re.sub(r"[A-Z]+$", "", devicename)
-        # Gowin UG306, Tables 5-1 and 5-11; DS1231, section 2.1 for 15K SiP variants.
-        if device in (
-            "GW5A-25",   "GW5A-60",
-            "GW5AR-25",  "GW5AS-25",
-            "GW5AT-15",  "GW5AT-60",
-            "GW5ART-15", "GW5ANT-15", "GW5ANRT-15",
-        ):
-            return "PLLA"
-        elif device in (
-            "GW5A-138", "GW5AS-138",
-            "GW5AT-75", "GW5AT-138", "GW5AST-138",
-        ):
-            return "PLL"
+        # Gowin UG306: the PLL type depends on density, not the GW5 variant.
+        # Extract the density, ignoring die revisions (A, B, C, ES, ...).
+        match = re.search(r"-(\d+)[A-Z]*$", devicename)
+        if match is not None:
+            size = int(match.group(1))
+            if size in (15, 25, 60):
+                return "PLLA"
+            elif size in (75, 138):
+                return "PLL"
         raise ValueError(f"Unsupported device {devicename}.")
 
     @classmethod

--- a/litex/soc/cores/clock/gowin_gw5a.py
+++ b/litex/soc/cores/clock/gowin_gw5a.py
@@ -42,10 +42,18 @@ class GW5APLL(LiteXModule):
     def get_primitive(devicename):
         # Ignore the die revision suffix (A, B, C, ES, ...).
         device = re.sub(r"[A-Z]+$", "", devicename)
-        # Gowin UG306, Tables 5-1 and 5-11.
-        if device in ("GW5A-25", "GW5A-60", "GW5AT-15", "GW5AT-60"):
+        # Gowin UG306, Tables 5-1 and 5-11; DS1231, section 2.1 for 15K SiP variants.
+        if device in (
+            "GW5A-25",   "GW5A-60",
+            "GW5AR-25",  "GW5AS-25",
+            "GW5AT-15",  "GW5AT-60",
+            "GW5ART-15", "GW5ANT-15", "GW5ANRT-15",
+        ):
             return "PLLA"
-        elif device in ("GW5A-138", "GW5AT-75", "GW5AT-138", "GW5AST-138"):
+        elif device in (
+            "GW5A-138", "GW5AS-138",
+            "GW5AT-75", "GW5AT-138", "GW5AST-138",
+        ):
             return "PLL"
         raise ValueError(f"Unsupported device {devicename}.")
 
@@ -59,7 +67,7 @@ class GW5APLL(LiteXModule):
 
     @classmethod
     def get_pfd_freq_range(cls, devicename):
-        # PLL Switching Characteristics in Gowin DS1103, DS981 and DS1239.
+        # PLL Switching Characteristics in the Gowin device datasheets.
         return {
             "PLLA": (19e6, 87.5e6),
             "PLL":  (19e6, 81.25e6),

--- a/test/cores/test_clock.py
+++ b/test/cores/test_clock.py
@@ -558,6 +558,64 @@ class TestClock(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, r"No PLL config found.*ClkIn=50.00MHz.*ClkOut0=10000.00MHz"):
             pll.compute_config()
 
+    def test_gw5a_pll_device_limits_and_primitives(self):
+        # Gowin UG306, DS1103, DS981 and DS1239.
+        test_cases = [
+            ("GW5A-25",    "PLLA", 700e6, 1400e6, 87.5e6),
+            ("GW5A-60",    "PLLA", 700e6, 1400e6, 87.5e6),
+            ("GW5A-138",   "PLL",  650e6, 1300e6, 81.25e6),
+            ("GW5AST-138", "PLL",  650e6, 1300e6, 81.25e6),
+            ("GW5AT-15",   "PLLA", 700e6, 1400e6, 87.5e6),
+            ("GW5AT-60",   "PLLA", 700e6, 1400e6, 87.5e6),
+            ("GW5AT-75",   "PLL",  650e6, 1300e6, 81.25e6),
+            ("GW5AT-138",  "PLL",  650e6, 1300e6, 81.25e6),
+        ]
+        for devicename, primitive, vco_min, vco_max, pfd_max in test_cases:
+            # Exercise the lower VCO boundary and input division above the PFD limit.
+            for clkin_freq, clkout_freq in [(25e6, vco_min/128), (100e6, 100e6)]:
+                with self.subTest(device=devicename, clkin=clkin_freq, clkout=clkout_freq):
+                    pll = GW5APLL(devicename, devicename)
+                    pll.register_clkin(Signal(), clkin_freq)
+                    pll.create_clkout(ClockDomain("clkout"), clkout_freq, margin=0)
+                    config = pll.compute_config()
+                    self.assertEqual(pll.vco_freq_range, (vco_min, vco_max))
+                    self.assertEqual(pll.pfd_freq_range, (19e6, pfd_max))
+                    self.assertGreaterEqual(config["vco"], vco_min)
+                    self.assertLessEqual(config["vco"], vco_max)
+                    self.assertGreaterEqual(clkin_freq/config["idiv"], 19e6)
+                    self.assertLessEqual(clkin_freq/config["idiv"], pfd_max)
+                    self.assertEqual(config["vco"]/config["odiv0"], clkout_freq)
+                    fragment = pll.get_fragment()
+                    self.assertIn(primitive, [s.of for s in fragment.specials if isinstance(s, Instance)])
+
+    def test_gw5a_pll_devicename_revisions(self):
+        test_cases = [
+            ("GW5A-25A",    "GW5A-LV25MG121NC1/I0",   "PLLA"),
+            ("GW5AT-60B",   "GW5AT-LV60PG484AC1/I0",  "PLLA"),
+            ("GW5AT-60ES",  "GW5AT-LV60PG484AC1/I0",  "PLLA"),
+            ("GW5AST-138B", "GW5AST-LV138FPG676AES",  "PLL"),
+            ("GW5AST-138C", "GW5AST-LV138PG484AC1/I0", "PLL"),
+        ]
+        for devicename, device, primitive in test_cases:
+            with self.subTest(devicename=devicename):
+                pll = GW5APLL(devicename, device)
+                self.assertEqual(pll.primitive, primitive)
+
+    def test_gw5a_pll_rejects_unsupported_device_names(self):
+        for devicename in ("GW5A", "GW5A-250", "GW5AT-600", "GW5A-75", "GW5AST-60", "GW2A-18"):
+            with self.subTest(devicename=devicename):
+                with self.assertRaisesRegex(ValueError, "Unsupported device"):
+                    GW5APLL(devicename, devicename)
+
+    def test_gw5a_pll_rejects_sub_minimum_pfd(self):
+        for devicename in ("GW5AT-60B", "GW5AST-138C"):
+            with self.subTest(devicename=devicename):
+                pll = GW5APLL(devicename, devicename)
+                pll.register_clkin(Signal(), 18.75e6)
+                pll.create_clkout(ClockDomain("clkout"), 100e6)
+                with self.assertRaisesRegex(ValueError, "No PLL config found"):
+                    pll.compute_config()
+
     def test_gw1n_pll_rejects_multiple_nonzero_phases(self):
         pll = GW1NPLL("GW1N-9", "GW1N-9C")
         pll.register_clkin(Signal(), 50e6)

--- a/test/cores/test_clock.py
+++ b/test/cores/test_clock.py
@@ -607,10 +607,17 @@ class TestClock(unittest.TestCase):
                 pll = GW5APLL(devicename, device)
                 self.assertEqual(pll.primitive, primitive)
 
+    def test_gw5a_pll_density_selection(self):
+        # Variant names must not require another entry in the PLL core.
+        for variant in ("A", "AS", "AST", "RN"):
+            for size, primitive in ((15, "PLLA"), (25, "PLLA"), (60, "PLLA"), (75, "PLL"), (138, "PLL")):
+                with self.subTest(variant=variant, size=size):
+                    self.assertEqual(GW5APLL.get_primitive(f"GW5{variant}-{size}C"), primitive)
+
     def test_gw5a_pll_rejects_unsupported_device_names(self):
         for devicename in (
-            "GW5A", "GW5A-250", "GW5AT-600", "GW5A-75", "GW5AST-60",
-            "GW5AS-60", "GW5AR-138", "GW2A-18",
+            "GW5A", "GW5A-", "GW5A-250", "GW5AT-600", "GW2A-18",
+            "GW5A-60B1", "GW5A-25/60",
         ):
             with self.subTest(devicename=devicename):
                 with self.assertRaisesRegex(ValueError, "Unsupported device"):

--- a/test/cores/test_clock.py
+++ b/test/cores/test_clock.py
@@ -559,7 +559,7 @@ class TestClock(unittest.TestCase):
             pll.compute_config()
 
     def test_gw5a_pll_device_limits_and_primitives(self):
-        # Gowin UG306, DS1103, DS981 and DS1239.
+        # Gowin Arora V clock guide, device datasheets and PLL_ADV device list.
         test_cases = [
             ("GW5A-25",    "PLLA", 700e6, 1400e6, 87.5e6),
             ("GW5A-60",    "PLLA", 700e6, 1400e6, 87.5e6),
@@ -569,6 +569,12 @@ class TestClock(unittest.TestCase):
             ("GW5AT-60",   "PLLA", 700e6, 1400e6, 87.5e6),
             ("GW5AT-75",   "PLL",  650e6, 1300e6, 81.25e6),
             ("GW5AT-138",  "PLL",  650e6, 1300e6, 81.25e6),
+            ("GW5AS-25",   "PLLA", 700e6, 1400e6, 87.5e6),
+            ("GW5AS-138",  "PLL",  650e6, 1300e6, 81.25e6),
+            ("GW5AR-25",   "PLLA", 700e6, 1400e6, 87.5e6),
+            ("GW5ART-15",  "PLLA", 700e6, 1400e6, 87.5e6),
+            ("GW5ANT-15",  "PLLA", 700e6, 1400e6, 87.5e6),
+            ("GW5ANRT-15", "PLLA", 700e6, 1400e6, 87.5e6),
         ]
         for devicename, primitive, vco_min, vco_max, pfd_max in test_cases:
             # Exercise the lower VCO boundary and input division above the PFD limit.
@@ -602,7 +608,10 @@ class TestClock(unittest.TestCase):
                 self.assertEqual(pll.primitive, primitive)
 
     def test_gw5a_pll_rejects_unsupported_device_names(self):
-        for devicename in ("GW5A", "GW5A-250", "GW5AT-600", "GW5A-75", "GW5AST-60", "GW2A-18"):
+        for devicename in (
+            "GW5A", "GW5A-250", "GW5AT-600", "GW5A-75", "GW5AST-60",
+            "GW5AS-60", "GW5AR-138", "GW2A-18",
+        ):
             with self.subTest(devicename=devicename):
                 with self.assertRaisesRegex(ValueError, "Unsupported device"):
                     GW5APLL(devicename, devicename)


### PR DESCRIPTION
GW5APLL currently chooses frequency limits and the PLL primitive from the family prefix alone. This lets the solver exceed documented VCO/PFD limits and selects PLLA for GW5A-138 and GW5AT-75/138, which require PLL.

Extract the density from `devicename` and use it to select the primitive and its limits, ignoring revision suffixes such as A, B, C and ES. GW5APLL already identifies the FPGA family, so selection does not enumerate GW5 variant prefixes. Reject malformed density suffixes and unsupported densities. The two density groups cover all 14 GW5 models (26 device/revision entries) listed by the installed Gowin 1.9.12 PLL_ADV IP generator.

| GW5 density | Primitive | VCO range | PFD range |
| --- | --- | --- | --- |
| 15K / 25K / 60K | PLLA | 700–1400 MHz | 19–87.5 MHz |
| 75K / 138K | PLL | 650–1300 MHz | 19–81.25 MHz |

Sources checked against Gowin documentation:

- [UG306-1.0.9E](https://cdn.gowinsemi.com.cn/UG306E.pdf): section 2.3 gives the VCO ranges; tables 5-1 and 5-11 identify PLL/PLLA devices.
- [DS1103-1.0.9E](https://cdn.gowinsemi.com.cn/DS1103E.pdf): tables 3-35 through 3-37 give GW5A PLL switching characteristics.
- [DS981-1.1.3E](https://cdn.gowinsemi.com.cn/DS981E.pdf): tables 3-42 through 3-45 give GW5AT PLL switching characteristics.
- [DS1239-1.0.3E](https://cdn.gowinsemi.com.cn/DS1239E.pdf): table 3-18 gives GW5AST-138 PLL switching characteristics.
- [DS1105-1.0.4E](https://cdn.gowinsemi.com.cn/DS1105E.pdf): tables 3-27 and 3-28 give GW5AS-138/25 PLL switching characteristics.
- [DS1108-1.0.6E](https://cdn.gowinsemi.com.cn/DS1108E.pdf): table 3-19 gives GW5AR-25 PLL switching characteristics.
- [DS1118-1.0.5E](https://cdn.gowinsemi.com.cn/DS1118E.pdf): table 3-18 gives GW5ART-15 PLL switching characteristics.
- [DS1231-1.0 preliminary](https://cdn.gowinsemi.com.cn/DS1231-1.0_Arora_V_15K_FPGA%E4%BA%A7%E5%93%81%28%E8%BD%A6%E8%A7%84%E7%BA%A7%29%E6%95%B0%E6%8D%AE%E6%89%8B%E5%86%8C-Preliminary.pdf): section 2.1 identifies GW5ANT-15 and GW5ANRT-15 as SiP variants containing a GW5AT-15 die and additional memory. Their mapping applies the current GW5AT-15 PLL limits on this basis, rather than the older preliminary frequency values.
- [DS1228-1.1.1E](https://cdn.gowinsemi.com.cn/DS1228E.pdf) and Gowin 1.9.12 `IDE/ipcore/PLL_ADV/plladv.ipspec` corroborate the additional 15K device variants.

Validation:

- `python3 -m unittest test.cores.test_clock`: 66 tests passed. New coverage exercises all 14 catalog models, the lower VCO boundary, PFD constraints, emitted primitives, revision suffixes, selection independent of the variant prefix, and rejection of malformed or unsupported density suffixes. The solver regression tests fail against the previous implementation.
- Computed and elaborated a 50 MHz input / 100 MHz output PLL for all 26 GW5 device/revision entries in the installed Gowin PLL_ADV catalog.
- Elaborated 15 existing Tang clock/reset configurations: Console 60K/138K and Mega/Mega Pro DDR3 at 50 MHz (1:2), 25 MHz (1:4) and 83⅓ MHz (1:4); Primer 25K at 50 MHz with and without SDRAM (1:1 and 1:2).
- `git diff --check` passed.

Validation for this change covers software tests and clock/reset elaboration; no new FPGA bitstream or hardware qualification was performed.
