### PR TITLE
test/soc: allow slow BIOS startup in serialboot recovery test

### DIFF
--- a/test/soc/test_integration.py
+++ b/test/soc/test_integration.py
@@ -151,7 +151,9 @@ def test_serialboot_abort_recovers_and_loads(tmp_path):
             p.expect(f"Found port {port}", timeout=1200)
             sock = _connect_tcp_uart(port)
 
-            _recv_until(sock, litex_prompt, timeout=20)
+            # BIOS startup includes memory tests and the automatic serial-boot
+            # timeout, which can take longer on busy simulation workers.
+            _recv_until(sock, litex_prompt, timeout=120)
             sock.sendall(b"serialboot\n")
             _recv_until(sock, sfl_magic_req, timeout=10)
 
@@ -178,9 +180,10 @@ def test_serialboot_abort_recovers_and_loads(tmp_path):
             jump.payload = (0x40000000).to_bytes(4, "big")
             sock.sendall(jump.encode())
             _recv_until(sock, sfl_ack_success, timeout=10)
-        except (OSError, subprocess.CalledProcessError, pexpect.EOF, pexpect.TIMEOUT, TimeoutError):
+        except (OSError, subprocess.CalledProcessError, pexpect.EOF, pexpect.TIMEOUT, TimeoutError) as e:
             is_success = False
             print("*** Serialboot abort recovery failure: {}".format(" ".join(cmd)))
+            print(e)
             log_file.seek(0)
             print(log_file.read())
         finally:


### PR DESCRIPTION
The serial-boot recovery integration test waits only 20 seconds for the initial BIOS prompt. BIOS startup includes RAM tests and the automatic serial-boot timeout, so a slow simulator can hit that deadline before the recovery protocol is even exercised. The exception handler then discards the TimeoutError details and reports only `assert False` plus the simulator's startup log.

Allow 120 seconds for the initial prompt and print the caught exception. This changes only the integration test; protocol response waits remain at 10 seconds.

Investigated after the merge CI run of #2584 failed this test while all four branch CI jobs passed. That original log omitted the exception, so its exact cause cannot be established retrospectively.

Validation:

- Ran the existing full serial-boot integration test locally, including firmware and Verilator compilation: passed.
- Reused that simulator with the process allowed to run for 15 ms out of each 100 ms, simulating a slow worker without adding CPU load. The original test reproducibly timed out at 20 seconds while the BIOS was still in its RAM test.
- With this change, the same slowed simulator reached the prompt after 33.75 seconds and completed the partial-frame timeout, abort, restart, load and jump acknowledgments successfully.
- The corrected test also passes at normal simulator speed.
