### PR TITLE
cores/clock/lattice_ecp5: simplify feedback configuration

### DIFF
--- a/litex/soc/cores/clock/lattice_ecp5.py
+++ b/litex/soc/cores/clock/lattice_ecp5.py
@@ -59,11 +59,8 @@ class ECP5PLL(LiteXModule):
     def compute_config(self):
         check_clkin_registered(hasattr(self, "clkin"))
         check_clkouts(self.nclkouts)
-        best_config            = None
-        best_score             = None
-        best_feedback_clkout   = None
-        active_clkouts         = {n: clkout for n, clkout in self.clkouts.items() if clkout.freq > 0}
-        feedback_only_clkouts  = [n for n, clkout in self.clkouts.items() if clkout.freq == 0]
+        best_config = None
+        best_score  = None
         # Iterate on CLKI dividers...
         for clki_div in range(*self.clki_div_range):
             # Check if in PFD range.
@@ -84,15 +81,13 @@ class ECP5PLL(LiteXModule):
                         config["clkfb"]  = None
                         clkout_configs   = {}
                         feedback_configs = {}
-                        for n, clkout in sorted(active_clkouts.items()):
-                            for d in range(*self.clko_div_range):
-                                clk_freq = vco_freq/d
-                                error    = clkout_freq_error(clk_freq, clkout.freq)
-                                # Check if output can be used as feedback, if so save it.
-                                # (We cannot use clocks with dynamic phase adjustment enabled)
-                                if error <= clkout.margin and (d == clkofb_div) and (not (clkout.uses_dpa and self.dpa_en)):
-                                    if n not in feedback_configs or error < feedback_configs[n][0]:
-                                        feedback_configs[n] = (error, clk_freq, d, clkout.phase)
+                        for n, clkout in sorted(self.clkouts.items()):
+                            # Only the current feedback divider can serve as feedback.
+                            # Outputs using dynamic phase adjustment cannot be reused.
+                            clk_freq = vco_freq/clkofb_div
+                            error    = clkout_freq_error(clk_freq, clkout.freq)
+                            if error <= clkout.margin and not (clkout.uses_dpa and self.dpa_en):
+                                feedback_configs[n] = (error, clk_freq, clkofb_div, clkout.phase)
                             best_clkout = clkout_best_divider(
                                 clkout.freq,
                                 clkout.margin,
@@ -109,7 +104,7 @@ class ECP5PLL(LiteXModule):
                                 if n in feedback_configs and d == feedback_configs[n][2]:
                                     config["clkfb"] = n
 
-                            if config["clkfb"] is None and self.nclkouts == self.nclkouts_max and not feedback_only_clkouts:
+                            if config["clkfb"] is None and self.nclkouts == self.nclkouts_max:
                                 best_feedback_score  = None
                                 best_feedback_clkout = None
                                 for n, feedback_config in feedback_configs.items():
@@ -137,26 +132,15 @@ class ECP5PLL(LiteXModule):
                     else:
                         all_valid = False
                     if all_valid:
-                        # If no output suitable for feedback, create a new output for it.
+                        # Reserve a spare output for feedback when no requested output is suitable.
                         if config["clkfb"] is None:
-                            # We need at least a free output...
-                            if feedback_only_clkouts:
-                                feedback_clkout = feedback_only_clkouts[0]
-                            else:
-                                feedback_clkout = self.nclkouts
+                            feedback_clkout = self.nclkouts
                             config["clkfb"] = feedback_clkout
-                            config[f"clko{feedback_clkout}_div"] = int((vco_freq*clki_div)/(self.clkin_freq*clkfb_div))
-                        else:
-                            feedback_clkout = None
+                            config[f"clko{feedback_clkout}_div"] = clkofb_div
                         config["vco"]       = vco_freq
                         config["clkfb_div"] = clkfb_div
-                        best_config, new_score = update_best_config(best_config, best_score, dict(config), errors, vco_freq)
-                        if new_score != best_score:
-                            best_score           = new_score
-                            best_feedback_clkout = feedback_clkout
+                        best_config, best_score = update_best_config(best_config, best_score, config, errors, vco_freq)
         if best_config is not None:
-            if best_feedback_clkout is not None and best_feedback_clkout not in self.clkouts:
-                self.clkouts[best_feedback_clkout] = ClkOutDPA(Signal(), 0, 0, 0, 0)
             compute_config_log(self.logger, best_config)
             return best_config
         raise pll_config_error(self.clkin_freq, self.clkouts)
@@ -199,7 +183,10 @@ class ECP5PLL(LiteXModule):
             p_CLKI_DIV      = config["clki_div"]
         )
         self.comb += self.locked.eq(locked & ~self.reset)
-        for n, clkout in sorted(self.clkouts.items()):
+        clkouts = dict(self.clkouts)
+        if config["clkfb"] not in clkouts:
+            clkouts[config["clkfb"]] = ClkOutDPA(Signal(), 0, 0, 0, False)
+        for n, clkout in sorted(clkouts.items()):
             div    = config[f"clko{n}_div"]
             phase  = round(clkout.phase*div/45)
             self.params[f"p_CLKO{n_to_l[n]}_ENABLE"] = "ENABLED"

--- a/test/cores/test_lattice_ecp5.py
+++ b/test/cores/test_lattice_ecp5.py
@@ -1,0 +1,64 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import ClockDomain, Signal
+
+from litex.soc.cores.clock.lattice_ecp5 import ECP5PLL
+
+
+class TestECP5PLL(unittest.TestCase):
+    def test_configuration_queries_leave_outputs_unchanged(self):
+        pll = ECP5PLL()
+        pll.register_clkin(Signal(), 100e6)
+        pll.create_clkout(ClockDomain("sys"), 80e6)
+        pll.expose_dpa()
+        outputs = dict(pll.clkouts)
+        first = pll.compute_config()
+        self.assertEqual(pll.clkouts, outputs)
+        self.assertEqual(pll.compute_config(), first)
+        self.assertEqual(pll.clkouts, outputs)
+        self.assertEqual(first["clkfb"], 1)
+        pll.get_fragment()
+        self.assertEqual(pll.clkouts, outputs)
+        self.assertEqual(pll.params["p_FEEDBK_PATH"], "INT_OS")
+        self.assertEqual(pll.params["p_CLKOS_DIV"], first["clko1_div"])
+
+    def test_can_add_output_after_configuration_query(self):
+        pll = ECP5PLL()
+        pll.register_clkin(Signal(), 100e6)
+        pll.create_clkout(ClockDomain("sys"), 80e6)
+        pll.expose_dpa()
+        pll.compute_config()
+        pll.create_clkout(ClockDomain("other"), 40e6)
+        config = pll.compute_config()
+        self.assertEqual(set(pll.clkouts), {0, 1})
+        self.assertEqual(config["clkfb"], 2)
+        pll.get_fragment()
+        self.assertEqual(pll.params["p_FEEDBK_PATH"], "INT_OS2")
+
+    def test_four_outputs_reuse_eligible_feedback(self):
+        pll = ECP5PLL()
+        pll.register_clkin(Signal(), 100e6)
+        for n in range(4):
+            pll.create_clkout(ClockDomain("out" + str(n)), 200e6, uses_dpa=(n != 0))
+        pll.expose_dpa()
+        config = pll.compute_config()
+        self.assertEqual(config["clkfb"], 0)
+        self.assertEqual(set(pll.clkouts), {0, 1, 2, 3})
+        pll.get_fragment()
+        self.assertEqual(pll.params["p_FEEDBK_PATH"], "INT_OP")
+
+    def test_four_dynamic_outputs_have_no_spare_feedback(self):
+        pll = ECP5PLL()
+        pll.register_clkin(Signal(), 100e6)
+        for n in range(4):
+            pll.create_clkout(ClockDomain("out" + str(n)), 200e6)
+        pll.expose_dpa()
+        with self.assertRaisesRegex(ValueError, "No PLL config"):
+            pll.compute_config()
+        self.assertEqual(set(pll.clkouts), {0, 1, 2, 3})


### PR DESCRIPTION
ECP5PLL's configuration search currently inserts a feedback-only signal into `self.clkouts`. A query therefore changes the requested-output collection, and later queries need special handling for the inserted zero-frequency entry.

Keep configuration search free of these mutations: return the selected feedback index/divider, and create any spare feedback output only in the finalizer's local output map. This removes feedback-placeholder bookkeeping and permits repeated queries or adding requested outputs after a query. Preserve the existing four-output and dynamic-phase feedback rules.

Also replace the 128-divider feedback scan with a direct check of the current feedback divider, and retain that integer divider instead of reconstructing it through floating-point arithmetic.

The feedback routing and dynamic-phase restrictions were checked against the [ECP5 sysCLOCK guide, FPGA-TN-02200-1.4](https://www.latticesemi.com/view_document?document_id=50465).

Validation:

- Existing clock suite: 66 tests passed (`python3 -m unittest test.cores.test_clock`).
- New regressions: four tests passed (`python3 -m unittest test.cores.test_lattice_ecp5`), covering repeated queries, adding an output after a query, spare-output emission, four-output feedback reuse, and rejection when all four outputs require dynamic phase adjustment. The mutation regressions fail before this change.
- Compared 14 configuration cases before/after: identical results (12 successful configurations and two rejections). The local solver sweep took approximately 0.76 seconds before and 0.40 seconds after.
- Elaborated Versa ECP5 at 75 MHz and ULX3S at 50 MHz with video clocks and both SDRAM ratios.
- `git diff --check` passed.

The optional ULX3S USB PLL (25 MHz input, exact 12/48 MHz outputs) fails configuration both before and after this change under the existing 10 MHz PFD minimum. That pre-existing limitation is outside this cleanup. Validation covers software and elaboration; no new FPGA bitstream or hardware test was performed.
