### PR TITLE
cores/clock/xilinx: enforce PLL and MMCM PFD frequency limits

### DIFF
--- a/litex/soc/cores/clock/xilinx_common.py
+++ b/litex/soc/cores/clock/xilinx_common.py
@@ -17,6 +17,7 @@ from litex.soc.cores.clock.common import *
 # Xilinx / Generic ---------------------------------------------------------------------------------
 
 class XilinxClocking(LiteXModule):
+    pfd_freq_range = None
 
     def __init__(self, vco_margin=0):
         check_margin(vco_margin, "VCO margin")
@@ -82,6 +83,10 @@ class XilinxClocking(LiteXModule):
         best_config = None
         best_score  = None
         for divclk_divide in range(*self.divclk_divide_range):
+            pfd_freq = self.clkin_freq/divclk_divide
+            if self.pfd_freq_range is not None:
+                if not (self.pfd_freq_range[0] <= pfd_freq <= self.pfd_freq_range[1]):
+                    continue
             for clkfbout_mult in reversed(list(clkdiv_range(*self.clkfbout_mult_frange))): # Reverse to use highest VCO frequency.
                 all_valid = True
                 errors    = []

--- a/litex/soc/cores/clock/xilinx_s6.py
+++ b/litex/soc/cores/clock/xilinx_s6.py
@@ -22,6 +22,12 @@ class S6PLL(XilinxClocking):
         XilinxClocking.__init__(self)
         self.name = name
         self.divclk_divide_range = (1, 52 + 1)
+        # DS162, Table 52: limits after DIVCLK_DIVIDE.
+        self.pfd_freq_range = {
+            -1: (19e6, 300e6),
+            -2: (19e6, 400e6),
+            -3: (19e6, 500e6),
+        }[speedgrade]
         self.vco_freq_range      = {
             -1: (400e6, 1000e6),
             -2: (400e6, 1000e6),

--- a/litex/soc/cores/clock/xilinx_s7.py
+++ b/litex/soc/cores/clock/xilinx_s7.py
@@ -26,6 +26,12 @@ class S7PLL(XilinxClocking):
         XilinxClocking.__init__(self)
         self.name = name
         self.divclk_divide_range = (1, 56+1)
+        # DS181/DS183, PLL specifications: limits after DIVCLK_DIVIDE.
+        self.pfd_freq_range = {
+            -1: (19e6, 450e6),
+            -2: (19e6, 500e6),
+            -3: (19e6, 550e6),
+        }[speedgrade]
         self.vco_freq_range = {
             -1: (800e6, 1600e6),
             -2: (800e6, 1866e6),
@@ -75,6 +81,12 @@ class S7MMCM(XilinxClocking):
             -3: (10e6, 1066e6),
         }[speedgrade]
 
+        # DS181/DS183, MMCM specifications: limits after DIVCLK_DIVIDE.
+        self.pfd_freq_range = {
+            -1: (10e6, 450e6),
+            -2: (10e6, 500e6),
+            -3: (10e6, 550e6),
+        }[speedgrade]
         self.vco_freq_range = {
             -1: (600e6, 1200e6),
             -2: (600e6, 1440e6),

--- a/litex/soc/cores/clock/xilinx_us.py
+++ b/litex/soc/cores/clock/xilinx_us.py
@@ -1,7 +1,7 @@
 #
 # This file is part of LiteX.
 #
-# Copyright (c) 2018-2020 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2018-2026 Florent Kermarrec <florent@enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
 from litex.gen import *
@@ -76,6 +76,12 @@ class USMMCM(XilinxClocking):
             -1: (10e6,  800e6),
             -2: (10e6,  933e6),
             -3: (10e6, 1066e6),
+        }[speedgrade]
+        # DS892, MMCM specifications: limits after DIVCLK_DIVIDE.
+        self.pfd_freq_range = {
+            -1: (10e6, 450e6),
+            -2: (10e6, 500e6),
+            -3: (10e6, 550e6),
         }[speedgrade]
         self.vco_freq_range = {
             -1: (600e6, 1200e6),

--- a/litex/soc/cores/clock/xilinx_usp.py
+++ b/litex/soc/cores/clock/xilinx_usp.py
@@ -79,6 +79,12 @@ class USPMMCM(XilinxClocking):
             -2: (10e6,  933e6),
             -3: (10e6, 1066e6),
         }[speedgrade]
+        # DS922, MMCM specifications: limits after DIVCLK_DIVIDE.
+        self.pfd_freq_range = {
+            -1: (10e6, 450e6),
+            -2: (10e6, 500e6),
+            -3: (10e6, 550e6),
+        }[speedgrade]
         self.vco_freq_range = {
             -1: (800e6, 1600e6),
             -2: (800e6, 1600e6),

--- a/test/cores/test_xilinx_pfd.py
+++ b/test/cores/test_xilinx_pfd.py
@@ -1,0 +1,60 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import *
+
+from litex.soc.cores.clock import S6PLL, S7PLL, S7MMCM, USMMCM, USPMMCM
+
+
+class TestXilinxPFD(unittest.TestCase):
+    def test_rejects_configs_below_minimum_pfd(self):
+        # These ratios require DIVCLK_DIVIDE=2, with an out-of-spec PFD frequency.
+        for pll_cls, clkin_freq, clkout_freq in [
+            (S6PLL,     19e6,    9.3515625e6),
+            (S7PLL,     30e6,   14.765625e6),
+            (S7MMCM,    19e6, 4.74072265625e6),
+            (USMMCM,  19.5e6,  4.798828125e6),
+            (USPMMCM,   19e6, 9.49072265625e6),
+        ]:
+            with self.subTest(pll=pll_cls.__name__):
+                pll = pll_cls()
+                pll.register_clkin(Signal(), clkin_freq)
+                pll.create_clkout(ClockDomain("clkout"), clkout_freq, margin=0)
+                with self.assertRaisesRegex(ValueError, "No PLL config found"):
+                    pll.compute_config()
+
+    def test_divides_input_above_maximum_pfd(self):
+        for pll_cls in [S6PLL, S7PLL, S7MMCM, USMMCM, USPMMCM]:
+            max_freqs = [300e6, 400e6, 500e6] if pll_cls is S6PLL else [450e6, 500e6, 550e6]
+            for speedgrade, max_freq in zip([-1, -2, -3], max_freqs):
+                with self.subTest(pll=pll_cls.__name__, speedgrade=speedgrade):
+                    clkin_freq = max_freq + 1e6
+                    pll = pll_cls(speedgrade=speedgrade)
+                    pll.register_clkin(Signal(), clkin_freq)
+                    pll.create_clkout(ClockDomain("clkout"), clkin_freq/4, margin=0)
+                    config = pll.compute_config()
+                    self.assertLessEqual(clkin_freq/config["divclk_divide"], max_freq)
+                    self.assertEqual(config["clkout0_freq"], clkin_freq/4)
+
+    def test_accepts_pfd_boundaries(self):
+        for pll_cls, min_freq, max_freq in [
+            (S6PLL,   19e6, 300e6),
+            (S7PLL,   19e6, 450e6),
+            (S7MMCM,  10e6, 450e6),
+            (USMMCM,  10e6, 450e6),
+            (USPMMCM, 10e6, 450e6),
+        ]:
+            for clkin_freq in [min_freq, max_freq]:
+                with self.subTest(pll=pll_cls.__name__, clkin_freq=clkin_freq):
+                    pll = pll_cls()
+                    pll.divclk_divide_range = (1, 2)
+                    pll.register_clkin(Signal(), clkin_freq)
+                    pll.create_clkout(ClockDomain("clkout"), clkin_freq, margin=0)
+                    config = pll.compute_config()
+                    self.assertEqual(config["divclk_divide"], 1)
+                    self.assertEqual(config["clkout0_freq"], clkin_freq)


### PR DESCRIPTION
The Xilinx solver checks the input and VCO frequencies, but never checks the PFD frequency after DIVCLK_DIVIDE. It can therefore return mathematically accurate configurations outside the PLL/MMCM locking specifications.

For example, S7PLL(-1) with 30 MHz input and an exact 14.765625 MHz output currently chooses M=63, D=2, O=64: the VCO is legal at 945 MHz, but the PFD is 15 MHz, below its 19 MHz minimum. The solver now rejects that exact request. With a permitted output margin, it can select a legal approximation. High input frequencies are divided down when needed: 800 MHz → 100 MHz uses D=2 instead of the illegal 800 MHz PFD at D=1.

Add an optional PFD-range check before searching feedback multipliers, and define speed-grade limits for S6PLL, S7PLL, S7MMCM, USMMCM and USPMMCM:

| Core | Minimum | Maximum (-1 / -2 / -3) |
| --- | --- | --- |
| S6PLL | 19 MHz | 300 / 400 / 500 MHz |
| S7PLL | 19 MHz | 450 / 500 / 550 MHz |
| S7MMCM, USMMCM, USPMMCM | 10 MHz | 450 / 500 / 550 MHz |

Sources: [DS162 Table 52](https://docs.amd.com/api/khub/documents/5xGMdRIxMi0ioQ1azGBsvQ/content), [DS181 Tables 37/38](https://docs.amd.com/api/khub/documents/iAkxxTOk96ANLJqYf2hgrQ/content), [DS183 Tables 40/41](https://docs.amd.com/api/khub/documents/0xNmm3k8xThChrbQ60WB3Q/content), [DS892 MMCM specifications](https://docs.amd.com/api/khub/documents/Oxoo8YTGAXVmh~EL2xjgGw/content), and [DS922 MMCM specifications](https://docs.amd.com/r/en-US/ds922-kintex-ultrascale-plus/MMCM-Switching-Characteristics).

This PR is based on #2584, which makes USPMMCM use the shared solver. The diff contains only the PFD-limit change.

Validation:

- `python3 -m unittest test.cores.test_xilinx_pfd test.cores.test_xilinx_usp test.cores.test_clock -q`: 74 tests pass, including below-minimum rejection, above-maximum input division across speed grades, and inclusive endpoints. The new tests reproduce eight failing subcases before the change.
- Regular LiteX-Boards clock/reset generation and Verilog conversion: Arty A7 at 100 MHz, Basys3 at 100 MHz, KC705 at 125 MHz, KCU105 at 125 MHz and KCU116 at 125 MHz.
- Vivado 2024.1 out-of-context synthesis, optimization and PDRC/REQP checks pass for five generated S7PLL/S7MMCM/USMMCM/USPMMCM designs, including high-input division and the legal approximation of the 30 MHz example.
- Combined locally with #2585: all 80 clock tests pass and the changes apply without conflicts.

No hardware testing or routed timing qualification is claimed.
