### PR TITLE
cores/clock/xilinx_usp: reuse the shared MMCM solver

### DIFF
--- a/litex/soc/cores/clock/xilinx_usp.py
+++ b/litex/soc/cores/clock/xilinx_usp.py
@@ -8,7 +8,6 @@ from litex.gen import *
 
 from litex.soc.cores.clock.common import *
 from litex.soc.cores.clock.xilinx_common import *
-from typing import Dict, Any
 
 # Xilinx / Ultrascale Plus PLL ---------------------------------------------------------------------
 
@@ -72,6 +71,9 @@ class USPMMCM(XilinxClocking):
         XilinxClocking.__init__(self)
         self.name = name
         self.divclk_divide_range = (1, 106+1)
+        # UG572: fractional feedback and CLKOUT0 dividers use 1/8 steps.
+        self.clkfbout_mult_frange = (2, 128+1/8, 1/8)
+        self.clkout0_divide_range = (2, 128+1/8, 1/8)
         self.clkin_freq_range = {
             -1: (10e6,  800e6),
             -2: (10e6,  933e6),
@@ -111,75 +113,6 @@ class USPMMCM(XilinxClocking):
             self.params["p_CLKOUT{}_PHASE".format(n)] = config["clkout{}_phase".format(n)]
             self.params["o_CLKOUT{}".format(n)]       = clkout.clk
         self.specials += Instance("MMCME4_ADV", name=self.name or "", **self.params)
-
-    def compute_config(self) -> Dict[str, Any]:
-        """
-        Computes the MMCM configuration based on input parameters.
-
-        Returns:
-            Dict[str, Any]: A dictionary containing MMCM configuration parameters.
-
-        Raises:
-            ValueError: If no valid MMCM configuration is found.
-        """
-        vco_min_margin = self.vco_freq_range[0] * (1 + self.vco_margin)
-        vco_max_margin = self.vco_freq_range[1] * (1 - self.vco_margin)
-        # ref: https://docs.amd.com/r/en-US/ug572-ultrascale-clocking/MMCM-Attributes
-        # CLKFBOUT_MULT_F: 2.0 to 128.0 with step 0.125
-        clkfbout_mult_f_values = [x / 8 for x in range(16, 1025)]
-
-        best_config = None
-        best_score  = None
-
-        for divclk_divide in range(*self.divclk_divide_range):
-            for clkfbout_mult in reversed(clkfbout_mult_f_values):
-                vco_freq = self.clkin_freq * clkfbout_mult / divclk_divide
-                if not (vco_min_margin <= vco_freq <= vco_max_margin):
-                    continue # vco_freq out of range
-
-                config: Dict[str, Any] = {
-                    "divclk_divide": divclk_divide,
-                    "clkfbout_mult": clkfbout_mult,
-                    "vco": vco_freq
-                }
-                errors = []
-                all_valid = True
-                for n, clkout in sorted(self.clkouts.items()):
-                    div_ranges = [self.clkout_divide_range]
-                    # Add specific range dividers if they exist
-                    specific_div_range = getattr(self, f"clkout{n}_divide_range", None)
-                    if specific_div_range:
-                        div_ranges.append(specific_div_range)
-
-                    # For clkout0, CLKOUT[0]_DIVIDE_F also has range 2.0 to 128.0 with step 0.125
-                    if n == 0:
-                        div_ranges = [(2, 128 + 1/8, 1/8)]
-
-                    best_clkout = clkout_best_divider(
-                        clkout.freq,
-                        clkout.margin,
-                        clkdiv_candidates(div_ranges, ideal=vco_freq/clkout.freq),
-                        lambda d: vco_freq/d
-                    )
-
-                    if best_clkout is None:
-                        all_valid = False
-                        break # Exit early if any clock output is invalid
-
-                    error, clk_freq, d = best_clkout
-                    errors.append(error)
-                    config[f"clkout{n}_freq"] = clk_freq
-                    config[f"clkout{n}_divide"] = d
-                    config[f"clkout{n}_phase"] = clkout.phase
-
-                if all_valid:
-                    best_config, best_score = update_best_config(best_config, best_score, config, errors, vco_freq)
-
-        if best_config is not None:
-            compute_config_log(self.logger, best_config)
-            return best_config
-
-        raise ValueError("No MMCM config found")
 
 # Xilinx / Ultrascale Plus IDELAY CTRL -------------------------------------------------------------
 

--- a/test/cores/test_xilinx_usp.py
+++ b/test/cores/test_xilinx_usp.py
@@ -1,0 +1,62 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import *
+
+from litex.soc.cores.clock.xilinx_usp import USPMMCM
+
+
+class TestUSPMMCM(unittest.TestCase):
+    def test_missing_clocks(self):
+        mmcm = USPMMCM()
+        with self.assertRaisesRegex(ValueError, "Input clock"):
+            mmcm.compute_config()
+        mmcm.register_clkin(Signal(), 100e6)
+        with self.assertRaisesRegex(ValueError, "output clock"):
+            mmcm.compute_config()
+
+    def test_clkout0_divide_by_one(self):
+        mmcm = USPMMCM(speedgrade=-3)
+        mmcm.register_clkin(Signal(), 101.25e6)
+        mmcm.create_clkout(ClockDomain("clkout"), 810e6, margin=0)
+        mmcm.get_fragment()
+        self.assertEqual(mmcm.params["p_CLKOUT0_DIVIDE_F"], 1)
+        self.assertEqual(mmcm.params["p_CLKFBOUT_MULT_F"], 8)
+
+    def test_fractional_feedback_and_output(self):
+        mmcm = USPMMCM()
+        mmcm.register_clkin(Signal(), 12e6)
+        mmcm.create_clkout(ClockDomain("clkout"), 148.5e6, margin=0)
+        config = mmcm.compute_config()
+        self.assertEqual(config["clkfbout_mult"], 123.75)
+        self.assertEqual(config["clkout0_freq"], 148.5e6)
+
+        mmcm = USPMMCM()
+        mmcm.register_clkin(Signal(), 100e6)
+        mmcm.create_clkout(ClockDomain("clkout0"), 80e6, margin=0)
+        mmcm.create_clkout(ClockDomain("clkout1"), 125e6, margin=0)
+        config = mmcm.compute_config()
+        self.assertEqual(config["clkout0_divide"], 18.75)
+        self.assertEqual(config["clkout1_divide"], 12)
+        self.assertEqual(config["clkout0_freq"], 80e6)
+        self.assertEqual(config["clkout1_freq"], 125e6)
+
+    def test_multiplier_and_divider_endpoints(self):
+        mmcm = USPMMCM()
+        mmcm.register_clkin(Signal(), 10e6)
+        mmcm.create_clkout(ClockDomain("clkout"), 10e6, margin=0)
+        config = mmcm.compute_config()
+        self.assertEqual(config["clkfbout_mult"], 128)
+        self.assertEqual(config["clkout0_divide"], 128)
+
+    def test_no_config_diagnostic(self):
+        mmcm = USPMMCM()
+        mmcm.register_clkin(Signal(), 100e6)
+        mmcm.create_clkout(ClockDomain("clkout"), 1e6, margin=0)
+        with self.assertRaisesRegex(ValueError, "No PLL config found.*ClkIn=100.00MHz, ClkOut0=1.00MHz"):
+            mmcm.compute_config()


### PR DESCRIPTION
USPMMCM has a separate configuration search that duplicates XilinxClocking, bypasses its missing-clock checks and detailed failure diagnostics, and excludes CLKOUT0 divide-by-one. For example, 101.25 MHz → 810 MHz on a -3 device has a legal M=8, D=1, O=1 configuration that the existing code rejects.

Describe the UltraScale+ fractional ranges in the constructor and reuse the shared solver. This removes 70 lines of duplicated code while retaining feedback multipliers through 128 and 1/8-step fractional operation. The shared output search includes integer divide-by-one without admitting the unsupported fractional interval between 1 and 2.

References: [UG572 MMCM attributes](https://docs.amd.com/r/en-US/ug572-ultrascale-clocking/MMCM-Attributes), [DS922 MMCM specifications](https://docs.amd.com/r/en-US/ds922-kintex-ultrascale-plus/MMCM-Switching-Characteristics). Also checked against the installed Vivado 2024.1 MMCME4_ADV model.

Validation:

- `python3 -m unittest test.cores.test_xilinx_usp test.cores.test_clock -q`: 71 tests pass; new tests reproduce the missing-clock, divide-by-one and diagnostic failures before the change.
- Regular LiteX-Boards clock/reset generation and Verilog conversion: KCU116 at 100/125 MHz and Alibaba KU3P at 100 MHz.
- Vivado 2024.1 out-of-context synthesis, optimization and PDRC/REQP checks pass for four generated designs: divide-by-one at 810 MHz, fractional feedback at 148.5 MHz, fractional CLKOUT0 with a second integer output, and the multiplier/divider 128 endpoints.

No hardware testing or routed timing qualification is claimed.
