### PR TITLE
cores/clock/lattice_ice40: enforce PFD and output limits

### DIFF
--- a/litex/soc/cores/clock/lattice_ice40.py
+++ b/litex/soc/cores/clock/lattice_ice40.py
@@ -17,13 +17,14 @@ from litex.soc.cores.clock.common import *
 # - add support for GENCLK_HALF to be able to generate clock down to 8MHz.
 
 class iCE40PLL(LiteXModule):
-    nclkouts_max = 1
-    divr_range = (0,  16)
-    divf_range = (0, 128)
-    divq_range = (0,   7)
+    nclkouts_max    = 1
+    divr_range      = (0,  16)
+    divf_range      = (0, 128)
+    divq_range      = (0,   8)
     clki_freq_range = ( 10e6,  133e6)
     clko_freq_range = ( 16e6,  275e6)
     vco_freq_range  = (533e6, 1066e6)
+    pfd_freq_range  = ( 10e6,  133e6)
 
     def __init__(self, primitive="SB_PLL40_CORE", name=None):
         if primitive not in ["SB_PLL40_CORE", "SB_PLL40_PAD"]:
@@ -63,35 +64,36 @@ class iCE40PLL(LiteXModule):
         check_clkouts(self.nclkouts)
         best_config = None
         best_score  = None
+        clkout = self.clkouts[0]
+        pfd_freq_min, pfd_freq_max = self.pfd_freq_range
+        vco_freq_min, vco_freq_max = self.vco_freq_range
+        clko_freq_min, clko_freq_max = self.clko_freq_range
         for divr in range(*self.divr_range):
+            pfd_freq = self.clkin_freq/(divr + 1)
+            if not (pfd_freq_min <= pfd_freq <= pfd_freq_max):
+                continue
             for divf in range(*self.divf_range):
-                all_valid = True
-                errors    = []
-                config    = {}
-                vco_freq = self.clkin_freq/(divr + 1)*(divf +  1)
-                (vco_freq_min, vco_freq_max) = self.vco_freq_range
-                if vco_freq >= vco_freq_min and vco_freq <= vco_freq_max:
-                    for n, clkout in sorted(self.clkouts.items()):
-                        best_clkout = clkout_best_divider(
-                            clkout.freq,
-                            clkout.margin,
-                            range(*self.divq_range),
-                            lambda divq: vco_freq/(2**divq)
-                        )
-                        if best_clkout is None:
-                            all_valid = False
-                            break
-                        error, clk_freq, divq = best_clkout
-                        errors.append(error)
-                        config["clkout_freq"] = clk_freq
-                        config["divq"]        = divq
-                else:
-                    all_valid = False
-                if all_valid:
-                    config["vco"] = vco_freq
-                    config["divr"] = divr
-                    config["divf"] = divf
-                    best_config, best_score = update_best_config(best_config, best_score, config, errors, vco_freq)
+                vco_freq = pfd_freq*(divf + 1)
+                if not (vco_freq_min <= vco_freq <= vco_freq_max):
+                    continue
+                # The requested margin must not relax the hardware output limits.
+                best_clkout = clkout_best_divider(
+                    clkout.freq,
+                    clkout.margin,
+                    (q for q in range(*self.divq_range) if clko_freq_min <= vco_freq/(2**q) <= clko_freq_max),
+                    lambda q: vco_freq/(2**q)
+                )
+                if best_clkout is None:
+                    continue
+                error, clk_freq, divq = best_clkout
+                config = {
+                    "clkout_freq": clk_freq,
+                    "vco":         vco_freq,
+                    "divr":        divr,
+                    "divf":        divf,
+                    "divq":        divq,
+                }
+                best_config, best_score = update_best_config(best_config, best_score, config, [error], vco_freq)
         if best_config is not None:
             compute_config_log(self.logger, best_config)
             return best_config
@@ -99,9 +101,8 @@ class iCE40PLL(LiteXModule):
 
     def do_finalize(self):
         config = self.compute_config()
-        clkfb = Signal()
+        pfd_freq = self.clkin_freq/(config["divr"] + 1)
         for f, v in [(17e6, 1), (26e6, 2), (44e6, 3), (66e6, 4), (101e6, 5), (133e6, 6)]:
-            pfd_freq = self.clkin_freq/(config["divr"] + 1)
             if pfd_freq <= f:
                 filter_range = v
                 break

--- a/test/cores/test_lattice_ice40.py
+++ b/test/cores/test_lattice_ice40.py
@@ -1,0 +1,55 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import ClockDomain, Signal
+
+from litex.soc.cores.clock.lattice_ice40 import iCE40PLL
+
+
+class TestiCE40PLL(unittest.TestCase):
+    def test_divided_reference_stays_in_pfd_range(self):
+        for clkin, clkout in ((12e6, 40e6), (16e6, 125e6), (24e6, 16e6), (48e6, 74.25e6)):
+            with self.subTest(clkin=clkin, clkout=clkout):
+                pll = iCE40PLL()
+                pll.register_clkin(Signal(), clkin)
+                pll.create_clkout(ClockDomain("sys"), clkout)
+                config = pll.compute_config()
+                self.assertGreaterEqual(clkin/(config["divr"] + 1), 10e6)
+                self.assertLessEqual(clkin/(config["divr"] + 1), 133e6)
+                self.assertLessEqual(abs(config["clkout_freq"]/clkout - 1), 1e-2)
+
+    def test_exact_frequency_requiring_invalid_pfd_is_rejected(self):
+        pll = iCE40PLL()
+        pll.register_clkin(Signal(), 24e6)
+        pll.create_clkout(ClockDomain("sys"), 16e6, margin=0)
+        with self.assertRaisesRegex(ValueError, "No PLL config"):
+            pll.compute_config()
+
+    def test_margin_does_not_relax_hardware_output_limits(self):
+        for clkin in (12e6, 27e6, 48e6, 133e6):
+            for clkout in (16e6, 275e6):
+                with self.subTest(clkin=clkin, clkout=clkout):
+                    pll = iCE40PLL()
+                    pll.register_clkin(Signal(), clkin)
+                    pll.create_clkout(ClockDomain("sys"), clkout, margin=0.05)
+                    config = pll.compute_config()
+                    self.assertGreaterEqual(config["clkout_freq"], 16e6)
+                    self.assertLessEqual(config["clkout_freq"], 275e6)
+
+    def test_emitted_dividers_and_filter(self):
+        for primitive in ("SB_PLL40_CORE", "SB_PLL40_PAD"):
+            with self.subTest(primitive=primitive):
+                pll = iCE40PLL(primitive=primitive)
+                pll.register_clkin(Signal(), 12e6)
+                pll.create_clkout(ClockDomain("sys"), 40e6)
+                config = pll.compute_config()
+                pll.get_fragment()
+                actual = 12e6*(pll.params["p_DIVF"] + 1)/(pll.params["p_DIVR"] + 1)/2**pll.params["p_DIVQ"]
+                self.assertEqual(actual, config["clkout_freq"])
+                self.assertEqual(pll.params["p_FILTER_RANGE"], 1)
+                self.assertIn("i_REFERENCECLK" if primitive == "SB_PLL40_CORE" else "i_PACKAGEPIN", pll.params)


### PR DESCRIPTION
iCE40PLL validates the external input clock but does not check the divided reference frequency at the phase detector. It can therefore choose configurations outside the documented 10–133 MHz PFD range. For example, a 12 MHz input and 40 MHz request currently select DIVR=1, giving a 6 MHz PFD; the corrected solver selects a legal 39.75 MHz output within the requested 1% margin.

Check the PFD before searching feedback dividers, and restrict candidate output frequencies to the hardware's 16–275 MHz range even when the requested margin would permit an out-of-range result. Simplify the search around this core's single output, reject invalid candidates early, cover all DIVQ encodings, and remove the unused feedback signal.

Sources: [iCE40 UltraPlus datasheet](https://www.latticesemi.com/view_document?document_id=51968), sysCLOCK PLL Timing, specifies PFD, VCO and output limits; [iCE40 sysCLOCK guide](https://www.latticesemi.com/view_document?document_id=52236) describes the SIMPLE feedback divider formula and DIVQ field.

Validation:

- Existing clock suite: 66 tests passed (`python3 -m unittest test.cores.test_clock`).
- New regressions: four tests passed (`python3 -m unittest test.cores.test_lattice_ice40`), covering invalid divided references, impossible exact requests, output-limit handling, and CORE/PAD primitive parameters. These tests fail against the previous implementation.
- Elaborated the existing iCEBreaker clock/reset generator at 24, 40 and 48 MHz.
- `git diff --check` passed.

Validation covers software and elaboration; no new FPGA bitstream or hardware test was performed. Some requests previously accepted through an out-of-spec PFD are now rejected or use a different legal frequency within their margin.
