### PR TITLE
jtag: avoid delayed TCP acknowledgements in the OpenOCD bridge

### DIFF
--- a/litex/tools/litex_term.py
+++ b/litex/tools/litex_term.py
@@ -174,6 +174,9 @@ class JTAGUART:
                 except (ConnectionRefusedError, TimeoutError):
                     self.stop_event.wait(0.1)
             self.tcp.settimeout(None)
+            # JTAGBone command bytes must reach OpenOCD without waiting for
+            # a delayed TCP ACK before the rest of the command is sent.
+            self.tcp.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             self.pty2tcp_thread.start()
             self.tcp2pty_thread.start()
         except BaseException:


### PR DESCRIPTION
JTAGUART forwards commands byte by byte to OpenOCD. With Nagle enabled, a command can wait for a delayed TCP acknowledgement before its remaining bytes are sent. Disable Nagle on that socket so short JTAGBone reads complete promptly.

On an FT4232H/Acorn at 5 MHz TCK, single-word reads fell from about 42 ms to 1.5 ms; 2040-word reads fell from 413 ms to 89 ms. SPEC-A7 independently measured 1.5 ms and 90 ms after the change. This removed FIFO overflow during native-rate WR PLL burst capture.

Validation: 21 JTAG UART and terminal tests passed, including repeated open/close and failed-startup cleanup. Both real boards reconnected with valid identities and returned the expected identity on every read. The Acorn FPGA image and clocks were unchanged for the latency comparison.
