### PR TITLE
cores/clock/gowin_gw1n: select PLL primitives and limits by device

### DIFF
--- a/litex/soc/cores/clock/gowin_gw1n.py
+++ b/litex/soc/cores/clock/gowin_gw1n.py
@@ -4,6 +4,8 @@
 # Copyright (c) 2021-2026 Florent Kermarrec <florent@enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
+import re
+
 from migen import *
 
 from litex.gen import *
@@ -70,43 +72,106 @@ class GW1NPLL(LiteXModule):
         self.clkouts    = {}
         self.config     = {}
         self.params     = {}
-        self.vco_freq_range = self.get_vco_freq_range(device)
-        self.pfd_freq_range = self.get_pfd_freq_range(device)
+        self.primitive      = self.get_primitive(devicename)
+        self.vco_freq_range = self.get_vco_freq_range(device, devicename)
+        self.pfd_freq_range = self.get_pfd_freq_range(device, devicename)
 
     @staticmethod
-    def get_vco_freq_range(device):
-        vco_freq_range = None
-        if device.startswith('GW1NS'):
-            if 'C7/I6' in device or 'C6/I5' in device:
-                vco_freq_range = (600e6, 1200e6)  # datasheet says (400, 1200) but compiler enforces (600, 1200)
-            elif 'C5/I4' in device:
-                vco_freq_range = (320e6, 960e6)  # datasheet values, not tested
-        elif device.startswith('GW1N-1S'):
-            vco_freq_range = (400e6, 1200e6)
-        elif device.startswith('GW1N-') or device.startswith('GW1NR-'):
-            vco_freq_range = (400e6, 900e6)
-        if vco_freq_range is None:
-            raise ValueError(f"Unsupported device {device}.")
-        return vco_freq_range
+    def get_device_model(devicename):
+        # A/B/C/D are die revisions; retain functional suffixes such as 1S and 1P5.
+        return re.sub(r"[ABCD]$", "", devicename)
 
     @staticmethod
-    def get_pfd_freq_range(device):
-        pfd_freq_range = None
-        if device.startswith('GW1NS'):
-            if 'C7/I6' in device or 'C6/I5' in device:
-                pfd_freq_range = (3e6, 400e6)
-            elif 'C5/I4' in device:
-                pfd_freq_range = (3e6, 320e6)
-        elif device.startswith('GW1N-1S'):
-            pfd_freq_range = (3e6, 400e6)  # not verified: not found in the datasheet
-        elif device.startswith('GW1N-') or device.startswith('GW1NR-'):
-            pfd_freq_range = (3e6, 400e6)  # not verified: not found in the datasheet
-        if pfd_freq_range is None:
-            raise ValueError(f"Unsupported device {device}.")
-        return pfd_freq_range
+    def get_speed_grade(device):
+        match = re.search(r"C([0-9]+)(?:/I([0-9]+))?$|I([0-9]+)$", device)
+        if match is None:
+            return None
+        if match.group(1) is not None:
+            grade = int(match.group(1))
+            if match.group(2) is not None and int(match.group(2)) != grade - 1:
+                raise ValueError(f"Unsupported speed grade in {device}.")
+            return grade
+        return int(match.group(3)) + 1
+
+    @classmethod
+    def get_primitive(cls, devicename):
+        # Gowin UG286, Tables 5-1 and 5-10; rPLL/PLLVR IP device lists.
+        model = cls.get_device_model(devicename)
+        if model in ("GW1NS-4", "GW1NSR-4", "GW1NSER-4"):
+            return "PLLVR"
+        if model in (
+            "GW1N-1", "GW1N-1S", "GW1N-4", "GW1N-9",
+            "GW1NR-1", "GW1NR-4", "GW1NR-9", "GW1NRF-4",
+            "GW1NS-2", "GW1NSR-2", "GW1NSE-2", "GW1NZ-1",
+            "GW1A-1", "GW1AN-1",
+        ):
+            return "rPLL"
+        raise ValueError(f"Unsupported rPLL/PLLVR device {devicename}.")
+
+    @classmethod
+    def get_freq_ranges(cls, device, devicename=None):
+        if devicename is None:
+            # Retain support for frequency queries using a full part number.
+            match = re.match(r"(GW1[A-Z]*)-(?:LV|UV|EV|ZV)?([0-9]+(?:P5|S)?)", device)
+            if match is None:
+                raise ValueError(f"Unsupported device {device}.")
+            devicename = "-".join(match.groups())
+        model = cls.get_device_model(devicename)
+        primitive = cls.get_primitive(devicename)
+        grade = cls.get_speed_grade(device)
+
+        # Values are (VCO minimum, VCO maximum, PFD maximum), in MHz.
+        # DS100, DS117, DS821, DS861, DS871, DS881, DS891, DS1501 and DS186.
+        if model in ("GW1N-1", "GW1NR-1"):
+            ranges = {5: (320, 720, 320), 6: (400, 900, 400), 7: (400, 900, 400)}
+        elif model == "GW1N-4":
+            ranges = {5: (320, 800, 320), 6: (400, 1000, 400), 7: (400, 1000, 400)}
+        elif model == "GW1NR-4":
+            ranges = {6: (400, 1000, 400), 7: (400, 1000, 400)}
+        elif model == "GW1NRF-4":
+            ranges = {5: (320, 800, 320), 6: (400, 1000, 400)}
+        elif model in ("GW1N-9", "GW1NR-9"):
+            ranges = {6: (400, 1200, 400), 7: (400, 1200, 400)}
+        elif model in ("GW1A-1", "GW1AN-1"):
+            ranges = {6: (400, 900, 400)}
+        elif model == "GW1N-1S":
+            # Legacy GW1N-1S limits from DS100-2.9.4.
+            ranges = {5: (320, 960, 320), 6: (400, 1200, 400), 7: (400, 1200, 400)}
+        elif model == "GW1NZ-1":
+            # DS841: the low-voltage ZV parts have different PLL limits.
+            if "-ZV" in device:
+                ranges = {3: (100, 200, 100), 4: (150, 300, 150), 5: (200, 400, 200)}
+            elif "-LV" in device:
+                ranges = {5: (320, 640, 320), 6: (400, 800, 400)}
+            else:
+                raise ValueError(f"GW1NZ PLL limits require an LV or ZV part number: {device}.")
+        else:
+            ranges = {5: (320, 960, 320), 6: (400, 1200, 400), 7: (400, 1200, 400)}
+            if primitive == "PLLVR":
+                # Keep the 600MHz lower bound enforced by the Gowin toolchain.
+                ranges.update({6: (600, 1200, 400), 7: (600, 1200, 400)})
+
+        if grade is None:
+            # Without a speed grade, use the intersection of documented ranges.
+            vco_min = max(r[0] for r in ranges.values())
+            vco_max = min(r[1] for r in ranges.values())
+            pfd_max = min(r[2] for r in ranges.values())
+        elif grade in ranges:
+            vco_min, vco_max, pfd_max = ranges[grade]
+        else:
+            raise ValueError(f"Unsupported speed grade for {devicename}: {device}.")
+        return (vco_min*1e6, vco_max*1e6), (3e6, pfd_max*1e6)
+
+    @classmethod
+    def get_vco_freq_range(cls, device, devicename=None):
+        return cls.get_freq_ranges(device, devicename)[0]
+
+    @classmethod
+    def get_pfd_freq_range(cls, device, devicename=None):
+        return cls.get_freq_ranges(device, devicename)[1]
 
     def register_clkin(self, clkin, freq):
-        check_freq_positive(freq, "Input clock frequency")
+        check_freq_range(freq, self.pfd_freq_range, "Input clock frequency")
         self.clkin = connect_clkin(self, clkin)
         self.clkin_freq = freq
         register_clkin_log(self.logger, clkin, freq)
@@ -263,20 +328,17 @@ class GW1NPLL(LiteXModule):
         )
 
         # Dynamic CLKOUTP delay control. UG286 table 5-9
-        if self.device.startswith("GW1N-1"):
+        if self.get_device_model(self.devicename) in ("GW1N-1", "GW1N-1S"):
             self.params.update(i_FDLY=Constant(0, 4))
         else:
             self.params.update(i_FDLY=Constant(0xf, 4))
 
-        if self.device.startswith('GW1NS'):
-            primitive_name = 'PLLVR'
+        if self.primitive == "PLLVR":
             self.params.update(i_VREN=1)
-        else:
-            primitive_name = 'rPLL'
         for clk_name in ["CLKOUT", "CLKOUTP", "CLKOUTD", "CLKOUTD3"]:
             self.params[f"o_{clk_name}"] = config.get(clk_name, Open()) # Clock output.
             if clk_name in ["CLKOUTD", "CLKOUTD3"]: # Recopy CLKOUTx to CLKOUTDx
                 self.params[f"p_{clk_name}_SRC"] = config.get(f"{clk_name}_SRC", "CLKOUT")
 
         self.params.update(o_LOCK=self.locked) # PLL lock status.
-        self.specials += Instance(primitive_name, name=self.name or "", **self.params)
+        self.specials += Instance(self.primitive, name=self.name or "", **self.params)

--- a/litex/soc/cores/clock/gowin_gw2a.py
+++ b/litex/soc/cores/clock/gowin_gw2a.py
@@ -15,7 +15,11 @@ class GW2APLL(GW1NPLL):
     # GW2A has the same PLL primitive than GW1N but vco/pfd_freq_range are specific to device.
 
     @staticmethod
-    def get_vco_freq_range(device):
+    def get_primitive(devicename):
+        return "rPLL"
+
+    @staticmethod
+    def get_vco_freq_range(device, devicename=None):
         vco_freq_range = None
         if device.startswith('GW2A-') or device.startswith('GW2AR-'):
             vco_freq_range = (500e6, 1250e6) # datasheet values
@@ -24,7 +28,7 @@ class GW2APLL(GW1NPLL):
         return vco_freq_range
 
     @staticmethod
-    def get_pfd_freq_range(device):
+    def get_pfd_freq_range(device, devicename=None):
         pfd_freq_range = None
         if device.startswith('GW2A-') or device.startswith('GW2AR-'):
             pfd_freq_range = (3e6, 500e6)  # datasheet values

--- a/test/cores/test_gowin_gw1.py
+++ b/test/cores/test_gowin_gw1.py
@@ -1,0 +1,118 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import ClockDomain, Instance, Signal
+
+from litex.soc.cores.clock.gowin_gw1n import GW1NPLL
+from litex.soc.cores.clock.gowin_gw2a import GW2APLL
+
+
+class TestGW1PLL(unittest.TestCase):
+    def test_device_primitives(self):
+        # Gowin rPLL/PLLVR IP catalog device/revision names.
+        rpll_devices = (
+            "GW1N-1", "GW1N-1S", "GW1N-4", "GW1N-4B", "GW1N-4D", "GW1N-9", "GW1N-9C",
+            "GW1NR-1", "GW1NR-4", "GW1NR-4B", "GW1NR-4D", "GW1NR-9", "GW1NR-9C",
+            "GW1NRF-4B", "GW1NS-2", "GW1NS-2C", "GW1NSR-2", "GW1NSR-2C", "GW1NSE-2C",
+            "GW1NZ-1", "GW1NZ-1C", "GW1A-1A", "GW1AN-1C",
+        )
+        pllvr_devices = ("GW1NS-4", "GW1NS-4C", "GW1NSR-4", "GW1NSR-4C", "GW1NSER-4C")
+        for primitive, devices in (("rPLL", rpll_devices), ("PLLVR", pllvr_devices)):
+            for devicename in devices:
+                with self.subTest(device=devicename):
+                    family, density = GW1NPLL.get_device_model(devicename).split("-")
+                    device = f"{family}-LV{density}QN48C6/I5"
+                    pll = GW1NPLL(devicename, device)
+                    pll.register_clkin(Signal(), 50e6)
+                    pll.create_clkout(ClockDomain("sys"), 100e6)
+                    fragment = pll.get_fragment()
+                    self.assertIn(primitive, [s.of for s in fragment.specials if isinstance(s, Instance)])
+                    self.assertEqual("i_VREN" in pll.params, primitive == "PLLVR")
+
+    def test_documented_limits(self):
+        cases = [
+            ("GW1N-1",     "GW1N-LV1QN48C5/I4",    (320e6, 720e6), 320e6),
+            ("GW1N-4B",    "GW1N-LV4LQ144C6/I5",   (400e6, 1000e6), 400e6),
+            ("GW1NR-9C",   "GW1NR-LV9QN88PC6/I5",  (400e6, 1200e6), 400e6),
+            ("GW1NRF-4B",  "GW1NRF-LV4BQN48C5/I4", (320e6, 800e6), 320e6),
+            ("GW1N-1S",    "GW1N-LV1SQN48C5/I4",   (320e6, 960e6), 320e6),
+            ("GW1NS-2C",   "GW1NS-LV2CQN48C6/I5",  (400e6, 1200e6), 400e6),
+            ("GW1NSR-4C",  "GW1NSR-LV4CQN48PC6/I5", (600e6, 1200e6), 400e6),
+            ("GW1NSER-4C", "GW1NSER-LV4CQN48C5/I4", (320e6, 960e6), 320e6),
+            ("GW1NZ-1C",   "GW1NZ-LV1QN48C5/I4",   (320e6, 640e6), 320e6),
+            ("GW1NZ-1C",   "GW1NZ-ZV1QN48C5/I4",   (200e6, 400e6), 200e6),
+            ("GW1NZ-1C",   "GW1NZ-ZV1QN48I3",      (150e6, 300e6), 150e6),
+            ("GW1NZ-1C",   "GW1NZ-ZV1QN48I2",      (100e6, 200e6), 100e6),
+        ]
+        for devicename, device, vco_range, pfd_max in cases:
+            with self.subTest(device=device):
+                pll = GW1NPLL(devicename, device)
+                self.assertEqual(pll.vco_freq_range, vco_range)
+                self.assertEqual(pll.pfd_freq_range, (3e6, pfd_max))
+                # The highest output requires the documented maximum VCO.
+                pll.register_clkin(Signal(), vco_range[1]/20)
+                pll.create_clkout(ClockDomain("sys"), vco_range[1]/2, margin=0)
+                self.assertEqual(pll.compute_config()["vco"], vco_range[1])
+                with self.assertRaisesRegex(ValueError, "Input clock frequency"):
+                    pll.register_clkin(Signal(), pfd_max + 1)
+
+    def test_high_frequency_on_9k(self):
+        pll = GW1NPLL("GW1NR-9C", "GW1NR-LV9QN88PC6/I5")
+        pll.register_clkin(Signal(), 50e6)
+        pll.create_clkout(ClockDomain("sys"), 600e6, margin=0)
+        self.assertEqual(pll.compute_config()["vco"], 1200e6)
+
+    def test_slow_grade_rejects_fast_grade_frequency(self):
+        for suffix, valid in (("C5/I4", False), ("C6/I5", True)):
+            with self.subTest(suffix=suffix):
+                pll = GW1NPLL("GW1N-1", "GW1N-LV1QN48" + suffix)
+                pll.register_clkin(Signal(), 50e6)
+                pll.create_clkout(ClockDomain("sys"), 400e6, margin=0)
+                if valid:
+                    self.assertEqual(pll.compute_config()["vco"], 800e6)
+                else:
+                    with self.assertRaisesRegex(ValueError, "No PLL config"):
+                        pll.compute_config()
+
+    def test_speed_grade_aliases_and_missing_grade(self):
+        for suffix in ("C5/I4", "C5", "I4"):
+            with self.subTest(suffix=suffix):
+                pll = GW1NPLL("GW1N-1", "GW1N-LV1QN48" + suffix)
+                self.assertEqual(pll.vco_freq_range, (320e6, 720e6))
+        pll = GW1NPLL("GW1N-1", "GW1N-1")
+        self.assertEqual(pll.vco_freq_range, (400e6, 720e6))
+        self.assertEqual(pll.pfd_freq_range, (3e6, 320e6))
+        with self.assertRaisesRegex(ValueError, "speed grade"):
+            GW1NPLL("GW1N-1", "GW1N-LV1QN48C6/I4")
+
+    def test_fdly_uses_devicename(self):
+        for devicename, device, fdly in (
+            ("GW1N-1", "GW1N-LV1QN48C6/I5", 0),
+            ("GW1N-1S", "GW1N-LV1SQN48C6/I5", 0),
+            ("GW1NR-9C", "GW1NR-LV9QN88PC6/I5", 15),
+        ):
+            with self.subTest(device=devicename):
+                pll = GW1NPLL(devicename, device)
+                pll.register_clkin(Signal(), 50e6)
+                pll.create_clkout(ClockDomain("sys"), 100e6)
+                pll.get_fragment()
+                self.assertEqual(pll.params["i_FDLY"].value, fdly)
+
+    def test_incompatible_primitives_are_rejected(self):
+        for device in ("GW1N-2", "GW1N-1P5", "GW1NR-2", "GW1NZ-2C", "GW1N-90"):
+            with self.subTest(device=device):
+                with self.assertRaisesRegex(ValueError, "Unsupported"):
+                    GW1NPLL(device, device)
+
+    def test_gw2_subclass_compatibility(self):
+        pll = GW2APLL("GW2AR-18C", "GW2AR-LV18QN88C8/I7")
+        pll.register_clkin(Signal(), 27e6)
+        pll.create_clkout(ClockDomain("sys"), 54e6)
+        fragment = pll.get_fragment()
+        self.assertEqual(pll.vco_freq_range, (500e6, 1250e6))
+        self.assertIn("rPLL", [s.of for s in fragment.specials if isinstance(s, Instance)])


### PR DESCRIPTION
GW1NPLL currently assigns 400–900 MHz to most GW1 devices and selects PLLVR for the entire GW1NS prefix. This rejects valid 4K/9K configurations, permits clocks outside slower devices' limits, and emits PLLVR for NS-2 devices that use rPLL.

Select the primitive from `devicename` and the frequency limits from the model, speed grade and, for GW1NZ, LV/ZV voltage variant. This covers all 28 GW1 device/revision entries in Gowin 1.9.12's rPLL and PLLVR IP catalogs, including GW1NRF, GW1NSR, GW1NSE, GW1NSER, GW1NZ, GW1A and GW1AN variants.

- Use the documented VCO and PFD limits instead of family-wide defaults. For example, GW1NR-9 C6/I5 supports a 400–1200 MHz VCO, while GW1N-1 C5/I4 is limited to 320–720 MHz.
- Accept commercial, industrial and combined speed-grade suffixes. When no speed grade is supplied, use the intersection of the documented ranges. Reject unsupported grades and device models.
- Validate CLKIN against the documented input range, which matches the PFD range on these devices.
- Use `devicename` for the FDLY tie-off as well: full part numbers such as `GW1N-LV1QN48C6/I5` never matched the previous `GW1N-1` prefix check.
- Preserve the existing 600 MHz PLLVR lower bound for C6/I5 and C7/I6, originally added for a Gowin compiler restriction despite the datasheet's 400 MHz minimum.

The small GW2APLL adjustment preserves subclass compatibility. Its device coverage and speed-dependent limits are handled in #2580. Devices using the distinct PLLO interface (such as GW1N-2/1P5) are explicitly rejected by this rPLL/PLLVR core.

Sources:

- [UG286](https://cdn.gowinsemi.com.cn/UG286E.pdf), sections 5.1 and 5.2: primitive device lists, ports and FDLY encoding; cross-checked with the installed Gowin 1.9.12 IP catalogs and simulation primitives.
- [DS100](https://cdn.gowinsemi.com.cn/DS100E.pdf) and [DS117](https://cdn.gowinsemi.com.cn/DS117E.pdf): GW1N/GW1NR PLL switching characteristics. Legacy GW1N-1S and C7 entries are retained using [DS100-2.9.4](https://cdn.gowinsemi.com.cn/DS100-2.9.4_GW1N%E7%B3%BB%E5%88%97FPGA%E4%BA%A7%E5%93%81%E6%95%B0%E6%8D%AE%E6%89%8B%E5%86%8C.pdf) and [DS100-3.2.7](https://cdn.gowinsemi.com.cn/DS100-3.2.7_GW1N%E7%B3%BB%E5%88%97FPGA%E4%BA%A7%E5%93%81%E6%95%B0%E6%8D%AE%E6%89%8B%E5%86%8C.pdf).
- [DS821](https://cdn.gowinsemi.com.cn/DS821E.pdf), [DS861](https://cdn.gowinsemi.com.cn/DS861E.pdf), [DS871](https://cdn.gowinsemi.com.cn/DS871E.pdf) and [DS881](https://www.gowinsemi.com/upload/database_doc/1718/document/683a0d209561b.pdf): NS/NSR/NSE/NSER limits.
- [DS841](https://cdn.gowinsemi.com.cn/DS841E.pdf), table 3-20: GW1NZ LV/ZV and speed-grade limits.
- [DS891](https://cdn.gowinsemi.com.cn/DS891E.pdf), [DS1501](https://cdn.gowinsemi.com.cn/DS1501E.pdf) and [DS186](https://cdn.gowinsemi.com.cn/DS186E.pdf): NRF/A/AN limits.

Validation:

- `python3 -m unittest test.cores.test_clock test.cores.test_gowin_gw1`: 69 tests passed. New tests cover all 28 catalog entries, emitted primitives and FDLY/VREN inputs, voltage/speed-grade limits, maximum-VCO configurations, and rejection of a fast-grade frequency on a slower part. The new tests fail against unmodified master.
- Elaborated 14 existing board clock/reset configurations: Tang Nano, Nano 4K/9K with and without video, TEC0117 with both SDRAM ratios, Brisbane BRS-100, and Nano 20K/Primer 20K/LJPI including video and DDR configurations.
- `git diff --check` passed.

Validation is software tests and clock/reset elaboration; no new bitstreams or physical hardware tests were performed for these devices.
