### PR TITLE
cores/clock/lattice_nx: correct reference divider and analog configuration

### DIFF
--- a/litex/soc/cores/clock/lattice_nx.py
+++ b/litex/soc/cores/clock/lattice_nx.py
@@ -7,8 +7,7 @@
 
 from collections import namedtuple
 import logging
-import math
-from math import log, log10, exp, pi
+from math import log10, pi
 from cmath import phase
 
 from migen import *
@@ -122,9 +121,9 @@ class NXPLL(LiteXModule):
     clki_div_range      = ( 1, 128+1)
     clkfb_div_range     = ( 1, 128+1)
     clko_div_range      = ( 1, 128+1)
-    clki_freq_range     = ( 10e6,   500e6)
+    clki_freq_range     = ( 18e6,   500e6)
     clko_freq_range     = ( 6.25e6, 800e6)
-    vco_in_freq_range   = ( 10e6,   500e6)
+    vco_in_freq_range   = ( 18e6,   500e6)
     vco_out_freq_range  = ( 800e6,  1600e6)
     instance_num        = 0
 
@@ -173,11 +172,15 @@ class NXPLL(LiteXModule):
         best_config = None
         best_score  = None
         for clki_div in range(*self.clki_div_range):
+            pfd_freq = self.clkin_freq/clki_div
+            pfd_freq_min, pfd_freq_max = self.vco_in_freq_range
+            if not (pfd_freq_min <= pfd_freq <= pfd_freq_max):
+                continue
             for clkfb_div in range(*self.clkfb_div_range):
                 all_valid = True
                 errors    = []
                 config    = {"clki_div": clki_div}
-                vco_freq  = self.clkin_freq/clki_div*clkfb_div
+                vco_freq  = pfd_freq*clkfb_div
                 (vco_freq_min, vco_freq_max) = self.vco_out_freq_range
                 if vco_freq >= vco_freq_min and vco_freq <= vco_freq_max:
                     for n, clkout in sorted(self.clkouts.items()):
@@ -235,7 +238,8 @@ class NXPLL(LiteXModule):
             p_PLLPD_N           = "USED",
             p_PLLRESET_ENA      = "ENABLED",
             p_REF_INTEGER_MODE  = "ENABLED", # Ref manual has a discrepency so lets always set this value just in case
-            p_REF_MMD_DIG       = "1", # Divider for the input clock, ie 'M'
+            p_REF_MMD_DIG       = str(config["clki_div"]),
+            p_REF_MMD_PULS_CTL  = "0b0000" if config["clki_div"] <= 2 else "0b0001",
 
             i_PLLRESET          = self.reset,
             i_REFCK             = self.clkin,
@@ -256,7 +260,7 @@ class NXPLL(LiteXModule):
             p_FBK_MMD_DIG       = "1",
         )
 
-        analog_params = self.calculate_analog_parameters(self.clkin_freq, config["clkfb_div"])
+        analog_params = self.calculate_analog_parameters(self.clkin_freq/config["clki_div"], config["clkfb_div"])
         self.params.update(analog_params)
         n_to_l = {0: "P", 1: "S", 2: "S2", 3:"S3", 4:"S4"}
 
@@ -275,10 +279,9 @@ class NXPLL(LiteXModule):
             # on generated clocks that are causing timing problems and Lattice
             # hasn't responded to my support requests on the matter.
             if self.platform and self.create_output_port_clocks:
-                self.platform.add_platform_command("create_clock -period {} -name {} [get_pins {}.PLL_inst/CLKO{}]".format(str(1/clkout.freq*1e9), self.name + "_" + n_to_l[n], self.name, n_to_l[n]))
+                clk_freq = config["clko{}_freq".format(n)]
+                self.platform.add_platform_command("create_clock -period {} -name {} [get_pins {}.PLL_inst/CLKO{}]".format(str(1/clk_freq*1e9), self.name + "_" + n_to_l[n], self.name, n_to_l[n]))
 
-        if self.platform and self.create_output_port_clocks:
-            i = 0
         self.specials += Instance("PLL", name = self.name, **self.params)
 
     # The gist of calculating the analog parameters is to run through all the
@@ -308,7 +311,8 @@ class NXPLL(LiteXModule):
                 continue
 
             closed_loop_3db = self.closed_loop_3db(fbkdiv, params)
-            bw_factor = fref*1e6 / M / closed_loop_3db["f"]
+            # Both the reference and loop bandwidth are expressed in Hz.
+            bw_factor = fref / M / closed_loop_3db["f"]
             if bw_factor < BW_FACTOR:
                 continue
 
@@ -316,6 +320,8 @@ class NXPLL(LiteXModule):
                 best_3db = closed_loop_3db["f"]
                 best_params = params
 
+        if best_params is None:
+            raise ValueError("No PLL analog parameters found.")
         HDL_params = self.numerical_params_to_HDL_params(best_params)
         self.logger.debug("Done calculating analog parameters: %s", HDL_params)
 

--- a/test/cores/test_lattice_nx.py
+++ b/test/cores/test_lattice_nx.py
@@ -1,0 +1,67 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+from unittest.mock import Mock, patch
+
+from migen import ClockDomain, Signal
+
+from litex.soc.cores.clock.lattice_nx import NXPLL
+
+
+class TestNXPLL(unittest.TestCase):
+    def test_reference_and_pfd_limits(self):
+        pll = NXPLL()
+        with self.assertRaisesRegex(ValueError, "Input clock frequency"):
+            pll.register_clkin(Signal(), 17e6)
+        pll.register_clkin(Signal(), 100e6)
+        pll.create_clkout(ClockDomain("sys"), 74.25e6)
+        config = pll.compute_config()
+        self.assertGreaterEqual(100e6/config["clki_div"], 18e6)
+        self.assertLessEqual(100e6/config["clki_div"], 500e6)
+        self.assertLessEqual(abs(config["clko0_freq"]/74.25e6 - 1), 1e-2)
+
+    def test_emitted_input_divider(self):
+        for frequency, divider in ((200e6, 1), (310e6, 2), (74.25e6, 5)):
+            with self.subTest(frequency=frequency):
+                pll = NXPLL()
+                pll.register_clkin(Signal(), 100e6)
+                pll.create_clkout(ClockDomain("sys"), frequency)
+                config = pll.compute_config()
+                self.assertEqual(config["clki_div"], divider)
+                with patch.object(pll, "calculate_analog_parameters", wraps=pll.calculate_analog_parameters) as analog:
+                    pll.get_fragment()
+                    analog.assert_called_once_with(100e6/divider, config["clkfb_div"])
+                reference_div = int(pll.params["p_REF_MMD_DIG"])
+                feedback_div  = int(pll.params["p_DIVF"]) + 1
+                output_div    = int(pll.params["p_DIVA"]) + 1
+                actual = 100e6/reference_div*feedback_div/output_div
+                self.assertAlmostEqual(actual, config["clko0_freq"])
+                self.assertEqual(pll.params["p_REF_MMD_PULS_CTL"], "0b0000" if divider <= 2 else "0b0001")
+
+    def test_output_constraint_uses_actual_frequency(self):
+        platform = Mock()
+        pll = NXPLL(platform=platform, create_output_port_clocks=True, name="sys_pll")
+        pll.register_clkin(Signal(), 100e6)
+        pll.create_clkout(ClockDomain("sys"), 74.25e6)
+        config = pll.compute_config()
+        self.assertNotEqual(config["clko0_freq"], 74.25e6)
+        pll.get_fragment()
+        command = platform.add_platform_command.call_args.args[0]
+        period = float(command.split("-period ", 1)[1].split()[0])
+        self.assertAlmostEqual(1e9/period, config["clko0_freq"])
+
+    def test_analog_bandwidth_uses_hz(self):
+        pll = NXPLL()
+        for reference, feedback in ((20e6, 78), (18e6, 88)):
+            with self.subTest(reference=reference):
+                selected = pll.calculate_analog_parameters(reference, feedback, bw_factor=5)
+                candidate = next(p for p in pll.transfer_func_coefficients
+                    if {"p_" + key: value for key, value in pll.numerical_params_to_HDL_params(p).items()} == selected)
+                bandwidth = pll.closed_loop_3db(feedback, candidate)["f"]
+                self.assertGreaterEqual(reference/bandwidth, 5)
+        with self.assertRaisesRegex(ValueError, "No PLL analog parameters"):
+            pll.calculate_analog_parameters(20e6, 78, bw_factor=1e6)


### PR DESCRIPTION
NXPLL searches input dividers but always emits `REF_MMD_DIG="1"`. A 100 MHz input / 310 MHz output configuration selects divide-by-two in software, then emits a PLL with no input division. The solver also ignores its PFD range, allowing divided references below the documented 18 MHz minimum.

- Emit the selected input divider and its pulse-control setting, following Lattice's reference PLL wrapper.
- Enforce the documented 18–500 MHz input and integer-mode PFD limits.
- Calculate analog parameters using the divided reference frequency. Correct the Hz/MHz mismatch in the bandwidth ratio and report a clear error if no analog parameter set meets the constraints. The existing transfer-function model and default bandwidth factor are retained.
- When output-port clock constraints are requested, use the selected output frequency, including any accepted approximation.
- Remove unused imports and dead finalization code.

Sources:

- [CrossLink-NX datasheet](https://www.latticesemi.com/view_document?document_id=52780), [Certus-NX datasheet](https://www.latticesemi.com/view_document?document_id=52890), and [CertusPro-NX datasheet](https://www.latticesemi.com/view_document?document_id=53126): sysCLOCK PLL timing specifies the input/PFD limits.
- [Nexus sysCLOCK guide, FPGA-TN-02095-2.7](https://www.latticesemi.com/view_document?document_id=52789): reference divider and `lmmi_ref_mmd_puls_ctl` settings. Cross-checked against the installed Radiant `ip/lifcl/pll/rtl/lscc_pll.v` and PLL plugin's bandwidth-ratio calculation.

Validation:

- `python3 -m unittest test.cores.test_clock test.cores.test_lattice_nx`: 70 tests passed. Regressions reconstruct the output frequency from emitted primitive parameters for input divisors 1, 2 and 5, check the PFD range and timing constraint, and verify the selected analog loop bandwidth. These tests fail against the previous implementation.
- Elaborated CrossLink-NX EVN at 75 MHz and Certus-NX Versa at 75 MHz with/without DDR3 and at 74.25 MHz, exercising a non-unity reference divider.
- `git diff --check` passed.

Validation covers software and elaboration; no new FPGA bitstream or hardware test was performed. Divider and analog-filter settings can change, and inputs below the documented 18 MHz limit are now rejected.
