### PR TITLE
jtag: clean up OpenOCD and PTYs on shutdown and failed startup

### DIFF
--- a/litex/build/openocd.py
+++ b/litex/build/openocd.py
@@ -7,6 +7,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import os
+import subprocess
 import tempfile
 
 from litex.build.generic_programmer import GenericProgrammer
@@ -127,7 +128,7 @@ class OpenOCD(GenericProgrammer):
         else:
             return ""
 
-    def stream(self, port=20000, chain=1):
+    def stream(self, port=20000, chain=1, stop_event=None):
         """
         Create a TCP server to stream data to/from the internal JTAG TAP of the FPGA
 
@@ -275,11 +276,31 @@ proc jtagstream_serve {tap port} {
                 f.write(cfg)
             script = "; ".join([
                 "init",
+                # init can continue after an invalid scan chain. Require a
+                # successful TAP check before exposing a JTAG byte stream.
+                "jtag arp_init",
                 #"poll off", # FIXME: not supported for ECP5
                 "irscan {} {:d}".format(tap_name, ir),
                 "jtagstream_serve {} {:d}".format(tap_name, port),
                 "exit",
             ])
-            self.call([get_openocd_cmd(), "-f", config, "-f", cfg_file, "-c", script])
+            command = [get_openocd_cmd(), "-f", config, "-f", cfg_file, "-c", script]
+            if stop_event is None:
+                self.call(command)
+            else:
+                process = subprocess.Popen(command)
+                try:
+                    while process.poll() is None and not stop_event.wait(0.1):
+                        pass
+                    if not stop_event.is_set() and process.returncode:
+                        raise OSError(f"OpenOCD exited with status {process.returncode}")
+                finally:
+                    if process.poll() is None:
+                        process.terminate()
+                        try:
+                            process.wait(timeout=1)
+                        except subprocess.TimeoutExpired:
+                            process.kill()
+                    process.wait(timeout=1)
         finally:
             os.remove(cfg_file)

--- a/litex/tools/litex_server.py
+++ b/litex/tools/litex_server.py
@@ -13,6 +13,7 @@ import argparse
 import os
 import sys
 import socket
+import signal
 import threading
 
 from litex.tools.remote.etherbone import EtherbonePacket, EtherboneRecord, EtherboneWrites
@@ -184,7 +185,7 @@ class RemoteServer(EtherboneIPC):
 
 # Run ----------------------------------------------------------------------------------------------
 
-def main():
+def _main():
     parser = argparse.ArgumentParser(description="LiteX Server utility", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     # Common arguments
     parser.add_argument("--bind-ip",         default="localhost",    help="Host bind address.")
@@ -235,6 +236,7 @@ def main():
         parser.error("select only one interface (got: {}).".format(
             ", ".join("--" + name for name in selected_interfaces)))
 
+    jtag_uart = None
     # UART mode
     if args.uart:
         from litex.tools.remote.comm_uart import CommUART
@@ -252,7 +254,11 @@ def main():
         jtag_uart = JTAGUART(config=args.jtag_config, port=args.jtag_port, chain=int(args.jtag_chain))
         jtag_uart.open()
         print("[CommUART] port: JTAG / ", end="")
-        comm = CommUART(os.ttyname(jtag_uart.name), debug=args.debug, addr_width=int(args.addr_width))
+        try:
+            comm = CommUART(os.ttyname(jtag_uart.name), debug=args.debug, addr_width=int(args.addr_width))
+        except BaseException:
+            jtag_uart.close()
+            raise
 
     # UDP mode
     elif args.udp:
@@ -305,14 +311,33 @@ def main():
         print("[CommDevMem] base: 0x{:08x} / size: 0x{:08x} / ".format(devmem_base, devmem_size), end="")
         comm = CommDevMem(base=devmem_base, size=devmem_size, debug=args.debug)
 
-    server = RemoteServer(comm, args.bind_ip, int(args.bind_port), addr_width=int(args.addr_width))
-    server.open()
-    server.start(4)
+    server = None
     try:
+        server = RemoteServer(comm, args.bind_ip, int(args.bind_port), addr_width=int(args.addr_width))
+        server.open()
+        server.start(4)
         import time
         while True: time.sleep(100)
     except KeyboardInterrupt:
         pass
+    finally:
+        try:
+            if server is not None:
+                server.close()
+        finally:
+            if jtag_uart is not None:
+                jtag_uart.close()
+
+
+def main():
+    def terminate(signum, frame):
+        raise KeyboardInterrupt
+
+    previous = signal.signal(signal.SIGTERM, terminate)
+    try:
+        _main()
+    finally:
+        signal.signal(signal.SIGTERM, previous)
 
 if __name__ == "__main__":
     main()

--- a/litex/tools/litex_term.py
+++ b/litex/tools/litex_term.py
@@ -18,6 +18,7 @@ import threading
 import argparse
 import json
 import socket
+import select
 from collections import deque
 
 # Console ------------------------------------------------------------------------------------------
@@ -140,59 +141,88 @@ class JTAGUART:
         self.config = config
         self.port   = port
         self.chain  = chain
+        self.alive = False
+        self.stop_event = threading.Event()
+        self.error = None
+        self.file = self.name = self.tcp = None
+        self.threads = []
 
-    def open(self):
+    def open(self, timeout=5):
+        if self.alive:
+            return
+        if timeout <= 0:
+            raise ValueError("JTAG startup timeout must be positive")
+        self.close()
+        self.stop_event.clear()
+        self.error = None
         self.file, self.name = pty.openpty()
         self.alive = True
         self.jtag2tcp_thread = threading.Thread(target=self.jtag2tcp, daemon=True)
-        self.jtag2tcp_thread.start()
         self.pty2tcp_thread  = threading.Thread(target=self.pty2tcp, daemon=True)
         self.tcp2pty_thread  = threading.Thread(target=self.tcp2pty, daemon=True)
-        self.tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        connected = False
-        for _ in range(0, 50):
-            try:
-                self.tcp.connect(("localhost", self.port))
-                connected = True
-                break
-            except ConnectionRefusedError:
-                time.sleep(0.1)
-        if not connected:
-            raise ConnectionError(f"Failed to connect to OpenOCD jtagstream on port {self.port}")
-        self.pty2tcp_thread.start()
-        self.tcp2pty_thread.start()
+        self.threads = [self.jtag2tcp_thread, self.pty2tcp_thread, self.tcp2pty_thread]
+        try:
+            self.jtag2tcp_thread.start()
+            deadline = time.monotonic() + timeout
+            while self.tcp is None:
+                if self.error is not None:
+                    raise ConnectionError("OpenOCD startup failed") from self.error
+                if time.monotonic() >= deadline:
+                    raise ConnectionError(f"Failed to connect to OpenOCD jtagstream on port {self.port}")
+                try:
+                    self.tcp = socket.create_connection(("localhost", self.port), timeout=0.1)
+                except (ConnectionRefusedError, TimeoutError):
+                    self.stop_event.wait(0.1)
+            self.tcp.settimeout(None)
+            self.pty2tcp_thread.start()
+            self.tcp2pty_thread.start()
+        except BaseException:
+            self.close()
+            raise
 
     def close(self):
         self.alive = False
+        self.stop_event.set()
         # Close TCP socket to unblock recv/send
         try:
             self.tcp.shutdown(socket.SHUT_RDWR)
-        except OSError:
+        except (AttributeError, OSError):
             pass
         try:
             self.tcp.close()
-        except OSError:
+        except (AttributeError, OSError):
             pass
-        # Close PTY to unblock os.read
-        try:
-            os.close(self.file)
-        except OSError:
-            pass
-        self.jtag2tcp_thread.join(timeout=0.5)
-        self.pty2tcp_thread.join(timeout=0.5)
-        self.tcp2pty_thread.join(timeout=0.5)
+        for thread in self.threads:
+            if thread.ident is not None and thread is not threading.current_thread():
+                thread.join(timeout=3)
+        if any(thread.is_alive() for thread in self.threads):
+            raise RuntimeError("JTAG workers did not stop; refusing to reuse their resources")
+        # Both ends of openpty are owned here. Close after the workers stop,
+        # so descriptor reuse cannot send a worker into an unrelated file.
+        for fd in (self.file, self.name):
+            if fd is not None:
+                os.close(fd)
+        self.file = self.name = self.tcp = None
+        self.threads = []
 
     def jtag2tcp(self):
-        prog = OpenOCD(self.config)
-        prog.stream(self.port, self.chain)
+        try:
+            prog = OpenOCD(self.config)
+            prog.stream(self.port, self.chain, stop_event=self.stop_event)
+        except Exception as error:
+            self.error = error
+        finally:
+            self.alive = False
 
     def pty2tcp(self):
         try:
             while self.alive:
+                if not select.select([self.file], [], [], 0.1)[0]:
+                    continue
                 r = os.read(self.file, 1)
                 if not r:
                     break
-                self.tcp.send(r)
+                self.tcp.sendall(r)
         except (ConnectionResetError, BrokenPipeError, OSError):
             pass
         finally:

--- a/test/tools/test_jtag_uart.py
+++ b/test/tools/test_jtag_uart.py
@@ -1,0 +1,104 @@
+#
+# This file is part of LiteX.
+#
+# Copyright (c) 2026 Enjoy-Digital <enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import json
+import os
+from pathlib import Path
+import socket
+import time
+
+import pytest
+import serial
+
+from litex.tools.litex_term import JTAGUART
+
+
+@pytest.fixture
+def backend(tmp_path, monkeypatch):
+    executable = tmp_path / "openocd"
+    executable.write_text('''#!/usr/bin/env python3
+import json, os, re, signal, socket, sys, time
+from pathlib import Path
+mode = os.environ.get("FAKE_JTAG_MODE", "echo")
+cfg = sys.argv[sys.argv.index("-c") - 1]
+Path(os.environ["FAKE_JTAG_STATE"]).write_text(json.dumps({"pid": os.getpid(), "cfg": cfg}))
+assert "jtag arp_init" in sys.argv[-1]
+if mode == "failure":
+    sys.exit(3)
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+if mode == "timeout":
+    while True:
+        time.sleep(1)
+port = int(re.search(r"jtagstream_serve \\S+ (\\d+)", sys.argv[-1])[1])
+with socket.socket() as listener:
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", port))
+    listener.listen()
+    while True:
+        connection, _ = listener.accept()
+        with connection:
+            while True:
+                data = connection.recv(4096)
+                if not data:
+                    break
+                connection.sendall(data)
+''')
+    executable.chmod(0o755)
+    config = tmp_path / "target.cfg"
+    config.write_text("# xc7 test fixture\n")
+    state = tmp_path / "state.json"
+    monkeypatch.setenv("OPENOCD", str(executable))
+    monkeypatch.setenv("FAKE_JTAG_STATE", str(state))
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        port = listener.getsockname()[1]
+    return JTAGUART(str(config), port=port), state
+
+
+def assert_reaped(state):
+    record = json.loads(state.read_text())
+    with pytest.raises(ProcessLookupError):
+        os.kill(record["pid"], 0)
+    assert not Path(record["cfg"]).exists()
+
+
+def test_repeated_open_close_reaps_openocd_and_closes_both_pty_ends(backend):
+    uart, state = backend
+    descriptors = len(list(Path("/proc/self/fd").iterdir()))
+    for _ in range(3):
+        try:
+            uart.open()
+            with serial.Serial(os.ttyname(uart.name), timeout=2) as port:
+                payload = bytes(range(256))
+                port.write(payload)
+                assert port.read(len(payload)) == payload
+        finally:
+            workers = list(uart.threads)
+            uart.close()
+        assert all(not worker.is_alive() for worker in workers)
+        uart.close()
+        assert_reaped(state)
+        assert len(list(Path("/proc/self/fd").iterdir())) == descriptors
+
+
+@pytest.mark.parametrize("mode", ["failure", "timeout"])
+def test_failed_startup_cleans_up_and_can_be_retried(backend, monkeypatch, mode):
+    uart, state = backend
+    monkeypatch.setenv("FAKE_JTAG_MODE", mode)
+    descriptors = len(list(Path("/proc/self/fd").iterdir()))
+    started = time.monotonic()
+    with pytest.raises(ConnectionError):
+        uart.open(timeout=0.3)
+    assert time.monotonic() - started < 3
+    assert_reaped(state)
+    assert len(list(Path("/proc/self/fd").iterdir())) == descriptors
+    monkeypatch.setenv("FAKE_JTAG_MODE", "echo")
+    try:
+        uart.open()
+        assert uart.alive
+    finally:
+        uart.close()
+    assert_reaped(state)

--- a/test/tools/test_server_cli.py
+++ b/test/tools/test_server_cli.py
@@ -25,6 +25,8 @@ class TestServerCLI(unittest.TestCase):
                     litex_server.main()
                     self.assertEqual(uart.call_args.kwargs["port"], expected)
                     self.assertEqual(server.call_args.args[2], 1235)
+                    server.return_value.close.assert_called_once()
+                    uart.return_value.close.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stopping a JTAG `litex_server` could leave OpenOCD running and holding the USB adapter. `JTAGUART.close()` only joined the thread blocked in `OpenOCD.stream()` and leaked the slave PTY descriptor; failed startup also left resources behind.

Manage the streaming OpenOCD child through a stop event, terminate/kill and reap it on shutdown, close both PTY ends, and clean up partial startup before allowing a retry. The server now closes its transport on SIGINT/SIGTERM and startup errors. An explicit `jtag arp_init` rejects an invalid scan chain before exposing the stream instead of continuing after OpenOCD's permissive `init`.

Validation: 19 tests and 2 subtests passed, including real subprocess/PTY tests with binary data, repeated open/close, early child failure and timeout with an OpenOCD stand-in that ignores SIGTERM. On the connected Acorn and SPEC-A7, three PID-only SIGTERM shutdown/reconnect cycles per board passed; OpenOCD exited and both TCP ports were released each time. A separate bench supervisor also recovered an Acorn OpenOCD orphan after forcibly killing its server, using persisted PID/start-time records.

This fixes resource ownership and makes startup failures bounded. It does not establish the electrical cause of the single garbled JTAG ID seen during earlier WR testing. Hard-killing the parent still requires the bench supervisor's persisted ownership record for later cleanup.
