### PR TITLE
cores/clock/gowin_gw2a: cover rPLL variants and speed-grade limits

### DIFF
--- a/litex/soc/cores/clock/gowin_gw2a.py
+++ b/litex/soc/cores/clock/gowin_gw2a.py
@@ -2,36 +2,44 @@
 # This file is part of LiteX.
 #
 # Copyright (c) 2022 Icenowy Zheng <icenowy@aosc.io>
-# Copyright (c) 2022 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2022-2026 Florent Kermarrec <florent@enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
-from migen import *
+import re
 
 from litex.soc.cores.clock.gowin_gw1n import GW1NPLL
 
 # GoWin / GW2APLL ----------------------------------------------------------------------------------
 
 class GW2APLL(GW1NPLL):
-    # GW2A has the same PLL primitive than GW1N but vco/pfd_freq_range are specific to device.
+    # GW2A uses rPLL with device- and speed-dependent frequency limits.
 
-    @staticmethod
-    def get_primitive(devicename):
-        return "rPLL"
+    @classmethod
+    def get_primitive(cls, devicename):
+        # UG286 Table 5-1. GW2AN-9X/18X use the distinct PLLO primitive.
+        if cls.get_device_model(devicename) in (
+            "GW2A-18", "GW2A-55", "GW2AR-18", "GW2AN-55", "GW2ANR-18",
+        ):
+            return "rPLL"
+        raise ValueError(f"Unsupported rPLL device {devicename}.")
 
-    @staticmethod
-    def get_vco_freq_range(device, devicename=None):
-        vco_freq_range = None
-        if device.startswith('GW2A-') or device.startswith('GW2AR-'):
-            vco_freq_range = (500e6, 1250e6) # datasheet values
-        if vco_freq_range is None:
-            raise ValueError(f"Unsupported device {device}.")
-        return vco_freq_range
+    @classmethod
+    def get_freq_ranges(cls, device, devicename=None):
+        if devicename is None:
+            match = re.match(r"(GW2[A-Z]*)-(?:LV|UV|EV)?([0-9]+X?)", device)
+            if match is None:
+                raise ValueError(f"Unsupported device {device}.")
+            devicename = "-".join(match.groups())
+        cls.get_primitive(devicename)
+        model = cls.get_device_model(devicename)
+        grade = cls.get_speed_grade(device)
 
-    @staticmethod
-    def get_pfd_freq_range(device, devicename=None):
-        pfd_freq_range = None
-        if device.startswith('GW2A-') or device.startswith('GW2AR-'):
-            pfd_freq_range = (3e6, 500e6)  # datasheet values
-        if pfd_freq_range is None:
-            raise ValueError(f"Unsupported device {device}.")
-        return pfd_freq_range
+        # DS102, DS226, DS976 and DS961 PLL switching characteristics.
+        if grade == 7:
+            return (400e6, 1000e6), (3e6, 400e6)
+        if grade == 8 or (grade == 9 and model in ("GW2A-18", "GW2A-55", "GW2AR-18")):
+            return (500e6, 1250e6), (3e6, 500e6)
+        if grade is None:
+            # Intersection of the documented speed-grade ranges.
+            return (500e6, 1000e6), (3e6, 400e6)
+        raise ValueError(f"Unsupported speed grade for {devicename}: {device}.")

--- a/test/cores/test_gowin_gw2.py
+++ b/test/cores/test_gowin_gw2.py
@@ -1,0 +1,74 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import ClockDomain, Instance, Signal
+
+from litex.soc.cores.clock.gowin_gw2a import GW2APLL
+
+
+class TestGW2PLL(unittest.TestCase):
+    def test_catalog_devices_and_speed_grades(self):
+        # All GW2 device/revision entries in Gowin's rPLL IP catalog.
+        devices = (
+            "GW2A-18", "GW2A-18C", "GW2A-55", "GW2A-55C",
+            "GW2AR-18", "GW2AR-18C", "GW2AN-55C", "GW2ANR-18C",
+        )
+        for devicename in devices:
+            for grade, vco_range, pfd_max in ((7, (400e6, 1000e6), 400e6), (8, (500e6, 1250e6), 500e6)):
+                with self.subTest(device=devicename, grade=grade):
+                    family, density = GW2APLL.get_device_model(devicename).split("-")
+                    device = f"{family}-LV{density}PG256C{grade}/I{grade-1}"
+                    pll = GW2APLL(devicename, device)
+                    self.assertEqual(pll.vco_freq_range, vco_range)
+                    self.assertEqual(pll.pfd_freq_range, (3e6, pfd_max))
+                    pll.register_clkin(Signal(), 50e6)
+                    pll.create_clkout(ClockDomain("sys"), vco_range[1]/2, margin=0)
+                    self.assertEqual(pll.compute_config()["vco"], vco_range[1])
+                    fragment = pll.get_fragment()
+                    self.assertIn("rPLL", [s.of for s in fragment.specials if isinstance(s, Instance)])
+                    self.assertNotIn("i_VREN", pll.params)
+                    with self.assertRaisesRegex(ValueError, "Input clock frequency"):
+                        pll.register_clkin(Signal(), pfd_max + 1)
+
+    def test_slow_grade_rejects_fast_grade_frequency(self):
+        for suffix, valid in (("C7/I6", False), ("C8/I7", True)):
+            with self.subTest(suffix=suffix):
+                pll = GW2APLL("GW2A-18C", "GW2A-LV18PG256" + suffix)
+                pll.register_clkin(Signal(), 50e6)
+                pll.create_clkout(ClockDomain("sys"), 600e6, margin=0)
+                if valid:
+                    self.assertEqual(pll.compute_config()["vco"], 1200e6)
+                else:
+                    with self.assertRaisesRegex(ValueError, "No PLL config"):
+                        pll.compute_config()
+
+    def test_slow_grade_minimum_vco(self):
+        pll = GW2APLL("GW2A-18C", "GW2A-LV18PG256C7/I6")
+        pll.register_clkin(Signal(), 25e6)
+        pll.create_clkout(ClockDomain("sys"), 3.125e6, margin=0)
+        self.assertEqual(pll.compute_config()["vco"], 400e6)
+
+    def test_speed_grade_aliases_and_missing_grade(self):
+        for suffix in ("C7/I6", "C7", "I6"):
+            with self.subTest(suffix=suffix):
+                device = "GW2A-LV18PG256" + suffix
+                self.assertEqual(GW2APLL.get_vco_freq_range(device), (400e6, 1000e6))
+                self.assertEqual(GW2APLL.get_pfd_freq_range(device), (3e6, 400e6))
+        pll = GW2APLL("GW2A-18C", "GW2A-18C")
+        self.assertEqual(pll.vco_freq_range, (500e6, 1000e6))
+        self.assertEqual(pll.pfd_freq_range, (3e6, 400e6))
+        for device in ("GW2A-LV18PG256C9/I8", "GW2AR-LV18QN88C9/I8"):
+            self.assertEqual(GW2APLL.get_vco_freq_range(device), (500e6, 1250e6))
+        with self.assertRaisesRegex(ValueError, "speed grade"):
+            GW2APLL("GW2AN-55C", "GW2AN-LV55UG676C9/I8")
+
+    def test_unsupported_devices(self):
+        for devicename in ("GW2AN-18X", "GW2AN-9X", "GW2A-180", "GW2AR-55", "GW1N-9"):
+            with self.subTest(device=devicename):
+                with self.assertRaisesRegex(ValueError, "Unsupported rPLL device"):
+                    GW2APLL(devicename, devicename)


### PR DESCRIPTION
GW2APLL currently uses the C8/I7 frequency limits for every part, including slower C7/I6 devices, and rejects the rPLL-compatible GW2AN-55 and GW2ANR-18 variants. This can select a VCO above a C7/I6 part's 1000 MHz maximum and also rejects valid configurations below 500 MHz.

Select supported models from `devicename` and apply the documented speed-grade limits:

| Devices | Grade | VCO | PFD / CLKIN |
| --- | --- | --- | --- |
| GW2A-18/55, GW2AR-18, GW2AN-55, GW2ANR-18 | C7/I6 | 400–1000 MHz | 3–400 MHz |
| Same devices | C8/I7 | 500–1250 MHz | 3–500 MHz |
| GW2A-18/55, GW2AR-18 | C9/I8 | 500–1250 MHz | 3–500 MHz |

All eight GW2 device/revision entries in Gowin 1.9.12's rPLL IP catalog are covered. Commercial-only and industrial-only grade suffixes are accepted; missing speed grades use the intersection of documented limits. Unknown models and unsupported grades are rejected. GW2AN-9X/18X use the distinct PLLO primitive and are not accepted by this rPLL core.

This PR is based on #2579 to reuse its model and speed-grade helpers. Merge #2579 first, then retarget this PR to master; the incremental change is confined to GW2APLL and its tests.

Sources:

- [DS102](https://cdn.gowinsemi.com.cn/DS102E.pdf), table 3-21: GW2A-18/55.
- [DS226](https://cdn.gowinsemi.com.cn/DS226E.pdf), table 3-20: GW2AR-18.
- [DS976](https://cdn.gowinsemi.com.cn/DS976E.pdf), table 3-20: GW2AN-55.
- [DS961](https://cdn.gowinsemi.com.cn/DS961E.pdf), table 3-20: GW2ANR-18.
- [UG286](https://cdn.gowinsemi.com.cn/UG286E.pdf), sections 5.1 and 5.3: rPLL and PLLO interfaces and supported devices, cross-checked against the installed Gowin 1.9.12 IP catalogs.

Validation:

- `python3 -m unittest test.cores.test_clock test.cores.test_gowin_gw1 test.cores.test_gowin_gw2`: 74 tests passed. New coverage elaborates all eight catalog entries at both C7/I6 and C8/I7, checks VCO/PFD/input limits, verifies the 400 MHz lower VCO boundary, and rejects a 600 MHz output on C7/I6 while allowing it on C8/I7. These regressions fail before this change.
- Elaborated 14 existing board clock/reset configurations, including Tang Nano 20K, Primer 20K and LJPI with video/DDR clocks, plus GW1 boards to check inherited-core compatibility.
- `git diff --check` passed.

Validation is software tests and clock/reset elaboration; no new bitstreams or physical hardware tests were performed for these devices.
