### PR TITLE
cores/clock/xilinx_s6: respect DCM_CLKGEN divider and frequency limits

### DIFF
--- a/litex/soc/cores/clock/xilinx_s6.py
+++ b/litex/soc/cores/clock/xilinx_s6.py
@@ -64,26 +64,62 @@ class S6PLL(XilinxClocking):
 class S6DCM(XilinxClocking):
     """ single output with f_out = f_in * {2 .. 256} / {1 .. 256} """
     nclkouts_max = 1
-    clkfbout_mult_frange = (2, 256 + 1)
-    clkout_divide_range  = (1, 256 + 1)
 
     def __init__(self, speedgrade=-1, name=None):
         self.logger = logging.getLogger("S6DCM")
         self.logger.info("Creating S6DCM, {}.".format(colorer("speedgrade {}".format(speedgrade))))
         XilinxClocking.__init__(self)
         self.name = name
-        self.divclk_divide_range = (1, 2) # FIXME
+        self.clkfbout_mult_frange = (2, 256+1)
+        self.clkout_divide_range  = (1, 256+1)
         self.clkin_freq_range = {
             -1: (0.5e6, 200e6),
             -2: (0.5e6, 333e6),
             -3: (0.5e6, 375e6),
         }[speedgrade]
 
-        self.vco_freq_range = {
-            -1: (5e6, 1e16),
-            -2: (5e6, 1e16),
-            -3: (5e6, 1e16),
+        # DS162, Table 57: DCM_CLKGEN CLKFX output frequency limits.
+        self.clkout_freq_range = {
+            -1: (5e6, 200e6),
+            -2: (5e6, 333e6),
+            -3: (5e6, 375e6),
         }[speedgrade]
+
+    def create_clkout(self, cd, freq, phase=0, buf="bufg", margin=1e-2, with_reset=True, reset_buf=None, ce=None):
+        check_freq_range(freq, self.clkout_freq_range, "Output clock frequency")
+        if phase != 0:
+            raise ValueError("S6DCM does not support output phase shifts.")
+        XilinxClocking.create_clkout(self, cd, freq, phase, buf, margin, with_reset, reset_buf, ce)
+
+    def compute_config(self):
+        check_clkin_registered(hasattr(self, "clkin"))
+        check_clkouts(self.nclkouts)
+        clkout = self.clkouts[0]
+        best_config = None
+        best_score  = None
+        for divider in range(*self.clkout_divide_range):
+            # UG382, Table 2-9: required for locking below 52MHz.
+            if self.clkin_freq < 52e6 and divider >= self.clkin_freq/0.5e6:
+                continue
+            for multiplier in range(*self.clkfbout_mult_frange):
+                clkout_freq = self.clkin_freq*multiplier/divider
+                if not (self.clkout_freq_range[0] <= clkout_freq <= self.clkout_freq_range[1]):
+                    continue
+                error = clkout_freq_error(clkout_freq, clkout.freq)
+                if error > clkout.margin:
+                    continue
+                config = {
+                    "clkfbout_mult": multiplier,
+                    "divclk_divide": 1,
+                    "clkout0_freq": clkout_freq,
+                    "clkout0_divide": divider,
+                    "clkout0_phase": clkout.phase,
+                }
+                best_config, best_score = update_best_config(best_config, best_score, config, [error])
+        if best_config is not None:
+            compute_config_log(self.logger, best_config)
+            return best_config
+        raise pll_config_error(self.clkin_freq, self.clkouts)
 
     def do_finalize(self):
         XilinxClocking.do_finalize(self)
@@ -91,7 +127,7 @@ class S6DCM(XilinxClocking):
         clkout = sorted(self.clkouts.items())[0][1]
         self.params.update(
             p_CLKFX_MULTIPLY  = config["clkfbout_mult"],
-            p_CLKFX_DIVIDE    = config["clkout0_divide"] * config["divclk_divide"],
+            p_CLKFX_DIVIDE    = config["clkout0_divide"],
             p_SPREAD_SPECTRUM = "NONE",
             p_CLKIN_PERIOD    = 1e9/self.clkin_freq,
             i_CLKIN           = self.clkin,

--- a/test/cores/test_xilinx_s6.py
+++ b/test/cores/test_xilinx_s6.py
@@ -1,0 +1,72 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import *
+
+from litex.soc.cores.clock.xilinx_s6 import S6DCM
+
+
+class TestS6DCM(unittest.TestCase):
+    def test_full_multiplier_and_divider_ranges(self):
+        for clkin_freq, clkout_freq, multiplier, divider in [
+            (  1e6,       256e6, 256,   1),
+            (100e6, 6.640625e6,  17, 256),
+        ]:
+            with self.subTest(clkin_freq=clkin_freq, clkout_freq=clkout_freq):
+                dcm = S6DCM(speedgrade=-2)
+                dcm.register_clkin(Signal(), clkin_freq)
+                dcm.create_clkout(ClockDomain("clkout"), clkout_freq, margin=0)
+                dcm.get_fragment()
+                self.assertEqual(dcm.params["p_CLKFX_MULTIPLY"], multiplier)
+                self.assertEqual(dcm.params["p_CLKFX_DIVIDE"], divider)
+
+    def test_low_input_frequency_locking(self):
+        for clkin_freq in [1e6, 12e6, 51e6, 52e6]:
+            with self.subTest(clkin_freq=clkin_freq):
+                dcm = S6DCM()
+                dcm.register_clkin(Signal(), clkin_freq)
+                dcm.create_clkout(ClockDomain("clkout"), 12e6, margin=0)
+                config = dcm.compute_config()
+                self.assertEqual(config["clkout0_freq"], 12e6)
+                if clkin_freq < 52e6:
+                    self.assertLess(config["clkout0_divide"], clkin_freq/0.5e6)
+
+    def test_output_frequency_limits(self):
+        for speedgrade, max_freq in [(-1, 200e6), (-2, 333e6), (-3, 375e6)]:
+            for freq in [4e6, max_freq + 1e6]:
+                with self.subTest(speedgrade=speedgrade, freq=freq):
+                    dcm = S6DCM(speedgrade=speedgrade)
+                    dcm.register_clkin(Signal(), 100e6)
+                    with self.assertRaisesRegex(ValueError, "Output clock frequency"):
+                        dcm.create_clkout(ClockDomain("clkout"), freq)
+
+    def test_low_input_frequency_threshold(self):
+        for clkin_freq in [51e6, 52e6]:
+            dcm = S6DCM()
+            dcm.register_clkin(Signal(), clkin_freq)
+            dcm.create_clkout(ClockDomain("clkout"), clkin_freq*25/128, margin=0)
+            if clkin_freq < 52e6:
+                with self.assertRaisesRegex(ValueError, "No PLL config found"):
+                    dcm.compute_config()
+            else:
+                config = dcm.compute_config()
+                self.assertEqual(config["clkfbout_mult"], 25)
+                self.assertEqual(config["clkout0_divide"], 128)
+
+    def test_margin_does_not_relax_output_limits(self):
+        dcm = S6DCM()
+        dcm.register_clkin(Signal(), 27.123e6)
+        dcm.create_clkout(ClockDomain("clkout"), 200e6, margin=1e-2)
+        config = dcm.compute_config()
+        self.assertLessEqual(config["clkout0_freq"], 200e6)
+        self.assertAlmostEqual(config["clkout0_freq"], 200e6, delta=2e6)
+
+    def test_unsupported_phase(self):
+        dcm = S6DCM()
+        with self.assertRaisesRegex(ValueError, "phase"):
+            dcm.create_clkout(ClockDomain("clkout"), 100e6, phase=90)


### PR DESCRIPTION
S6DCM declares multiplier/divider ranges up to 256, but XilinxClocking.__init__ replaces them with the PLL defaults of 64/128. Its shared PLL search also uses a placeholder VCO range and can select CLKFX_DIVIDE values that violate the DCM locking requirement for low input frequencies.

Give DCM_CLKGEN a direct M/D search with its actual limits:

- Restore CLKFX_MULTIPLY=2..256 and CLKFX_DIVIDE=1..256.
- Below 52 MHz input, require CLKFX_DIVIDE < F_CLKIN / 0.5 MHz.
- Enforce the speed-grade CLKFX output limits on both requested and generated frequencies, including when an output margin is supplied.
- Reject nonzero output phases, which the emitted CLKFX connection previously ignored.

The solver chooses the smallest divider among equally accurate configurations, instead of maximizing an artificial VCO frequency. Existing create_clkout arguments and emitted DCM_CLKGEN primitive are retained.

Examples newly accepted: 1 MHz → 256 MHz on -2 (M=256, D=1), and 100 MHz → 6.640625 MHz (M=17, D=256). A 27.123 MHz → 200 MHz request previously selected 200.032125 MHz, above the -1 output limit; the search now stays within the hardware range.

Sources: [UG382 v1.10, Table 2-9](https://docs.amd.com/api/khub/documents/uZmELOYPcEuAutWXD8u6FA/content) and [DS162 v3.1.1, Tables 55/57](https://docs.amd.com/api/khub/documents/5xGMdRIxMi0ioQ1azGBsvQ/content).

Validation:

- `python3 -m unittest test.cores.test_xilinx_s6 test.cores.test_clock -q`: 72 tests pass. Regressions cover full ranges, low-input locking and its 52 MHz threshold, output limits/margins, and unsupported phase requests.
- Generated Verilog simulated with the installed Xilinx DCM_CLKGEN/FDCE models using Icarus Verilog: 1→256 MHz, 100→6.640625 MHz and 12→12 MHz all lock and produce the expected measured periods.

No hardware testing or routed timing qualification is claimed.
