### PR TITLE
litex_server: allow independent JTAG stream ports for multiple boards

### DIFF
--- a/litex/tools/litex_server.py
+++ b/litex/tools/litex_server.py
@@ -201,6 +201,7 @@ def main():
     parser.add_argument("--jtag",            action="store_true",             help="Select JTAG interface.")
     parser.add_argument("--jtag-config",     default="openocd_xc7_ft232.cfg", help="OpenOCD JTAG configuration file.")
     parser.add_argument("--jtag-chain",      default=1,                       help="JTAG chain.")
+    parser.add_argument("--jtag-port",       default=20000, type=int,         help="OpenOCD JTAG stream port.")
 
     # UDP arguments
     parser.add_argument("--udp",             action="store_true",    help="Select UDP interface.")
@@ -248,7 +249,7 @@ def main():
     elif args.jtag:
         from litex.tools.litex_term import JTAGUART
         from litex.tools.remote.comm_uart import CommUART
-        jtag_uart = JTAGUART(config=args.jtag_config, chain=int(args.jtag_chain))
+        jtag_uart = JTAGUART(config=args.jtag_config, port=args.jtag_port, chain=int(args.jtag_chain))
         jtag_uart.open()
         print("[CommUART] port: JTAG / ", end="")
         comm = CommUART(os.ttyname(jtag_uart.name), debug=args.debug, addr_width=int(args.addr_width))

--- a/test/tools/test_server_cli.py
+++ b/test/tools/test_server_cli.py
@@ -1,0 +1,31 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+from unittest import mock
+
+from litex.tools import litex_server
+
+
+class TestServerCLI(unittest.TestCase):
+    def test_jtag_stream_port_selection(self):
+        # Two board servers need separate OpenOCD stream ports as well as
+        # separate public Etherbone ports. Preserve the single-board default.
+        for arguments, expected in (([], 20000), (["--jtag-port", "20001"], 20001)):
+            with self.subTest(arguments=arguments):
+                with mock.patch("sys.argv", ["litex_server", "--jtag", "--bind-port", "1235"] + arguments), \
+                     mock.patch("litex.tools.litex_term.JTAGUART") as uart, \
+                     mock.patch("litex.tools.remote.comm_uart.CommUART"), \
+                     mock.patch("litex.tools.litex_server.os.ttyname", return_value="/dev/pts/test"), \
+                     mock.patch("litex.tools.litex_server.RemoteServer") as server, \
+                     mock.patch("time.sleep", side_effect=KeyboardInterrupt):
+                    litex_server.main()
+                    self.assertEqual(uart.call_args.kwargs["port"], expected)
+                    self.assertEqual(server.call_args.args[2], 1235)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Running two `litex_server --jtag` instances fails even with different `--bind-port` values because both OpenOCD streams use TCP port 20000. Add `--jtag-port` and forward it to `JTAGUART`; the default remains 20000.

Validated with CLI regression coverage for default/custom stream ports (independent of the public server port), plus the remote-access suite: 38 tests passed. On USB-connected SPEC-A7 and Acorn boards, independently selected stream ports 20001/20002 and public ports 1235/1236 allowed concurrent JTAGBone identity, CSR and WR-core reads. The SPEC run used this patched standard CLI.
